### PR TITLE
feat: per-identity push content tiers for mail-arrival notifications

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,14 @@ NTFY_ADMIN_PASSWORD=change-me-generate-with-openssl-rand-hex-24
 
 # Optional public origin of the human dashboard. When set, mail-arrival ntfy
 # pushes include a click action that opens this URL (no deep link path).
+# Must not include userinfo (https://user:pass@… is rejected) — credentials
+# must never ride the notification channel.
 # DASHBOARD_PUBLIC_URL=https://mail.example.com/ui
+
+# Identity store directory (default ./data in the API process). Designed for a
+# single writer process (Compose runs one API); multi-process shared DATA_DIR
+# is unsupported even though each save is atomic on disk.
+# DATA_DIR=./data
 
 # Per-identity send rate limit, messages per rolling hour (0 = unlimited).
 # SEND_RATE_LIMIT=20

--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,10 @@ NTFY_ADMIN_PASSWORD=change-me-generate-with-openssl-rand-hex-24
 # verification code or link; external mail never wakes an agent topic.
 # PUSH_POLICY=otp
 
+# Optional public origin of the human dashboard. When set, mail-arrival ntfy
+# pushes include a click action that opens this URL (no deep link path).
+# DASHBOARD_PUBLIC_URL=https://mail.example.com/ui
+
 # Per-identity send rate limit, messages per rolling hour (0 = unlimited).
 # SEND_RATE_LIMIT=20
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,10 @@ Deliberate limits, so nothing here is a surprise later:
 - **Server-side notifications** — private ntfy transport for human alerts and
   managed-agent wake-ups, with OTP-only mail notifications by default. Topics
   and ntfy credentials stay on the server; phone setup is deliberately a later
-  v0.3.1 step.
+  v0.3.1 step. Per-identity **push content tiers** control how much of each
+  mail-arrival alert leaves the server: tier 1 interrupt only (default),
+  tier 2 adds subject/from, tier 3 (admin + explicit risk confirm) adds a
+  short body preview and extracted OTP codes/links.
 - **`mail_wait_for` / `POST /v1/messages/wait`** — long-poll an inbox until a
   matching message arrives, with OTP codes and verification links already extracted.
   Built for automated signups.

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -31,6 +31,8 @@ services:
       SMTP_USER: ${SMTP_USER:?Set SMTP_USER in .env}
       SMTP_PASS: ${SMTP_PASS:?Set SMTP_PASS in .env}
       TASK_SIGNING_SECRET: ${TASK_SIGNING_SECRET:?Set TASK_SIGNING_SECRET in .env (openssl rand -hex 32)}
+      # Optional dashboard origin for ntfy click actions on mail-arrival pushes.
+      DASHBOARD_PUBLIC_URL: ${DASHBOARD_PUBLIC_URL:-}
       # Identity store (json) survives container recreation:
       DATA_DIR: /app/data
       # Per-identity send limit (messages/hour, 0 = off):

--- a/compose.yaml
+++ b/compose.yaml
@@ -192,6 +192,8 @@ services:
       NTFY_ADMIN_PASSWORD: ${NTFY_ADMIN_PASSWORD:?Set NTFY_ADMIN_PASSWORD in .env (openssl rand -hex 24)}
       NOTIFY_RATE_LIMIT: ${NOTIFY_RATE_LIMIT:-10}
       PUSH_POLICY: ${PUSH_POLICY:-otp}
+      # Optional dashboard origin for ntfy click actions on mail-arrival pushes.
+      DASHBOARD_PUBLIC_URL: ${DASHBOARD_PUBLIC_URL:-}
       # Identity store (json) survives container recreation:
       DATA_DIR: /app/data
       # Per-identity send limit (messages/hour, 0 = off):

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -32,8 +32,10 @@ bun run typecheck
 
 All `/v1/*` require `Authorization: Bearer <key>`.
 
-- `POST /v1/identities` `{name?, localpart?}` → `201 {address, name?}` (409 if taken)
-- `GET /v1/identities` → `{identities:[{address,name?,createdAt}]}`
+- `POST /v1/identities` `{name?, localpart?}` → `201 {address, name?, pushContentTier, token}` (409 if taken)
+- `GET /v1/identities` → `{identities:[{address,name?,createdAt,pushContentTier,...}]}`
+- `GET /v1/identities/:address/push-tier` → `{address, pushContentTier, warning?}` (admin any; identity own only)
+- `PUT /v1/identities/:address/push-tier` `{pushContentTier:1|2|3, confirm_risk?}` → admin only; tier 3 requires `confirm_risk: true`
 - `GET /v1/messages?address=&limit=50` → `{messages:[{id,from,to,subject,date,seen,snippet}]}`. Only the **newest 500 messages in the shared catch-all** are scanned for a match, so on a very busy instance an identity's older mail can fall outside that window and stop being listed even though retention has not deleted it yet
 - `GET /v1/messages/:id?address=` → `{id,from,to,subject,date,text,html?,otp:{codes,links}}`
 - `POST /v1/messages/:id/seen` `{address, seen}` → `{id, seen}` (404 if the message is not addressed to `address`; reading never sets `\Seen` by itself — agents mark messages processed through here)

--- a/packages/api/dev/preview.ts
+++ b/packages/api/dev/preview.ts
@@ -204,6 +204,12 @@ const dependencies = {
   getMessage: async (address: string, id: string) =>
     address === 'fox@preview.test' ? (details.get(id) ?? null) : null,
   getMailboxScan,
+  setPushContentTier: (address: string, tier: 1 | 2 | 3) => {
+    const identity = identities.find((entry) => entry.address === address.toLowerCase());
+    if (!identity) return null;
+    (identity as { pushContentTier?: 1 | 2 | 3 }).pushContentTier = tier;
+    return identity as typeof identity & { pushContentTier: 1 | 2 | 3 };
+  },
 };
 
 const app = new Hono();

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -68,6 +68,9 @@ const envSchema = z.object({
   // Only identities explicitly granted can_notify_user may spend this budget.
   NOTIFY_RATE_LIMIT: z.coerce.number().int().min(0).default(10),
   PUSH_POLICY: z.enum(['otp', 'all', 'none']).default('otp'),
+  // Optional public origin of the human dashboard. When set, mail-arrival
+  // ntfy pushes include a click action that opens this URL (no deep link).
+  DASHBOARD_PUBLIC_URL: z.string().url().optional(),
 
   // Per-identity send rate limit (messages per rolling hour). 0 disables.
   SEND_RATE_LIMIT: z.coerce.number().int().min(0).default(20),
@@ -134,6 +137,9 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
       pushPolicy: raw.PUSH_POLICY,
       notifyRateLimit: raw.NOTIFY_RATE_LIMIT,
     },
+    dashboardPublicUrl: raw.DASHBOARD_PUBLIC_URL
+      ? normalizeUrl(raw.DASHBOARD_PUBLIC_URL)
+      : undefined,
     sendRateLimit: raw.SEND_RATE_LIMIT,
     retentionDays: raw.RETENTION_DAYS,
     retentionCheckHours: raw.RETENTION_CHECK_HOURS,

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -128,8 +128,9 @@ function splitCsv(value: string): string[] {
  * Canonical form keeps configured and request URLs comparable as origins.
  * Only drops a redundant trailing slash on the pathname — never rewrites
  * query values or fragments (e.g. `?next=/` and `#/` must survive).
+ * Exported so notify device pairing uses the same normalizer as config.
  */
-function normalizeUrl(value: string): string {
+export function normalizeUrl(value: string): string {
   const url = new URL(value);
   if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
     url.pathname = url.pathname.replace(/\/+$/, '') || '/';

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -89,9 +89,22 @@ function splitCsv(value: string): string[] {
     .filter(Boolean);
 }
 
-/** Canonical form keeps configured and request URLs comparable as origins. */
+/**
+ * Canonical form keeps configured and request URLs comparable as origins.
+ * Only drops a redundant trailing slash on the pathname — never rewrites
+ * query values or fragments (e.g. `?next=/` and `#/` must survive).
+ */
 function normalizeUrl(value: string): string {
-  return new URL(value).href.replace(/\/+$/, '');
+  const url = new URL(value);
+  if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
+    url.pathname = url.pathname.replace(/\/+$/, '') || '/';
+  }
+  // Root path serializes as "https://host/"; strip that slash for stable
+  // origin comparison without touching search/hash when they are present.
+  if (url.pathname === '/' && url.search === '' && url.hash === '') {
+    return url.origin;
+  }
+  return url.href;
 }
 
 /** Parse an environment object so TLS defaults and validation stay testable. */

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -46,6 +46,9 @@ function envUrl(fallback?: string) {
  * Public dashboard origin for ntfy click actions (F80). Rejects userinfo so
  * credentials never ride the notification channel. Internal ntfy URLs keep
  * envUrl() (credentials may be required on private networks).
+ * F114: query strings and fragments are rejected too — the value is attached
+ * verbatim as the ntfy click field on every mail-arrival push, so a copied
+ * authenticated URL (`…/ui?token=secret`) would leak the credential.
  */
 function dashboardPublicUrlEnv() {
   return z.preprocess(
@@ -55,12 +58,20 @@ function dashboardPublicUrlEnv() {
         (value) => {
           try {
             const url = new URL(value);
-            return url.username === '' && url.password === '';
+            return (
+              url.username === '' &&
+              url.password === '' &&
+              url.search === '' &&
+              url.hash === ''
+            );
           } catch {
             return false;
           }
         },
-        { message: 'DASHBOARD_PUBLIC_URL must not include credentials (userinfo)' },
+        {
+          message:
+            'DASHBOARD_PUBLIC_URL must not include credentials (userinfo, query, or fragment)',
+        },
       )
       .optional(),
   );
@@ -131,6 +142,8 @@ const envSchema = z.object({
   // Optional public origin of the human dashboard. When set, mail-arrival
   // ntfy pushes include a click action that opens this URL (no deep link).
   // Must not contain userinfo — credentials must not leave via ntfy (F80).
+  // Query/fragment are rejected too (F114): a copied authenticated URL would
+  // leak its token verbatim on every push.
   DASHBOARD_PUBLIC_URL: dashboardPublicUrlEnv(),
 
   // Per-identity send rate limit (messages per rolling hour). 0 disables.

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -16,14 +16,30 @@ function emptyAsUndefined(value: unknown): unknown {
   return value.trim() === '' ? undefined : value;
 }
 
+/** Only http(s) — these values feed ntfy HTTP calls and push click actions. */
+const httpUrl = z
+  .string()
+  .url()
+  .refine(
+    (value) => {
+      try {
+        const protocol = new URL(value).protocol;
+        return protocol === 'http:' || protocol === 'https:';
+      } catch {
+        return false;
+      }
+    },
+    { message: 'URL must use http or https' },
+  );
+
 /** URL env: empty string → undefined (optional or fall through to default). */
 function envUrl(): z.ZodType<string | undefined>;
 function envUrl(fallback: string): z.ZodType<string>;
 function envUrl(fallback?: string) {
   if (fallback !== undefined) {
-    return z.preprocess(emptyAsUndefined, z.string().url().default(fallback));
+    return z.preprocess(emptyAsUndefined, httpUrl.default(fallback));
   }
-  return z.preprocess(emptyAsUndefined, z.string().url().optional());
+  return z.preprocess(emptyAsUndefined, httpUrl.optional());
 }
 
 const envSchema = z.object({

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -42,6 +42,30 @@ function envUrl(fallback?: string) {
   return z.preprocess(emptyAsUndefined, httpUrl.optional());
 }
 
+/**
+ * Public dashboard origin for ntfy click actions (F80). Rejects userinfo so
+ * credentials never ride the notification channel. Internal ntfy URLs keep
+ * envUrl() (credentials may be required on private networks).
+ */
+function dashboardPublicUrlEnv() {
+  return z.preprocess(
+    emptyAsUndefined,
+    httpUrl
+      .refine(
+        (value) => {
+          try {
+            const url = new URL(value);
+            return url.username === '' && url.password === '';
+          } catch {
+            return false;
+          }
+        },
+        { message: 'DASHBOARD_PUBLIC_URL must not include credentials (userinfo)' },
+      )
+      .optional(),
+  );
+}
+
 const envSchema = z.object({
   // HTTP port for the API service.
   PORT: z.coerce.number().int().positive().default(3100),
@@ -78,7 +102,8 @@ const envSchema = z.object({
   // Defaults to [DOMAIN]. Sending to any recipient domain is unrestricted.
   ALLOWED_SEND_DOMAINS: z.string().optional(),
 
-  // Directory for the identity store JSON file.
+  // Directory for the identity store JSON file. Single-writer process only
+  // (Compose runs one API); multi-process shared DATA_DIR is unsupported.
   DATA_DIR: z.string().default('./data'),
 
   // Built-in, read-only human inbox. Disable to make every /ui route 404.
@@ -105,7 +130,8 @@ const envSchema = z.object({
   PUSH_POLICY: z.enum(['otp', 'all', 'none']).default('otp'),
   // Optional public origin of the human dashboard. When set, mail-arrival
   // ntfy pushes include a click action that opens this URL (no deep link).
-  DASHBOARD_PUBLIC_URL: envUrl(),
+  // Must not contain userinfo — credentials must not leave via ntfy (F80).
+  DASHBOARD_PUBLIC_URL: dashboardPublicUrlEnv(),
 
   // Per-identity send rate limit (messages per rolling hour). 0 disables.
   SEND_RATE_LIMIT: z.coerce.number().int().min(0).default(20),

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -7,6 +7,25 @@
 import { join } from 'node:path';
 import { z } from 'zod';
 
+/**
+ * Compose `${VAR:-}` injects "" when the var is unset. Treat empty/whitespace
+ * as missing so optional fields stay optional and `.default()` can apply.
+ */
+function emptyAsUndefined(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  return value.trim() === '' ? undefined : value;
+}
+
+/** URL env: empty string → undefined (optional or fall through to default). */
+function envUrl(): z.ZodType<string | undefined>;
+function envUrl(fallback: string): z.ZodType<string>;
+function envUrl(fallback?: string) {
+  if (fallback !== undefined) {
+    return z.preprocess(emptyAsUndefined, z.string().url().default(fallback));
+  }
+  return z.preprocess(emptyAsUndefined, z.string().url().optional());
+}
+
 const envSchema = z.object({
   // HTTP port for the API service.
   PORT: z.coerce.number().int().positive().default(3100),
@@ -52,13 +71,13 @@ const envSchema = z.object({
   // Notification transport. Docker Compose enables ntfy by default; keeping
   // the bare-process default off preserves the lightweight API test/runtime.
   NTFY_ENABLED: z.enum(['true', 'false']).default('false'),
-  NTFY_INTERNAL_URL: z.string().url().default('http://ntfy'),
+  NTFY_INTERNAL_URL: envUrl('http://ntfy'),
   // Path as seen by the ntfy container. The API writes the same named volume
   // at /app/data, so this must not be derived from DATA_DIR.
   NTFY_STORAGE_DIR: z.string().min(1).default('/var/lib/openagentemail/ntfy'),
   // This can stay on a private address for server-only notifications. Phone
   // delivery needs a deliberate public HTTPS reverse proxy and full restart.
-  NOTIFY_PUBLIC_URL: z.string().url().default('http://127.0.0.1:2586'),
+  NOTIFY_PUBLIC_URL: envUrl('http://127.0.0.1:2586'),
   // Forward unknown topics to ntfy.sh unless an operator explicitly disables
   // it with NTFY_UPSTREAM=false.
   NTFY_UPSTREAM: z.enum(['true', 'false']).default('true'),
@@ -70,7 +89,7 @@ const envSchema = z.object({
   PUSH_POLICY: z.enum(['otp', 'all', 'none']).default('otp'),
   // Optional public origin of the human dashboard. When set, mail-arrival
   // ntfy pushes include a click action that opens this URL (no deep link).
-  DASHBOARD_PUBLIC_URL: z.string().url().optional(),
+  DASHBOARD_PUBLIC_URL: envUrl(),
 
   // Per-identity send rate limit (messages per rolling hour). 0 disables.
   SEND_RATE_LIMIT: z.coerce.number().int().min(0).default(20),

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -135,10 +135,11 @@ export function normalizeUrl(value: string): string {
   if (url.pathname.length > 1 && url.pathname.endsWith('/')) {
     url.pathname = url.pathname.replace(/\/+$/, '') || '/';
   }
-  // Root path serializes as "https://host/"; strip that slash for stable
-  // origin comparison without touching search/hash when they are present.
+  // Root path serializes as "https://host/" (or with userinfo). Prefer href so
+  // publisher:secret@host credentials survive; origin alone drops userinfo.
+  // Only apply when search/hash are empty so those branches keep full href.
   if (url.pathname === '/' && url.search === '' && url.hash === '') {
-    return url.origin;
+    return url.href.replace(/\/+$/, '');
   }
   return url.href;
 }

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -88,19 +88,26 @@ function isIdentityShape(value: unknown): value is Record<string, unknown> {
   );
 }
 
-/** Drop an invalid pushContentTier so resolvePushContentTier falls back to 1. */
+/**
+ * Coerce a structurally valid store record into an Identity for in-memory use.
+ *
+ * Spread the raw record so unknown per-identity fields (and future
+ * `pushContentTier` enum values written by a newer binary) survive store
+ * rewrites on this older binary (F94). Downgrade→upgrade must not permanently
+ * strip forward-compatible data.
+ *
+ * Read safety: `resolvePushContentTier` maps anything other than 2/3 to the
+ * default tier 1, and all consumers go through resolve or `=== 2` / `=== 3`
+ * checks — an old binary never discloses more than tier 1 for a future tier
+ * value. Explicit API tier updates still overwrite `pushContentTier` with a
+ * known 1|2|3 value.
+ */
 function coerceIdentity(raw: Record<string, unknown>): Identity {
-  const identity: Identity = {
+  return {
+    ...raw,
     address: raw.address as string,
     createdAt: raw.createdAt as string,
-    ...(typeof raw.name === 'string' ? { name: raw.name } : {}),
-    ...(raw.canNotifyUser === true ? { canNotifyUser: true } : {}),
-    ...(typeof raw.tokenHash === 'string' ? { tokenHash: raw.tokenHash } : {}),
-  };
-  if (isPushContentTier(raw.pushContentTier)) {
-    identity.pushContentTier = raw.pushContentTier;
-  }
-  return identity;
+  } as Identity;
 }
 
 /**

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -217,6 +217,14 @@ function load(): Identity[] {
   }
 }
 
+/**
+ * Persist the identity store. DATA_DIR is designed for a **single writer**
+ * process (the Compose/API-only stacks run one API). `save` uses tmp+rename
+ * so one process never tears the JSON file, but concurrent writers across
+ * multiple processes sharing the same DATA_DIR are **unsupported** — last
+ * writer wins without CAS/file locking (F78: document only; no multi-process
+ * storage rewrite in this product).
+ */
 function save(identities: Identity[]): void {
   // Drop the cache *before* any write attempt. Callers mutate the array/objects
   // returned by load() then call save(); if we only invalidated after rename,

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -104,12 +104,35 @@ function coerceIdentity(raw: Record<string, unknown>): Identity {
 }
 
 /**
- * Parsed store cache keyed by mtimeMs. Cross-process writers rely on mtime
- * changes (ms precision). In-process writers call invalidateStoreCache() so a
- * same-tick rewrite is visible without waiting on mtime.
+ * Identity-store parse cache keyed by a composite file-version signal (one
+ * statSync): dev, ino, mtimeMs, ctimeMs, size. Cross-process writers are
+ * detected without relying on mtime alone:
+ * - atomic replace (tmp + rename) → ino (and usually mtime) changes;
+ * - in-place rewrite with preserved mtime → ctimeMs and/or size change;
+ * - if ino is 0/unstable on a filesystem, keys may thrash (extra re-reads)
+ *   but correctness is preserved — never serve stale identities/tokens.
+ * In-process writers call invalidateStoreCache() before writing so same-tick
+ * rewrites stay visible without waiting on stat.
  */
-type StoreCache = {
+type StoreFileVersion = {
+  dev: number;
+  ino: number;
   mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+};
+
+/** Sentinel version for a missing store file (mtimeMs === -1). */
+const MISSING_STORE_VERSION: StoreFileVersion = {
+  dev: 0,
+  ino: 0,
+  mtimeMs: -1,
+  ctimeMs: -1,
+  size: -1,
+};
+
+type StoreCache = {
+  version: StoreFileVersion;
   identities: Identity[];
   byAddress: Map<string, Identity>;
 };
@@ -118,6 +141,32 @@ let storeCache: StoreCache | undefined;
 
 function invalidateStoreCache(): void {
   storeCache = undefined;
+}
+
+function fileVersionFromStat(st: {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+}): StoreFileVersion {
+  return {
+    dev: st.dev,
+    ino: st.ino,
+    mtimeMs: st.mtimeMs,
+    ctimeMs: st.ctimeMs,
+    size: st.size,
+  };
+}
+
+function storeVersionsEqual(a: StoreFileVersion, b: StoreFileVersion): boolean {
+  return (
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.mtimeMs === b.mtimeMs &&
+    a.ctimeMs === b.ctimeMs &&
+    a.size === b.size
+  );
 }
 
 function buildAddressIndex(identities: Identity[]): Map<string, Identity> {
@@ -131,14 +180,20 @@ function buildAddressIndex(identities: Identity[]): Map<string, Identity> {
 function load(): Identity[] {
   const path = storePath();
   if (!existsSync(path)) {
-    // Sentinel mtime so a later create is detected (file appears with real mtime).
-    if (storeCache?.mtimeMs === -1) return storeCache.identities;
-    storeCache = { mtimeMs: -1, identities: [], byAddress: new Map() };
+    // Sentinel so a later create is detected (file appears with a real version).
+    if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
+      return storeCache.identities;
+    }
+    storeCache = {
+      version: MISSING_STORE_VERSION,
+      identities: [],
+      byAddress: new Map(),
+    };
     return storeCache.identities;
   }
   try {
-    const mtimeMs = statSync(path).mtimeMs;
-    if (storeCache && storeCache.mtimeMs === mtimeMs) {
+    const version = fileVersionFromStat(statSync(path));
+    if (storeCache && storeVersionsEqual(storeCache.version, version)) {
       return storeCache.identities;
     }
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
@@ -147,7 +202,7 @@ function load(): Identity[] {
     }
     const identities = parsed.map((entry) => coerceIdentity(entry as Record<string, unknown>));
     storeCache = {
-      mtimeMs,
+      version,
       identities,
       byAddress: buildAddressIndex(identities),
     };

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -62,7 +62,13 @@ function storePath(): string {
   return join(config.dataDir, 'identities.json');
 }
 
-function isIdentity(value: unknown): value is Identity {
+/**
+ * Structural identity check. `pushContentTier` is intentionally *not*
+ * validated here: an unknown enum value is a compatibility case (normalize
+ * to default tier 1), not store corruption that should take every identity
+ * offline.
+ */
+function isIdentityShape(value: unknown): value is Record<string, unknown> {
   if (!value || typeof value !== 'object') return false;
   const identity = value as Record<string, unknown>;
   return (
@@ -70,9 +76,23 @@ function isIdentity(value: unknown): value is Identity {
     typeof identity.createdAt === 'string' &&
     (identity.name === undefined || typeof identity.name === 'string') &&
     (identity.canNotifyUser === undefined || typeof identity.canNotifyUser === 'boolean') &&
-    (identity.pushContentTier === undefined || isPushContentTier(identity.pushContentTier)) &&
     (identity.tokenHash === undefined || typeof identity.tokenHash === 'string')
   );
+}
+
+/** Drop an invalid pushContentTier so resolvePushContentTier falls back to 1. */
+function coerceIdentity(raw: Record<string, unknown>): Identity {
+  const identity: Identity = {
+    address: raw.address as string,
+    createdAt: raw.createdAt as string,
+    ...(typeof raw.name === 'string' ? { name: raw.name } : {}),
+    ...(raw.canNotifyUser === true ? { canNotifyUser: true } : {}),
+    ...(typeof raw.tokenHash === 'string' ? { tokenHash: raw.tokenHash } : {}),
+  };
+  if (isPushContentTier(raw.pushContentTier)) {
+    identity.pushContentTier = raw.pushContentTier;
+  }
+  return identity;
 }
 
 function load(): Identity[] {
@@ -80,10 +100,10 @@ function load(): Identity[] {
   if (!existsSync(path)) return [];
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
-    if (!Array.isArray(parsed) || !parsed.every(isIdentity)) {
+    if (!Array.isArray(parsed) || !parsed.every(isIdentityShape)) {
       throw new Error('invalid identity store shape');
     }
-    return parsed;
+    return parsed.map((entry) => coerceIdentity(entry as Record<string, unknown>));
   } catch {
     // Fail closed. Treating a damaged store as empty looks harmless until the
     // next create/rotate saves over it: every existing identity and token is

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -12,7 +12,15 @@
  * v0.x; swap for sqlite if identity volume ever matters.
  */
 
-import { chmodSync, mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 import { createHash, randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
 import { config } from './config.ts';
@@ -95,16 +103,58 @@ function coerceIdentity(raw: Record<string, unknown>): Identity {
   return identity;
 }
 
+/**
+ * Parsed store cache keyed by mtimeMs. Cross-process writers rely on mtime
+ * changes (ms precision). In-process writers call invalidateStoreCache() so a
+ * same-tick rewrite is visible without waiting on mtime.
+ */
+type StoreCache = {
+  mtimeMs: number;
+  identities: Identity[];
+  byAddress: Map<string, Identity>;
+};
+
+let storeCache: StoreCache | undefined;
+
+function invalidateStoreCache(): void {
+  storeCache = undefined;
+}
+
+function buildAddressIndex(identities: Identity[]): Map<string, Identity> {
+  const byAddress = new Map<string, Identity>();
+  for (const identity of identities) {
+    byAddress.set(identity.address.toLowerCase(), identity);
+  }
+  return byAddress;
+}
+
 function load(): Identity[] {
   const path = storePath();
-  if (!existsSync(path)) return [];
+  if (!existsSync(path)) {
+    // Sentinel mtime so a later create is detected (file appears with real mtime).
+    if (storeCache?.mtimeMs === -1) return storeCache.identities;
+    storeCache = { mtimeMs: -1, identities: [], byAddress: new Map() };
+    return storeCache.identities;
+  }
   try {
+    const mtimeMs = statSync(path).mtimeMs;
+    if (storeCache && storeCache.mtimeMs === mtimeMs) {
+      return storeCache.identities;
+    }
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
     if (!Array.isArray(parsed) || !parsed.every(isIdentityShape)) {
       throw new Error('invalid identity store shape');
     }
-    return parsed.map((entry) => coerceIdentity(entry as Record<string, unknown>));
-  } catch {
+    const identities = parsed.map((entry) => coerceIdentity(entry as Record<string, unknown>));
+    storeCache = {
+      mtimeMs,
+      identities,
+      byAddress: buildAddressIndex(identities),
+    };
+    return storeCache.identities;
+  } catch (err) {
+    invalidateStoreCache();
+    if ((err as Error).message === 'identity_store_corrupt') throw err;
     // Fail closed. Treating a damaged store as empty looks harmless until the
     // next create/rotate saves over it: every existing identity and token is
     // gone. The message carries no file content on purpose.
@@ -129,6 +179,8 @@ function save(identities: Identity[]): void {
   writeFileSync(tmp, JSON.stringify(identities, null, 2), { mode: 0o600 });
   chmodSync(tmp, 0o600);
   renameSync(tmp, path);
+  // Explicit invalidate: same-ms rewrites must be visible without mtime help.
+  invalidateStoreCache();
 }
 
 export function randomLocalpart(): string {
@@ -143,8 +195,8 @@ export function listIdentities(): Identity[] {
 }
 
 export function findIdentity(address: string): Identity | undefined {
-  const needle = address.toLowerCase();
-  return load().find((i) => i.address === needle);
+  load();
+  return storeCache?.byAddress.get(address.toLowerCase());
 }
 
 /** Generate a new scoped token. Plaintext is returned once; only its hash persists. */

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -163,6 +163,13 @@ function load(): Identity[] {
 }
 
 function save(identities: Identity[]): void {
+  // Drop the cache *before* any write attempt. Callers mutate the array/objects
+  // returned by load() then call save(); if we only invalidated after rename,
+  // a failed write (disk full, read-only volume) would leave those unpersisted
+  // mutations in cache and diverge memory from disk until restart. Invalidate
+  // first: success → next load re-reads the new file; failure → next load
+  // re-reads the old file. Same-ms in-process rewrites stay visible either way.
+  invalidateStoreCache();
   // The store holds every identity's token hash — keep it to the owner.
   // chmod explicitly in both places: mkdirSync's mode does nothing when the
   // directory already exists, and writeFileSync's mode is masked by umask
@@ -179,8 +186,6 @@ function save(identities: Identity[]): void {
   writeFileSync(tmp, JSON.stringify(identities, null, 2), { mode: 0o600 });
   chmodSync(tmp, 0o600);
   renameSync(tmp, path);
-  // Explicit invalidate: same-ms rewrites must be visible without mtime help.
-  invalidateStoreCache();
 }
 
 export function randomLocalpart(): string {

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -17,14 +17,37 @@ import { join } from 'node:path';
 import { createHash, randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
 import { config } from './config.ts';
 
+/** Mail-arrival push content detail. 1 = interrupt only (default), 2 = +subject/from, 3 = +body preview/OTP. */
+export type PushContentTier = 1 | 2 | 3;
+
+export const DEFAULT_PUSH_CONTENT_TIER: PushContentTier = 1;
+
+/** Shown when tier 3 is set or returned; body/OTP leave the server via ntfy. */
+export const PUSH_TIER3_WARNING =
+  'Tier 3 includes message body previews and OTP codes/links in push notifications. That content leaves this server for the ntfy channel.';
+
 export interface Identity {
   address: string;
   name?: string;
   createdAt: string;
   /** Explicit root-level permission to notify the human-alert topics. */
   canNotifyUser?: boolean;
+  /**
+   * How much content mail-arrival user pushes include for this identity.
+   * Absent means tier 1 (interrupt only) for backward compatibility.
+   */
+  pushContentTier?: PushContentTier;
   /** SHA-256 hex of the identity's API token. Absent on pre-token stores. */
   tokenHash?: string;
+}
+
+export function resolvePushContentTier(identity: Pick<Identity, 'pushContentTier'>): PushContentTier {
+  const tier = identity.pushContentTier;
+  return tier === 2 || tier === 3 ? tier : DEFAULT_PUSH_CONTENT_TIER;
+}
+
+function isPushContentTier(value: unknown): value is PushContentTier {
+  return value === 1 || value === 2 || value === 3;
 }
 
 const WORDS = [
@@ -47,6 +70,7 @@ function isIdentity(value: unknown): value is Identity {
     typeof identity.createdAt === 'string' &&
     (identity.name === undefined || typeof identity.name === 'string') &&
     (identity.canNotifyUser === undefined || typeof identity.canNotifyUser === 'boolean') &&
+    (identity.pushContentTier === undefined || isPushContentTier(identity.pushContentTier)) &&
     (identity.tokenHash === undefined || typeof identity.tokenHash === 'string')
   );
 }
@@ -192,4 +216,24 @@ export function deleteIdentity(address: string): boolean {
   if (kept.length === identities.length) return false;
   save(kept);
   return true;
+}
+
+/**
+ * Set the mail-arrival push content tier for an identity (admin-only at the
+ * route layer). Returns the updated public identity fields, or null if missing.
+ * Tier 1 is stored explicitly so list/read stay stable after a deliberate set.
+ */
+export function setIdentityPushContentTier(
+  address: string,
+  tier: PushContentTier,
+): Identity | null {
+  if (!isPushContentTier(tier)) throw new Error('invalid_push_content_tier');
+  const identities = load();
+  const needle = address.toLowerCase();
+  const identity = identities.find((i) => i.address === needle);
+  if (!identity) return null;
+  identity.pushContentTier = tier;
+  save(identities);
+  const { tokenHash: _tokenHash, ...rest } = identity;
+  return rest;
 }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -20,7 +20,13 @@ import {
 } from './identities.ts';
 import { connectImap, messageRecipients } from './imap.ts';
 import { NotifyError, type NotifyService, notificationService } from './notify.ts';
-import { extractHttpLinks, extractOtp, htmlToText, maskNormalizedHttpUrls } from './otp.ts';
+import {
+  extractHttpLinks,
+  extractOtp,
+  htmlToText,
+  maskNormalizedHttpUrls,
+  otpCodeRunRe,
+} from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
 const RECONNECT_MS = 3_000;
@@ -140,15 +146,6 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
   return boundTextBytes(body, maxBytes);
 }
 
-/**
- * Fresh each call: continuous 4–8 digit runs and delimited OTP forms (F68)
- * that extractCodes may yield. Delimited alternative is first so `1234-5678`
- * is one span, not two continuous runs.
- */
-function metaCodeRunRe(): RegExp {
-  return /\b\d{3,4}[-–—. ]\d{3,4}\b|\b\d{4,8}\b/g;
-}
-
 /** Digit-only form so body `123456` and subject `123-456` compare equal (F69). */
 function canonicalDigits(s: string): string {
   return s.replace(/\D/g, '');
@@ -157,9 +154,9 @@ function canonicalDigits(s: string): string {
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
- * (maskNormalizedHttpUrls). Codes: scan continuous \b\d{4,8}\b and delimited
- * \b\d{3,4}[-–—. ]\d{3,4}\b runs; replace when the run's digit-only form is in
- * the code set (F69 — body continuous / meta delimited are the same OTP).
+ * (maskNormalizedHttpUrls). Codes: scan continuous / delimited runs via shared
+ * otpCodeRunRe (F68/F70 separators including Unicode spaces); replace when the
+ * run's digit-only form is in the code set (F69 cross-form).
  *
  * Membership is O(text) Set lookups on canonical digits — no multi-branch
  * needle alternation. Extract still yields original spelling (extractCodes).
@@ -179,7 +176,7 @@ export function maskSensitiveFragments(
     if (canon) codeSet.add(canon);
   }
   if (codeSet.size === 0) return result;
-  return result.replace(metaCodeRunRe(), (run) =>
+  return result.replace(otpCodeRunRe(), (run) =>
     codeSet.has(canonicalDigits(run)) ? '•••' : run,
   );
 }
@@ -204,8 +201,9 @@ export function maskTier2Metadata(
   // Body codes enter the mask list when their digit-only form appears as any
   // continuous/delimited meta run (F69: body `123456` ↔ subject `123-456`).
   // O(|meta|) collect + O(|codes|) filter — not a per-needle scan of meta.
+  // otpCodeRunRe excludes newlines so from\nsubject cannot glue digits (F70).
   const metaCanonRuns = new Set<string>();
-  for (const match of metaText.matchAll(metaCodeRunRe())) {
+  for (const match of metaText.matchAll(otpCodeRunRe())) {
     const canon = canonicalDigits(match[0]!);
     if (canon) metaCanonRuns.add(canon);
   }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -243,10 +243,10 @@ const META_ALNUM_LETTER = 'A-Za-z\\uFF21-\\uFF3A\\uFF41-\\uFF5A';
 const META_ALNUM_DIGIT = '0-9\\uFF10-\\uFF19';
 
 /**
- * Continuous alnum OTP for tier-2 *metadata only* (F77/F81/F86/F95): 4–8 alnum
- * (ASCII and/or fullwidth). Accepted after match when mixed (letter+digit) or
- * letter-only all-caps (F95). Bounds exclude adjacent alnum (incl. fullwidth)
- * so CJK-glued forms still match.
+ * Continuous alnum OTP for tier-2 *metadata only* (F77/F81/F86/F95/F101): 4–8
+ * alnum (ASCII and/or fullwidth). Accepted after match when mixed (letter+digit)
+ * or letter-only continuous case-insensitive (F101). Bounds exclude adjacent
+ * alnum (incl. fullwidth) so CJK-glued forms still match.
  */
 const META_ALNUM_OTP_RE = new RegExp(
   `${META_ALNUM_BOUND_LEFT}([${META_ALNUM_CHAR}]{4,8})${META_ALNUM_BOUND_RIGHT}`,
@@ -345,23 +345,25 @@ function isMixedAlnumOtp(form: string): boolean {
 }
 
 /**
- * Letter-only continuous OTP for tier-2 metadata under a strong cue (F95).
- * NFKC then `/^[A-Z]{4,8}$/`: real letter-only codes are almost always
- * shouted (`WXYZ`); all-uppercase excludes prose (`pending`, `Ready`, `wxyz`).
- * Fullwidth uppercase (ＷＸＹＺ) NFKC-normalizes to ASCII and is covered.
+ * Letter-only continuous OTP for tier-2 metadata under a strong cue (F95/F101).
+ * NFKC then `/^[A-Za-z]{4,8}$/` — case-insensitive continuous tokens so
+ * lowercase/title-case codes (`abcd`, `Abcd`) mask like shouted `ABCD`.
+ * Fullwidth letters NFKC-normalize to ASCII and are covered.
  *
- * Tradeoff under the strong-cue gate: an all-caps non-code word of length 4–8
- * (e.g. `READY` in `Your verification code is READY NOW`) is masked — accepted
- * for the metadata privacy boundary; the rest of the subject stays readable.
+ * Scope is **continuous only**. Delimited letter-only (F97) stays all-caps:
+ * lowercase hyphens would over-mask English compounds (`sign-in`, `follow-up`).
+ *
+ * Tradeoff under the strong-cue gate: any 4–8 letter word (ready/here/valid/
+ * Pending) is masked — privacy over readability; the rest of the subject stays.
  */
 function isLetterOnlyOtp(form: string): boolean {
-  return /^[A-Z]{4,8}$/.test(form.normalize('NFKC'));
+  return /^[A-Za-z]{4,8}$/.test(form.normalize('NFKC'));
 }
 
 /**
  * Letter-only delimited OTP under a strong cue (F97): NFKC, split on tight or
- * space sep runs, require 2–4 groups each `/^[A-Z]{2,4}$/`. All-uppercase keeps
- * prose out (`Wx-Yz` rejected). Tradeoff: all-caps acronym chains under a
+ * space sep runs, require 2–4 groups each `/^[A-Z]{2,4}$/` (uppercase only —
+ * F101 does **not** relax this). Tradeoff: all-caps acronym chains under a
  * strong cue (`NASA HQ`, `GO NOW`) may mask — accepted for privacy.
  *
  * Tight path reuses META_ALNUM_DELIMITED_TIGHT; space path uses
@@ -580,15 +582,29 @@ export function maskTier2Metadata(
   // O(|meta|) collect + O(|codes|) filter — not a per-needle scan of meta.
   // otpCodeRunRe excludes newlines so from\nsubject cannot glue digits (F70).
   const metaCanonRuns = new Set<string>();
+  // Surface spellings of meta digit runs (continuous + delimited shapes).
+  const metaDigitSurfaces: string[] = [];
   for (const match of metaText.matchAll(otpCodeRunRe())) {
-    const canon = canonicalDigits(match[0]!);
-    if (canon) metaCanonRuns.add(canon);
+    const surface = match[0]!;
+    const canon = canonicalDigits(surface);
+    if (!canon) continue;
+    metaCanonRuns.add(canon);
+    metaDigitSurfaces.push(surface);
   }
+  // F102: under a strong cue on joined meta, every meta digit run joins
+  // maskCodes by surface form — no KEYWORD_WINDOW / body confirmation.
+  // Side effects: strong-cue subject can mask years/order ids and a digit run
+  // only in From when Subject carries the cue — privacy over readability.
+  const strongMetaCue = hasStrongOtpCue(metaText);
+  // Alnum meta extract is **per field** (each needs its own strong cue) so a
+  // cue on Subject does not treat From localparts like `auth`/`example` as
+  // letter-only OTPs under F101 case-insensitive continuous matching.
   const maskCodes = [
     ...metaOtp.codes,
     ...extras.codes.filter((code) => metaCanonRuns.has(canonicalDigits(code))),
-    // Strong-cue alnum OTPs in metadata only (F77) — not body extract.
-    ...extractMetaAlnumCodes(metaText),
+    ...extractMetaAlnumCodes(extras.subject),
+    ...extractMetaAlnumCodes(extras.from),
+    ...(strongMetaCue ? metaDigitSurfaces : []),
   ];
   const maskLinks = [...extras.links, ...metaHttpLinks];
   from = maskSensitiveFragments(from, maskCodes, maskLinks);

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -98,6 +98,11 @@ export type MailContentExtras = {
  * F111: a recreated mailbox (new UIDVALIDITY) restarts UIDs from scratch, so
  * the old numeric watermark would reject every replacement message until its
  * counter climbs back; re-anchor at the new generation's high-water mark.
+ * F115: only the FIRST sight of a generation keeps the no-replay startup
+ * behavior. When an already-observed mailbox changes UIDVALIDITY, the
+ * replacement INBOX may already hold mail delivered during the disconnect —
+ * treat every current UID as pending so reconnects still catch offline
+ * deliveries (watermark still anchors at the high-water mark afterwards).
  */
 export function unseenWatcherUids(
   uids: number[],
@@ -106,11 +111,12 @@ export function unseenWatcherUids(
 ): number[] {
   const currentHighWater = Math.max(0, ...uids);
   if (uidValidity !== undefined && watermark.uidValidity !== uidValidity) {
+    const firstSight = watermark.uidValidity === undefined;
     // First sight of this mailbox generation, or a recreated INBOX: re-anchor
     // instead of comparing against the previous generation's UIDs.
     watermark.uidValidity = uidValidity;
     watermark.uid = currentHighWater;
-    return [];
+    return firstSight ? [] : uids.slice();
   }
   if (watermark.uid === undefined) {
     watermark.uid = currentHighWater;
@@ -966,11 +972,16 @@ export async function processWatchedMessage(
   }
   // F110: classify on the subject too — a subject-only code or verify link
   // (`Subject: Your verification code is 123456` with a plain body) must still
-  // pass the `otp` policy. extras.codes/links stay body-sourced; the subject
-  // line itself shows at tier ≥2 (masked at tier 2), so no payload merge.
+  // pass the `otp` policy. The subject line itself shows at tier ≥2 (masked at
+  // tier 2). F116: also merge subject credentials into extras — tier 3 would
+  // otherwise truncate a long signed subject URL at the metadata cap and
+  // publish an unusable partial link. This branch runs only when the body had
+  // no codes/links, so the merge cannot duplicate body-sourced entries.
   if (!hasOtpOrLink && extras.subject) {
     const subjectOtp = extractOtp(extras.subject);
     hasOtpOrLink = subjectOtp.codes.length > 0 || subjectOtp.links.length > 0;
+    if (subjectOtp.codes.length > 0) extras.codes.push(...subjectOtp.codes);
+    if (subjectOtp.links.length > 0) extras.links.push(...subjectOtp.links);
   }
   if (policy === 'otp' && !hasOtpOrLink) return;
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1095,6 +1095,17 @@ export async function processWatchedMessage(
       hasOtpOrLink = otp.codes.length > 0 || otp.links.length > 0;
       extras.codes = otp.codes;
       extras.links = otp.links;
+      // F137: strongly cued alphanumeric BODY codes classify too (the
+      // subject path F134/F136 covered only metadata). Same code-shaped
+      // filter; the global cue gate may over-classify prose that mentions
+      // a cue near a shouted word — a safe extra alert next to a missed
+      // credential. Bodies never publish at tier ≤2, so no masking path.
+      const bodyAlnum = extractMetaAlnumCodes(text);
+      if (bodyAlnum.some(isDisplayableAlnumCode)) hasOtpOrLink = true;
+      for (const code of bodyAlnum) {
+        if (!isDisplayableAlnumCode(code)) continue;
+        if (!extras.codes.includes(code)) extras.codes.push(code);
+      }
       extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
     } catch {
       // A malformed message is never an OTP match. `all` policy still sends a

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -212,19 +212,22 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{4,8})(?![A-Za-z0-9])/g;
 
 /**
- * Delimited mixed alnum OTP (F84): 2–4 groups of 2–4 ASCII alnum.
+ * Delimited mixed alnum OTP (F84/F85): 2–4 groups of 2–4 ASCII alnum.
  *
  * Non-whitespace seps (hyphen/dash/dot/fullwidth) allow 2–4 groups with F74-style
- * mid-chain lead/tail guards. Whitespace seps only allow **exactly two** groups
- * so English words (`is ABC-123`) cannot glue into a false 3-group form when
- * space is both a word break and an OTP separator.
+ * mid-chain lead/tail guards.
+ *
+ * Whitespace seps (F85):
+ * - Longest run of **digit-bearing** groups (`A1 B2 C3`) so English words never
+ *   join the chain; accept 2–4 groups, reject 5+ whole.
+ * - Classic two-group letter-block (3–4 letters) + digit-block (`ABC 123`).
+ * No “tail rejects more space+alnum” half-window: consume the full run then decide.
  *
  * Pure-digit forms are left to the digit delimited path (≥1 letter + ≥1 digit).
  */
 const META_ALNUM_GROUP = '[A-Za-z0-9]{2,4}';
 /**
  * Split of otp.ts DELIMITED_OTP_SEP_CLASS: non-whitespace vs whitespace.
- * Whitespace is restricted to exactly-two-group forms (see above).
  */
 const META_ALNUM_SEP_TIGHT = '[-–—.\uFF0D\uFF0E]';
 const META_ALNUM_SEP_SPACE =
@@ -236,11 +239,24 @@ const META_ALNUM_DELIMITED_TIGHT = new RegExp(
     `(?!${META_ALNUM_SEP_TIGHT}[A-Za-z0-9])(?![A-Za-z0-9])`,
   'g',
 );
-// Exactly two groups with a whitespace sep (e.g. `ABC 123`).
-const META_ALNUM_DELIMITED_SPACE = new RegExp(
+/**
+ * 2–4 alnum chars that include a digit (lookahead fixes length; then consume).
+ * Used for space runs so pure-letter English tokens are not groups.
+ */
+const META_ALNUM_GROUP_WITH_DIGIT =
+  '(?=[A-Za-z0-9]{2,4}(?![A-Za-z0-9]))(?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{2,4}';
+// Longest space-separated digit-bearing group run (F85).
+const META_ALNUM_DELIMITED_SPACE_DIGIT = new RegExp(
   `(?<![A-Za-z0-9])` +
-    `(${META_ALNUM_GROUP}${META_ALNUM_SEP_SPACE}${META_ALNUM_GROUP})` +
-    `(?!${META_ALNUM_SEP_SPACE}[A-Za-z0-9])(?![A-Za-z0-9])`,
+    `(${META_ALNUM_GROUP_WITH_DIGIT}(?:${META_ALNUM_SEP_SPACE}${META_ALNUM_GROUP_WITH_DIGIT})+)` +
+    `(?![A-Za-z0-9])`,
+  'g',
+);
+// Classic `ABC 123` (letter block 3–4 + digit block 2–4); year filter applied after.
+const META_ALNUM_DELIMITED_SPACE_CLASSIC = new RegExp(
+  `(?<![A-Za-z0-9])` +
+    `([A-Za-z]{3,4}${META_ALNUM_SEP_SPACE}[0-9]{2,4})` +
+    `(?![A-Za-z0-9])`,
   'g',
 );
 
@@ -248,20 +264,28 @@ function isMixedAlnumOtp(form: string): boolean {
   return /[A-Za-z]/.test(form) && /[0-9]/.test(form);
 }
 
-/**
- * Space-separated forms only: reject English glue like `is 123` / `is A1B2`
- * (1–2 letter pure-letter group) and year-ish pure digits (`Mar 2026`, F65).
- * Real OTPs use ≥3 letter blocks (`ABC 123`) or a mixed group on either side.
- */
-function isPlausibleSpaceDelimitedAlnum(form: string): boolean {
+function splitSpaceAlnumGroups(form: string): string[] {
+  return form.split(new RegExp(META_ALNUM_SEP_SPACE)).filter(Boolean);
+}
+
+/** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
+function isPlausibleSpaceDigitRun(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
-  const parts = form.split(new RegExp(META_ALNUM_SEP_SPACE));
+  const parts = splitSpaceAlnumGroups(form);
+  if (parts.length < 2 || parts.length > 4) return false;
+  // Every group already digit-bearing by construction; still reject years as a side.
+  return parts.every((g) => /[0-9]/.test(g) && !/^(19|20)\d{2}$/.test(g));
+}
+
+/** Accept classic two-group letter-block + digit-block (`ABC 123`). */
+function isPlausibleSpaceClassic(form: string): boolean {
+  if (!isMixedAlnumOtp(form)) return false;
+  const parts = splitSpaceAlnumGroups(form);
   if (parts.length !== 2) return false;
-  for (const g of parts) {
-    if (/^[A-Za-z]{1,2}$/.test(g)) return false;
-    // Year-shaped pure digits next to a letter block are not alnum OTPs.
-    if (/^(19|20)\d{2}$/.test(g)) return false;
-  }
+  const [letters, digits] = parts;
+  if (!/^[A-Za-z]{3,4}$/.test(letters!)) return false;
+  if (!/^[0-9]{2,4}$/.test(digits!)) return false;
+  if (/^(19|20)\d{2}$/.test(digits!)) return false;
   return true;
 }
 
@@ -271,7 +295,8 @@ function escapeRegExpLiteral(s: string): string {
 
 /**
  * Collect alnum OTPs from from/subject when a strong cue is present
- * (F77/F81 continuous + F84 delimited). Does not touch body extract semantics.
+ * (F77/F81 continuous + F84 tight delimited + F85 space runs).
+ * Does not touch body extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
@@ -282,16 +307,22 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
     seen.add(form);
     codes.push(form);
   };
+  // Space digit-bearing runs first: whole-chain consume, then 2–4 accept / 5+ drop.
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_DIGIT)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceDigitRun(form)) continue;
+    push(form);
+  }
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_CLASSIC)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceClassic(form)) continue;
+    push(form);
+  }
   for (const match of metaText.matchAll(META_ALNUM_OTP_RE)) {
     push(match[1]!);
   }
   for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT)) {
     push(match[1]!);
-  }
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE)) {
-    const form = match[1]!;
-    if (!isPlausibleSpaceDelimitedAlnum(form)) continue;
-    push(form);
   }
   return codes;
 }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -431,8 +431,10 @@ export function buildAlnumMaskRe(forms: string[]): RegExp | null {
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
- * (maskNormalizedHttpUrls). Digit codes: otpCodeRunRe + canonicalDigits
- * (F69/F75). Alnum codes (F77/F83): single alternation replace with alnum bounds.
+ * (maskNormalizedHttpUrls). Alnum codes (F77/F83/F91): exact-form alternation
+ * before digit runs so `ABC-1234` is not half-masked to `ABC-•••` when both
+ * `ABC-1234` and `1234` are in the code set. Digit codes: otpCodeRunRe +
+ * canonicalDigits (F69/F75) after alnum.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -440,7 +442,7 @@ export function maskSensitiveFragments(
   links: string[],
 ): string {
   if (!text) return text;
-  // URLs first so a full verify link is one unit before digit-code scans.
+  // URLs first so a full verify link is one unit before code scans.
   let result = maskNormalizedHttpUrls(text, links);
   const digitCanon = new Set<string>();
   const exactAlnum: string[] = [];
@@ -453,14 +455,16 @@ export function maskSensitiveFragments(
     const canon = canonicalDigits(code);
     if (canon) digitCanon.add(canon);
   }
+  // F91: alnum spans before digit sub-runs — digit pass would otherwise rewrite
+  // `ABC-1234` → `ABC-•••` and leave a non-matching `ABC-` prefix leak.
+  const alnumRe = buildAlnumMaskRe(exactAlnum);
+  if (alnumRe) {
+    result = result.replace(alnumRe, '•••');
+  }
   if (digitCanon.size > 0) {
     result = result.replace(otpCodeRunRe(), (run) =>
       digitCanon.has(canonicalDigits(run)) ? '•••' : run,
     );
-  }
-  const alnumRe = buildAlnumMaskRe(exactAlnum);
-  if (alnumRe) {
-    result = result.replace(alnumRe, '•••');
   }
   return result;
 }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -346,6 +346,21 @@ const META_ALNUM_DELIMITED_SPACE_LETTER = new RegExp(
     `${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
+/**
+ * Space-separated single-character chains (F106): `A 1 B 2`. Each internal
+ * group is a single alnum **not glued to a following alnum**, so the run
+ * cannot eat the first char of a following word (`A 1 B 2 today` stops at
+ * `2`). Unbounded consume: the whole run is matched, then the predicate
+ * accepts 4–8 groups / drops others whole (F85 doctrine). Candidate only —
+ * mixed acceptance happens in push(); pure-digit and letter-only chains drop.
+ */
+const META_ALNUM_SINGLE = `[${META_ALNUM_CHAR}](?![${META_ALNUM_CHAR}])`;
+const META_ALNUM_DELIMITED_SPACE_SINGLE = new RegExp(
+  `${META_ALNUM_BOUND_LEFT}` +
+    `([${META_ALNUM_CHAR}](?:${META_ALNUM_SEP_SPACE}+${META_ALNUM_SINGLE})+)` +
+    `${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
 /** Split form into groups on any tight or space sep run (F97). */
 const META_ALNUM_SEP_ANY_RUN = new RegExp(
   `(?:${META_ALNUM_SEP_TIGHT}|${META_ALNUM_SEP_SPACE})+`,
@@ -424,6 +439,19 @@ function isPlausibleSingleChain(form: string): boolean {
   return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
 }
 
+/**
+ * Accept a space single-char chain (F106): NFKC, split on space runs, 4–8
+ * groups of exactly 1 char. Mixed/letter acceptance happens in push() via
+ * isMetaAlnumOtpForm — pure-digit and letter-only chains drop there.
+ */
+function isPlausibleSpaceSingleChain(form: string): boolean {
+  const parts = form
+    .normalize('NFKC')
+    .split(new RegExp(`${META_ALNUM_SEP_SPACE}+`))
+    .filter(Boolean);
+  return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
+}
+
 /** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
 function isPlausibleSpaceDigitRun(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
@@ -456,8 +484,9 @@ function escapeRegExpLiteral(s: string): string {
 /**
  * Collect alnum OTPs from from/subject when a strong cue is present
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
- * F95 letter-only continuous + F97 letter-only delimited + F105 single-char
- * tight chains). Does not touch body extract semantics.
+ * F95 letter-only continuous + F97 letter-only delimited + F105 tight
+ * single-char chains + F106 space single-char chains). Does not touch body
+ * extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
@@ -503,6 +532,12 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
   for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT_SINGLE)) {
     const form = match[1]!;
     if (!isPlausibleSingleChain(form)) continue;
+    push(form);
+  }
+  // F106: space single-char chains (`A 1 B 2`); same predicate split as F105.
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceSingleChain(form)) continue;
     push(form);
   }
   return codes;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -81,7 +81,7 @@ export type ProcessWatchedOptions = {
 };
 
 /** In-memory watermark survives a dropped IMAP connection in this process. */
-export type WatcherWatermark = { uid?: number };
+export type WatcherWatermark = { uid?: number; uidValidity?: bigint };
 
 export type MailContentExtras = {
   subject: string;
@@ -95,9 +95,23 @@ export type MailContentExtras = {
  * The first successful connection starts at the mailbox high-water mark so an
  * enable does not replay old mail. Later connections reuse that watermark and
  * therefore pick up mail delivered while the socket was reconnecting.
+ * F111: a recreated mailbox (new UIDVALIDITY) restarts UIDs from scratch, so
+ * the old numeric watermark would reject every replacement message until its
+ * counter climbs back; re-anchor at the new generation's high-water mark.
  */
-export function unseenWatcherUids(uids: number[], watermark: WatcherWatermark): number[] {
+export function unseenWatcherUids(
+  uids: number[],
+  watermark: WatcherWatermark,
+  uidValidity?: bigint,
+): number[] {
   const currentHighWater = Math.max(0, ...uids);
+  if (uidValidity !== undefined && watermark.uidValidity !== uidValidity) {
+    // First sight of this mailbox generation, or a recreated INBOX: re-anchor
+    // instead of comparing against the previous generation's UIDs.
+    watermark.uidValidity = uidValidity;
+    watermark.uid = currentHighWater;
+    return [];
+  }
   if (watermark.uid === undefined) {
     watermark.uid = currentHighWater;
     return [];
@@ -361,6 +375,20 @@ const META_ALNUM_DELIMITED_SPACE_SINGLE = new RegExp(
     `${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
+/**
+ * Mixed-separator single-character chains (F109): `A 1-B 2` — sep runs mixing
+ * whitespace and tight chars of any length between 4–8 groups of exactly 1
+ * alnum. Whole-run consume + SINGLE tail chars mirror F106: a following word's
+ * first char cannot join, and a 9+-group chain drops whole at the predicate.
+ * Pure-space chains stay F106's; push()'s seen set dedupes any overlap.
+ */
+const META_ALNUM_SEP_RUN_MIXED = `(?:${META_ALNUM_SEP_TIGHT}|${META_ALNUM_SEP_SPACE})+`;
+const META_ALNUM_DELIMITED_MIXED_SINGLE = new RegExp(
+  `${META_ALNUM_BOUND_LEFT}` +
+    `([${META_ALNUM_CHAR}](?:${META_ALNUM_SEP_RUN_MIXED}${META_ALNUM_SINGLE})+)` +
+    `${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
 /** Split form into groups on any tight or space sep run (F97). */
 const META_ALNUM_SEP_ANY_RUN = new RegExp(
   `(?:${META_ALNUM_SEP_TIGHT}|${META_ALNUM_SEP_SPACE})+`,
@@ -485,8 +513,8 @@ function escapeRegExpLiteral(s: string): string {
  * Collect alnum OTPs from from/subject when a strong cue is present
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
  * F95 letter-only continuous + F97 letter-only delimited + F105 tight
- * single-char chains + F106 space single-char chains). Does not touch body
- * extract semantics.
+ * single-char chains + F106 space single-char chains + F109 mixed-separator
+ * single-char chains). Does not touch body extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
@@ -538,6 +566,13 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
   for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_SINGLE)) {
     const form = match[1]!;
     if (!isPlausibleSpaceSingleChain(form)) continue;
+    push(form);
+  }
+  // F109: mixed-separator single-char chains (`A 1-B 2`); same predicate as
+  // F105 — overlaps with the tight/space matchers dedupe in push().
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_MIXED_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleSingleChain(form)) continue;
     push(form);
   }
   return codes;
@@ -877,6 +912,14 @@ export async function processWatchedMessage(
       // payload with no message content, which is safe and useful.
     }
   }
+  // F110: classify on the subject too — a subject-only code or verify link
+  // (`Subject: Your verification code is 123456` with a plain body) must still
+  // pass the `otp` policy. extras.codes/links stay body-sourced; the subject
+  // line itself shows at tier ≥2 (masked at tier 2), so no payload merge.
+  if (!hasOtpOrLink && extras.subject) {
+    const subjectOtp = extractOtp(extras.subject);
+    hasOtpOrLink = subjectOtp.codes.length > 0 || subjectOtp.links.length > 0;
+  }
   if (policy === 'otp' && !hasOtpOrLink) return;
 
   const clickUrl = options.clickUrl;
@@ -953,8 +996,12 @@ async function watchConnection(
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
   try {
     lock = await client.getMailboxLock('INBOX');
+    // F111: track the selected mailbox generation so a recreated INBOX
+    // re-anchors the watermark instead of starving notifications.
+    // (client.mailbox is `false | MailboxObject` before/without selection.)
+    const uidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
     const initial = await client.search({ all: true }, { uid: true });
-    let pending = unseenWatcherUids(Array.isArray(initial) ? initial : [], watermark);
+    let pending = unseenWatcherUids(Array.isArray(initial) ? initial : [], watermark, uidValidity);
 
     while (!signal.aborted) {
       if (pending.length > 0) {
@@ -986,7 +1033,7 @@ async function watchConnection(
       await Promise.race([client.idle(), sleep(3_000)]);
       if (signal.aborted) break;
       const found = await client.search({ all: true }, { uid: true });
-      pending = unseenWatcherUids(Array.isArray(found) ? found : [], watermark);
+      pending = unseenWatcherUids(Array.isArray(found) ? found : [], watermark, uidValidity);
     }
   } finally {
     lock?.release();

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -205,18 +205,22 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 }
 
 /**
- * Alphanumeric OTP shape for tier-2 *metadata only* (F77): 6–8 ASCII alnum
- * with at least one letter and one digit. Bounds exclude adjacent alnum so
- * CJK-glued `验证码是A1B2C3` still matches (same no-\p{L} idea as F75).
+ * Alphanumeric OTP shape for tier-2 *metadata only* (F77/F81): 4–8 ASCII alnum
+ * with at least one letter and one digit (aligned with digit-code min length 4).
+ * Bounds exclude adjacent alnum so CJK-glued `验证码是A1B2C3` still matches.
  */
-const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{6,8})(?![A-Za-z0-9])/g;
+const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{4,8})(?![A-Za-z0-9])/g;
 
 function isMixedAlnumOtp(form: string): boolean {
   return /[A-Za-z]/.test(form) && /[0-9]/.test(form);
 }
 
+function escapeRegExpLiteral(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
- * Collect alnum OTPs from from/subject when a strong cue is present (F77).
+ * Collect alnum OTPs from from/subject when a strong cue is present (F77/F81).
  * Does not touch body extractCodes / extractOtp semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
@@ -233,10 +237,30 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
 }
 
 /**
+ * One global regex that masks every exact alnum form in a single left-to-right
+ * pass (F83). Forms are length-desc so longer spellings win at each position.
+ * Empty input → null (caller skips). Exported for structural unit tests.
+ */
+export function buildAlnumMaskRe(forms: string[]): RegExp | null {
+  if (forms.length === 0) return null;
+  // Dedupe while preserving longest-first order for alternation priority.
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const form of [...forms].sort((a, b) => b.length - a.length || a.localeCompare(b))) {
+    if (!form || seen.has(form)) continue;
+    seen.add(form);
+    ordered.push(form);
+  }
+  if (ordered.length === 0) return null;
+  const alt = ordered.map(escapeRegExpLiteral).join('|');
+  return new RegExp(`(?<![A-Za-z0-9])(?:${alt})(?![A-Za-z0-9])`, 'g');
+}
+
+/**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
  * (maskNormalizedHttpUrls). Digit codes: otpCodeRunRe + canonicalDigits
- * (F69/F75). Alnum codes (F77): exact spelling replace with alnum bounds.
+ * (F69/F75). Alnum codes (F77/F83): single alternation replace with alnum bounds.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -262,16 +286,28 @@ export function maskSensitiveFragments(
       digitCanon.has(canonicalDigits(run)) ? '•••' : run,
     );
   }
-  // Longest first so overlapping spellings prefer the full form.
-  exactAlnum.sort((a, b) => b.length - a.length);
-  for (const form of exactAlnum) {
-    const re = new RegExp(
-      `(?<![A-Za-z0-9])${form.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![A-Za-z0-9])`,
-      'g',
-    );
-    result = result.replace(re, '•••');
+  const alnumRe = buildAlnumMaskRe(exactAlnum);
+  if (alnumRe) {
+    result = result.replace(alnumRe, '•••');
   }
   return result;
+}
+
+/**
+ * Truncate plain-text preview on a Unicode code-point boundary (F82).
+ * Avoids lone surrogates from `String#slice` mid-emoji. Count is code points,
+ * same numeric cap as PUSH_BODY_PREVIEW_CHARS.
+ */
+export function boundPreviewChars(text: string, maxChars = PUSH_BODY_PREVIEW_CHARS): string {
+  if (!text) return text;
+  let count = 0;
+  let end = 0;
+  for (const point of text) {
+    if (count >= maxChars) break;
+    count += 1;
+    end += point.length;
+  }
+  return text.slice(0, end);
 }
 
 /**
@@ -393,7 +429,7 @@ export async function processWatchedMessage(
       hasOtpOrLink = otp.codes.length > 0 || otp.links.length > 0;
       extras.codes = otp.codes;
       extras.links = otp.links;
-      extras.preview = text.slice(0, PUSH_BODY_PREVIEW_CHARS);
+      extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
     } catch {
       // A malformed message is never an OTP match. `all` policy still sends a
       // payload with no message content, which is safe and useful.

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -19,7 +19,7 @@ import {
   type PushContentTier,
 } from './identities.ts';
 import { connectImap, messageRecipients } from './imap.ts';
-import { type NotifyService, notificationService } from './notify.ts';
+import { NotifyError, type NotifyService, notificationService } from './notify.ts';
 import { extractHttpLinks, extractOtp, htmlToText, maskNormalizedHttpUrls } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
@@ -50,6 +50,7 @@ const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve,
 export type WatchedMessage = Pick<FetchMessageObject, 'envelope' | 'headers' | 'source'>;
 
 export type WatcherDispatch = {
+  /** May carry NotifyInput.beforeSend for final tier/delete checks at fetch boundary. */
   publish: NotifyService['publish'];
 };
 
@@ -281,14 +282,29 @@ export async function processWatchedMessage(
     const tier = resolvePushContentTier(current);
     const body = buildMailArrivalMessage(current.address, tier, hasOtpOrLink, extras);
     const level = hasOtpOrLink ? 'urgent' : 'normal';
-    await dispatch.publish({
-      target: 'user',
-      title: 'openagent.email new mail',
-      message: body,
-      level,
-      tags: ['email'],
-      ...(clickUrl ? { click: clickUrl } : {}),
-    });
+    // Re-check at the publish fetch boundary (after publish's own awaits).
+    // Abort only when privacy tightened (delete or downgrade); upgrades keep
+    // the already-safe lower-tier body.
+    const beforeSend = options.refreshIdentity
+      ? (): boolean => {
+          const again = options.refreshIdentity!(identity.address);
+          return again !== undefined && resolvePushContentTier(again) >= tier;
+        }
+      : undefined;
+    try {
+      await dispatch.publish({
+        target: 'user',
+        title: 'openagent.email new mail',
+        message: body,
+        level,
+        tags: ['email'],
+        ...(clickUrl ? { click: clickUrl } : {}),
+        ...(beforeSend ? { beforeSend } : {}),
+      });
+    } catch (err) {
+      if (err instanceof NotifyError && err.code === 'notify_cancelled') continue;
+      throw err;
+    }
   }
 }
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -30,11 +30,15 @@ export const PUSH_OTP_ITEM_MAX = 5;
 /** Max characters per code/link entry before truncation. */
 export const PUSH_OTP_ENTRY_CHARS = 200;
 /**
- * Hard cap on the full ntfy message body. ntfy rejects ~4096 bytes; leave
- * headroom for title/tags/JSON framing so one oversized mail cannot make
- * publish() throw and stall the UID watermark forever.
+ * Hard cap on the full ntfy message body in UTF-8 bytes. ntfy rejects ~4096
+ * bytes; leave headroom for title/tags/JSON framing so one oversized mail
+ * cannot make publish() throw and stall the UID watermark forever.
+ * Measured as encoded bytes, not JS string length (CJK/emoji are multi-byte).
  */
-export const PUSH_MESSAGE_MAX_CHARS = 3500;
+export const PUSH_MESSAGE_MAX_BYTES = 3500;
+/** UTF-8 ellipsis used when the body is truncated to stay under the byte budget. */
+const PUSH_BODY_ELLIPSIS = '…';
+const PUSH_BODY_ELLIPSIS_BYTES = Buffer.byteLength(PUSH_BODY_ELLIPSIS, 'utf8');
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export type WatchedMessage = Pick<FetchMessageObject, 'envelope' | 'headers' | 'source'>;
@@ -97,11 +101,25 @@ export function boundPushOtpEntries(items: string[]): string[] {
   });
 }
 
-/** Enforce the total-body cap, appending an ellipsis when truncated. */
-export function boundPushMessage(body: string): string {
-  if (body.length <= PUSH_MESSAGE_MAX_CHARS) return body;
-  if (PUSH_MESSAGE_MAX_CHARS <= 1) return '…';
-  return `${body.slice(0, PUSH_MESSAGE_MAX_CHARS - 1)}…`;
+/**
+ * Enforce the total-body UTF-8 byte cap. Truncates on a code-point boundary
+ * (never mid-surrogate or mid multi-byte sequence) and reserves room for `…`.
+ */
+export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES): string {
+  if (Buffer.byteLength(body, 'utf8') <= maxBytes) return body;
+  if (maxBytes < PUSH_BODY_ELLIPSIS_BYTES) return '';
+  const budget = maxBytes - PUSH_BODY_ELLIPSIS_BYTES;
+  if (budget <= 0) return PUSH_BODY_ELLIPSIS;
+
+  let used = 0;
+  let end = 0;
+  for (const point of body) {
+    const cost = Buffer.byteLength(point, 'utf8');
+    if (used + cost > budget) break;
+    used += cost;
+    end += point.length;
+  }
+  return `${body.slice(0, end)}${PUSH_BODY_ELLIPSIS}`;
 }
 
 /** Build the human-facing push body for one identity's content tier. */

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -987,20 +987,26 @@ export function buildMailArrivalMessage(
     );
     if (
       options.clickUrl &&
-      packedWith.droppedLinks > 0 &&
       maxNoClick > maxWithClick
     ) {
-      const packedNo = packTier3ArrivalBody(
-        head,
-        codesLine,
-        extras.preview,
-        extras.links,
-        maxNoClick,
-      );
-      // Prefer fewer link evictions; publish() click-drop (F76) delivers the
-      // larger body. Equal eviction → keep with-click packing (click survives).
-      if (packedNo.droppedLinks < packedWith.droppedLinks) {
-        return packedNo.body;
+      // F125: when the head alone is over the with-click budget the click
+      // cannot survive this payload at all — any with-click degradation
+      // (omitted/truncated preview) was for nothing, so also repack no-click.
+      const clickDoomed = jsonEscapedByteLength(packedWith.body) > maxWithClick;
+      if (clickDoomed || packedWith.droppedLinks > 0) {
+        const packedNo = packTier3ArrivalBody(
+          head,
+          codesLine,
+          extras.preview,
+          extras.links,
+          maxNoClick,
+        );
+        // Click doomed → roomier pack retains more preview, publish()'s
+        // click-drop (F76) delivers it minus the action. Otherwise prefer
+        // fewer link evictions; equal eviction → keep with-click packing.
+        if (clickDoomed || packedNo.droppedLinks < packedWith.droppedLinks) {
+          return packedNo.body;
+        }
       }
     }
     return packedWith.body;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -141,14 +141,23 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 }
 
 /**
+ * Fresh each call: continuous 4–8 digit runs and delimited OTP forms (F68)
+ * that extractCodes may yield. Delimited alternative is first so `1234-5678`
+ * is one span, not two continuous runs.
+ */
+function metaCodeRunRe(): RegExp {
+  return /\b\d{3,4}[-–—. ]\d{3,4}\b|\b\d{4,8}\b/g;
+}
+
+/**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
- * (maskNormalizedHttpUrls). Codes: scan text for \b\d{4,8}\b and replace when
- * present in the code set (O(text) Set lookups — no multi-branch regex).
+ * (maskNormalizedHttpUrls). Codes: scan continuous \b\d{4,8}\b and delimited
+ * \b\d{3,4}[-–—. ]\d{3,4}\b runs; replace when present in the code set
+ * (O(text) Set lookups — no multi-branch needle alternation).
  *
- * Codes from extractCodes are those same digit runs; scanning the text with
- * the same shape and checking membership masks the same spans without
- * compiling a needle-count alternation.
+ * Codes from extractCodes are those same shapes; scanning with the same forms
+ * and checking membership masks the same spans.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -160,7 +169,7 @@ export function maskSensitiveFragments(
   let result = maskNormalizedHttpUrls(text, links);
   const codeSet = new Set(codes.filter(Boolean));
   if (codeSet.size === 0) return result;
-  return result.replace(/\b\d{4,8}\b/g, (run) => (codeSet.has(run) ? '•••' : run));
+  return result.replace(metaCodeRunRe(), (run) => (codeSet.has(run) ? '•••' : run));
 }
 
 /**
@@ -180,12 +189,12 @@ export function maskTier2Metadata(
   const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
   const metaOtp = extractOtp(metaText);
   const metaHttpLinks = extractHttpLinks(metaText);
-  // Body codes only enter the mask list if they appear as a longest
-  // \b\d{4,8}\b run in metadata (same shape extractCodes would yield).
-  // Intersecting against meta digit runs is O(|meta|) instead of scanning
-  // every body code into per-needle replaces on short subject/from.
+  // Body codes only enter the mask list if they appear as the same continuous
+  // or delimited shape extractCodes yields (F68). Intersecting against meta
+  // runs is O(|meta|) instead of scanning every body code into per-needle
+  // replaces on short subject/from.
   const metaDigitRuns = new Set<string>();
-  for (const match of metaText.matchAll(/\b\d{4,8}\b/g)) {
+  for (const match of metaText.matchAll(metaCodeRunRe())) {
     metaDigitRuns.add(match[0]!);
   }
   const maskCodes = [

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -205,14 +205,30 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 }
 
 /**
- * Continuous alnum OTP for tier-2 *metadata only* (F77/F81): 4–8 ASCII alnum
- * with at least one letter and one digit. Bounds exclude adjacent alnum so
- * CJK-glued `验证码是A1B2C3` still matches.
+ * ASCII + fullwidth Latin letters/digits only (F86). Explicit FF ranges —
+ * never `\p{L}` / Alphabetic (would swallow CJK and break glue bounds).
  */
-const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{4,8})(?![A-Za-z0-9])/g;
+const META_ALNUM_CHAR = 'A-Za-z0-9\\uFF10-\\uFF19\\uFF21-\\uFF3A\\uFF41-\\uFF5A';
+const META_ALNUM_BOUND_LEFT = `(?<![${META_ALNUM_CHAR}])`;
+const META_ALNUM_BOUND_RIGHT = `(?![${META_ALNUM_CHAR}])`;
+/** Letters only (ASCII + fullwidth) for classic space forms. */
+const META_ALNUM_LETTER = 'A-Za-z\\uFF21-\\uFF3A\\uFF41-\\uFF5A';
+/** Digits only (ASCII + fullwidth) for classic space forms / year checks. */
+const META_ALNUM_DIGIT = '0-9\\uFF10-\\uFF19';
 
 /**
- * Delimited mixed alnum OTP (F84/F85): 2–4 groups of 2–4 ASCII alnum.
+ * Continuous alnum OTP for tier-2 *metadata only* (F77/F81/F86): 4–8 alnum
+ * (ASCII and/or fullwidth) with ≥1 letter + ≥1 digit after NFKC. Bounds exclude
+ * adjacent alnum (incl. fullwidth) so CJK-glued forms still match.
+ */
+const META_ALNUM_OTP_RE = new RegExp(
+  `${META_ALNUM_BOUND_LEFT}([${META_ALNUM_CHAR}]{4,8})${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
+
+/**
+ * Delimited mixed alnum OTP (F84/F85/F86): 2–4 groups of 2–4 alnum
+ * (ASCII + fullwidth).
  *
  * Non-whitespace seps (hyphen/dash/dot/fullwidth) allow 2–4 groups with F74-style
  * mid-chain lead/tail guards.
@@ -225,7 +241,7 @@ const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{4,8})(?![A-Za-z0-9])/g;
  *
  * Pure-digit forms are left to the digit delimited path (≥1 letter + ≥1 digit).
  */
-const META_ALNUM_GROUP = '[A-Za-z0-9]{2,4}';
+const META_ALNUM_GROUP = `[${META_ALNUM_CHAR}]{2,4}`;
 /**
  * Split of otp.ts DELIMITED_OTP_SEP_CLASS: non-whitespace vs whitespace.
  */
@@ -234,38 +250,46 @@ const META_ALNUM_SEP_SPACE =
   '[\\t \\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000\\uFEFF]';
 // 2–4 groups with tight seps; lead blocks mid-chain after alnum+tight-sep.
 const META_ALNUM_DELIMITED_TIGHT = new RegExp(
-  `(?<![A-Za-z0-9]${META_ALNUM_SEP_TIGHT})(?<![A-Za-z0-9])` +
+  `(?<![${META_ALNUM_CHAR}]${META_ALNUM_SEP_TIGHT})${META_ALNUM_BOUND_LEFT}` +
     `(${META_ALNUM_GROUP}(?:${META_ALNUM_SEP_TIGHT}${META_ALNUM_GROUP}){1,3})` +
-    `(?!${META_ALNUM_SEP_TIGHT}[A-Za-z0-9])(?![A-Za-z0-9])`,
+    `(?!${META_ALNUM_SEP_TIGHT}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
 /**
- * 2–4 alnum chars that include a digit (lookahead fixes length; then consume).
+ * 2–4 alnum chars that include a digit after NFKC (lookahead fixes length).
  * Used for space runs so pure-letter English tokens are not groups.
  */
 const META_ALNUM_GROUP_WITH_DIGIT =
-  '(?=[A-Za-z0-9]{2,4}(?![A-Za-z0-9]))(?=[A-Za-z0-9]*[0-9])[A-Za-z0-9]{2,4}';
+  `(?=[${META_ALNUM_CHAR}]{2,4}(?![${META_ALNUM_CHAR}]))` +
+  `(?=[${META_ALNUM_CHAR}]*[${META_ALNUM_DIGIT}])` +
+  `[${META_ALNUM_CHAR}]{2,4}`;
 // Longest space-separated digit-bearing group run (F85).
 const META_ALNUM_DELIMITED_SPACE_DIGIT = new RegExp(
-  `(?<![A-Za-z0-9])` +
+  `${META_ALNUM_BOUND_LEFT}` +
     `(${META_ALNUM_GROUP_WITH_DIGIT}(?:${META_ALNUM_SEP_SPACE}${META_ALNUM_GROUP_WITH_DIGIT})+)` +
-    `(?![A-Za-z0-9])`,
+    `${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
-// Classic `ABC 123` (letter block 3–4 + digit block 2–4); year filter applied after.
+// Classic `ABC 123` / fullwidth (letter block 3–4 + digit block 2–4).
 const META_ALNUM_DELIMITED_SPACE_CLASSIC = new RegExp(
-  `(?<![A-Za-z0-9])` +
-    `([A-Za-z]{3,4}${META_ALNUM_SEP_SPACE}[0-9]{2,4})` +
-    `(?![A-Za-z0-9])`,
+  `${META_ALNUM_BOUND_LEFT}` +
+    `([${META_ALNUM_LETTER}]{3,4}${META_ALNUM_SEP_SPACE}[${META_ALNUM_DIGIT}]{2,4})` +
+    `${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
 
+/** NFKC then require ≥1 Latin letter and ≥1 digit (F86 fullwidth → ASCII). */
 function isMixedAlnumOtp(form: string): boolean {
-  return /[A-Za-z]/.test(form) && /[0-9]/.test(form);
+  const nfkc = form.normalize('NFKC');
+  return /[A-Za-z]/.test(nfkc) && /[0-9]/.test(nfkc);
 }
 
 function splitSpaceAlnumGroups(form: string): string[] {
   return form.split(new RegExp(META_ALNUM_SEP_SPACE)).filter(Boolean);
+}
+
+function nfkcGroup(g: string): string {
+  return g.normalize('NFKC');
 }
 
 /** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
@@ -273,19 +297,23 @@ function isPlausibleSpaceDigitRun(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
   const parts = splitSpaceAlnumGroups(form);
   if (parts.length < 2 || parts.length > 4) return false;
-  // Every group already digit-bearing by construction; still reject years as a side.
-  return parts.every((g) => /[0-9]/.test(g) && !/^(19|20)\d{2}$/.test(g));
+  // Digit check after NFKC so fullwidth digits count; reject year-shaped groups.
+  return parts.every((g) => {
+    const n = nfkcGroup(g);
+    return /[0-9]/.test(n) && !/^(19|20)\d{2}$/.test(n);
+  });
 }
 
-/** Accept classic two-group letter-block + digit-block (`ABC 123`). */
+/** Accept classic two-group letter-block + digit-block (`ABC 123` / fullwidth). */
 function isPlausibleSpaceClassic(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
   const parts = splitSpaceAlnumGroups(form);
   if (parts.length !== 2) return false;
-  const [letters, digits] = parts;
-  if (!/^[A-Za-z]{3,4}$/.test(letters!)) return false;
-  if (!/^[0-9]{2,4}$/.test(digits!)) return false;
-  if (/^(19|20)\d{2}$/.test(digits!)) return false;
+  const letters = nfkcGroup(parts[0]!);
+  const digits = nfkcGroup(parts[1]!);
+  if (!/^[A-Za-z]{3,4}$/.test(letters)) return false;
+  if (!/^[0-9]{2,4}$/.test(digits)) return false;
+  if (/^(19|20)\d{2}$/.test(digits)) return false;
   return true;
 }
 
@@ -295,7 +323,7 @@ function escapeRegExpLiteral(s: string): string {
 
 /**
  * Collect alnum OTPs from from/subject when a strong cue is present
- * (F77/F81 continuous + F84 tight delimited + F85 space runs).
+ * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth).
  * Does not touch body extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
@@ -345,9 +373,12 @@ export function buildAlnumMaskRe(forms: string[]): RegExp | null {
   }
   if (ordered.length === 0) return null;
   const alt = ordered.map(escapeRegExpLiteral).join('|');
-  // Bounds are ASCII-alnum only so forms containing hyphens/spaces still match
-  // when adjacent to punctuation or CJK (not glued to a longer alnum run).
-  return new RegExp(`(?<![A-Za-z0-9])(?:${alt})(?![A-Za-z0-9])`, 'g');
+  // Bounds include fullwidth alnum (F86) so we do not leave a half-run next to
+  // longer fullwidth tokens; hyphens/spaces/CJK still allow a match.
+  return new RegExp(
+    `${META_ALNUM_BOUND_LEFT}(?:${alt})${META_ALNUM_BOUND_RIGHT}`,
+    'g',
+  );
 }
 
 /**

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -132,11 +132,19 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
   return boundTextBytes(body, maxBytes);
 }
 
+/** Escape a needle for use as a single RegExp alternative. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
- * Codes: exact string replace. Links: normalize via validatedHttpUrl then
- * replace the original spelling (maskNormalizedHttpUrls) so EXAMPLE.com:443
- * still redacts when extractOtp returned https://example.com/....
+ * Links: normalize via validatedHttpUrl then replace original spelling
+ * (maskNormalizedHttpUrls). Codes: one alternation regex replace (O(text)),
+ * not per-needle includes+split which is O(codes × text) DoS.
+ *
+ * Codes are longest \b\d{4,8}\b runs and do not overlap, so longest-first
+ * alternation matches the same spans as sequential split/join.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -146,14 +154,17 @@ export function maskSensitiveFragments(
   if (!text) return text;
   // URLs first so a full verify link is one unit before digit-code scans.
   let result = maskNormalizedHttpUrls(text, links);
-  const codeNeedles = codes
-    .filter((value) => value.length > 0)
-    .sort((a, b) => b.length - a.length);
-  for (const needle of codeNeedles) {
-    if (!result.includes(needle)) continue;
-    result = result.split(needle).join('•••');
+  const seen = new Set<string>();
+  const codeNeedles: string[] = [];
+  for (const value of codes) {
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    codeNeedles.push(value);
   }
-  return result;
+  codeNeedles.sort((a, b) => b.length - a.length);
+  if (codeNeedles.length === 0) return result;
+  const pattern = codeNeedles.map(escapeRegExp).join('|');
+  return result.replace(new RegExp(pattern, 'g'), '•••');
 }
 
 /** Build the human-facing push body for one identity's content tier. */
@@ -181,7 +192,18 @@ export function buildMailArrivalMessage(
       const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
       const metaOtp = extractOtp(metaText);
       const metaHttpLinks = extractHttpLinks(metaText);
-      const maskCodes = [...extras.codes, ...metaOtp.codes];
+      // Body codes only enter the mask list if they appear as a longest
+      // \b\d{4,8}\b run in metadata (same shape extractCodes would yield).
+      // Intersecting against meta digit runs is O(|meta|) instead of scanning
+      // every body code into per-needle replaces on short subject/from.
+      const metaDigitRuns = new Set<string>();
+      for (const match of metaText.matchAll(/\b\d{4,8}\b/g)) {
+        metaDigitRuns.add(match[0]!);
+      }
+      const maskCodes = [
+        ...metaOtp.codes,
+        ...extras.codes.filter((code) => metaDigitRuns.has(code)),
+      ];
       const maskLinks = [...extras.links, ...metaHttpLinks];
       from = maskSensitiveFragments(from, maskCodes, maskLinks);
       subject = maskSensitiveFragments(subject, maskCodes, maskLinks);

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -11,13 +11,20 @@
 import { simpleParser } from 'mailparser';
 import type { FetchMessageObject, ImapFlow } from 'imapflow';
 import { config } from './config.ts';
-import { listIdentities, type Identity } from './identities.ts';
+import {
+  listIdentities,
+  resolvePushContentTier,
+  type Identity,
+  type PushContentTier,
+} from './identities.ts';
 import { connectImap, messageRecipients } from './imap.ts';
 import { type NotifyService, notificationService } from './notify.ts';
 import { extractOtp, htmlToText } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
 const RECONNECT_MS = 3_000;
+/** Bounded plain-text preview length for tier-3 mail-arrival pushes. */
+export const PUSH_BODY_PREVIEW_CHARS = 280;
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export type WatchedMessage = Pick<FetchMessageObject, 'envelope' | 'headers' | 'source'>;
@@ -26,8 +33,22 @@ export type WatcherDispatch = {
   publish: NotifyService['publish'];
 };
 
+/** Optional processWatchedMessage knobs (tests inject clickUrl; prod uses config). */
+export type ProcessWatchedOptions = {
+  /** When set, each mail-arrival push includes ntfy `click` = this URL. */
+  clickUrl?: string;
+};
+
 /** In-memory watermark survives a dropped IMAP connection in this process. */
 export type WatcherWatermark = { uid?: number };
+
+export type MailContentExtras = {
+  subject: string;
+  from: string;
+  preview: string;
+  codes: string[];
+  links: string[];
+};
 
 /**
  * The first successful connection starts at the mailbox high-water mark so an
@@ -43,12 +64,55 @@ export function unseenWatcherUids(uids: number[], watermark: WatcherWatermark): 
   return uids.filter((uid) => uid > watermark.uid!);
 }
 
+function formatAddressList(
+  list: Array<{ name?: string | null; address?: string | null }> | undefined,
+): string {
+  if (!list?.length) return '';
+  return list
+    .map((entry) => {
+      const address = (entry.address ?? '').trim();
+      const name = (entry.name ?? '').trim();
+      if (name && address) return `${name} <${address}>`;
+      return address || name;
+    })
+    .filter(Boolean)
+    .join(', ');
+}
+
+/** Build the human-facing push body for one identity's content tier. */
+export function buildMailArrivalMessage(
+  address: string,
+  tier: PushContentTier,
+  hasOtpOrLink: boolean,
+  extras: MailContentExtras,
+): string {
+  const lines: string[] = [
+    hasOtpOrLink
+      ? `${address} received new email (contains OTP or verification link)`
+      : `${address} received new email`,
+  ];
+
+  if (tier >= 2) {
+    if (extras.from) lines.push(`From: ${extras.from}`);
+    if (extras.subject) lines.push(`Subject: ${extras.subject}`);
+  }
+
+  if (tier >= 3) {
+    if (extras.preview) lines.push(`Preview: ${extras.preview}`);
+    if (extras.codes.length) lines.push(`Codes: ${extras.codes.join(', ')}`);
+    if (extras.links.length) lines.push(`Links:\n${extras.links.join('\n')}`);
+  }
+
+  return lines.join('\n');
+}
+
 /** Process one newly delivered message. Exported for policy/security tests. */
 export async function processWatchedMessage(
   message: WatchedMessage,
   identities: Identity[],
   policy: 'otp' | 'all' | 'none',
   dispatch: WatcherDispatch,
+  options: ProcessWatchedOptions = {},
 ): Promise<void> {
   if (policy === 'none') return;
   const recipients = messageRecipients(message as FetchMessageObject);
@@ -56,15 +120,32 @@ export async function processWatchedMessage(
   if (matched.length === 0) return;
 
   let hasOtpOrLink = false;
+  const extras: MailContentExtras = {
+    subject: typeof message.envelope?.subject === 'string' ? message.envelope.subject : '',
+    from: formatAddressList(message.envelope?.from as Array<{ name?: string | null; address?: string | null }> | undefined),
+    preview: '',
+    codes: [],
+    links: [],
+  };
+
   if (message.source) {
     try {
       const parsed = await simpleParser(message.source);
+      if (!extras.subject && typeof parsed.subject === 'string') {
+        extras.subject = parsed.subject;
+      }
+      if (!extras.from && parsed.from?.text) {
+        extras.from = parsed.from.text;
+      }
       const html = typeof parsed.html === 'string' && parsed.html.length <= MAX_EMAIL_HTML_LENGTH
         ? parsed.html
         : undefined;
       const text = (parsed.text ?? '').trim() || (html ? htmlToText(html) : '');
       const otp = extractOtp(text, html);
       hasOtpOrLink = otp.codes.length > 0 || otp.links.length > 0;
+      extras.codes = otp.codes;
+      extras.links = otp.links;
+      extras.preview = text.slice(0, PUSH_BODY_PREVIEW_CHARS);
     } catch {
       // A malformed message is never an OTP match. `all` policy still sends a
       // payload with no message content, which is safe and useful.
@@ -72,12 +153,10 @@ export async function processWatchedMessage(
   }
   if (policy === 'otp' && !hasOtpOrLink) return;
 
+  const clickUrl = options.clickUrl;
   for (const identity of matched) {
-    // The payload intentionally contains no subject, sender, preview or OTP.
-    // It is only an interrupt; agents fetch the protected mailbox to read it.
-    const body = hasOtpOrLink
-      ? `${identity.address} received new email (contains OTP or verification link)`
-      : `${identity.address} received new email`;
+    const tier = resolvePushContentTier(identity);
+    const body = buildMailArrivalMessage(identity.address, tier, hasOtpOrLink, extras);
     const level = hasOtpOrLink ? 'urgent' : 'normal';
     await dispatch.publish({
       target: 'user',
@@ -85,6 +164,7 @@ export async function processWatchedMessage(
       message: body,
       level,
       tags: ['email'],
+      ...(clickUrl ? { click: clickUrl } : {}),
     });
   }
 }
@@ -108,7 +188,13 @@ async function watchConnection(
           { envelope: true, headers: ['delivered-to'], source: true },
           { uid: true },
         )) {
-          await processWatchedMessage(message, listIdentities(), config.ntfy.pushPolicy, dispatch);
+          await processWatchedMessage(
+            message,
+            listIdentities(),
+            config.ntfy.pushPolicy,
+            dispatch,
+            { clickUrl: config.dashboardPublicUrl },
+          );
           watermark.uid = Math.max(watermark.uid ?? 0, message.uid);
         }
       }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -21,6 +21,7 @@ import {
 import { connectImap, messageRecipients } from './imap.ts';
 import { NotifyError, type NotifyService, notificationService } from './notify.ts';
 import {
+  canonicalDigits,
   extractHttpLinks,
   extractOtp,
   htmlToText,
@@ -146,17 +147,12 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
   return boundTextBytes(body, maxBytes);
 }
 
-/** Digit-only form so body `123456` and subject `123-456` compare equal (F69). */
-function canonicalDigits(s: string): string {
-  return s.replace(/\D/g, '');
-}
-
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
  * (maskNormalizedHttpUrls). Codes: scan continuous / delimited runs via shared
- * otpCodeRunRe (F68/F70 separators including Unicode spaces); replace when the
- * run's digit-only form is in the code set (F69 cross-form).
+ * otpCodeRunRe (Unicode Nd + seps, F68–F75); replace when the run's
+ * canonicalDigits form is in the code set (F69/F75 cross-form/script).
  *
  * Membership is O(text) Set lookups on canonical digits — no multi-branch
  * needle alternation. Extract still yields original spelling (extractCodes).

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -991,10 +991,17 @@ export function buildMailArrivalMessage(
   }
 
   // Tier 1–2: raw byte bound is fine (no long verify links).
-  return boundPushMessage(
-    lines.join('\n'),
-    Math.min(PUSH_MESSAGE_MAX_BYTES, maxWithClick),
-  );
+  const body = lines.join('\n');
+  const withClickCap = Math.min(PUSH_MESSAGE_MAX_BYTES, maxWithClick);
+  // F123: never truncate the core alert to preserve the click action — a long
+  // DASHBOARD_PUBLIC_URL would otherwise shrink the with-click budget below
+  // the interrupt text itself (`fox@example.…`). When the body only fits
+  // without the click, pack under the no-click budget; publish()'s click-drop
+  // fallback (F76) delivers it minus the action.
+  if (options.clickUrl && Buffer.byteLength(body, 'utf8') > withClickCap) {
+    return boundPushMessage(body, Math.min(PUSH_MESSAGE_MAX_BYTES, maxNoClick));
+  }
+  return boundPushMessage(body, withClickCap);
 }
 
 /** Process one newly delivered message. Exported for policy/security tests. */

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -318,6 +318,25 @@ const META_ALNUM_DELIMITED_SPACE_CLASSIC = new RegExp(
     `${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
+/**
+ * 2–4 all-caps letter groups of 2–4 (ASCII A–Z + fullwidth FF21–FF3A),
+ * space-joined (F97). Uppercase-only groups prevent English glue (`code is WX YZ`
+ * must not form one space chain). isLetterOnlyDelimitedOtp still NFKC-checks.
+ */
+const META_ALNUM_UPPER = 'A-Z\\uFF21-\\uFF3A';
+const META_ALNUM_GROUP_UPPER =
+  `(?=[${META_ALNUM_UPPER}]{2,4}(?![${META_ALNUM_CHAR}]))` +
+  `[${META_ALNUM_UPPER}]{2,4}`;
+const META_ALNUM_DELIMITED_SPACE_LETTER = new RegExp(
+  `${META_ALNUM_BOUND_LEFT}` +
+    `(${META_ALNUM_GROUP_UPPER}(?:${META_ALNUM_SEP_SPACE}${META_ALNUM_GROUP_UPPER})+)` +
+    `${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
+/** Split form into groups on any tight or space sep run (F97). */
+const META_ALNUM_SEP_ANY_RUN = new RegExp(
+  `(?:${META_ALNUM_SEP_TIGHT}|${META_ALNUM_SEP_SPACE})+`,
+);
 
 /** NFKC then require ≥1 Latin letter and ≥1 digit (F86 fullwidth → ASCII). */
 function isMixedAlnumOtp(form: string): boolean {
@@ -334,17 +353,34 @@ function isMixedAlnumOtp(form: string): boolean {
  * Tradeoff under the strong-cue gate: an all-caps non-code word of length 4–8
  * (e.g. `READY` in `Your verification code is READY NOW`) is masked — accepted
  * for the metadata privacy boundary; the rest of the subject stays readable.
- *
- * Delimited letter-only forms (`WX-YZ`) are out of scope: this predicate only
- * matches continuous tokens, so tight/space loops never accept them.
  */
 function isLetterOnlyOtp(form: string): boolean {
   return /^[A-Z]{4,8}$/.test(form.normalize('NFKC'));
 }
 
-/** Mixed alnum or strongly labeled letter-only continuous form (F77/F95). */
+/**
+ * Letter-only delimited OTP under a strong cue (F97): NFKC, split on tight or
+ * space sep runs, require 2–4 groups each `/^[A-Z]{2,4}$/`. All-uppercase keeps
+ * prose out (`Wx-Yz` rejected). Tradeoff: all-caps acronym chains under a
+ * strong cue (`NASA HQ`, `GO NOW`) may mask — accepted for privacy.
+ *
+ * Tight path reuses META_ALNUM_DELIMITED_TIGHT; space path uses
+ * META_ALNUM_DELIMITED_SPACE_LETTER (consume full run, reject 5+ whole).
+ */
+function isLetterOnlyDelimitedOtp(form: string): boolean {
+  const parts = form
+    .normalize('NFKC')
+    .split(META_ALNUM_SEP_ANY_RUN)
+    .filter(Boolean);
+  if (parts.length < 2 || parts.length > 4) return false;
+  return parts.every((g) => /^[A-Z]{2,4}$/.test(g));
+}
+
+/** Mixed, continuous letter-only, or delimited letter-only form (F77/F95/F97). */
 function isMetaAlnumOtpForm(form: string): boolean {
-  return isMixedAlnumOtp(form) || isLetterOnlyOtp(form);
+  return (
+    isMixedAlnumOtp(form) || isLetterOnlyOtp(form) || isLetterOnlyDelimitedOtp(form)
+  );
 }
 
 function splitSpaceAlnumGroups(form: string): string[] {
@@ -353,6 +389,11 @@ function splitSpaceAlnumGroups(form: string): string[] {
 
 function nfkcGroup(g: string): string {
   return g.normalize('NFKC');
+}
+
+/** Accept space letter-only run: 2–4 all-caps groups (5+ refused whole, F97). */
+function isPlausibleSpaceLetterRun(form: string): boolean {
+  return isLetterOnlyDelimitedOtp(form);
 }
 
 /** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
@@ -387,14 +428,14 @@ function escapeRegExpLiteral(s: string): string {
 /**
  * Collect alnum OTPs from from/subject when a strong cue is present
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
- * F95 letter-only all-caps continuous). Does not touch body extract semantics.
+ * F95 letter-only continuous + F97 letter-only delimited). Does not touch body
+ * extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
   const codes: string[] = [];
   const seen = new Set<string>();
   const push = (form: string) => {
-    // Delimited letter-only (WX-YZ) stays rejected: isLetterOnlyOtp is continuous-only.
     if (!isMetaAlnumOtpForm(form) || seen.has(form)) return;
     seen.add(form);
     codes.push(form);
@@ -408,6 +449,12 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
   for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_CLASSIC)) {
     const form = match[1]!;
     if (!isPlausibleSpaceClassic(form)) continue;
+    push(form);
+  }
+  // F97: space letter-only runs (`WX YZ`); 2–4 groups after full-run consume.
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_LETTER)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceLetterRun(form)) continue;
     push(form);
   }
   for (const match of metaText.matchAll(META_ALNUM_OTP_RE)) {

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -24,6 +24,7 @@ import {
   canonicalDigits,
   extractHttpLinks,
   extractOtp,
+  hasStrongOtpCue,
   htmlToText,
   maskNormalizedHttpUrls,
   otpCodeRunRe,
@@ -113,12 +114,68 @@ function formatAddressList(
     .join(', ');
 }
 
-/** Cap list length and per-entry size for tier-3 OTP fields. */
+/** Cap list length and per-entry size for tier-3 OTP *code* fields. */
 export function boundPushOtpEntries(items: string[]): string[] {
   return items.slice(0, PUSH_OTP_ITEM_MAX).map((item) => {
     if (item.length <= PUSH_OTP_ENTRY_CHARS) return item;
     return `${item.slice(0, PUSH_OTP_ENTRY_CHARS)}…`;
   });
+}
+
+/**
+ * Tier-3 verification links must stay complete (F79) — truncating mid-token
+ * yields unusable URLs. Keep full strings up to PUSH_OTP_ITEM_MAX; callers pack
+ * under the total body byte budget and omit the tail with an honest note.
+ */
+export function boundPushLinkEntries(items: string[]): string[] {
+  return items.slice(0, PUSH_OTP_ITEM_MAX);
+}
+
+const MORE_LINKS_NOTE = (n: number) =>
+  `(+${n} more links, open the dashboard to view)`;
+
+/**
+ * Pack full verification links under the remaining UTF-8 body budget (F79).
+ * Never mid-truncates a URL; drops the tail and appends a +N note when needed.
+ */
+export function packPushLinkLines(
+  baseBody: string,
+  links: string[],
+  maxBytes = PUSH_MESSAGE_MAX_BYTES,
+): string[] {
+  if (links.length === 0) return [];
+  const candidates = boundPushLinkEntries(links);
+  let dropped = Math.max(0, links.length - candidates.length);
+  const kept: string[] = [];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const tryKept = [...kept, candidates[i]!];
+    const stillDrop = dropped + (candidates.length - tryKept.length);
+    const note = stillDrop > 0 ? `\n${MORE_LINKS_NOTE(stillDrop)}` : '';
+    const trial = `${baseBody}\nLinks:\n${tryKept.join('\n')}${note}`;
+    if (Buffer.byteLength(trial, 'utf8') <= maxBytes) {
+      kept.push(candidates[i]!);
+      continue;
+    }
+    dropped += candidates.length - kept.length;
+    break;
+  }
+
+  if (kept.length === 0) {
+    // Even one full link does not fit; prefer an honest note over a broken URL.
+    if (links.length > 0) {
+      const onlyNote = `${baseBody}\nLinks:\n${MORE_LINKS_NOTE(links.length)}`;
+      if (Buffer.byteLength(onlyNote, 'utf8') <= maxBytes) {
+        return [`Links:\n${MORE_LINKS_NOTE(links.length)}`];
+      }
+    }
+    return [];
+  }
+
+  const out = [`Links:\n${kept.join('\n')}`];
+  // dropped already includes candidates not kept + beyond PUSH_OTP_ITEM_MAX.
+  if (dropped > 0) out.push(MORE_LINKS_NOTE(dropped));
+  return out;
 }
 
 /**
@@ -148,14 +205,38 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 }
 
 /**
+ * Alphanumeric OTP shape for tier-2 *metadata only* (F77): 6–8 ASCII alnum
+ * with at least one letter and one digit. Bounds exclude adjacent alnum so
+ * CJK-glued `验证码是A1B2C3` still matches (same no-\p{L} idea as F75).
+ */
+const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{6,8})(?![A-Za-z0-9])/g;
+
+function isMixedAlnumOtp(form: string): boolean {
+  return /[A-Za-z]/.test(form) && /[0-9]/.test(form);
+}
+
+/**
+ * Collect alnum OTPs from from/subject when a strong cue is present (F77).
+ * Does not touch body extractCodes / extractOtp semantics.
+ */
+export function extractMetaAlnumCodes(metaText: string): string[] {
+  if (!metaText || !hasStrongOtpCue(metaText)) return [];
+  const codes: string[] = [];
+  const seen = new Set<string>();
+  for (const match of metaText.matchAll(META_ALNUM_OTP_RE)) {
+    const form = match[1]!;
+    if (!isMixedAlnumOtp(form) || seen.has(form)) continue;
+    seen.add(form);
+    codes.push(form);
+  }
+  return codes;
+}
+
+/**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
- * (maskNormalizedHttpUrls). Codes: scan continuous / delimited runs via shared
- * otpCodeRunRe (Unicode Nd + seps, F68–F75); replace when the run's
- * canonicalDigits form is in the code set (F69/F75 cross-form/script).
- *
- * Membership is O(text) Set lookups on canonical digits — no multi-branch
- * needle alternation. Extract still yields original spelling (extractCodes).
+ * (maskNormalizedHttpUrls). Digit codes: otpCodeRunRe + canonicalDigits
+ * (F69/F75). Alnum codes (F77): exact spelling replace with alnum bounds.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -165,16 +246,32 @@ export function maskSensitiveFragments(
   if (!text) return text;
   // URLs first so a full verify link is one unit before digit-code scans.
   let result = maskNormalizedHttpUrls(text, links);
-  const codeSet = new Set<string>();
+  const digitCanon = new Set<string>();
+  const exactAlnum: string[] = [];
   for (const code of codes) {
     if (!code) continue;
+    if (isMixedAlnumOtp(code)) {
+      exactAlnum.push(code);
+      continue;
+    }
     const canon = canonicalDigits(code);
-    if (canon) codeSet.add(canon);
+    if (canon) digitCanon.add(canon);
   }
-  if (codeSet.size === 0) return result;
-  return result.replace(otpCodeRunRe(), (run) =>
-    codeSet.has(canonicalDigits(run)) ? '•••' : run,
-  );
+  if (digitCanon.size > 0) {
+    result = result.replace(otpCodeRunRe(), (run) =>
+      digitCanon.has(canonicalDigits(run)) ? '•••' : run,
+    );
+  }
+  // Longest first so overlapping spellings prefer the full form.
+  exactAlnum.sort((a, b) => b.length - a.length);
+  for (const form of exactAlnum) {
+    const re = new RegExp(
+      `(?<![A-Za-z0-9])${form.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?![A-Za-z0-9])`,
+      'g',
+    );
+    result = result.replace(re, '•••');
+  }
+  return result;
 }
 
 /**
@@ -206,6 +303,8 @@ export function maskTier2Metadata(
   const maskCodes = [
     ...metaOtp.codes,
     ...extras.codes.filter((code) => metaCanonRuns.has(canonicalDigits(code))),
+    // Strong-cue alnum OTPs in metadata only (F77) — not body extract.
+    ...extractMetaAlnumCodes(metaText),
   ];
   const maskLinks = [...extras.links, ...metaHttpLinks];
   from = maskSensitiveFragments(from, maskCodes, maskLinks);
@@ -246,9 +345,10 @@ export function buildMailArrivalMessage(
   if (tier >= 3) {
     if (extras.preview) lines.push(`Preview: ${extras.preview}`);
     const codes = boundPushOtpEntries(extras.codes);
-    const links = boundPushOtpEntries(extras.links);
     if (codes.length) lines.push(`Codes: ${codes.join(', ')}`);
-    if (links.length) lines.push(`Links:\n${links.join('\n')}`);
+    // Links: full URLs only; pack under total body budget (F79).
+    const baseForLinks = lines.join('\n');
+    lines.push(...packPushLinkLines(baseForLinks, extras.links));
   }
 
   return boundPushMessage(lines.join('\n'));

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -149,15 +149,20 @@ function metaCodeRunRe(): RegExp {
   return /\b\d{3,4}[-–—. ]\d{3,4}\b|\b\d{4,8}\b/g;
 }
 
+/** Digit-only form so body `123456` and subject `123-456` compare equal (F69). */
+function canonicalDigits(s: string): string {
+  return s.replace(/\D/g, '');
+}
+
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
  * (maskNormalizedHttpUrls). Codes: scan continuous \b\d{4,8}\b and delimited
- * \b\d{3,4}[-–—. ]\d{3,4}\b runs; replace when present in the code set
- * (O(text) Set lookups — no multi-branch needle alternation).
+ * \b\d{3,4}[-–—. ]\d{3,4}\b runs; replace when the run's digit-only form is in
+ * the code set (F69 — body continuous / meta delimited are the same OTP).
  *
- * Codes from extractCodes are those same shapes; scanning with the same forms
- * and checking membership masks the same spans.
+ * Membership is O(text) Set lookups on canonical digits — no multi-branch
+ * needle alternation. Extract still yields original spelling (extractCodes).
  */
 export function maskSensitiveFragments(
   text: string,
@@ -167,9 +172,16 @@ export function maskSensitiveFragments(
   if (!text) return text;
   // URLs first so a full verify link is one unit before digit-code scans.
   let result = maskNormalizedHttpUrls(text, links);
-  const codeSet = new Set(codes.filter(Boolean));
+  const codeSet = new Set<string>();
+  for (const code of codes) {
+    if (!code) continue;
+    const canon = canonicalDigits(code);
+    if (canon) codeSet.add(canon);
+  }
   if (codeSet.size === 0) return result;
-  return result.replace(metaCodeRunRe(), (run) => (codeSet.has(run) ? '•••' : run));
+  return result.replace(metaCodeRunRe(), (run) =>
+    codeSet.has(canonicalDigits(run)) ? '•••' : run,
+  );
 }
 
 /**
@@ -189,17 +201,17 @@ export function maskTier2Metadata(
   const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
   const metaOtp = extractOtp(metaText);
   const metaHttpLinks = extractHttpLinks(metaText);
-  // Body codes only enter the mask list if they appear as the same continuous
-  // or delimited shape extractCodes yields (F68). Intersecting against meta
-  // runs is O(|meta|) instead of scanning every body code into per-needle
-  // replaces on short subject/from.
-  const metaDigitRuns = new Set<string>();
+  // Body codes enter the mask list when their digit-only form appears as any
+  // continuous/delimited meta run (F69: body `123456` ↔ subject `123-456`).
+  // O(|meta|) collect + O(|codes|) filter — not a per-needle scan of meta.
+  const metaCanonRuns = new Set<string>();
   for (const match of metaText.matchAll(metaCodeRunRe())) {
-    metaDigitRuns.add(match[0]!);
+    const canon = canonicalDigits(match[0]!);
+    if (canon) metaCanonRuns.add(canon);
   }
   const maskCodes = [
     ...metaOtp.codes,
-    ...extras.codes.filter((code) => metaDigitRuns.has(code)),
+    ...extras.codes.filter((code) => metaCanonRuns.has(canonicalDigits(code))),
   ];
   const maskLinks = [...extras.links, ...metaHttpLinks];
   from = maskSensitiveFragments(from, maskCodes, maskLinks);

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -297,6 +297,19 @@ const META_ALNUM_DELIMITED_TIGHT = new RegExp(
   'g',
 );
 /**
+ * Tight-delimited single-character chains (F105): 4–8 groups of exactly 1
+ * alnum (`A-1-B-2`). LEAD_MID + the tail guard reject 9+-group chains whole
+ * (no mid-chain restart after a tight sep). Candidate only — acceptance is
+ * the predicate: joined form must be mixed (letter+digit); letter-only chains
+ * stay rejected (delimited letter-only = F97 uppercase 2–4 groups of 2–4).
+ */
+const META_ALNUM_DELIMITED_TIGHT_SINGLE = new RegExp(
+  `${META_ALNUM_LEAD_MID}${META_ALNUM_BOUND_LEFT}` +
+    `([${META_ALNUM_CHAR}](?:${META_ALNUM_SEP_RUN_WITH_TIGHT}[${META_ALNUM_CHAR}]){3,7})` +
+    `(?!${META_ALNUM_SEP_RUN_WITH_TIGHT}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
+/**
  * 2–4 alnum chars that include a digit after NFKC (lookahead fixes length).
  * Used for space runs so pure-letter English tokens are not groups.
  */
@@ -398,6 +411,19 @@ function isPlausibleSpaceLetterRun(form: string): boolean {
   return isLetterOnlyDelimitedOtp(form);
 }
 
+/**
+ * Accept a tight single-char chain (F105): NFKC, split on any sep run, 4–8
+ * groups of exactly 1 char. Mixed/letter acceptance happens in push() via
+ * isMetaAlnumOtpForm — pure-digit and letter-only chains drop there.
+ */
+function isPlausibleSingleChain(form: string): boolean {
+  const parts = form
+    .normalize('NFKC')
+    .split(META_ALNUM_SEP_ANY_RUN)
+    .filter(Boolean);
+  return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
+}
+
 /** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
 function isPlausibleSpaceDigitRun(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
@@ -430,8 +456,8 @@ function escapeRegExpLiteral(s: string): string {
 /**
  * Collect alnum OTPs from from/subject when a strong cue is present
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
- * F95 letter-only continuous + F97 letter-only delimited). Does not touch body
- * extract semantics.
+ * F95 letter-only continuous + F97 letter-only delimited + F105 single-char
+ * tight chains). Does not touch body extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
@@ -470,6 +496,13 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
       .map((g) => g.trim())
       .filter(Boolean);
     if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
+    push(form);
+  }
+  // F105: tight single-char chains (`A-1-B-2`); mixed passes push(), pure-digit
+  // and letter-only chains drop at the predicate.
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleSingleChain(form)) continue;
     push(form);
   }
   return codes;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -271,7 +271,7 @@ const META_ALNUM_OTP_RE = new RegExp(
  * Delimited mixed alnum OTP (F84/F85/F86): 2–4 groups of 2–4 alnum
  * (ASCII + fullwidth).
  *
- * Non-whitespace seps (hyphen/dash/dot/fullwidth) allow 2–4 groups with F74-style
+ * Non-whitespace seps (hyphen/dash/dot/slash + fullwidth) allow 2–4 groups with F74-style
  * mid-chain lead/tail guards.
  *
  * Whitespace seps (F85):
@@ -288,8 +288,10 @@ const META_ALNUM_GROUP = `[${META_ALNUM_CHAR}]{2,4}`;
  * F87: sep runs of 1–3 that include **at least one tight** sep so `ABC - 123`
  * and `ABC--123` match, while pure-space chains stay on F85 paths and English
  * `code is ABC-123` cannot glue via space-only gaps.
+ * F112: slash (ASCII + fullwidth) joins the tight class — `A1/B2` metadata
+ * codes bypassed every matcher; URLs are unaffected (link-masked first).
  */
-const META_ALNUM_SEP_TIGHT = '[-–—.\uFF0D\uFF0E]';
+const META_ALNUM_SEP_TIGHT = '[-–—./\uFF0D\uFF0E\uFF0F]';
 const META_ALNUM_SEP_SPACE =
   '[\\t \\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000\\uFEFF]';
 const T = META_ALNUM_SEP_TIGHT;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -243,9 +243,10 @@ const META_ALNUM_LETTER = 'A-Za-z\\uFF21-\\uFF3A\\uFF41-\\uFF5A';
 const META_ALNUM_DIGIT = '0-9\\uFF10-\\uFF19';
 
 /**
- * Continuous alnum OTP for tier-2 *metadata only* (F77/F81/F86): 4–8 alnum
- * (ASCII and/or fullwidth) with ≥1 letter + ≥1 digit after NFKC. Bounds exclude
- * adjacent alnum (incl. fullwidth) so CJK-glued forms still match.
+ * Continuous alnum OTP for tier-2 *metadata only* (F77/F81/F86/F95): 4–8 alnum
+ * (ASCII and/or fullwidth). Accepted after match when mixed (letter+digit) or
+ * letter-only all-caps (F95). Bounds exclude adjacent alnum (incl. fullwidth)
+ * so CJK-glued forms still match.
  */
 const META_ALNUM_OTP_RE = new RegExp(
   `${META_ALNUM_BOUND_LEFT}([${META_ALNUM_CHAR}]{4,8})${META_ALNUM_BOUND_RIGHT}`,
@@ -324,6 +325,28 @@ function isMixedAlnumOtp(form: string): boolean {
   return /[A-Za-z]/.test(nfkc) && /[0-9]/.test(nfkc);
 }
 
+/**
+ * Letter-only continuous OTP for tier-2 metadata under a strong cue (F95).
+ * NFKC then `/^[A-Z]{4,8}$/`: real letter-only codes are almost always
+ * shouted (`WXYZ`); all-uppercase excludes prose (`pending`, `Ready`, `wxyz`).
+ * Fullwidth uppercase (ＷＸＹＺ) NFKC-normalizes to ASCII and is covered.
+ *
+ * Tradeoff under the strong-cue gate: an all-caps non-code word of length 4–8
+ * (e.g. `READY` in `Your verification code is READY NOW`) is masked — accepted
+ * for the metadata privacy boundary; the rest of the subject stays readable.
+ *
+ * Delimited letter-only forms (`WX-YZ`) are out of scope: this predicate only
+ * matches continuous tokens, so tight/space loops never accept them.
+ */
+function isLetterOnlyOtp(form: string): boolean {
+  return /^[A-Z]{4,8}$/.test(form.normalize('NFKC'));
+}
+
+/** Mixed alnum or strongly labeled letter-only continuous form (F77/F95). */
+function isMetaAlnumOtpForm(form: string): boolean {
+  return isMixedAlnumOtp(form) || isLetterOnlyOtp(form);
+}
+
 function splitSpaceAlnumGroups(form: string): string[] {
   return form.split(new RegExp(META_ALNUM_SEP_SPACE)).filter(Boolean);
 }
@@ -363,15 +386,16 @@ function escapeRegExpLiteral(s: string): string {
 
 /**
  * Collect alnum OTPs from from/subject when a strong cue is present
- * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth).
- * Does not touch body extract semantics.
+ * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
+ * F95 letter-only all-caps continuous). Does not touch body extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
   const codes: string[] = [];
   const seen = new Set<string>();
   const push = (form: string) => {
-    if (!isMixedAlnumOtp(form) || seen.has(form)) return;
+    // Delimited letter-only (WX-YZ) stays rejected: isLetterOnlyOtp is continuous-only.
+    if (!isMetaAlnumOtpForm(form) || seen.has(form)) return;
     seen.add(form);
     codes.push(form);
   };
@@ -431,10 +455,11 @@ export function buildAlnumMaskRe(forms: string[]): RegExp | null {
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
- * (maskNormalizedHttpUrls). Alnum codes (F77/F83/F91): exact-form alternation
- * before digit runs so `ABC-1234` is not half-masked to `ABC-•••` when both
- * `ABC-1234` and `1234` are in the code set. Digit codes: otpCodeRunRe +
- * canonicalDigits (F69/F75) after alnum.
+ * (maskNormalizedHttpUrls). Alnum codes (F77/F83/F91/F95): exact-form
+ * alternation before digit runs so `ABC-1234` is not half-masked to `ABC-•••`
+ * when both spellings are in the code set, and letter-only `WXYZ` is bucketed
+ * as exact alnum (not silently dropped via empty canonicalDigits). Digit codes:
+ * otpCodeRunRe + canonicalDigits (F69/F75) after alnum.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -448,7 +473,7 @@ export function maskSensitiveFragments(
   const exactAlnum: string[] = [];
   for (const code of codes) {
     if (!code) continue;
-    if (isMixedAlnumOtp(code)) {
+    if (isMetaAlnumOtpForm(code)) {
       exactAlnum.push(code);
       continue;
     }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -470,13 +470,16 @@ function isMixedAlnumOtp(form: string): boolean {
 }
 
 /**
- * Code-shaped alnum form for the tier-3 `Codes:` line (F134): mixed
- * letter+digit, or shouted letter-only (`WXYZ`). Cue words the masking
- * path deliberately over-extracts (`Your`, `code`, title/lowercase words)
- * are not codes worth listing.
+ * Code-shaped alnum form (F134–F136): mixed letter+digit, or shouted
+ * letter-only with separators stripped (`WXYZ`, `A-B-C-D`). Cue words the
+ * masking path deliberately over-extracts (`Your`, `code`, title/lowercase
+ * words) are not codes — not listed at tier 3, and per F136 not an OTP
+ * classification signal either.
  */
 function isDisplayableAlnumCode(form: string): boolean {
-  return isMixedAlnumOtp(form) || /^[A-Z]{4,8}$/.test(form.normalize('NFKC'));
+  if (isMixedAlnumOtp(form)) return true;
+  const core = form.normalize('NFKC').split(META_ALNUM_SEP_ANY_RUN).join('');
+  return /^[A-Z]{4,8}$/.test(core);
 }
 
 /**
@@ -513,10 +516,27 @@ function isLetterOnlyDelimitedOtp(form: string): boolean {
   return parts.every((g) => /^[A-Z]{2,4}$/.test(g));
 }
 
-/** Mixed, continuous letter-only, or delimited letter-only form (F77/F95/F97). */
+/**
+ * Letter-only single-char chain OTP under a strong cue (F135): NFKC, split
+ * on any sep run, 4–8 groups of exactly 1 letter. All-caps only, mirroring
+ * the delimited letter-only scope (F97) — lowercase chains (`a b c d`) stay
+ * rejected so English prose is not over-masked.
+ */
+function isLetterOnlySingleChainOtp(form: string): boolean {
+  const parts = form
+    .normalize('NFKC')
+    .split(META_ALNUM_SEP_ANY_RUN)
+    .filter(Boolean);
+  return parts.length >= 4 && parts.length <= 8 && parts.every((g) => /^[A-Z]$/.test(g));
+}
+
+/** Mixed, letter-only continuous/delimited/single-chain form (F77/F95/F97/F135). */
 function isMetaAlnumOtpForm(form: string): boolean {
   return (
-    isMixedAlnumOtp(form) || isLetterOnlyOtp(form) || isLetterOnlyDelimitedOtp(form)
+    isMixedAlnumOtp(form) ||
+    isLetterOnlyOtp(form) ||
+    isLetterOnlyDelimitedOtp(form) ||
+    isLetterOnlySingleChainOtp(form)
   );
 }
 
@@ -536,7 +556,7 @@ function isPlausibleSpaceLetterRun(form: string): boolean {
 /**
  * Accept a tight single-char chain (F105): NFKC, split on any sep run, 4–8
  * groups of exactly 1 char. Mixed/letter acceptance happens in push() via
- * isMetaAlnumOtpForm — pure-digit and letter-only chains drop there.
+ * isMetaAlnumOtpForm — letter-only chains pass since F135; pure-digit drops.
  */
 function isPlausibleSingleChain(form: string): boolean {
   const parts = form
@@ -549,7 +569,7 @@ function isPlausibleSingleChain(form: string): boolean {
 /**
  * Accept a space single-char chain (F106): NFKC, split on space runs, 4–8
  * groups of exactly 1 char. Mixed/letter acceptance happens in push() via
- * isMetaAlnumOtpForm — pure-digit and letter-only chains drop there.
+ * isMetaAlnumOtpForm — letter-only chains pass since F135; pure-digit drops.
  */
 function isPlausibleSpaceSingleChain(form: string): boolean {
   const parts = form
@@ -1105,7 +1125,9 @@ export async function processWatchedMessage(
     // strongly cued form; `Codes:` display takes only code-shaped forms so
     // over-extracted cue words (`Your`, `code`) stay out of tier 3.
     const subjectAlnum = extractMetaAlnumCodes(extras.subject);
-    if (subjectAlnum.length > 0) hasOtpOrLink = true;
+    // F136: classify only on code-shaped candidates — `Error code has
+    // expired` over-extracts English words for masking but is not an OTP.
+    if (subjectAlnum.some(isDisplayableAlnumCode)) hasOtpOrLink = true;
     for (const code of subjectAlnum) {
       if (!isDisplayableAlnumCode(code)) continue;
       if (!extras.codes.includes(code)) extras.codes.push(code);

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -36,6 +36,11 @@ export const PUSH_OTP_ENTRY_CHARS = 200;
  * Measured as encoded bytes, not JS string length (CJK/emoji are multi-byte).
  */
 export const PUSH_MESSAGE_MAX_BYTES = 3500;
+/**
+ * Per-field UTF-8 byte cap for tier-2+ From/Subject lines so a huge subject
+ * cannot consume the whole message budget before Preview/Codes/Links.
+ */
+export const PUSH_META_FIELD_MAX_BYTES = 400;
 /** UTF-8 ellipsis used when the body is truncated to stay under the byte budget. */
 const PUSH_BODY_ELLIPSIS = '…';
 const PUSH_BODY_ELLIPSIS_BYTES = Buffer.byteLength(PUSH_BODY_ELLIPSIS, 'utf8');
@@ -102,24 +107,29 @@ export function boundPushOtpEntries(items: string[]): string[] {
 }
 
 /**
- * Enforce the total-body UTF-8 byte cap. Truncates on a code-point boundary
- * (never mid-surrogate or mid multi-byte sequence) and reserves room for `…`.
+ * Truncate `text` to at most `maxBytes` UTF-8 bytes on a code-point boundary
+ * (never mid-surrogate or mid multi-byte sequence), reserving room for `…`.
  */
-export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES): string {
-  if (Buffer.byteLength(body, 'utf8') <= maxBytes) return body;
+export function boundTextBytes(text: string, maxBytes: number): string {
+  if (Buffer.byteLength(text, 'utf8') <= maxBytes) return text;
   if (maxBytes < PUSH_BODY_ELLIPSIS_BYTES) return '';
   const budget = maxBytes - PUSH_BODY_ELLIPSIS_BYTES;
   if (budget <= 0) return PUSH_BODY_ELLIPSIS;
 
   let used = 0;
   let end = 0;
-  for (const point of body) {
+  for (const point of text) {
     const cost = Buffer.byteLength(point, 'utf8');
     if (used + cost > budget) break;
     used += cost;
     end += point.length;
   }
-  return `${body.slice(0, end)}${PUSH_BODY_ELLIPSIS}`;
+  return `${text.slice(0, end)}${PUSH_BODY_ELLIPSIS}`;
+}
+
+/** Enforce the total-body UTF-8 byte cap (final backstop after field caps). */
+export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES): string {
+  return boundTextBytes(body, maxBytes);
 }
 
 /** Build the human-facing push body for one identity's content tier. */
@@ -136,8 +146,13 @@ export function buildMailArrivalMessage(
   ];
 
   if (tier >= 2) {
-    if (extras.from) lines.push(`From: ${extras.from}`);
-    if (extras.subject) lines.push(`Subject: ${extras.subject}`);
+    // Cap From/Subject independently so OTP/preview content still fits.
+    if (extras.from) {
+      lines.push(`From: ${boundTextBytes(extras.from, PUSH_META_FIELD_MAX_BYTES)}`);
+    }
+    if (extras.subject) {
+      lines.push(`Subject: ${boundTextBytes(extras.subject, PUSH_META_FIELD_MAX_BYTES)}`);
+    }
   }
 
   if (tier >= 3) {

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -56,6 +56,12 @@ export type WatcherDispatch = {
 export type ProcessWatchedOptions = {
   /** When set, each mail-arrival push includes ntfy `click` = this URL. */
   clickUrl?: string;
+  /**
+   * Re-read identity tier immediately before each payload so a mid-flight
+   * admin downgrade is not applied against a stale listIdentities() snapshot.
+   * Undefined means keep the matched snapshot entry.
+   */
+  refreshIdentity?: (address: string) => Identity | undefined;
 };
 
 /** In-memory watermark survives a dropped IMAP connection in this process. */
@@ -132,19 +138,15 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
   return boundTextBytes(body, maxBytes);
 }
 
-/** Escape a needle for use as a single RegExp alternative. */
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
-
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
  * Links: normalize via validatedHttpUrl then replace original spelling
- * (maskNormalizedHttpUrls). Codes: one alternation regex replace (O(text)),
- * not per-needle includes+split which is O(codes × text) DoS.
+ * (maskNormalizedHttpUrls). Codes: scan text for \b\d{4,8}\b and replace when
+ * present in the code set (O(text) Set lookups — no multi-branch regex).
  *
- * Codes are longest \b\d{4,8}\b runs and do not overlap, so longest-first
- * alternation matches the same spans as sequential split/join.
+ * Codes from extractCodes are those same digit runs; scanning the text with
+ * the same shape and checking membership masks the same spans without
+ * compiling a needle-count alternation.
  */
 export function maskSensitiveFragments(
   text: string,
@@ -154,17 +156,9 @@ export function maskSensitiveFragments(
   if (!text) return text;
   // URLs first so a full verify link is one unit before digit-code scans.
   let result = maskNormalizedHttpUrls(text, links);
-  const seen = new Set<string>();
-  const codeNeedles: string[] = [];
-  for (const value of codes) {
-    if (!value || seen.has(value)) continue;
-    seen.add(value);
-    codeNeedles.push(value);
-  }
-  codeNeedles.sort((a, b) => b.length - a.length);
-  if (codeNeedles.length === 0) return result;
-  const pattern = codeNeedles.map(escapeRegExp).join('|');
-  return result.replace(new RegExp(pattern, 'g'), '•••');
+  const codeSet = new Set(codes.filter(Boolean));
+  if (codeSet.size === 0) return result;
+  return result.replace(/\b\d{4,8}\b/g, (run) => (codeSet.has(run) ? '•••' : run));
 }
 
 /** Build the human-facing push body for one identity's content tier. */
@@ -276,8 +270,11 @@ export async function processWatchedMessage(
 
   const clickUrl = options.clickUrl;
   for (const identity of matched) {
-    const tier = resolvePushContentTier(identity);
-    const body = buildMailArrivalMessage(identity.address, tier, hasOtpOrLink, extras);
+    // Re-read per identity after await simpleParser / previous publish so a
+    // concurrent tier downgrade is visible before the next payload is built.
+    const current = options.refreshIdentity?.(identity.address) ?? identity;
+    const tier = resolvePushContentTier(current);
+    const body = buildMailArrivalMessage(current.address, tier, hasOtpOrLink, extras);
     const level = hasOtpOrLink ? 'urgent' : 'normal';
     await dispatch.publish({
       target: 'user',
@@ -314,7 +311,11 @@ async function watchConnection(
             listIdentities(),
             config.ntfy.pushPolicy,
             dispatch,
-            { clickUrl: config.dashboardPublicUrl },
+            {
+              clickUrl: config.dashboardPublicUrl,
+              refreshIdentity: (address) =>
+                listIdentities().find((entry) => entry.address === address),
+            },
           );
           watermark.uid = Math.max(watermark.uid ?? 0, message.uid);
         }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -25,6 +25,16 @@ import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 const RECONNECT_MS = 3_000;
 /** Bounded plain-text preview length for tier-3 mail-arrival pushes. */
 export const PUSH_BODY_PREVIEW_CHARS = 280;
+/** Max OTP codes/links included in a tier-3 push (each list). */
+export const PUSH_OTP_ITEM_MAX = 5;
+/** Max characters per code/link entry before truncation. */
+export const PUSH_OTP_ENTRY_CHARS = 200;
+/**
+ * Hard cap on the full ntfy message body. ntfy rejects ~4096 bytes; leave
+ * headroom for title/tags/JSON framing so one oversized mail cannot make
+ * publish() throw and stall the UID watermark forever.
+ */
+export const PUSH_MESSAGE_MAX_CHARS = 3500;
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
 export type WatchedMessage = Pick<FetchMessageObject, 'envelope' | 'headers' | 'source'>;
@@ -79,6 +89,21 @@ function formatAddressList(
     .join(', ');
 }
 
+/** Cap list length and per-entry size for tier-3 OTP fields. */
+export function boundPushOtpEntries(items: string[]): string[] {
+  return items.slice(0, PUSH_OTP_ITEM_MAX).map((item) => {
+    if (item.length <= PUSH_OTP_ENTRY_CHARS) return item;
+    return `${item.slice(0, PUSH_OTP_ENTRY_CHARS)}…`;
+  });
+}
+
+/** Enforce the total-body cap, appending an ellipsis when truncated. */
+export function boundPushMessage(body: string): string {
+  if (body.length <= PUSH_MESSAGE_MAX_CHARS) return body;
+  if (PUSH_MESSAGE_MAX_CHARS <= 1) return '…';
+  return `${body.slice(0, PUSH_MESSAGE_MAX_CHARS - 1)}…`;
+}
+
 /** Build the human-facing push body for one identity's content tier. */
 export function buildMailArrivalMessage(
   address: string,
@@ -99,11 +124,13 @@ export function buildMailArrivalMessage(
 
   if (tier >= 3) {
     if (extras.preview) lines.push(`Preview: ${extras.preview}`);
-    if (extras.codes.length) lines.push(`Codes: ${extras.codes.join(', ')}`);
-    if (extras.links.length) lines.push(`Links:\n${extras.links.join('\n')}`);
+    const codes = boundPushOtpEntries(extras.codes);
+    const links = boundPushOtpEntries(extras.links);
+    if (codes.length) lines.push(`Codes: ${codes.join(', ')}`);
+    if (links.length) lines.push(`Links:\n${links.join('\n')}`);
   }
 
-  return lines.join('\n');
+  return boundPushMessage(lines.join('\n'));
 }
 
 /** Process one newly delivered message. Exported for policy/security tests. */

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -132,6 +132,27 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
   return boundTextBytes(body, maxBytes);
 }
 
+/**
+ * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
+ * Uses the same extractOtp results as policy matching — no second regex set.
+ */
+export function maskSensitiveFragments(
+  text: string,
+  codes: string[],
+  links: string[],
+): string {
+  if (!text) return text;
+  const needles = [...links, ...codes]
+    .filter((value) => value.length > 0)
+    .sort((a, b) => b.length - a.length);
+  let result = text;
+  for (const needle of needles) {
+    if (!result.includes(needle)) continue;
+    result = result.split(needle).join('•••');
+  }
+  return result;
+}
+
 /** Build the human-facing push body for one identity's content tier. */
 export function buildMailArrivalMessage(
   address: string,
@@ -147,11 +168,20 @@ export function buildMailArrivalMessage(
 
   if (tier >= 2) {
     // Cap From/Subject independently so OTP/preview content still fits.
-    if (extras.from) {
-      lines.push(`From: ${boundTextBytes(extras.from, PUSH_META_FIELD_MAX_BYTES)}`);
+    // Tier 2 must not leak OTP/link strings that sit in the subject line.
+    const from =
+      tier < 3
+        ? maskSensitiveFragments(extras.from, extras.codes, extras.links)
+        : extras.from;
+    const subject =
+      tier < 3
+        ? maskSensitiveFragments(extras.subject, extras.codes, extras.links)
+        : extras.subject;
+    if (from) {
+      lines.push(`From: ${boundTextBytes(from, PUSH_META_FIELD_MAX_BYTES)}`);
     }
-    if (extras.subject) {
-      lines.push(`Subject: ${boundTextBytes(extras.subject, PUSH_META_FIELD_MAX_BYTES)}`);
+    if (subject) {
+      lines.push(`Subject: ${boundTextBytes(subject, PUSH_META_FIELD_MAX_BYTES)}`);
     }
   }
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -305,8 +305,11 @@ const META_ALNUM_GROUP = `[${META_ALNUM_CHAR}]{2,4}`;
  * `code is ABC-123` cannot glue via space-only gaps.
  * F112: slash (ASCII + fullwidth) joins the tight class — `A1/B2` metadata
  * codes bypassed every matcher; URLs are unaffected (link-masked first).
+ * F121: nonbreaking hyphen U+2011 and its NFKC form U+2010 join too —
+ * `AB‑12` (U+2011) published unmasked; NFKC maps U+2011 → U+2010, so the
+ * compatibility pass only recovers it when both are in the class.
  */
-const META_ALNUM_SEP_TIGHT = '[-–—./\uFF0D\uFF0E\uFF0F]';
+const META_ALNUM_SEP_TIGHT = '[-–—./\u2010\u2011\uFF0D\uFF0E\uFF0F]';
 const META_ALNUM_SEP_SPACE =
   '[\\t \\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000\\uFEFF]';
 const T = META_ALNUM_SEP_TIGHT;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -342,6 +342,9 @@ export async function processWatchedMessage(
           message: body,
           level,
           tags: ['email'],
+          // Truncate rather than throw: publish errors before UID advance stall
+          // the watcher (F76). Manual /v1/notify keeps the default overflow=error.
+          overflow: 'truncate',
           ...(clickUrl ? { click: clickUrl } : {}),
           ...(beforeSend ? { beforeSend } : {}),
         });

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -205,14 +205,64 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 }
 
 /**
- * Alphanumeric OTP shape for tier-2 *metadata only* (F77/F81): 4–8 ASCII alnum
- * with at least one letter and one digit (aligned with digit-code min length 4).
- * Bounds exclude adjacent alnum so CJK-glued `验证码是A1B2C3` still matches.
+ * Continuous alnum OTP for tier-2 *metadata only* (F77/F81): 4–8 ASCII alnum
+ * with at least one letter and one digit. Bounds exclude adjacent alnum so
+ * CJK-glued `验证码是A1B2C3` still matches.
  */
 const META_ALNUM_OTP_RE = /(?<![A-Za-z0-9])([A-Za-z0-9]{4,8})(?![A-Za-z0-9])/g;
 
+/**
+ * Delimited mixed alnum OTP (F84): 2–4 groups of 2–4 ASCII alnum.
+ *
+ * Non-whitespace seps (hyphen/dash/dot/fullwidth) allow 2–4 groups with F74-style
+ * mid-chain lead/tail guards. Whitespace seps only allow **exactly two** groups
+ * so English words (`is ABC-123`) cannot glue into a false 3-group form when
+ * space is both a word break and an OTP separator.
+ *
+ * Pure-digit forms are left to the digit delimited path (≥1 letter + ≥1 digit).
+ */
+const META_ALNUM_GROUP = '[A-Za-z0-9]{2,4}';
+/**
+ * Split of otp.ts DELIMITED_OTP_SEP_CLASS: non-whitespace vs whitespace.
+ * Whitespace is restricted to exactly-two-group forms (see above).
+ */
+const META_ALNUM_SEP_TIGHT = '[-–—.\uFF0D\uFF0E]';
+const META_ALNUM_SEP_SPACE =
+  '[\\t \\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000\\uFEFF]';
+// 2–4 groups with tight seps; lead blocks mid-chain after alnum+tight-sep.
+const META_ALNUM_DELIMITED_TIGHT = new RegExp(
+  `(?<![A-Za-z0-9]${META_ALNUM_SEP_TIGHT})(?<![A-Za-z0-9])` +
+    `(${META_ALNUM_GROUP}(?:${META_ALNUM_SEP_TIGHT}${META_ALNUM_GROUP}){1,3})` +
+    `(?!${META_ALNUM_SEP_TIGHT}[A-Za-z0-9])(?![A-Za-z0-9])`,
+  'g',
+);
+// Exactly two groups with a whitespace sep (e.g. `ABC 123`).
+const META_ALNUM_DELIMITED_SPACE = new RegExp(
+  `(?<![A-Za-z0-9])` +
+    `(${META_ALNUM_GROUP}${META_ALNUM_SEP_SPACE}${META_ALNUM_GROUP})` +
+    `(?!${META_ALNUM_SEP_SPACE}[A-Za-z0-9])(?![A-Za-z0-9])`,
+  'g',
+);
+
 function isMixedAlnumOtp(form: string): boolean {
   return /[A-Za-z]/.test(form) && /[0-9]/.test(form);
+}
+
+/**
+ * Space-separated forms only: reject English glue like `is 123` / `is A1B2`
+ * (1–2 letter pure-letter group) and year-ish pure digits (`Mar 2026`, F65).
+ * Real OTPs use ≥3 letter blocks (`ABC 123`) or a mixed group on either side.
+ */
+function isPlausibleSpaceDelimitedAlnum(form: string): boolean {
+  if (!isMixedAlnumOtp(form)) return false;
+  const parts = form.split(new RegExp(META_ALNUM_SEP_SPACE));
+  if (parts.length !== 2) return false;
+  for (const g of parts) {
+    if (/^[A-Za-z]{1,2}$/.test(g)) return false;
+    // Year-shaped pure digits next to a letter block are not alnum OTPs.
+    if (/^(19|20)\d{2}$/.test(g)) return false;
+  }
+  return true;
 }
 
 function escapeRegExpLiteral(s: string): string {
@@ -220,25 +270,36 @@ function escapeRegExpLiteral(s: string): string {
 }
 
 /**
- * Collect alnum OTPs from from/subject when a strong cue is present (F77/F81).
- * Does not touch body extractCodes / extractOtp semantics.
+ * Collect alnum OTPs from from/subject when a strong cue is present
+ * (F77/F81 continuous + F84 delimited). Does not touch body extract semantics.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
   const codes: string[] = [];
   const seen = new Set<string>();
-  for (const match of metaText.matchAll(META_ALNUM_OTP_RE)) {
-    const form = match[1]!;
-    if (!isMixedAlnumOtp(form) || seen.has(form)) continue;
+  const push = (form: string) => {
+    if (!isMixedAlnumOtp(form) || seen.has(form)) return;
     seen.add(form);
     codes.push(form);
+  };
+  for (const match of metaText.matchAll(META_ALNUM_OTP_RE)) {
+    push(match[1]!);
+  }
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT)) {
+    push(match[1]!);
+  }
+  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceDelimitedAlnum(form)) continue;
+    push(form);
   }
   return codes;
 }
 
 /**
  * One global regex that masks every exact alnum form in a single left-to-right
- * pass (F83). Forms are length-desc so longer spellings win at each position.
+ * pass (F83/F84). Forms are length-desc so longer spellings win at each
+ * position. Separators in forms (e.g. `ABC-123`) are escaped as literals.
  * Empty input → null (caller skips). Exported for structural unit tests.
  */
 export function buildAlnumMaskRe(forms: string[]): RegExp | null {
@@ -253,6 +314,8 @@ export function buildAlnumMaskRe(forms: string[]): RegExp | null {
   }
   if (ordered.length === 0) return null;
   const alt = ordered.map(escapeRegExpLiteral).join('|');
+  // Bounds are ASCII-alnum only so forms containing hyphens/spaces still match
+  // when adjacent to punctuation or CJK (not glued to a longer alnum run).
   return new RegExp(`(?<![A-Za-z0-9])(?:${alt})(?![A-Za-z0-9])`, 'g');
 }
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -512,11 +512,102 @@ function escapeRegExpLiteral(s: string): string {
 }
 
 /**
+ * NFKC-normalize per code point, remembering for every normalized UTF-16 unit
+ * the source-unit offset it came from (F113). Per-code-point normalization is
+ * deliberate: the map only needs to be self-consistent for span recovery.
+ */
+function nfkcWithSourceMap(text: string): { normalized: string; map: number[] } {
+  const parts: string[] = [];
+  const map: number[] = [];
+  let unit = 0;
+  for (const ch of text) {
+    const norm = ch.normalize('NFKC');
+    parts.push(norm);
+    for (let k = 0; k < norm.length; k++) map.push(unit);
+    unit += ch.length;
+  }
+  return { normalized: parts.join(''), map };
+}
+
+/**
+ * Run every metadata alnum matcher on `text` and report each accepted form
+ * with its span in the scanned text. Every matcher wraps its single capture
+ * in zero-width lookarounds, so the match start is the form start.
+ */
+function collectMetaAlnumForms(
+  text: string,
+  report: (form: string, start: number, end: number) => void,
+): void {
+  const emit = (match: RegExpMatchArray) => {
+    const form = match[1]!;
+    const start = (match.index ?? 0) + match[0]!.indexOf(form);
+    report(form, start, start + form.length);
+  };
+  // Space digit-bearing runs first: whole-chain consume, then 2–4 accept / 5+ drop.
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_SPACE_DIGIT)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceDigitRun(form)) continue;
+    emit(match);
+  }
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_SPACE_CLASSIC)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceClassic(form)) continue;
+    emit(match);
+  }
+  // F97: space letter-only runs (`WX YZ`); 2–4 groups after full-run consume.
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_SPACE_LETTER)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceLetterRun(form)) continue;
+    emit(match);
+  }
+  for (const match of text.matchAll(META_ALNUM_OTP_RE)) {
+    emit(match);
+  }
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_TIGHT)) {
+    const form = match[1]!;
+    // Year-shaped pure-digit groups (Mar - 2026) — privacy-safe to skip (F87 nit).
+    const groups = form
+      .split(new RegExp(`${META_ALNUM_SEP_RUN_WITH_TIGHT}`))
+      .map((g) => g.trim())
+      .filter(Boolean);
+    if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
+    emit(match);
+  }
+  // F105: tight single-char chains (`A-1-B-2`); mixed passes push(), pure-digit
+  // and letter-only chains drop at the predicate.
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_TIGHT_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleSingleChain(form)) continue;
+    emit(match);
+  }
+  // F106: space single-char chains (`A 1 B 2`); same predicate split as F105.
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_SPACE_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleSpaceSingleChain(form)) continue;
+    emit(match);
+  }
+  // F109: mixed-separator single-char chains (`A 1-B 2`); same predicate as
+  // F105 — overlaps with the tight/space matchers dedupe in push().
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_MIXED_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleSingleChain(form)) continue;
+    emit(match);
+  }
+}
+
+/**
  * Collect alnum OTPs from from/subject when a strong cue is present
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
  * F95 letter-only continuous + F97 letter-only delimited + F105 tight
  * single-char chains + F106 space single-char chains + F109 mixed-separator
- * single-char chains). Does not touch body extract semantics.
+ * single-char chains + F113 compatibility forms). Does not touch body
+ * extract semantics.
+ *
+ * F113: compatibility characters beyond the fullwidth ranges (Ⓐ①Ⓑ②, 𝐀𝟏𝐁𝟐)
+ * normalize to valid codes but never matched the classes above. When NFKC
+ * changes the text, the same matchers run once more on the normalized string
+ * and each hit is mapped back to its original span so masking keeps the
+ * source spelling.
  */
 export function extractMetaAlnumCodes(metaText: string): string[] {
   if (!metaText || !hasStrongOtpCue(metaText)) return [];
@@ -527,55 +618,14 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
     seen.add(form);
     codes.push(form);
   };
-  // Space digit-bearing runs first: whole-chain consume, then 2–4 accept / 5+ drop.
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_DIGIT)) {
-    const form = match[1]!;
-    if (!isPlausibleSpaceDigitRun(form)) continue;
-    push(form);
-  }
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_CLASSIC)) {
-    const form = match[1]!;
-    if (!isPlausibleSpaceClassic(form)) continue;
-    push(form);
-  }
-  // F97: space letter-only runs (`WX YZ`); 2–4 groups after full-run consume.
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_LETTER)) {
-    const form = match[1]!;
-    if (!isPlausibleSpaceLetterRun(form)) continue;
-    push(form);
-  }
-  for (const match of metaText.matchAll(META_ALNUM_OTP_RE)) {
-    push(match[1]!);
-  }
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT)) {
-    const form = match[1]!;
-    // Year-shaped pure-digit groups (Mar - 2026) — privacy-safe to skip (F87 nit).
-    const groups = form
-      .split(new RegExp(`${META_ALNUM_SEP_RUN_WITH_TIGHT}`))
-      .map((g) => g.trim())
-      .filter(Boolean);
-    if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
-    push(form);
-  }
-  // F105: tight single-char chains (`A-1-B-2`); mixed passes push(), pure-digit
-  // and letter-only chains drop at the predicate.
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT_SINGLE)) {
-    const form = match[1]!;
-    if (!isPlausibleSingleChain(form)) continue;
-    push(form);
-  }
-  // F106: space single-char chains (`A 1 B 2`); same predicate split as F105.
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_SPACE_SINGLE)) {
-    const form = match[1]!;
-    if (!isPlausibleSpaceSingleChain(form)) continue;
-    push(form);
-  }
-  // F109: mixed-separator single-char chains (`A 1-B 2`); same predicate as
-  // F105 — overlaps with the tight/space matchers dedupe in push().
-  for (const match of metaText.matchAll(META_ALNUM_DELIMITED_MIXED_SINGLE)) {
-    const form = match[1]!;
-    if (!isPlausibleSingleChain(form)) continue;
-    push(form);
+  collectMetaAlnumForms(metaText, (form) => push(form));
+  const { normalized, map } = nfkcWithSourceMap(metaText);
+  if (normalized !== metaText) {
+    collectMetaAlnumForms(normalized, (_form, start, end) => {
+      const sourceStart = map[start]!;
+      const sourceEnd = end < normalized.length ? map[end]! : metaText.length;
+      if (sourceEnd > sourceStart) push(metaText.slice(sourceStart, sourceEnd));
+    });
   }
   return codes;
 }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -344,30 +344,54 @@ const META_ALNUM_DELIMITED_TIGHT_SINGLE = new RegExp(
   'g',
 );
 /**
- * Colon-delimited codes (F117): `AB:12:CD`. Colon (ASCII + fullwidth) stays
- * OUT of the tight class — there it would glue `x:ABC-123` into mid-chain
- * blocks and URLs/versions into unrelated matchers. These two bounded forms
- * mirror the tight pair: 2–4 groups of 2–4, and 4–8 single-char chains.
- * Pure-digit joins (12:30) and letter-only joins drop at the push() predicate;
- * http(s) URLs are link-masked before the alnum pass.
+ * Bounded single-separator delimited pair (F117 colon, F124 underscore):
+ * 2–4 groups of 2–4 alnum, and 4–8 single-char chains, joined by ONE sep
+ * each. The separator stays OUT of the tight class on purpose:
+ * - colon would glue `x:ABC-123` into mid-chain blocks and URLs/versions into
+ *   unrelated matchers;
+ * - underscore is a word char — snake_case tokens (`otp_code`) would glue.
+ * Pure-digit joins (12:30) and letter-only joins (snake_case words) drop at
+ * the push() predicate; http(s) URLs are link-masked before the alnum pass.
  */
+function boundedDelimitedMatchers(sepClass: string): { multi: RegExp; single: RegExp } {
+  /** Lead: not immediately after `alnum<sep>` (blocks mid-chain restarts). */
+  const lead = `(?<![${META_ALNUM_CHAR}]${sepClass})`;
+  return {
+    multi: new RegExp(
+      `${lead}${META_ALNUM_BOUND_LEFT}` +
+        `(${META_ALNUM_GROUP}(?:${sepClass}${META_ALNUM_GROUP}){1,3})` +
+        `(?!${sepClass}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
+      'g',
+    ),
+    single: new RegExp(
+      `${lead}${META_ALNUM_BOUND_LEFT}` +
+        `([${META_ALNUM_CHAR}](?:${sepClass}[${META_ALNUM_CHAR}]){3,7})` +
+        `(?!${sepClass}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
+      'g',
+    ),
+  };
+}
+
+/** Single-chain acceptance for one separator class: NFKC, split on sep runs,
+ * 4–8 groups of exactly 1 char. Mixed/letter acceptance happens in push() via
+ * isMetaAlnumOtpForm — pure-digit and letter-only chains drop there.
+ */
+function singleChainPredicate(sepClass: string): (form: string) => boolean {
+  const splitRe = new RegExp(`${sepClass}+`);
+  return (form) => {
+    const parts = form.normalize('NFKC').split(splitRe).filter(Boolean);
+    return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
+  };
+}
+
+/** F117: `AB:12:CD`, `A:1:B:2` (ASCII + fullwidth colon). */
 const META_ALNUM_SEP_COLON = '[:：]';
-/** Lead: not immediately after `alnum:` (blocks mid-chain restarts). */
-const META_ALNUM_LEAD_COLON = `(?<![${META_ALNUM_CHAR}]${META_ALNUM_SEP_COLON})`;
-// 2–4 groups of 2–4 alnum joined by single colons.
-const META_ALNUM_DELIMITED_COLON = new RegExp(
-  `${META_ALNUM_LEAD_COLON}${META_ALNUM_BOUND_LEFT}` +
-    `(${META_ALNUM_GROUP}(?:${META_ALNUM_SEP_COLON}${META_ALNUM_GROUP}){1,3})` +
-    `(?!${META_ALNUM_SEP_COLON}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
-  'g',
-);
-// 4–8 groups of exactly 1 alnum joined by single colons (`A:1:B:2`).
-const META_ALNUM_DELIMITED_COLON_SINGLE = new RegExp(
-  `${META_ALNUM_LEAD_COLON}${META_ALNUM_BOUND_LEFT}` +
-    `([${META_ALNUM_CHAR}](?:${META_ALNUM_SEP_COLON}[${META_ALNUM_CHAR}]){3,7})` +
-    `(?!${META_ALNUM_SEP_COLON}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
-  'g',
-);
+const META_ALNUM_DELIMITED_COLON_PAIR = boundedDelimitedMatchers(META_ALNUM_SEP_COLON);
+const isPlausibleColonSingleChain = singleChainPredicate(META_ALNUM_SEP_COLON);
+/** F124: `AB_12`, `A_1_B_2` (ASCII + fullwidth underscore). */
+const META_ALNUM_SEP_UNDER = '[_＿]';
+const META_ALNUM_DELIMITED_UNDER_PAIR = boundedDelimitedMatchers(META_ALNUM_SEP_UNDER);
+const isPlausibleUnderSingleChain = singleChainPredicate(META_ALNUM_SEP_UNDER);
 /**
  * 2–4 alnum chars that include a digit after NFKC (lookahead fixes length).
  * Used for space runs so pure-letter English tokens are not groups.
@@ -525,18 +549,6 @@ function isPlausibleSpaceSingleChain(form: string): boolean {
   return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
 }
 
-/**
- * Accept a colon single-char chain (F117): NFKC, split on colon runs, 4–8
- * groups of exactly 1 char. Same push() predicate split as F105.
- */
-function isPlausibleColonSingleChain(form: string): boolean {
-  const parts = form
-    .normalize('NFKC')
-    .split(new RegExp(`${META_ALNUM_SEP_COLON}+`))
-    .filter(Boolean);
-  return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
-}
-
 /** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
 function isPlausibleSpaceDigitRun(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
@@ -648,20 +660,24 @@ function collectMetaAlnumForms(
     if (!isPlausibleSingleChain(form)) continue;
     emit(match);
   }
-  // F117: colon-delimited forms (`AB:12:CD`, `A:1:B:2`) — bounded matchers,
-  // colon never joins the tight class.
-  for (const match of text.matchAll(META_ALNUM_DELIMITED_COLON)) {
-    const form = match[1]!;
-    const groups = form
-      .split(new RegExp(`${META_ALNUM_SEP_COLON}+`))
-      .filter(Boolean);
-    if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
-    emit(match);
-  }
-  for (const match of text.matchAll(META_ALNUM_DELIMITED_COLON_SINGLE)) {
-    const form = match[1]!;
-    if (!isPlausibleColonSingleChain(form)) continue;
-    emit(match);
+  // F117/F124: colon- and underscore-delimited forms (`AB:12:CD`, `AB_12` and
+  // single-char chains) — bounded matcher pairs, neither separator joins the
+  // tight class.
+  for (const pair of [
+    { sep: META_ALNUM_SEP_COLON, matchers: META_ALNUM_DELIMITED_COLON_PAIR, plausible: isPlausibleColonSingleChain },
+    { sep: META_ALNUM_SEP_UNDER, matchers: META_ALNUM_DELIMITED_UNDER_PAIR, plausible: isPlausibleUnderSingleChain },
+  ]) {
+    for (const match of text.matchAll(pair.matchers.multi)) {
+      const form = match[1]!;
+      const groups = form.split(new RegExp(`${pair.sep}+`)).filter(Boolean);
+      if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
+      emit(match);
+    }
+    for (const match of text.matchAll(pair.matchers.single)) {
+      const form = match[1]!;
+      if (!pair.plausible(form)) continue;
+      emit(match);
+    }
   }
 }
 
@@ -670,8 +686,8 @@ function collectMetaAlnumForms(
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
  * F95 letter-only continuous + F97 letter-only delimited + F105 tight
  * single-char chains + F106 space single-char chains + F109 mixed-separator
- * single-char chains + F113 compatibility forms + F117 colon-delimited
- * forms). Does not touch body extract semantics.
+ * single-char chains + F113 compatibility forms + F117 colon-delimited +
+ * F124 underscore-delimited forms). Does not touch body extract semantics.
  *
  * F113: compatibility characters beyond the fullwidth ranges (Ⓐ①Ⓑ②, 𝐀𝟏𝐁𝟐)
  * normalize to valid codes but never matched the classes above. When NFKC

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -470,6 +470,16 @@ function isMixedAlnumOtp(form: string): boolean {
 }
 
 /**
+ * Code-shaped alnum form for the tier-3 `Codes:` line (F134): mixed
+ * letter+digit, or shouted letter-only (`WXYZ`). Cue words the masking
+ * path deliberately over-extracts (`Your`, `code`, title/lowercase words)
+ * are not codes worth listing.
+ */
+function isDisplayableAlnumCode(form: string): boolean {
+  return isMixedAlnumOtp(form) || /^[A-Z]{4,8}$/.test(form.normalize('NFKC'));
+}
+
+/**
  * Letter-only continuous OTP for tier-2 metadata under a strong cue (F95/F101).
  * NFKC then `/^[A-Za-z]{4,8}$/` — case-insensitive continuous tokens so
  * lowercase/title-case codes (`abcd`, `Abcd`) mask like shouted `ABCD`.
@@ -1087,6 +1097,18 @@ export async function processWatchedMessage(
     }
     for (const link of subjectOtp.links) {
       if (!extras.links.includes(link)) extras.links.push(link);
+    }
+    // F134: strongly cued alphanumeric subject codes classify too — the
+    // tier-2 mask path (extractMetaAlnumCodes) already recognizes `A1B2`,
+    // but numeric-only extractOtp misses it, and the default `otp` policy
+    // would silently drop the notification. Classification takes every
+    // strongly cued form; `Codes:` display takes only code-shaped forms so
+    // over-extracted cue words (`Your`, `code`) stay out of tier 3.
+    const subjectAlnum = extractMetaAlnumCodes(extras.subject);
+    if (subjectAlnum.length > 0) hasOtpOrLink = true;
+    for (const code of subjectAlnum) {
+      if (!isDisplayableAlnumCode(code)) continue;
+      if (!extras.codes.includes(code)) extras.codes.push(code);
     }
   }
   if (policy === 'otp' && !hasOtpOrLink) return;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -530,6 +530,59 @@ export type BuildMailArrivalOptions = {
   clickUrl?: string;
 };
 
+/** How many input links were omitted from a packPushLinkLines result. */
+function countDroppedPackedLinks(links: string[], linkLines: string[]): number {
+  if (links.length === 0) return 0;
+  let kept = 0;
+  for (const line of linkLines) {
+    if (!line.startsWith('Links:\n')) continue;
+    for (const part of line.slice('Links:\n'.length).split('\n')) {
+      // Note-only block is `Links:\n(+N more…)` — not a kept URL.
+      if (part && !part.startsWith('(+')) kept += 1;
+    }
+  }
+  return Math.max(0, links.length - kept);
+}
+
+/**
+ * Pack tier-3 body under one escaped-byte budget (F88 order: links first,
+ * preview eats remainder). Returns the body plus how many links were evicted.
+ */
+function packTier3ArrivalBody(
+  head: string,
+  codesLine: string,
+  previewSource: string,
+  links: string[],
+  maxEscaped: number,
+): { body: string; droppedLinks: number } {
+  const baseNoPreview = head + (codesLine ? `\n${codesLine}` : '');
+  const linkLines = packPushLinkLines(baseNoPreview, links, maxEscaped);
+  const withLinks =
+    linkLines.length > 0 ? `${baseNoPreview}\n${linkLines.join('\n')}` : baseNoPreview;
+
+  let previewLine = '';
+  if (previewSource) {
+    const roomForPreview =
+      maxEscaped -
+      jsonEscapedByteLength(withLinks) -
+      jsonEscapedByteLength('\nPreview: ');
+    if (roomForPreview > 0) {
+      const trimmed = boundPreviewByEscapedBytes(previewSource, roomForPreview);
+      if (trimmed) previewLine = `Preview: ${trimmed}`;
+    }
+  }
+
+  // Assembly: title/From/Subject → Preview → Codes → Links.
+  const parts = [head];
+  if (previewLine) parts.push(previewLine);
+  if (codesLine) parts.push(codesLine);
+  if (linkLines.length > 0) parts.push(...linkLines);
+  return {
+    body: parts.join('\n'),
+    droppedLinks: countDroppedPackedLinks(links, linkLines),
+  };
+}
+
 /** Build the human-facing push body for one identity's content tier. */
 export function buildMailArrivalMessage(
   address: string,
@@ -542,14 +595,24 @@ export function buildMailArrivalMessage(
   // Pack under the JSON-escaped message budget so full links survive publish()
   // serialization (F88). Conservative max topic length matches ntfy cap.
   const level = hasOtpOrLink ? 'urgent' : 'normal';
-  const availableEscaped = notifyAvailableMessageBytes({
+  const frameBase = {
     title: 'openagent.email new mail',
-    level,
+    level: level as 'urgent' | 'normal',
     tags: ['email'],
+  };
+  const availableWithClick = notifyAvailableMessageBytes({
+    ...frameBase,
     click: options.clickUrl,
   });
-  // Also respect local raw-byte headroom (historical PUSH_MESSAGE_MAX_BYTES).
-  const maxEscaped = Math.min(availableEscaped, PUSH_MESSAGE_MAX_BYTES);
+  const availableNoClick = notifyAvailableMessageBytes(frameBase);
+  // F93 dual budgets for tier-3 packing: ntfy residual with/without click.
+  // Both sides use the same residual source (notifyAvailableMessageBytes); we
+  // deliberately do **not** min with historical PUSH_MESSAGE_MAX_BYTES (3500)
+  // here — that undercut a larger no-click residual (~3846) and evicted links
+  // that publish()'s click-drop could still deliver. Tier 1–2 still use the
+  // historical raw-byte cap below.
+  const maxWithClick = availableWithClick;
+  const maxNoClick = availableNoClick;
 
   const lines: string[] = [
     hasOtpOrLink
@@ -576,39 +639,41 @@ export function buildMailArrivalMessage(
   if (tier >= 3) {
     const codes = boundPushOtpEntries(extras.codes);
     const codesLine = codes.length ? `Codes: ${codes.join(', ')}` : '';
-    // F88: pack full links against base WITHOUT preview first; preview eats the
-    // remainder. Putting a full Preview into the pack base first made the
-    // "shrink preview to keep links" path dead — body stayed under budget after
-    // packPushLinkLines dropped links for the oversized preview.
     const head = lines.join('\n');
-    const baseNoPreview = head + (codesLine ? `\n${codesLine}` : '');
-    const linkLines = packPushLinkLines(baseNoPreview, extras.links, maxEscaped);
-    const withLinks =
-      linkLines.length > 0 ? `${baseNoPreview}\n${linkLines.join('\n')}` : baseNoPreview;
-
-    let previewLine = '';
-    if (extras.preview) {
-      const roomForPreview =
-        maxEscaped -
-        jsonEscapedByteLength(withLinks) -
-        jsonEscapedByteLength('\nPreview: ');
-      if (roomForPreview > 0) {
-        const trimmed = boundPreviewByEscapedBytes(extras.preview, roomForPreview);
-        if (trimmed) previewLine = `Preview: ${trimmed}`;
+    // Prefer with-click packing so click survives when everything fits (F93).
+    const packedWith = packTier3ArrivalBody(
+      head,
+      codesLine,
+      extras.preview,
+      extras.links,
+      maxWithClick,
+    );
+    if (
+      options.clickUrl &&
+      packedWith.droppedLinks > 0 &&
+      maxNoClick > maxWithClick
+    ) {
+      const packedNo = packTier3ArrivalBody(
+        head,
+        codesLine,
+        extras.preview,
+        extras.links,
+        maxNoClick,
+      );
+      // Prefer fewer link evictions; publish() click-drop (F76) delivers the
+      // larger body. Equal eviction → keep with-click packing (click survives).
+      if (packedNo.droppedLinks < packedWith.droppedLinks) {
+        return packedNo.body;
       }
     }
-
-    // Assembly order unchanged: title/From/Subject → Preview → Codes → Links.
-    // Escaped length is additive over segments, so reordering vs withLinks is safe.
-    const parts = [head];
-    if (previewLine) parts.push(previewLine);
-    if (codesLine) parts.push(codesLine);
-    if (linkLines.length > 0) parts.push(...linkLines);
-    return parts.join('\n');
+    return packedWith.body;
   }
 
   // Tier 1–2: raw byte bound is fine (no long verify links).
-  return boundPushMessage(lines.join('\n'), Math.min(PUSH_MESSAGE_MAX_BYTES, maxEscaped));
+  return boundPushMessage(
+    lines.join('\n'),
+    Math.min(PUSH_MESSAGE_MAX_BYTES, maxWithClick),
+  );
 }
 
 /** Process one newly delivered message. Exported for policy/security tests. */

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -34,6 +34,7 @@ import {
   htmlToText,
   maskNormalizedHttpUrls,
   otpCodeRunRe,
+  STRONG_OTP_CUES,
 } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
@@ -477,6 +478,11 @@ function isMixedAlnumOtp(form: string): boolean {
  * classification signal either.
  */
 function isDisplayableAlnumCode(form: string): boolean {
+  // A shouted cue word (`CODE`, `OTP`) labeling a real code is not itself
+  // a code — listing/waking on it is noise.
+  if ((STRONG_OTP_CUES as readonly string[]).includes(form.normalize('NFKC').toLowerCase())) {
+    return false;
+  }
   if (isMixedAlnumOtp(form)) return true;
   const core = form.normalize('NFKC').split(META_ALNUM_SEP_ANY_RUN).join('');
   return /^[A-Z]{4,8}$/.test(core);
@@ -880,7 +886,12 @@ export function maskTier2Metadata(
   // letter-only OTPs under F101 case-insensitive continuous matching.
   const maskCodes = [
     ...metaOtp.codes,
-    ...extras.codes.filter((code) => metaCanonRuns.has(canonicalDigits(code))),
+    // F138: code-shaped alnum extras enter by exact/normalized form too —
+    // `Reference A1B2` has no cue and no digit run, so the digit-canon
+    // filter alone published the repeated body code unchanged.
+    ...extras.codes.filter(
+      (code) => metaCanonRuns.has(canonicalDigits(code)) || isMetaAlnumOtpForm(code),
+    ),
     ...extractMetaAlnumCodes(subject),
     ...extractMetaAlnumCodes(from),
     ...(strongMetaCue ? metaDigitSurfaces : []),
@@ -1056,6 +1067,68 @@ export function buildMailArrivalMessage(
   return boundPushMessage(body, withClickCap);
 }
 
+/** ASCII lowercase letter → fullwidth twin for cue-window surfaces (F139). */
+function toFullwidthLatin(s: string): string {
+  return s.replace(/[a-z]/g, (ch) => String.fromCodePoint(0xff41 + ch.codePointAt(0)! - 0x61));
+}
+
+/**
+ * Body window around one strong cue for alnum extraction (F139): 160
+ * code points each side covers cue-before/code-after phrasing with margin.
+ */
+const ALNUM_BODY_CUE_WINDOW = 160;
+
+/**
+ * Cue alternation for locating body windows on the ORIGINAL text (F139).
+ * Latin cues case-insensitive with word bounds; CJK cues and fullwidth-
+ * Latin spellings as substrings (hasStrongOtpCue reaches fullwidth forms
+ * through NFKC, which window finding cannot run without index drift).
+ */
+const BODY_CUE_WINDOW_SOURCE = ((): string => {
+  const latin: string[] = [];
+  const other: string[] = [];
+  for (const cue of STRONG_OTP_CUES) {
+    if (/^[a-z]+(?:-[a-z]+)*$/.test(cue)) {
+      latin.push(escapeRegExpLiteral(cue));
+      other.push(escapeRegExpLiteral(toFullwidthLatin(cue)));
+    } else {
+      other.push(escapeRegExpLiteral(cue));
+    }
+  }
+  return `\\b(?:${latin.join('|')})\\b|${other.join('|')}`;
+})();
+
+/**
+ * Bounded body windows around strong OTP cues (F139): alnum extraction
+ * runs per window, never over the whole untrusted body — one cue inside a
+ * multi-MB message must not turn every full-string regex/NFKC pass into a
+ * seconds-long stall while the single watcher awaits each message, and a
+ * shouted word far from any cue is not an OTP signal. Overlapping windows
+ * merge; a fresh regex instance per call keeps scans concurrency-safe.
+ */
+function bodyAlnumCueWindows(text: string): string[] {
+  const windows: string[] = [];
+  const re = new RegExp(BODY_CUE_WINDOW_SOURCE, 'giu');
+  let start = -1;
+  let end = -1;
+  for (const m of text.matchAll(re)) {
+    const wStart = Math.max(0, (m.index ?? 0) - ALNUM_BODY_CUE_WINDOW);
+    const wEnd = Math.min(text.length, (m.index ?? 0) + m[0].length + ALNUM_BODY_CUE_WINDOW);
+    if (start === -1) {
+      start = wStart;
+      end = wEnd;
+    } else if (wStart <= end) {
+      end = Math.max(end, wEnd);
+    } else {
+      windows.push(text.slice(start, end));
+      start = wStart;
+      end = wEnd;
+    }
+  }
+  if (start !== -1) windows.push(text.slice(start, end));
+  return windows;
+}
+
 /** Process one newly delivered message. Exported for policy/security tests. */
 export async function processWatchedMessage(
   message: WatchedMessage,
@@ -1097,14 +1170,14 @@ export async function processWatchedMessage(
       extras.links = otp.links;
       // F137: strongly cued alphanumeric BODY codes classify too (the
       // subject path F134/F136 covered only metadata). Same code-shaped
-      // filter; the global cue gate may over-classify prose that mentions
-      // a cue near a shouted word — a safe extra alert next to a missed
-      // credential. Bodies never publish at tier ≤2, so no masking path.
-      const bodyAlnum = extractMetaAlnumCodes(text);
-      if (bodyAlnum.some(isDisplayableAlnumCode)) hasOtpOrLink = true;
-      for (const code of bodyAlnum) {
-        if (!isDisplayableAlnumCode(code)) continue;
-        if (!extras.codes.includes(code)) extras.codes.push(code);
+      // filter. Bodies never publish at tier ≤2, so no masking path here.
+      // F139: extraction runs on bounded cue windows, not the whole body.
+      for (const cueWindow of bodyAlnumCueWindows(text)) {
+        for (const code of extractMetaAlnumCodes(cueWindow)) {
+          if (!isDisplayableAlnumCode(code)) continue;
+          hasOtpOrLink = true;
+          if (!extras.codes.includes(code)) extras.codes.push(code);
+        }
       }
       extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
     } catch {

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -102,7 +102,12 @@ export type MailContentExtras = {
  * behavior. When an already-observed mailbox changes UIDVALIDITY, the
  * replacement INBOX may already hold mail delivered during the disconnect —
  * treat every current UID as pending so reconnects still catch offline
- * deliveries (watermark still anchors at the high-water mark afterwards).
+ * deliveries.
+ * F118: the replacement generation starts BELOW all pending UIDs (UIDs
+ * restart at 1) instead of at the high-water mark, so the watcher's
+ * per-message advancement only records mail that was actually processed — a
+ * transient publish failure retries the remainder on reconnect rather than
+ * losing it to a prematurely raised watermark.
  */
 export function unseenWatcherUids(
   uids: number[],
@@ -115,8 +120,12 @@ export function unseenWatcherUids(
     // First sight of this mailbox generation, or a recreated INBOX: re-anchor
     // instead of comparing against the previous generation's UIDs.
     watermark.uidValidity = uidValidity;
-    watermark.uid = currentHighWater;
-    return firstSight ? [] : uids.slice();
+    if (firstSight) {
+      watermark.uid = currentHighWater;
+      return [];
+    }
+    watermark.uid = 0;
+    return uids.slice();
   }
   if (watermark.uid === undefined) {
     watermark.uid = currentHighWater;
@@ -332,6 +341,31 @@ const META_ALNUM_DELIMITED_TIGHT_SINGLE = new RegExp(
   'g',
 );
 /**
+ * Colon-delimited codes (F117): `AB:12:CD`. Colon (ASCII + fullwidth) stays
+ * OUT of the tight class — there it would glue `x:ABC-123` into mid-chain
+ * blocks and URLs/versions into unrelated matchers. These two bounded forms
+ * mirror the tight pair: 2–4 groups of 2–4, and 4–8 single-char chains.
+ * Pure-digit joins (12:30) and letter-only joins drop at the push() predicate;
+ * http(s) URLs are link-masked before the alnum pass.
+ */
+const META_ALNUM_SEP_COLON = '[:：]';
+/** Lead: not immediately after `alnum:` (blocks mid-chain restarts). */
+const META_ALNUM_LEAD_COLON = `(?<![${META_ALNUM_CHAR}]${META_ALNUM_SEP_COLON})`;
+// 2–4 groups of 2–4 alnum joined by single colons.
+const META_ALNUM_DELIMITED_COLON = new RegExp(
+  `${META_ALNUM_LEAD_COLON}${META_ALNUM_BOUND_LEFT}` +
+    `(${META_ALNUM_GROUP}(?:${META_ALNUM_SEP_COLON}${META_ALNUM_GROUP}){1,3})` +
+    `(?!${META_ALNUM_SEP_COLON}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
+// 4–8 groups of exactly 1 alnum joined by single colons (`A:1:B:2`).
+const META_ALNUM_DELIMITED_COLON_SINGLE = new RegExp(
+  `${META_ALNUM_LEAD_COLON}${META_ALNUM_BOUND_LEFT}` +
+    `([${META_ALNUM_CHAR}](?:${META_ALNUM_SEP_COLON}[${META_ALNUM_CHAR}]){3,7})` +
+    `(?!${META_ALNUM_SEP_COLON}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
+  'g',
+);
+/**
  * 2–4 alnum chars that include a digit after NFKC (lookahead fixes length).
  * Used for space runs so pure-letter English tokens are not groups.
  */
@@ -488,6 +522,18 @@ function isPlausibleSpaceSingleChain(form: string): boolean {
   return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
 }
 
+/**
+ * Accept a colon single-char chain (F117): NFKC, split on colon runs, 4–8
+ * groups of exactly 1 char. Same push() predicate split as F105.
+ */
+function isPlausibleColonSingleChain(form: string): boolean {
+  const parts = form
+    .normalize('NFKC')
+    .split(new RegExp(`${META_ALNUM_SEP_COLON}+`))
+    .filter(Boolean);
+  return parts.length >= 4 && parts.length <= 8 && parts.every((g) => g.length === 1);
+}
+
 /** Accept a digit-bearing space run: 2–4 groups only (5+ refused whole). */
 function isPlausibleSpaceDigitRun(form: string): boolean {
   if (!isMixedAlnumOtp(form)) return false;
@@ -599,6 +645,21 @@ function collectMetaAlnumForms(
     if (!isPlausibleSingleChain(form)) continue;
     emit(match);
   }
+  // F117: colon-delimited forms (`AB:12:CD`, `A:1:B:2`) — bounded matchers,
+  // colon never joins the tight class.
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_COLON)) {
+    const form = match[1]!;
+    const groups = form
+      .split(new RegExp(`${META_ALNUM_SEP_COLON}+`))
+      .filter(Boolean);
+    if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
+    emit(match);
+  }
+  for (const match of text.matchAll(META_ALNUM_DELIMITED_COLON_SINGLE)) {
+    const form = match[1]!;
+    if (!isPlausibleColonSingleChain(form)) continue;
+    emit(match);
+  }
 }
 
 /**
@@ -606,8 +667,8 @@ function collectMetaAlnumForms(
  * (F77/F81 continuous + F84 tight delimited + F85 space runs + F86 fullwidth +
  * F95 letter-only continuous + F97 letter-only delimited + F105 tight
  * single-char chains + F106 space single-char chains + F109 mixed-separator
- * single-char chains + F113 compatibility forms). Does not touch body
- * extract semantics.
+ * single-char chains + F113 compatibility forms + F117 colon-delimited
+ * forms). Does not touch body extract semantics.
  *
  * F113: compatibility characters beyond the fullwidth ranges (Ⓐ①Ⓑ②, 𝐀𝟏𝐁𝟐)
  * normalize to valid codes but never matched the classes above. When NFKC
@@ -733,9 +794,17 @@ export function maskTier2Metadata(
   // extractOtp over subject/from. Links in metadata: ALL http(s) URLs
   // (extractHttpLinks — no LINK_INTENT filter) so "Verify here: https://…"
   // still redacts; extras.links stay intent-filtered for policy/tier-3 only.
-  let from = extras.from;
-  let subject = extras.subject;
-  const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
+  //
+  // F120: cap metadata BEFORE extraction/masking. Only the capped prefixes are
+  // ever published (buildMailArrivalMessage re-caps at PUSH_META_FIELD_MAX_BYTES),
+  // so scanning untrusted full-length headers just lets a strong-cue subject
+  // with thousands of distinct tokens compile one enormous masking alternation
+  // and stall the single watcher. The window keeps 64 extra code points so any
+  // form starting inside the published prefix (max form ~30 chars) still ends
+  // inside the window and gets masked — no half-form leak at the cut.
+  let from = boundPreviewChars(extras.from, PUSH_META_FIELD_MAX_BYTES + 64);
+  let subject = boundPreviewChars(extras.subject, PUSH_META_FIELD_MAX_BYTES + 64);
+  const metaText = [from, subject].filter(Boolean).join('\n');
   const metaOtp = extractOtp(metaText);
   const metaHttpLinks = extractHttpLinks(metaText);
   // Body codes enter the mask list when their digit-only form appears as any
@@ -763,8 +832,8 @@ export function maskTier2Metadata(
   const maskCodes = [
     ...metaOtp.codes,
     ...extras.codes.filter((code) => metaCanonRuns.has(canonicalDigits(code))),
-    ...extractMetaAlnumCodes(extras.subject),
-    ...extractMetaAlnumCodes(extras.from),
+    ...extractMetaAlnumCodes(subject),
+    ...extractMetaAlnumCodes(from),
     ...(strongMetaCue ? metaDigitSurfaces : []),
   ];
   const maskLinks = [...extras.links, ...metaHttpLinks];
@@ -973,15 +1042,20 @@ export async function processWatchedMessage(
   // F110: classify on the subject too — a subject-only code or verify link
   // (`Subject: Your verification code is 123456` with a plain body) must still
   // pass the `otp` policy. The subject line itself shows at tier ≥2 (masked at
-  // tier 2). F116: also merge subject credentials into extras — tier 3 would
-  // otherwise truncate a long signed subject URL at the metadata cap and
-  // publish an unusable partial link. This branch runs only when the body had
-  // no codes/links, so the merge cannot duplicate body-sourced entries.
-  if (!hasOtpOrLink && extras.subject) {
+  // tier 2). F116/F119: ALWAYS merge subject credentials into extras (deduped)
+  // — tier 3 would otherwise truncate a long signed subject URL at the
+  // metadata cap and publish an unusable partial link, even when the body
+  // independently matched.
+  if (extras.subject) {
     const subjectOtp = extractOtp(extras.subject);
-    hasOtpOrLink = subjectOtp.codes.length > 0 || subjectOtp.links.length > 0;
-    if (subjectOtp.codes.length > 0) extras.codes.push(...subjectOtp.codes);
-    if (subjectOtp.links.length > 0) extras.links.push(...subjectOtp.links);
+    hasOtpOrLink =
+      hasOtpOrLink || subjectOtp.codes.length > 0 || subjectOtp.links.length > 0;
+    for (const code of subjectOtp.codes) {
+      if (!extras.codes.includes(code)) extras.codes.push(code);
+    }
+    for (const link of subjectOtp.links) {
+      if (!extras.links.includes(link)) extras.links.push(link);
+    }
   }
   if (policy === 'otp' && !hasOtpOrLink) return;
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -168,15 +168,18 @@ export function buildMailArrivalMessage(
 
   if (tier >= 2) {
     // Cap From/Subject independently so OTP/preview content still fits.
-    // Tier 2 must not leak OTP/link strings that sit in the subject line.
-    const from =
-      tier < 3
-        ? maskSensitiveFragments(extras.from, extras.codes, extras.links)
-        : extras.from;
-    const subject =
-      tier < 3
-        ? maskSensitiveFragments(extras.subject, extras.codes, extras.links)
-        : extras.subject;
+    // Tier 2 must not leak OTP/link strings in metadata — needles come from
+    // body extractOtp (extras) plus a separate extractOtp over subject/from
+    // (not mixed into extras, which tier-3 Codes/Links still use).
+    let from = extras.from;
+    let subject = extras.subject;
+    if (tier < 3) {
+      const metaOtp = extractOtp([extras.from, extras.subject].filter(Boolean).join('\n'));
+      const maskCodes = [...extras.codes, ...metaOtp.codes];
+      const maskLinks = [...extras.links, ...metaOtp.links];
+      from = maskSensitiveFragments(from, maskCodes, maskLinks);
+      subject = maskSensitiveFragments(subject, maskCodes, maskLinks);
+    }
     if (from) {
       lines.push(`From: ${boundTextBytes(from, PUSH_META_FIELD_MAX_BYTES)}`);
     }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -19,7 +19,13 @@ import {
   type PushContentTier,
 } from './identities.ts';
 import { connectImap, messageRecipients } from './imap.ts';
-import { NotifyError, type NotifyService, notificationService } from './notify.ts';
+import {
+  jsonEscapedByteLength,
+  notifyAvailableMessageBytes,
+  NotifyError,
+  type NotifyService,
+  notificationService,
+} from './notify.ts';
 import {
   canonicalDigits,
   extractHttpLinks,
@@ -135,13 +141,15 @@ const MORE_LINKS_NOTE = (n: number) =>
   `(+${n} more links, open the dashboard to view)`;
 
 /**
- * Pack full verification links under the remaining UTF-8 body budget (F79).
- * Never mid-truncates a URL; drops the tail and appends a +N note when needed.
+ * Pack full verification links under the remaining **JSON-escaped** body budget
+ * (F79/F88). Never mid-truncates a URL; drops the tail and appends a +N note.
+ * Measure with jsonEscapedByteLength so packing matches ntfy publish framing.
  */
 export function packPushLinkLines(
   baseBody: string,
   links: string[],
-  maxBytes = PUSH_MESSAGE_MAX_BYTES,
+  maxEscapedBytes = PUSH_MESSAGE_MAX_BYTES,
+  measure: (text: string) => number = jsonEscapedByteLength,
 ): string[] {
   if (links.length === 0) return [];
   const candidates = boundPushLinkEntries(links);
@@ -153,7 +161,7 @@ export function packPushLinkLines(
     const stillDrop = dropped + (candidates.length - tryKept.length);
     const note = stillDrop > 0 ? `\n${MORE_LINKS_NOTE(stillDrop)}` : '';
     const trial = `${baseBody}\nLinks:\n${tryKept.join('\n')}${note}`;
-    if (Buffer.byteLength(trial, 'utf8') <= maxBytes) {
+    if (measure(trial) <= maxEscapedBytes) {
       kept.push(candidates[i]!);
       continue;
     }
@@ -165,7 +173,7 @@ export function packPushLinkLines(
     // Even one full link does not fit; prefer an honest note over a broken URL.
     if (links.length > 0) {
       const onlyNote = `${baseBody}\nLinks:\n${MORE_LINKS_NOTE(links.length)}`;
-      if (Buffer.byteLength(onlyNote, 'utf8') <= maxBytes) {
+      if (measure(onlyNote) <= maxEscapedBytes) {
         return [`Links:\n${MORE_LINKS_NOTE(links.length)}`];
       }
     }
@@ -176,6 +184,24 @@ export function packPushLinkLines(
   // dropped already includes candidates not kept + beyond PUSH_OTP_ITEM_MAX.
   if (dropped > 0) out.push(MORE_LINKS_NOTE(dropped));
   return out;
+}
+
+/**
+ * Truncate plain text so its JSON-escaped form is ≤ maxEscapedBytes (F88).
+ * Prefer whole code points; used for Preview when packing under ntfy budget.
+ */
+export function boundPreviewByEscapedBytes(text: string, maxEscapedBytes: number): string {
+  if (jsonEscapedByteLength(text) <= maxEscapedBytes) return text;
+  if (maxEscapedBytes <= 0) return '';
+  let used = 0;
+  let end = 0;
+  for (const point of text) {
+    const cost = jsonEscapedByteLength(point);
+    if (used + cost > maxEscapedBytes) break;
+    used += cost;
+    end += point.length;
+  }
+  return text.slice(0, end);
 }
 
 /**
@@ -244,15 +270,29 @@ const META_ALNUM_OTP_RE = new RegExp(
 const META_ALNUM_GROUP = `[${META_ALNUM_CHAR}]{2,4}`;
 /**
  * Split of otp.ts DELIMITED_OTP_SEP_CLASS: non-whitespace vs whitespace.
+ * F87: sep runs of 1–3 that include **at least one tight** sep so `ABC - 123`
+ * and `ABC--123` match, while pure-space chains stay on F85 paths and English
+ * `code is ABC-123` cannot glue via space-only gaps.
  */
 const META_ALNUM_SEP_TIGHT = '[-–—.\uFF0D\uFF0E]';
 const META_ALNUM_SEP_SPACE =
   '[\\t \\u00A0\\u1680\\u2000-\\u200A\\u202F\\u205F\\u3000\\uFEFF]';
-// 2–4 groups with tight seps; lead blocks mid-chain after alnum+tight-sep.
+const T = META_ALNUM_SEP_TIGHT;
+const S = META_ALNUM_SEP_SPACE;
+/** 1–3 seps with ≥1 tight char (enumerated; max length 3). */
+const META_ALNUM_SEP_RUN_WITH_TIGHT =
+  `(?:${T}|${T}${T}|${T}${T}${T}|${T}${S}|${S}${T}|${T}${S}${T}|${T}${T}${S}|${S}${T}${T}|${T}${S}${S}|${S}${T}${S}|${S}${S}${T})`;
+/**
+ * Mid-chain lead: alnum then a sep-run that ends in a tight sep
+ * (blocks `AB - CD` starting at CD; allows `is ABC-123` after a bare space).
+ */
+const META_ALNUM_LEAD_MID =
+  `(?<![${META_ALNUM_CHAR}](?:${S}|${T}){0,2}${T})`;
+// 2–4 groups with mixed sep runs that include a tight separator (F87).
 const META_ALNUM_DELIMITED_TIGHT = new RegExp(
-  `(?<![${META_ALNUM_CHAR}]${META_ALNUM_SEP_TIGHT})${META_ALNUM_BOUND_LEFT}` +
-    `(${META_ALNUM_GROUP}(?:${META_ALNUM_SEP_TIGHT}${META_ALNUM_GROUP}){1,3})` +
-    `(?!${META_ALNUM_SEP_TIGHT}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
+  `${META_ALNUM_LEAD_MID}${META_ALNUM_BOUND_LEFT}` +
+    `(${META_ALNUM_GROUP}(?:${META_ALNUM_SEP_RUN_WITH_TIGHT}${META_ALNUM_GROUP}){1,3})` +
+    `(?!${META_ALNUM_SEP_RUN_WITH_TIGHT}[${META_ALNUM_CHAR}])${META_ALNUM_BOUND_RIGHT}`,
   'g',
 );
 /**
@@ -350,7 +390,14 @@ export function extractMetaAlnumCodes(metaText: string): string[] {
     push(match[1]!);
   }
   for (const match of metaText.matchAll(META_ALNUM_DELIMITED_TIGHT)) {
-    push(match[1]!);
+    const form = match[1]!;
+    // Year-shaped pure-digit groups (Mar - 2026) — privacy-safe to skip (F87 nit).
+    const groups = form
+      .split(new RegExp(`${META_ALNUM_SEP_RUN_WITH_TIGHT}`))
+      .map((g) => g.trim())
+      .filter(Boolean);
+    if (groups.some((g) => /^(19|20)\d{2}$/.test(g.normalize('NFKC')))) continue;
+    push(form);
   }
   return codes;
 }
@@ -473,6 +520,12 @@ export function maskTier2Metadata(
   return { from, subject };
 }
 
+/** Options for packing under the live ntfy JSON message budget (F88). */
+export type BuildMailArrivalOptions = {
+  /** When set, framing budget accounts for ntfy click (with click-drop). */
+  clickUrl?: string;
+};
+
 /** Build the human-facing push body for one identity's content tier. */
 export function buildMailArrivalMessage(
   address: string,
@@ -480,7 +533,20 @@ export function buildMailArrivalMessage(
   hasOtpOrLink: boolean,
   extras: MailContentExtras,
   maskedTier2Meta?: { from: string; subject: string },
+  options: BuildMailArrivalOptions = {},
 ): string {
+  // Pack under the JSON-escaped message budget so full links survive publish()
+  // serialization (F88). Conservative max topic length matches ntfy cap.
+  const level = hasOtpOrLink ? 'urgent' : 'normal';
+  const availableEscaped = notifyAvailableMessageBytes({
+    title: 'openagent.email new mail',
+    level,
+    tags: ['email'],
+    click: options.clickUrl,
+  });
+  // Also respect local raw-byte headroom (historical PUSH_MESSAGE_MAX_BYTES).
+  const maxEscaped = Math.min(availableEscaped, PUSH_MESSAGE_MAX_BYTES);
+
   const lines: string[] = [
     hasOtpOrLink
       ? `${address} received new email (contains OTP or verification link)`
@@ -504,15 +570,53 @@ export function buildMailArrivalMessage(
   }
 
   if (tier >= 3) {
-    if (extras.preview) lines.push(`Preview: ${extras.preview}`);
     const codes = boundPushOtpEntries(extras.codes);
-    if (codes.length) lines.push(`Codes: ${codes.join(', ')}`);
-    // Links: full URLs only; pack under total body budget (F79).
-    const baseForLinks = lines.join('\n');
-    lines.push(...packPushLinkLines(baseForLinks, extras.links));
+    const codesLine = codes.length ? `Codes: ${codes.join(', ')}` : '';
+    // Prefer full links: pack links first with codes, shrink/drop Preview.
+    const baseCore = lines.join('\n') + (codesLine ? `\n${codesLine}` : '');
+    let previewLine = extras.preview ? `Preview: ${extras.preview}` : '';
+
+    const tryWithPreview = (preview: string): string => {
+      const base =
+        preview.length > 0
+          ? `${lines.join('\n')}\n${preview}${codesLine ? `\n${codesLine}` : ''}`
+          : baseCore;
+      const linkLines = packPushLinkLines(base, extras.links, maxEscaped);
+      return linkLines.length ? `${base}\n${linkLines.join('\n')}` : base;
+    };
+
+    let body = tryWithPreview(previewLine);
+    if (jsonEscapedByteLength(body) > maxEscaped && extras.preview) {
+      // Shrink preview so links still fit whole.
+      const withoutPreview = tryWithPreview('');
+      const roomForPreview =
+        maxEscaped -
+        jsonEscapedByteLength(withoutPreview) -
+        jsonEscapedByteLength('\nPreview: ');
+      if (roomForPreview > 0) {
+        const trimmed = boundPreviewByEscapedBytes(extras.preview, roomForPreview);
+        previewLine = trimmed ? `Preview: ${trimmed}` : '';
+        body = tryWithPreview(previewLine);
+      } else {
+        body = withoutPreview;
+      }
+    }
+    // Drop preview entirely if still over (keep full links / note).
+    if (jsonEscapedByteLength(body) > maxEscaped && previewLine) {
+      body = tryWithPreview('');
+    }
+    // Last resort: omit links with honest note if core framing alone is huge.
+    if (jsonEscapedByteLength(body) > maxEscaped && extras.links.length > 0) {
+      const coreOnly = tryWithPreview('');
+      if (jsonEscapedByteLength(coreOnly) <= maxEscaped) return coreOnly;
+      const noteOnly = packPushLinkLines(baseCore, extras.links, maxEscaped);
+      body = noteOnly.length ? `${baseCore}\n${noteOnly.join('\n')}` : baseCore;
+    }
+    return body;
   }
 
-  return boundPushMessage(lines.join('\n'));
+  // Tier 1–2: raw byte bound is fine (no long verify links).
+  return boundPushMessage(lines.join('\n'), Math.min(PUSH_MESSAGE_MAX_BYTES, maxEscaped));
 }
 
 /** Process one newly delivered message. Exported for policy/security tests. */
@@ -579,14 +683,15 @@ export async function processWatchedMessage(
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const tier = resolvePushContentTier(current);
       if (tier === 2 && !tier2Meta) tier2Meta = maskTier2Metadata(extras);
+      const level = hasOtpOrLink ? 'urgent' : 'normal';
       const body = buildMailArrivalMessage(
         current.address,
         tier,
         hasOtpOrLink,
         extras,
         tier === 2 ? tier2Meta : undefined,
+        { clickUrl: options.clickUrl },
       );
-      const level = hasOtpOrLink ? 'urgent' : 'normal';
       // Re-check at the publish fetch boundary (after publish's own awaits).
       // Abort only when privacy tightened (delete or downgrade); upgrades keep
       // the already-safe lower-tier body. `tier` is closed over per attempt.

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -163,12 +163,48 @@ export function maskSensitiveFragments(
   return result.replace(/\b\d{4,8}\b/g, (run) => (codeSet.has(run) ? '•••' : run));
 }
 
+/**
+ * Mask From/Subject for tier-2 pushes. Message-level only (depends on extras,
+ * not the recipient) so processWatchedMessage can memoize once per mail.
+ */
+export function maskTier2Metadata(
+  extras: MailContentExtras,
+): { from: string; subject: string } {
+  // Cap From/Subject independently so OTP/preview content still fits.
+  // Tier 2 must not leak OTP/link strings in metadata. Codes: body extras +
+  // extractOtp over subject/from. Links in metadata: ALL http(s) URLs
+  // (extractHttpLinks — no LINK_INTENT filter) so "Verify here: https://…"
+  // still redacts; extras.links stay intent-filtered for policy/tier-3 only.
+  let from = extras.from;
+  let subject = extras.subject;
+  const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
+  const metaOtp = extractOtp(metaText);
+  const metaHttpLinks = extractHttpLinks(metaText);
+  // Body codes only enter the mask list if they appear as a longest
+  // \b\d{4,8}\b run in metadata (same shape extractCodes would yield).
+  // Intersecting against meta digit runs is O(|meta|) instead of scanning
+  // every body code into per-needle replaces on short subject/from.
+  const metaDigitRuns = new Set<string>();
+  for (const match of metaText.matchAll(/\b\d{4,8}\b/g)) {
+    metaDigitRuns.add(match[0]!);
+  }
+  const maskCodes = [
+    ...metaOtp.codes,
+    ...extras.codes.filter((code) => metaDigitRuns.has(code)),
+  ];
+  const maskLinks = [...extras.links, ...metaHttpLinks];
+  from = maskSensitiveFragments(from, maskCodes, maskLinks);
+  subject = maskSensitiveFragments(subject, maskCodes, maskLinks);
+  return { from, subject };
+}
+
 /** Build the human-facing push body for one identity's content tier. */
 export function buildMailArrivalMessage(
   address: string,
   tier: PushContentTier,
   hasOtpOrLink: boolean,
   extras: MailContentExtras,
+  maskedTier2Meta?: { from: string; subject: string },
 ): string {
   const lines: string[] = [
     hasOtpOrLink
@@ -177,32 +213,12 @@ export function buildMailArrivalMessage(
   ];
 
   if (tier >= 2) {
-    // Cap From/Subject independently so OTP/preview content still fits.
-    // Tier 2 must not leak OTP/link strings in metadata. Codes: body extras +
-    // extractOtp over subject/from. Links in metadata: ALL http(s) URLs
-    // (extractHttpLinks — no LINK_INTENT filter) so "Verify here: https://…"
-    // still redacts; extras.links stay intent-filtered for policy/tier-3 only.
     let from = extras.from;
     let subject = extras.subject;
     if (tier < 3) {
-      const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
-      const metaOtp = extractOtp(metaText);
-      const metaHttpLinks = extractHttpLinks(metaText);
-      // Body codes only enter the mask list if they appear as a longest
-      // \b\d{4,8}\b run in metadata (same shape extractCodes would yield).
-      // Intersecting against meta digit runs is O(|meta|) instead of scanning
-      // every body code into per-needle replaces on short subject/from.
-      const metaDigitRuns = new Set<string>();
-      for (const match of metaText.matchAll(/\b\d{4,8}\b/g)) {
-        metaDigitRuns.add(match[0]!);
-      }
-      const maskCodes = [
-        ...metaOtp.codes,
-        ...extras.codes.filter((code) => metaDigitRuns.has(code)),
-      ];
-      const maskLinks = [...extras.links, ...metaHttpLinks];
-      from = maskSensitiveFragments(from, maskCodes, maskLinks);
-      subject = maskSensitiveFragments(subject, maskCodes, maskLinks);
+      const masked = maskedTier2Meta ?? maskTier2Metadata(extras);
+      from = masked.from;
+      subject = masked.subject;
     }
     if (from) {
       lines.push(`From: ${boundTextBytes(from, PUSH_META_FIELD_MAX_BYTES)}`);
@@ -271,6 +287,10 @@ export async function processWatchedMessage(
   if (policy === 'otp' && !hasOtpOrLink) return;
 
   const clickUrl = options.clickUrl;
+  // Tier-2 metadata mask is message-level; compute at most once per mail.
+  let tier2Meta: { from: string; subject: string } | undefined;
+  const maxAttempts = 3;
+
   for (const identity of matched) {
     // Re-read per identity after await simpleParser / previous publish so a
     // concurrent tier change or DELETE is visible before the next payload.
@@ -278,32 +298,51 @@ export async function processWatchedMessage(
     // findIdentity undefined = deleted (store corrupt throws). Do not fall back
     // to the pre-parse snapshot — that would still emit tier-3 OTP after DELETE.
     if (options.refreshIdentity && !refreshed) continue;
-    const current = refreshed ?? identity;
-    const tier = resolvePushContentTier(current);
-    const body = buildMailArrivalMessage(current.address, tier, hasOtpOrLink, extras);
-    const level = hasOtpOrLink ? 'urgent' : 'normal';
-    // Re-check at the publish fetch boundary (after publish's own awaits).
-    // Abort only when privacy tightened (delete or downgrade); upgrades keep
-    // the already-safe lower-tier body.
-    const beforeSend = options.refreshIdentity
-      ? (): boolean => {
-          const again = options.refreshIdentity!(identity.address);
-          return again !== undefined && resolvePushContentTier(again) >= tier;
+    let current = refreshed ?? identity;
+
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      const tier = resolvePushContentTier(current);
+      if (tier === 2 && !tier2Meta) tier2Meta = maskTier2Metadata(extras);
+      const body = buildMailArrivalMessage(
+        current.address,
+        tier,
+        hasOtpOrLink,
+        extras,
+        tier === 2 ? tier2Meta : undefined,
+      );
+      const level = hasOtpOrLink ? 'urgent' : 'normal';
+      // Re-check at the publish fetch boundary (after publish's own awaits).
+      // Abort only when privacy tightened (delete or downgrade); upgrades keep
+      // the already-safe lower-tier body. `tier` is closed over per attempt.
+      const beforeSend = options.refreshIdentity
+        ? (): boolean => {
+            const again = options.refreshIdentity!(identity.address);
+            return again !== undefined && resolvePushContentTier(again) >= tier;
+          }
+        : undefined;
+      try {
+        await dispatch.publish({
+          target: 'user',
+          title: 'openagent.email new mail',
+          message: body,
+          level,
+          tags: ['email'],
+          ...(clickUrl ? { click: clickUrl } : {}),
+          ...(beforeSend ? { beforeSend } : {}),
+        });
+        break; // sent
+      } catch (err) {
+        if (!(err instanceof NotifyError && err.code === 'notify_cancelled')) throw err;
+        if (!options.refreshIdentity) break;
+        // Downgrade: rebuild at the safer tier. Delete: silent skip.
+        const again = options.refreshIdentity(identity.address);
+        if (!again) break;
+        if (resolvePushContentTier(again) < tier) {
+          current = again;
+          continue;
         }
-      : undefined;
-    try {
-      await dispatch.publish({
-        target: 'user',
-        title: 'openagent.email new mail',
-        message: body,
-        level,
-        tags: ['email'],
-        ...(clickUrl ? { click: clickUrl } : {}),
-        ...(beforeSend ? { beforeSend } : {}),
-      });
-    } catch (err) {
-      if (err instanceof NotifyError && err.code === 'notify_cancelled') continue;
-      throw err;
+        break;
+      }
     }
   }
 }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -12,6 +12,7 @@ import { simpleParser } from 'mailparser';
 import type { FetchMessageObject, ImapFlow } from 'imapflow';
 import { config } from './config.ts';
 import {
+  findIdentity,
   listIdentities,
   resolvePushContentTier,
   type Identity,
@@ -313,8 +314,8 @@ async function watchConnection(
             dispatch,
             {
               clickUrl: config.dashboardPublicUrl,
-              refreshIdentity: (address) =>
-                listIdentities().find((entry) => entry.address === address),
+              // O(1) indexed lookup; mtime/invalidate cache still sees tier PUTs.
+              refreshIdentity: (address) => findIdentity(address),
             },
           );
           watermark.uid = Math.max(watermark.uid ?? 0, message.uid);

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -19,7 +19,7 @@ import {
 } from './identities.ts';
 import { connectImap, messageRecipients } from './imap.ts';
 import { type NotifyService, notificationService } from './notify.ts';
-import { extractOtp, htmlToText, maskNormalizedHttpUrls } from './otp.ts';
+import { extractHttpLinks, extractOtp, htmlToText, maskNormalizedHttpUrls } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
 const RECONNECT_MS = 3_000;
@@ -171,15 +171,18 @@ export function buildMailArrivalMessage(
 
   if (tier >= 2) {
     // Cap From/Subject independently so OTP/preview content still fits.
-    // Tier 2 must not leak OTP/link strings in metadata — needles come from
-    // body extractOtp (extras) plus a separate extractOtp over subject/from
-    // (not mixed into extras, which tier-3 Codes/Links still use).
+    // Tier 2 must not leak OTP/link strings in metadata. Codes: body extras +
+    // extractOtp over subject/from. Links in metadata: ALL http(s) URLs
+    // (extractHttpLinks — no LINK_INTENT filter) so "Verify here: https://…"
+    // still redacts; extras.links stay intent-filtered for policy/tier-3 only.
     let from = extras.from;
     let subject = extras.subject;
     if (tier < 3) {
-      const metaOtp = extractOtp([extras.from, extras.subject].filter(Boolean).join('\n'));
+      const metaText = [extras.from, extras.subject].filter(Boolean).join('\n');
+      const metaOtp = extractOtp(metaText);
+      const metaHttpLinks = extractHttpLinks(metaText);
       const maskCodes = [...extras.codes, ...metaOtp.codes];
-      const maskLinks = [...extras.links, ...metaOtp.links];
+      const maskLinks = [...extras.links, ...metaHttpLinks];
       from = maskSensitiveFragments(from, maskCodes, maskLinks);
       subject = maskSensitiveFragments(subject, maskCodes, maskLinks);
     }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1163,7 +1163,9 @@ export async function processWatchedMessage(
       const html = typeof parsed.html === 'string' && parsed.html.length <= MAX_EMAIL_HTML_LENGTH
         ? parsed.html
         : undefined;
-      const text = (parsed.text ?? '').trim() || (html ? htmlToText(html) : '');
+      const parsedText = (parsed.text ?? '').trim();
+      const htmlText = html ? htmlToText(html) : '';
+      const text = parsedText || htmlText;
       const otp = extractOtp(text, html);
       hasOtpOrLink = otp.codes.length > 0 || otp.links.length > 0;
       extras.codes = otp.codes;
@@ -1172,11 +1174,16 @@ export async function processWatchedMessage(
       // subject path F134/F136 covered only metadata). Same code-shaped
       // filter. Bodies never publish at tier ≤2, so no masking path here.
       // F139: extraction runs on bounded cue windows, not the whole body.
-      for (const cueWindow of bodyAlnumCueWindows(text)) {
-        for (const code of extractMetaAlnumCodes(cueWindow)) {
-          if (!isDisplayableAlnumCode(code)) continue;
-          hasOtpOrLink = true;
-          if (!extras.codes.includes(code)) extras.codes.push(code);
+      // F140: scan the HTML alternative too — extractOtp already scans both
+      // parts, and a stub plain-text part (`open in an HTML client`) must
+      // not hide an HTML-only credential from the otp policy.
+      for (const scanText of new Set([text, htmlText].filter(Boolean))) {
+        for (const cueWindow of bodyAlnumCueWindows(scanText)) {
+          for (const code of extractMetaAlnumCodes(cueWindow)) {
+            if (!isDisplayableAlnumCode(code)) continue;
+            hasOtpOrLink = true;
+            if (!extras.codes.includes(code)) extras.codes.push(code);
+          }
         }
       }
       extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -572,47 +572,35 @@ export function buildMailArrivalMessage(
   if (tier >= 3) {
     const codes = boundPushOtpEntries(extras.codes);
     const codesLine = codes.length ? `Codes: ${codes.join(', ')}` : '';
-    // Prefer full links: pack links first with codes, shrink/drop Preview.
-    const baseCore = lines.join('\n') + (codesLine ? `\n${codesLine}` : '');
-    let previewLine = extras.preview ? `Preview: ${extras.preview}` : '';
+    // F88: pack full links against base WITHOUT preview first; preview eats the
+    // remainder. Putting a full Preview into the pack base first made the
+    // "shrink preview to keep links" path dead — body stayed under budget after
+    // packPushLinkLines dropped links for the oversized preview.
+    const head = lines.join('\n');
+    const baseNoPreview = head + (codesLine ? `\n${codesLine}` : '');
+    const linkLines = packPushLinkLines(baseNoPreview, extras.links, maxEscaped);
+    const withLinks =
+      linkLines.length > 0 ? `${baseNoPreview}\n${linkLines.join('\n')}` : baseNoPreview;
 
-    const tryWithPreview = (preview: string): string => {
-      const base =
-        preview.length > 0
-          ? `${lines.join('\n')}\n${preview}${codesLine ? `\n${codesLine}` : ''}`
-          : baseCore;
-      const linkLines = packPushLinkLines(base, extras.links, maxEscaped);
-      return linkLines.length ? `${base}\n${linkLines.join('\n')}` : base;
-    };
-
-    let body = tryWithPreview(previewLine);
-    if (jsonEscapedByteLength(body) > maxEscaped && extras.preview) {
-      // Shrink preview so links still fit whole.
-      const withoutPreview = tryWithPreview('');
+    let previewLine = '';
+    if (extras.preview) {
       const roomForPreview =
         maxEscaped -
-        jsonEscapedByteLength(withoutPreview) -
+        jsonEscapedByteLength(withLinks) -
         jsonEscapedByteLength('\nPreview: ');
       if (roomForPreview > 0) {
         const trimmed = boundPreviewByEscapedBytes(extras.preview, roomForPreview);
-        previewLine = trimmed ? `Preview: ${trimmed}` : '';
-        body = tryWithPreview(previewLine);
-      } else {
-        body = withoutPreview;
+        if (trimmed) previewLine = `Preview: ${trimmed}`;
       }
     }
-    // Drop preview entirely if still over (keep full links / note).
-    if (jsonEscapedByteLength(body) > maxEscaped && previewLine) {
-      body = tryWithPreview('');
-    }
-    // Last resort: omit links with honest note if core framing alone is huge.
-    if (jsonEscapedByteLength(body) > maxEscaped && extras.links.length > 0) {
-      const coreOnly = tryWithPreview('');
-      if (jsonEscapedByteLength(coreOnly) <= maxEscaped) return coreOnly;
-      const noteOnly = packPushLinkLines(baseCore, extras.links, maxEscaped);
-      body = noteOnly.length ? `${baseCore}\n${noteOnly.join('\n')}` : baseCore;
-    }
-    return body;
+
+    // Assembly order unchanged: title/From/Subject → Preview → Codes → Links.
+    // Escaped length is additive over segments, so reordering vs withLinks is safe.
+    const parts = [head];
+    if (previewLine) parts.push(previewLine);
+    if (codesLine) parts.push(codesLine);
+    if (linkLines.length > 0) parts.push(...linkLines);
+    return parts.join('\n');
   }
 
   // Tier 1–2: raw byte bound is fine (no long verify links).

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -19,7 +19,7 @@ import {
 } from './identities.ts';
 import { connectImap, messageRecipients } from './imap.ts';
 import { type NotifyService, notificationService } from './notify.ts';
-import { extractOtp, htmlToText } from './otp.ts';
+import { extractOtp, htmlToText, maskNormalizedHttpUrls } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
 const RECONNECT_MS = 3_000;
@@ -134,7 +134,9 @@ export function boundPushMessage(body: string, maxBytes = PUSH_MESSAGE_MAX_BYTES
 
 /**
  * Mask already-extracted OTP codes/links in metadata text for tier-2 pushes.
- * Uses the same extractOtp results as policy matching — no second regex set.
+ * Codes: exact string replace. Links: normalize via validatedHttpUrl then
+ * replace the original spelling (maskNormalizedHttpUrls) so EXAMPLE.com:443
+ * still redacts when extractOtp returned https://example.com/....
  */
 export function maskSensitiveFragments(
   text: string,
@@ -142,11 +144,12 @@ export function maskSensitiveFragments(
   links: string[],
 ): string {
   if (!text) return text;
-  const needles = [...links, ...codes]
+  // URLs first so a full verify link is one unit before digit-code scans.
+  let result = maskNormalizedHttpUrls(text, links);
+  const codeNeedles = codes
     .filter((value) => value.length > 0)
     .sort((a, b) => b.length - a.length);
-  let result = text;
-  for (const needle of needles) {
+  for (const needle of codeNeedles) {
     if (!result.includes(needle)) continue;
     result = result.split(needle).join('•••');
   }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -58,9 +58,9 @@ export type ProcessWatchedOptions = {
   /** When set, each mail-arrival push includes ntfy `click` = this URL. */
   clickUrl?: string;
   /**
-   * Re-read identity tier immediately before each payload so a mid-flight
-   * admin downgrade is not applied against a stale listIdentities() snapshot.
-   * Undefined means keep the matched snapshot entry.
+   * Re-read identity immediately before each payload so a mid-flight admin
+   * tier change is visible. When provided, `undefined` means the identity was
+   * deleted (skip publish); when omitted, the matched snapshot is used.
    */
   refreshIdentity?: (address: string) => Identity | undefined;
 };
@@ -272,8 +272,12 @@ export async function processWatchedMessage(
   const clickUrl = options.clickUrl;
   for (const identity of matched) {
     // Re-read per identity after await simpleParser / previous publish so a
-    // concurrent tier downgrade is visible before the next payload is built.
-    const current = options.refreshIdentity?.(identity.address) ?? identity;
+    // concurrent tier change or DELETE is visible before the next payload.
+    const refreshed = options.refreshIdentity?.(identity.address);
+    // findIdentity undefined = deleted (store corrupt throws). Do not fall back
+    // to the pre-parse snapshot — that would still emit tier-3 OTP after DELETE.
+    if (options.refreshIdentity && !refreshed) continue;
+    const current = refreshed ?? identity;
     const tier = resolvePushContentTier(current);
     const body = buildMailArrivalMessage(current.address, tier, hasOtpOrLink, extras);
     const level = hasOtpOrLink ? 'urgent' : 'normal';

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -489,13 +489,17 @@ const JSON_MESSAGE_ELLIPSIS_ESCAPED_BYTES = Buffer.byteLength(JSON_MESSAGE_ELLIP
 /**
  * Cost of one code point inside a JSON string (UTF-8 of the escaped form).
  * Matches JSON.stringify: quotes/backslash and the five single-letter escapes
- * cost 2; other C0 controls become \\u00XX (6); everything else is raw UTF-8.
+ * cost 2; other C0 controls become \\u00XX (6); lone surrogates (0xD800–0xDFFF)
+ * become \\uXXXX (6) — Buffer.byteLength would only count the U+FFFD replacement
+ * (3); paired surrogates form a >0xFFFF code point and take the UTF-8 branch.
+ * Everything else is raw UTF-8.
  */
 function jsonStringEscapeCost(point: string): number {
   const cp = point.codePointAt(0)!;
   if (point === '"' || point === '\\') return 2;
   if (cp === 0x08 || cp === 0x09 || cp === 0x0a || cp === 0x0c || cp === 0x0d) return 2;
   if (cp < 0x20) return 6;
+  if (cp >= 0xd800 && cp <= 0xdfff) return 6;
   return Buffer.byteLength(point, 'utf8');
 }
 

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -475,6 +475,58 @@ function parseMessages(text: string): NotifyMessage[] {
   return messages;
 }
 
+/**
+ * ntfy rejects request bodies near ~4096 bytes. Cap serialized publish JSON
+ * under this so a poison message cannot make publish throw and stall the
+ * watcher UID watermark forever.
+ */
+export const NTFY_REQUEST_MAX_BYTES = 4_000;
+
+/** UTF-8 ellipsis appended when JSON-escaped message content is truncated. */
+const JSON_MESSAGE_ELLIPSIS = '…';
+const JSON_MESSAGE_ELLIPSIS_ESCAPED_BYTES = Buffer.byteLength(JSON_MESSAGE_ELLIPSIS, 'utf8');
+
+/**
+ * Cost of one code point inside a JSON string (UTF-8 of the escaped form).
+ * Matches JSON.stringify: quotes/backslash and the five single-letter escapes
+ * cost 2; other C0 controls become \\u00XX (6); everything else is raw UTF-8.
+ */
+function jsonStringEscapeCost(point: string): number {
+  const cp = point.codePointAt(0)!;
+  if (point === '"' || point === '\\') return 2;
+  if (cp === 0x08 || cp === 0x09 || cp === 0x0a || cp === 0x0c || cp === 0x0d) return 2;
+  if (cp < 0x20) return 6;
+  return Buffer.byteLength(point, 'utf8');
+}
+
+/**
+ * Truncate `text` so its JSON string-escape length is ≤ maxEscapedBytes.
+ * Code-point aligned (same discipline as boundTextBytes); reserves room for `…`.
+ * Used only for ntfy publish message bodies after field caps — a second line of
+ * defense against JSON expansion of control characters.
+ */
+export function boundJsonEscapedText(text: string, maxEscapedBytes: number): string {
+  let total = 0;
+  for (const point of text) {
+    total += jsonStringEscapeCost(point);
+    if (total > maxEscapedBytes) break;
+  }
+  if (total <= maxEscapedBytes) return text;
+  if (maxEscapedBytes < JSON_MESSAGE_ELLIPSIS_ESCAPED_BYTES) return '';
+  const budget = maxEscapedBytes - JSON_MESSAGE_ELLIPSIS_ESCAPED_BYTES;
+  if (budget <= 0) return JSON_MESSAGE_ELLIPSIS;
+
+  let used = 0;
+  let end = 0;
+  for (const point of text) {
+    const cost = jsonStringEscapeCost(point);
+    if (used + cost > budget) break;
+    used += cost;
+    end += point.length;
+  }
+  return `${text.slice(0, end)}${JSON_MESSAGE_ELLIPSIS}`;
+}
+
 export class NtfyNotificationService implements NotifyService {
   private async assertEnabled(): Promise<NotifyState> {
     if (!config.ntfy.enabled) throw new NotifyError('notifications_disabled');
@@ -485,8 +537,11 @@ export class NtfyNotificationService implements NotifyService {
   async publish(input: NotifyInput): Promise<{ target: NotifyTarget; title: string; level: NotifyLevel }> {
     const current = await this.assertEnabled();
     const topic = await physicalTopic(input.target, input.level);
-    // ntfy rejects bodies near ~4096 bytes. message is capped at 3500; a long
-    // DASHBOARD_PUBLIC_URL click can still blow the request — drop click first.
+    // ntfy rejects bodies near ~4096 bytes. Prefer keeping click; if the
+    // serialized body is still over budget after dropping click, truncate only
+    // message (topic/title/tags are our short bounded strings, not attacker
+    // mail content). JSON escaping can expand control chars past the watcher
+    // raw-byte cap, so this is the final serialization-layer backstop.
     const basePayload = {
       topic,
       title: input.title,
@@ -497,7 +552,20 @@ export class NtfyNotificationService implements NotifyService {
     let body = JSON.stringify(
       input.click ? { ...basePayload, click: input.click } : basePayload,
     );
-    if (input.click && Buffer.byteLength(body, 'utf8') > 4_000) {
+    if (input.click && Buffer.byteLength(body, 'utf8') > NTFY_REQUEST_MAX_BYTES) {
+      body = JSON.stringify(basePayload);
+    }
+    if (Buffer.byteLength(body, 'utf8') > NTFY_REQUEST_MAX_BYTES) {
+      // overhead = all keys/quotes/commas except the message *content* (empty
+      // string still contributes the surrounding "" which stays in the final body).
+      const overhead = Buffer.byteLength(
+        JSON.stringify({ ...basePayload, message: '' }),
+        'utf8',
+      );
+      basePayload.message = boundJsonEscapedText(
+        input.message,
+        NTFY_REQUEST_MAX_BYTES - overhead,
+      );
       body = JSON.stringify(basePayload);
     }
     const response = await fetch(providerUrl('/'), {

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -526,6 +526,48 @@ function jsonStringEscapeCost(point: string): number {
 }
 
 /**
+ * UTF-8 byte length of `text` after JSON string escaping (content only, no
+ * surrounding quotes). Used by the watcher to pack under the same budget that
+ * publish() enforces after serialization (F88).
+ */
+export function jsonEscapedByteLength(text: string): number {
+  let total = 0;
+  for (const point of text) total += jsonStringEscapeCost(point);
+  return total;
+}
+
+/**
+ * Available UTF-8 bytes for the ntfy JSON `message` field content after framing
+ * (topic/title/priority/tags/click). Mirrors publish() click-drop: if including
+ * click overflows the request cap, click is dropped before measuring (F76/F88).
+ * Conservative default topic is max ntfy length so watcher packing never exceeds
+ * the live physical topic overhead.
+ */
+export function notifyAvailableMessageBytes(options: {
+  title: string;
+  level: NotifyLevel;
+  tags?: string[];
+  click?: string;
+  topic?: string;
+}): number {
+  const topic = options.topic ?? 'x'.repeat(64);
+  const basePayload = {
+    topic,
+    title: options.title,
+    message: '',
+    priority: priority(options.level),
+    ...(options.tags?.length ? { tags: options.tags } : {}),
+  };
+  let framing = JSON.stringify(
+    options.click ? { ...basePayload, click: options.click } : basePayload,
+  );
+  if (options.click && Buffer.byteLength(framing, 'utf8') > NTFY_REQUEST_MAX_BYTES) {
+    framing = JSON.stringify(basePayload);
+  }
+  return Math.max(0, NTFY_REQUEST_MAX_BYTES - Buffer.byteLength(framing, 'utf8'));
+}
+
+/**
  * Truncate `text` so its JSON string-escape length is ≤ maxEscapedBytes.
  * Code-point aligned (same discipline as boundTextBytes); reserves room for `…`.
  * Used only for ntfy publish message bodies after field caps — a second line of

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -26,6 +26,11 @@ export interface NotifyInput {
   tags?: string[];
   /** Optional ntfy click action URL (e.g. dashboard origin for mail-arrival pushes). */
   click?: string;
+  /**
+   * Final privacy check after all internal awaits and body serialization,
+   * immediately before fetch(). Return false to abort without sending.
+   */
+  beforeSend?: () => boolean;
 }
 
 export interface NotifyMessage {
@@ -60,6 +65,7 @@ export class NotifyError extends Error {
       | 'notifications_disabled'
       | 'notifications_unconfigured'
       | 'notify_unavailable'
+      | 'notify_cancelled'
       | 'verify_failed'
       | 'unknown_agent',
   ) {
@@ -571,6 +577,11 @@ export class NtfyNotificationService implements NotifyService {
         NTFY_REQUEST_MAX_BYTES - overhead,
       );
       body = JSON.stringify(basePayload);
+    }
+    // After assertEnabled/physicalTopic awaits: last chance to drop a payload
+    // whose privacy floor moved mid-flight (tier downgrade or DELETE).
+    if (input.beforeSend && !input.beforeSend()) {
+      throw new NotifyError('notify_cancelled');
     }
     const response = await fetch(providerUrl('/'), {
       method: 'POST',

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -485,17 +485,25 @@ export class NtfyNotificationService implements NotifyService {
   async publish(input: NotifyInput): Promise<{ target: NotifyTarget; title: string; level: NotifyLevel }> {
     const current = await this.assertEnabled();
     const topic = await physicalTopic(input.target, input.level);
+    // ntfy rejects bodies near ~4096 bytes. message is capped at 3500; a long
+    // DASHBOARD_PUBLIC_URL click can still blow the request — drop click first.
+    const basePayload = {
+      topic,
+      title: input.title,
+      message: input.message,
+      priority: priority(input.level),
+      ...(input.tags?.length ? { tags: input.tags } : {}),
+    };
+    let body = JSON.stringify(
+      input.click ? { ...basePayload, click: input.click } : basePayload,
+    );
+    if (input.click && Buffer.byteLength(body, 'utf8') > 4_000) {
+      body = JSON.stringify(basePayload);
+    }
     const response = await fetch(providerUrl('/'), {
       method: 'POST',
       headers: { ...bearer(current.publisherToken), 'content-type': 'application/json' },
-      body: JSON.stringify({
-        topic,
-        title: input.title,
-        message: input.message,
-        priority: priority(input.level),
-        ...(input.tags?.length ? { tags: input.tags } : {}),
-        ...(input.click ? { click: input.click } : {}),
-      }),
+      body,
     });
     if (!response.ok) throw new NotifyError('notify_unavailable');
     return { target: input.target, title: input.title, level: input.level };

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -17,6 +17,15 @@ import { findIdentity, listIdentities, type Identity } from './identities.ts';
 export type NotifyLevel = 'urgent' | 'normal' | 'low';
 export type NotifyTarget = 'user' | `agent:${string}`;
 export type NotifyTopic = 'self' | 'user-alerts' | 'user-low' | `agent:${string}`;
+/**
+ * When serialized ntfy JSON still exceeds NTFY_REQUEST_MAX_BYTES after optional
+ * click-drop (F76):
+ * - `truncate` — shorten message with ellipsis (mail-arrival watcher only; must
+ *   not throw or the UID watermark stalls).
+ * - `error` — throw message_too_large (default; manual /v1/notify must not
+ *   silently cut the body and return 200).
+ */
+export type NotifyOverflow = 'truncate' | 'error';
 
 export interface NotifyInput {
   target: NotifyTarget;
@@ -31,6 +40,8 @@ export interface NotifyInput {
    * immediately before fetch(). Return false to abort without sending.
    */
   beforeSend?: () => boolean;
+  /** Default `error`. Watcher passes `truncate`. Click-drop runs before this. */
+  overflow?: NotifyOverflow;
 }
 
 export interface NotifyMessage {
@@ -67,7 +78,12 @@ export class NotifyError extends Error {
       | 'notify_unavailable'
       | 'notify_cancelled'
       | 'verify_failed'
-      | 'unknown_agent',
+      | 'unknown_agent'
+      | 'message_too_large',
+    public readonly details?: {
+      maxRequestBytes: number;
+      availableMessageBytes: number;
+    },
   ) {
     super(code);
   }
@@ -548,10 +564,10 @@ export class NtfyNotificationService implements NotifyService {
     const current = await this.assertEnabled();
     const topic = await physicalTopic(input.target, input.level);
     // ntfy rejects bodies near ~4096 bytes. Prefer keeping click; if the
-    // serialized body is still over budget after dropping click, truncate only
-    // message (topic/title/tags are our short bounded strings, not attacker
-    // mail content). JSON escaping can expand control chars past the watcher
-    // raw-byte cap, so this is the final serialization-layer backstop.
+    // serialized body is still over budget after dropping click, either
+    // truncate message (watcher) or error (manual). Click-drop always runs
+    // first so its budget relief still counts for both overflow modes (F76).
+    const overflow = input.overflow ?? 'error';
     const basePayload = {
       topic,
       title: input.title,
@@ -572,10 +588,14 @@ export class NtfyNotificationService implements NotifyService {
         JSON.stringify({ ...basePayload, message: '' }),
         'utf8',
       );
-      basePayload.message = boundJsonEscapedText(
-        input.message,
-        NTFY_REQUEST_MAX_BYTES - overhead,
-      );
+      const availableMessageBytes = Math.max(0, NTFY_REQUEST_MAX_BYTES - overhead);
+      if (overflow === 'error') {
+        throw new NotifyError('message_too_large', {
+          maxRequestBytes: NTFY_REQUEST_MAX_BYTES,
+          availableMessageBytes,
+        });
+      }
+      basePayload.message = boundJsonEscapedText(input.message, availableMessageBytes);
       body = JSON.stringify(basePayload);
     }
     // After assertEnabled/physicalTopic awaits: last chance to drop a payload

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -24,6 +24,8 @@ export interface NotifyInput {
   message: string;
   level: NotifyLevel;
   tags?: string[];
+  /** Optional ntfy click action URL (e.g. dashboard origin for mail-arrival pushes). */
+  click?: string;
 }
 
 export interface NotifyMessage {
@@ -492,6 +494,7 @@ export class NtfyNotificationService implements NotifyService {
         message: input.message,
         priority: priority(input.level),
         ...(input.tags?.length ? { tags: input.tags } : {}),
+        ...(input.click ? { click: input.click } : {}),
       }),
     });
     if (!response.ok) throw new NotifyError('notify_unavailable');

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -126,10 +126,12 @@ function extractAnchors(html: string): Anchor[] {
 
 /**
  * Bare http(s) URLs in plain text; scheme is case-insensitive (RFC 3986).
- * Allows a balanced `[...]` host segment (IPv6 literals) but still stops before
- * a free trailing `]` / `)` so `[see https://x.example]` keeps the outer bracket.
+ * Paired `[...]` (IPv6 hosts) and `(...)` path segments are allowed as their
+ * own alternatives; the general class excludes `[]()` so free trailing brackets
+ * are not swallowed and a run of lone `[`/`(` stays O(n) (no nested backtrack).
  */
-export const BARE_URL_RE = /https?:\/\/(?:\[[^\s\]]+\]|[^\s<>"')\]])+/gi;
+export const BARE_URL_RE =
+  /https?:\/\/(?:\[[^\s\]]+\]|\([^()\s]*\)|[^\s<>"'()\[\]])+/gi;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -148,16 +148,9 @@ export function validatedHttpUrl(candidate: string): string | null {
   }
 }
 
-function isAsciiWhitespace(ch: string): boolean {
-  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f';
-}
-
-/** True if [from, to) has no ASCII whitespace (Markdown glue between links). */
-function isWhitespaceFree(text: string, from: number, to: number): boolean {
-  for (let i = from; i < to; i++) {
-    if (isAsciiWhitespace(text[i]!)) return false;
-  }
-  return true;
+/** JS `\\s` set (NBSP, em space, etc.) — same rule for scan and glue checks. */
+function isJsWhitespace(ch: string): boolean {
+  return /\s/.test(ch);
 }
 
 /** Non-overlapping positions of https?:// (case-insensitive). O(n). */
@@ -251,21 +244,31 @@ export type BareUrlSpan = {
  * an unbalanced closer is a hard cut only when the next scheme is glued with
  * no whitespace (Markdown chain); otherwise it stays in the URL (WHATWG).
  * Bounded tail peel removes free trailers without re-matching the remainder.
+ *
+ * Glue checks use a monotonic nextWs pointer (first JS-whitespace index at or
+ * after the current probe) so 40k unbalanced closers stay O(n), not O(n²).
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
   const schemePos = findSchemePositions(text);
   let schemeIdx = 0;
+  // First whitespace index at or after this value; only advances.
+  let nextWs = 0;
+  const ensureNextWs = (from: number) => {
+    if (nextWs < from) nextWs = from;
+    while (nextWs < text.length && !isJsWhitespace(text[nextWs]!)) nextWs += 1;
+  };
 
   while (schemeIdx < schemePos.length) {
     const start = schemePos[schemeIdx]!;
     let parenDepth = 0;
     let bracketDepth = 0;
     let end = text.length;
+    ensureNextWs(start);
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
-      if (isAsciiWhitespace(ch) || ch === '<' || ch === '>' || ch === '"') {
+      if (isJsWhitespace(ch) || ch === '<' || ch === '>' || ch === '"') {
         end = i;
         break;
       }
@@ -282,13 +285,11 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           parenDepth -= 1;
           continue;
         }
-        // Unbalanced closer: cut only if next scheme is glued (no whitespace).
+        // Unbalanced closer: glued to next scheme iff no whitespace in between.
+        // nextWs is the first whitespace index >= i+1 (monotonic O(1) query).
+        ensureNextWs(i + 1);
         const nextScheme = schemePos[schemeIdx + 1];
-        if (
-          nextScheme !== undefined &&
-          nextScheme > i &&
-          isWhitespaceFree(text, i + 1, nextScheme)
-        ) {
+        if (nextScheme !== undefined && nextScheme > i && nextWs >= nextScheme) {
           end = i;
           break;
         }
@@ -299,12 +300,9 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           bracketDepth -= 1;
           continue;
         }
+        ensureNextWs(i + 1);
         const nextScheme = schemePos[schemeIdx + 1];
-        if (
-          nextScheme !== undefined &&
-          nextScheme > i &&
-          isWhitespaceFree(text, i + 1, nextScheme)
-        ) {
+        if (nextScheme !== undefined && nextScheme > i && nextWs >= nextScheme) {
           end = i;
           break;
         }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -310,21 +310,21 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
         end = i;
         // Quote/angle hard cut: glued non-ws tail may hold secrets (e.g. "token=).
         // Whitespace cuts never record a tail (balanced "url" / <url> keep delimiters).
+        // F58: resolve nextScheme *before* walking the tail so dense "https://a/N"x=
+        // fragments stay O(n) (walk is bounded by the next scheme, not the full suffix).
         if (
           (ch === '<' || ch === '>' || ch === '"') &&
           i + 1 < text.length &&
           !isJsWhitespace(text[i + 1]!)
         ) {
-          let tailEnd = i + 1;
-          while (tailEnd < text.length && !isJsWhitespace(text[tailEnd]!)) {
-            tailEnd += 1;
-          }
           while (probeIdx < schemePos.length && schemePos[probeIdx]! <= i) {
             probeIdx += 1;
           }
           const nextScheme = schemePos[probeIdx];
-          if (nextScheme !== undefined && nextScheme < tailEnd) {
-            tailEnd = nextScheme;
+          const scanLimit = nextScheme !== undefined ? nextScheme : text.length;
+          let tailEnd = i + 1;
+          while (tailEnd < scanLimit && !isJsWhitespace(text[tailEnd]!)) {
+            tailEnd += 1;
           }
           if (tailEnd > i) {
             tailCut = { start: i, end: tailEnd };
@@ -395,6 +395,14 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   }
 }
 
+/** Exclusive end of a span including any recorded glue/tail after the clean URL. */
+function spanExtentEnd(span: BareUrlSpan): number {
+  let end = span.end;
+  if (span.glueAfter && span.glueAfter.end > end) end = span.glueAfter.end;
+  if (span.tailAfter && span.tailAfter.end > end) end = span.tailAfter.end;
+  return end;
+}
+
 /**
  * Replace bare URLs in `text` whose validatedHttpUrl form is in `normalizedLinks`
  * with `placeholder`, keeping the original spelling span as the match (so
@@ -403,6 +411,9 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
  * is redacted too so labels like `)[token=secret](` cannot leak between spans.
  * Quote/angle tails (span.tailAfter) are redacted when this URL is a target so
  * `"token=secret` / `>token=secret` cannot leak after a hard cut (F55).
+ * After a glue/tail redaction lands on the next span start, invalid spans
+ * (validatedHttpUrl null) are swallowed into the redaction zone so nested
+ * `https://[token=…` cannot leak (F57). Valid spans always stop the chain.
  */
 export function maskNormalizedHttpUrls(
   text: string,
@@ -417,12 +428,21 @@ export function maskNormalizedHttpUrls(
   let cursor = 0;
   for (let i = 0; i < spans.length; i++) {
     const span = spans[i]!;
-    out += text.slice(cursor, span.start);
+    // Span already consumed while swallowing invalid neighbors after a prior cut.
+    if (cursor > span.start) {
+      cursor = Math.max(cursor, spanExtentEnd(span));
+      continue;
+    }
+    if (cursor < span.start) {
+      out += text.slice(cursor, span.start);
+    }
+
     const validated = validatedHttpUrl(span.clean);
     const maskThis = Boolean(validated && targets.has(validated));
     out += maskThis ? placeholder : span.clean;
     cursor = span.end;
 
+    let redactedAdjacent = false;
     const glue = span.glueAfter;
     if (glue && glue.end > glue.start) {
       // Mask glue when either adjacent URL is a redaction target (label may hold secrets).
@@ -436,6 +456,7 @@ export function maskNormalizedHttpUrls(
         // Skip any peel gap before the closer, then redact [closer, nextScheme).
         out += placeholder;
         cursor = glue.end;
+        redactedAdjacent = true;
       }
     }
 
@@ -444,6 +465,21 @@ export function maskNormalizedHttpUrls(
       // URL was redacted: redact glued " / < / > tail so secrets cannot stick.
       out += placeholder;
       cursor = tail.end;
+      redactedAdjacent = true;
+    }
+
+    // F57: glue/tail may stop at a nested scheme that is not a valid URL; swallow
+    // those invalid spans (and their own glue/tail) while they remain adjacent.
+    if (redactedAdjacent) {
+      let j = i + 1;
+      while (j < spans.length) {
+        const neighbor = spans[j]!;
+        if (neighbor.start !== cursor) break;
+        if (validatedHttpUrl(neighbor.clean) !== null) break;
+        cursor = spanExtentEnd(neighbor);
+        j += 1;
+      }
+      if (j > i + 1) i = j - 1;
     }
   }
   out += text.slice(cursor);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -125,13 +125,12 @@ function extractAnchors(html: string): Anchor[] {
 }
 
 /**
- * Bare http(s) URLs in plain text; scheme is case-insensitive (RFC 3986).
- * Paired `[...]` (IPv6 hosts) and `(...)` path segments are allowed as their
- * own alternatives; the general class excludes `[]()` so free trailing brackets
- * are not swallowed and a run of lone `[`/`(` stays O(n) (no nested backtrack).
+ * Bare http(s) URL *candidates* in plain text (scheme case-insensitive).
+ * Intentionally greedy and linear — nested/paired delimiters are not expressed
+ * in the regex. Call splitBareUrlCandidate() to peel free trailing `)].,;`
+ * while keeping balanced brackets (IPv6 hosts, wiki paths, confirm(foo(bar))).
  */
-export const BARE_URL_RE =
-  /https?:\/\/(?:\[[^\s\]]+\]|\([^()\s]*\)|[^\s<>"'()\[\]])+/gi;
+export const BARE_URL_RE = /https?:\/\/[^\s<>"']+/gi;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);
@@ -152,6 +151,52 @@ export function validatedHttpUrl(candidate: string): string | null {
 }
 
 /**
+ * Split a bare-URL regex match into the real URL (`clean`) and prose tail
+ * (`trail`). One O(n) count of brackets, then one right-to-left pass:
+ * strip trailing `.,;`, and strip a trailing `)`/`]` only while closers
+ * outnumber openers. Balanced nested `()`/`[]` stay on the URL; free outer
+ * brackets and trailing punctuation stay in `trail` for the caller to reattach.
+ * Must stay O(n) — never re-count on each trim (that reintroduces O(n²)).
+ */
+export function splitBareUrlCandidate(candidate: string): { clean: string; trail: string } {
+  if (!candidate) return { clean: '', trail: '' };
+
+  let openParen = 0;
+  let closeParen = 0;
+  let openBracket = 0;
+  let closeBracket = 0;
+  for (let i = 0; i < candidate.length; i++) {
+    const ch = candidate[i]!;
+    if (ch === '(') openParen += 1;
+    else if (ch === ')') closeParen += 1;
+    else if (ch === '[') openBracket += 1;
+    else if (ch === ']') closeBracket += 1;
+  }
+
+  let end = candidate.length;
+  while (end > 0) {
+    const ch = candidate[end - 1]!;
+    if (ch === '.' || ch === ',' || ch === ';') {
+      end -= 1;
+      continue;
+    }
+    if (ch === ')' && closeParen > openParen) {
+      closeParen -= 1;
+      end -= 1;
+      continue;
+    }
+    if (ch === ']' && closeBracket > openBracket) {
+      closeBracket -= 1;
+      end -= 1;
+      continue;
+    }
+    break;
+  }
+
+  return { clean: candidate.slice(0, end), trail: candidate.slice(end) };
+}
+
+/**
  * Replace bare URLs in `text` whose validatedHttpUrl form is in `normalizedLinks`
  * with `placeholder`, keeping the original spelling span as the match (so
  * EXAMPLE.com:443 still redacts when the needle is https://example.com/...).
@@ -165,8 +210,7 @@ export function maskNormalizedHttpUrls(
   const targets = new Set(normalizedLinks.filter(Boolean));
   if (targets.size === 0) return text;
   return text.replace(BARE_URL_RE, (raw) => {
-    const clean = raw.replace(/[.,;]+$/, '');
-    const trail = raw.slice(clean.length);
+    const { clean, trail } = splitBareUrlCandidate(raw);
     const validated = validatedHttpUrl(clean);
     if (validated && targets.has(validated)) return `${placeholder}${trail}`;
     return raw;
@@ -182,7 +226,7 @@ export function extractLinks(text: string, html?: string): string[] {
   const links: string[] = [];
   const seen = new Set<string>();
   const push = (url: string) => {
-    const clean = url.replace(/[.,;]+$/, '');
+    const { clean } = splitBareUrlCandidate(url);
     const validated = validatedHttpUrl(clean);
     if (validated && !seen.has(validated)) {
       seen.add(validated);
@@ -222,7 +266,7 @@ export function extractHttpLinks(text: string, html?: string): string[] {
   const links: string[] = [];
   const seen = new Set<string>();
   const push = (candidate: string) => {
-    const clean = candidate.replace(/[.,;]+$/, '');
+    const { clean } = splitBareUrlCandidate(candidate);
     const validated = validatedHttpUrl(clean);
     if (validated && !seen.has(validated)) {
       seen.add(validated);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -241,30 +241,22 @@ export type BareUrlSpan = {
 /**
  * Single-pass bare URL tokenizer. O(n) over the full text:
  * pre-scan scheme positions, then for each start scan once with depth tracking;
- * an unbalanced closer is a hard cut only when the next scheme is glued with
- * no whitespace (Markdown chain); otherwise it stays in the URL (WHATWG).
- * Bounded tail peel removes free trailers without re-matching the remainder.
- *
- * Glue checks use a monotonic nextWs pointer (first JS-whitespace index at or
- * after the current probe) so 40k unbalanced closers stay O(n), not O(n²).
+ * an unbalanced closer is a hard cut only when immediately followed by `[` or
+ * `(` (Markdown chain glue: `)[`, `)(`, `][`, `](`). Nested redirects like
+ * `)token=…?next=https://` keep the closer inside the URL (WHATWG); the inner
+ * scheme is skipped by the post-span scheme advance. Bounded tail peel removes
+ * free trailers without re-matching the remainder.
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
   const schemePos = findSchemePositions(text);
   let schemeIdx = 0;
-  // First whitespace index at or after this value; only advances.
-  let nextWs = 0;
-  const ensureNextWs = (from: number) => {
-    if (nextWs < from) nextWs = from;
-    while (nextWs < text.length && !isJsWhitespace(text[nextWs]!)) nextWs += 1;
-  };
 
   while (schemeIdx < schemePos.length) {
     const start = schemePos[schemeIdx]!;
     let parenDepth = 0;
     let bracketDepth = 0;
     let end = text.length;
-    ensureNextWs(start);
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -285,11 +277,10 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           parenDepth -= 1;
           continue;
         }
-        // Unbalanced closer: glued to next scheme iff no whitespace in between.
-        // nextWs is the first whitespace index >= i+1 (monotonic O(1) query).
-        ensureNextWs(i + 1);
-        const nextScheme = schemePos[schemeIdx + 1];
-        if (nextScheme !== undefined && nextScheme > i && nextWs >= nextScheme) {
+        // Unbalanced closer: hard-cut only for tightly adjacent Markdown chain
+        // openers. `?next=https://` after `)token=…` is not a chain — keep ) in URL.
+        const next = text[i + 1];
+        if (next === '[' || next === '(') {
           end = i;
           break;
         }
@@ -300,9 +291,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           bracketDepth -= 1;
           continue;
         }
-        ensureNextWs(i + 1);
-        const nextScheme = schemePos[schemeIdx + 1];
-        if (nextScheme !== undefined && nextScheme > i && nextWs >= nextScheme) {
+        const next = text[i + 1];
+        if (next === '[' || next === '(') {
           end = i;
           break;
         }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -124,8 +124,8 @@ function extractAnchors(html: string): Anchor[] {
   return anchors;
 }
 
-/** Bare http(s) URLs in plain text; shared by extractors and tier-2 masking. */
-export const BARE_URL_RE = /https?:\/\/[^\s<>"')\]]+/g;
+/** Bare http(s) URLs in plain text; scheme is case-insensitive (RFC 3986). */
+export const BARE_URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -412,6 +412,27 @@ function isJsWhitespace(ch: string): boolean {
   return /\s/.test(ch);
 }
 
+/**
+ * Prose close-context after a quote closer (F64/F122): end of text,
+ * whitespace, or terminal punctuation — an internal apostrophe (`o'brien`)
+ * or quote-joined URL content sees anything else.
+ */
+function isProseCloseContext(next: string): boolean {
+  return (
+    next === '' ||
+    isJsWhitespace(next) ||
+    next === '!' ||
+    next === '.' ||
+    next === ',' ||
+    next === ';' ||
+    next === ':' ||
+    next === '?' ||
+    next === ')' ||
+    next === ']' ||
+    next === '}'
+  );
+}
+
 /** Non-overlapping positions of https?:// (case-insensitive). O(n). */
 function findSchemePositions(text: string): number[] {
   const positions: number[] = [];
@@ -704,6 +725,9 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
  * openQuoted spans also cut before a closing `'` when the next char is prose
  * close context (F64). Nested redirects stay inside the URL when no cut applies.
  * Bounded tail peel removes free trailers without re-matching.
+ * Smart-quoted spans (“…”/‘…’) likewise cut before the matching closing
+ * smart quote in close context (F122) so the quote is not percent-encoded
+ * into the published destination.
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
@@ -740,6 +764,16 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     // True when F64 cut left the outer closer outside the raw span — peel must
     // not also strip a legal URL-terminal ' (F63).
     let openQuotedCut = false;
+    // F122: span opened after a smart-quote opener (“…”/‘…’) — the matching
+    // closing quote is prose context, not URL content (the WHATWG parser
+    // percent-encodes it into a different, unusable destination).
+    const smartOpener = start >= 1 ? text[start - 1]! : '';
+    const openSmartQuote =
+      smartOpener === '\u201C'
+        ? '\u201D'
+        : smartOpener === '\u2018'
+          ? '\u2019'
+          : undefined;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -820,21 +854,19 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
       // (token'' + space → cut only the outer closer) stay in the URL.
       if (ch === "'" && openQuoted) {
         const next = i + 1 < text.length ? text[i + 1]! : '';
-        const closes =
-          next === '' ||
-          isJsWhitespace(next) ||
-          next === '!' ||
-          next === '.' ||
-          next === ',' ||
-          next === ';' ||
-          next === ':' ||
-          next === '?' ||
-          next === ')' ||
-          next === ']' ||
-          next === '}';
-        if (closes) {
+        if (isProseCloseContext(next)) {
           end = i;
           openQuotedCut = true;
+          break;
+        }
+        continue;
+      }
+      // F122: matching smart closer closes a smart-quoted span in close
+      // context; anything else keeps the quote as (rare, invalid) URL content.
+      if (openSmartQuote !== undefined && ch === openSmartQuote) {
+        const next = i + 1 < text.length ? text[i + 1]! : '';
+        if (isProseCloseContext(next)) {
+          end = i;
           break;
         }
         continue;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -125,13 +125,10 @@ function extractAnchors(html: string): Anchor[] {
 }
 
 /**
- * Bare http(s) URL *candidates* in plain text (scheme case-insensitive).
- * Intentionally greedy and linear. `'` is kept (RFC 3986 sub-delim / path
- * apostrophes); only whitespace, `<`, `>`, `"` stay excluded — those never
- * appear unencoded in a legal URL. Call splitBareUrlCandidate() to peel free
- * trailing prose delimiters while keeping balanced brackets and in-URL `'`.
+ * Scheme finder / tests only. Prose extraction uses bareUrlSpans (single-pass
+ * tokenizer). Kept for callers and tests that still import the pattern.
  */
-export const BARE_URL_RE = /https?:\/\/[^\s<>"]+/gi;
+export const BARE_URL_RE = /https?:\/\//gi;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);
@@ -151,58 +148,67 @@ export function validatedHttpUrl(candidate: string): string | null {
   }
 }
 
+function isAsciiWhitespace(ch: string): boolean {
+  return ch === ' ' || ch === '\t' || ch === '\n' || ch === '\r' || ch === '\f';
+}
+
+/** True if [from, to) has no ASCII whitespace (Markdown glue between links). */
+function isWhitespaceFree(text: string, from: number, to: number): boolean {
+  for (let i = from; i < to; i++) {
+    if (isAsciiWhitespace(text[i]!)) return false;
+  }
+  return true;
+}
+
+/** Non-overlapping positions of https?:// (case-insensitive). O(n). */
+function findSchemePositions(text: string): number[] {
+  const positions: number[] = [];
+  const re = /https?:\/\//gi;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    positions.push(match.index);
+  }
+  return positions;
+}
+
 /**
- * Split a bare-URL regex match into the real URL (`clean`) and prose tail
- * (`trail`). O(n):
- * 1) Left-to-right depth scan — first `)`/`]` that makes its depth negative is
- *    a hard cut (covers free trailers and mid-string boundaries like
- *    `…/verify)[Confirm](https://…` between adjacent Markdown links).
- * 2) On the remaining clean prefix, right-to-left peel of trailing `.,;` and
- *    of a trailing `'` while the remaining apostrophe count is odd; peeled
- *    chars are prepended onto trail to preserve order.
- * Balanced nested `()`/`[]` never go negative and stay on the URL.
+ * Peel trailing prose from a bounded candidate [0, length): `.,;`, unbalanced
+ * trailing `)`/`]`, and an odd trailing `'`. O(length).
  */
-export function splitBareUrlCandidate(candidate: string): { clean: string; trail: string } {
+function peelTrailingProse(candidate: string): { clean: string; trail: string } {
   if (!candidate) return { clean: '', trail: '' };
 
-  let parenDepth = 0;
-  let bracketDepth = 0;
-  let cut = candidate.length;
+  let openParen = 0;
+  let closeParen = 0;
+  let openBracket = 0;
+  let closeBracket = 0;
+  let apostrophes = 0;
   for (let i = 0; i < candidate.length; i++) {
     const ch = candidate[i]!;
-    if (ch === '(') parenDepth += 1;
-    else if (ch === ')') {
-      parenDepth -= 1;
-      if (parenDepth < 0) {
-        cut = i;
-        break;
-      }
-    } else if (ch === '[') bracketDepth += 1;
-    else if (ch === ']') {
-      bracketDepth -= 1;
-      if (bracketDepth < 0) {
-        cut = i;
-        break;
-      }
-    }
+    if (ch === '(') openParen += 1;
+    else if (ch === ')') closeParen += 1;
+    else if (ch === '[') openBracket += 1;
+    else if (ch === ']') closeBracket += 1;
+    else if (ch === "'") apostrophes += 1;
   }
 
-  let clean = candidate.slice(0, cut);
-  let trail = candidate.slice(cut);
-
-  let apostrophes = 0;
-  for (let i = 0; i < clean.length; i++) {
-    if (clean[i] === "'") apostrophes += 1;
-  }
-
-  let end = clean.length;
+  let end = candidate.length;
   while (end > 0) {
-    const ch = clean[end - 1]!;
+    const ch = candidate[end - 1]!;
     if (ch === '.' || ch === ',' || ch === ';') {
       end -= 1;
       continue;
     }
-    // Odd remaining apostrophe count ⇒ peel a free prose closer; even ⇒ keep.
+    if (ch === ')' && closeParen > openParen) {
+      closeParen -= 1;
+      end -= 1;
+      continue;
+    }
+    if (ch === ']' && closeBracket > openBracket) {
+      closeBracket -= 1;
+      end -= 1;
+      continue;
+    }
     if (ch === "'" && apostrophes % 2 === 1) {
       apostrophes -= 1;
       end -= 1;
@@ -211,15 +217,26 @@ export function splitBareUrlCandidate(candidate: string): { clean: string; trail
     break;
   }
 
-  if (end < clean.length) {
-    trail = clean.slice(end) + trail;
-    clean = clean.slice(0, end);
-  }
-
-  return { clean, trail };
+  return { clean: candidate.slice(0, end), trail: candidate.slice(end) };
 }
 
-/** One prose URL span after splitBareUrlCandidate (indices into the full text). */
+/**
+ * Split a single candidate (typically starting at a scheme) into clean URL +
+ * trail using the same glue/peel rules as bareUrlSpans. Prefer bareUrlSpans for
+ * full-text walks; this remains for unit tests and single-match call sites.
+ */
+export function splitBareUrlCandidate(candidate: string): { clean: string; trail: string } {
+  if (!candidate) return { clean: '', trail: '' };
+  for (const span of bareUrlSpans(candidate)) {
+    if (span.start === 0) {
+      return { clean: span.clean, trail: candidate.slice(span.end) };
+    }
+    break;
+  }
+  return { clean: candidate, trail: '' };
+}
+
+/** One prose URL span (indices into the full text). */
 export type BareUrlSpan = {
   /** Start index of `clean` in the full text. */
   start: number;
@@ -229,28 +246,85 @@ export type BareUrlSpan = {
 };
 
 /**
- * Walk prose for bare URL cleans. After each hit, resume scanning at
- * matchStart + clean.length so trail (e.g. `)[Confirm](https://…`) re-enters
- * the scan and adjacent Markdown links split correctly.
+ * Single-pass bare URL tokenizer. O(n) over the full text:
+ * pre-scan scheme positions, then for each start scan once with depth tracking;
+ * an unbalanced closer is a hard cut only when the next scheme is glued with
+ * no whitespace (Markdown chain); otherwise it stays in the URL (WHATWG).
+ * Bounded tail peel removes free trailers without re-matching the remainder.
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
-  const re = new RegExp(BARE_URL_RE.source, BARE_URL_RE.flags);
-  let pos = 0;
-  while (pos < text.length) {
-    re.lastIndex = pos;
-    const match = re.exec(text);
-    if (!match) break;
-    const matchStart = match.index;
-    const { clean } = splitBareUrlCandidate(match[0]);
+  const schemePos = findSchemePositions(text);
+  let schemeIdx = 0;
+
+  while (schemeIdx < schemePos.length) {
+    const start = schemePos[schemeIdx]!;
+    let parenDepth = 0;
+    let bracketDepth = 0;
+    let end = text.length;
+
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i]!;
+      if (isAsciiWhitespace(ch) || ch === '<' || ch === '>' || ch === '"') {
+        end = i;
+        break;
+      }
+      if (ch === '(') {
+        parenDepth += 1;
+        continue;
+      }
+      if (ch === '[') {
+        bracketDepth += 1;
+        continue;
+      }
+      if (ch === ')') {
+        if (parenDepth > 0) {
+          parenDepth -= 1;
+          continue;
+        }
+        // Unbalanced closer: cut only if next scheme is glued (no whitespace).
+        const nextScheme = schemePos[schemeIdx + 1];
+        if (
+          nextScheme !== undefined &&
+          nextScheme > i &&
+          isWhitespaceFree(text, i + 1, nextScheme)
+        ) {
+          end = i;
+          break;
+        }
+        continue;
+      }
+      if (ch === ']') {
+        if (bracketDepth > 0) {
+          bracketDepth -= 1;
+          continue;
+        }
+        const nextScheme = schemePos[schemeIdx + 1];
+        if (
+          nextScheme !== undefined &&
+          nextScheme > i &&
+          isWhitespaceFree(text, i + 1, nextScheme)
+        ) {
+          end = i;
+          break;
+        }
+        continue;
+      }
+    }
+
+    const raw = text.slice(start, end);
+    const { clean } = peelTrailingProse(raw);
     if (clean.length === 0) {
-      // Avoid an infinite loop on a pathological zero-length clean.
-      pos = matchStart + Math.max(1, match[0].length);
+      schemeIdx += 1;
       continue;
     }
-    // clean is always a prefix of the regex match under splitBareUrlCandidate.
-    yield { start: matchStart, end: matchStart + clean.length, clean };
-    pos = matchStart + clean.length;
+    const cleanEnd = start + clean.length;
+    yield { start, end: cleanEnd, clean };
+
+    // Skip schemes that fell inside this span (e.g. nested ?next=https://…).
+    while (schemeIdx < schemePos.length && schemePos[schemeIdx]! < cleanEnd) {
+      schemeIdx += 1;
+    }
   }
 }
 

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -409,12 +409,32 @@ function findSchemePositions(text: string): number[] {
   return positions;
 }
 
+/** Prose terminal punctuation that may trail a URL (peel loop / F90–F92). */
+function isUrlTerminalPunct(ch: string): boolean {
+  return ch === '.' || ch === ',' || ch === ';' || ch === '!' || ch === '?';
+}
+
 /**
- * Peel trailing prose from a bounded candidate [0, length): `.,;!?`, unbalanced
- * trailing `)`/`]`, and trailing `'`.
- * - Terminal `!`/`?` peel like `.`/`,`/`;` so non-adjacent wrappers that leave
- *   `)!` / `]!` / `'!` on the candidate can then expose the unbalanced closer
- *   (F90). Mid-URL `!`/`?` are never trailing and stay put.
+ * Whether a trailing `!` at candidate[end-1] is prose punctuation glued to a
+ * closer `)`/`]`/`'` (possibly with other terminal punct in between), not a
+ * legal URL-final bang (F92). Look-back is O(length) over the suffix only.
+ */
+function bangHasCloserContext(candidate: string, end: number): boolean {
+  // Skip the `!` itself, then any run of terminal punct, then require a closer.
+  let i = end - 2;
+  while (i >= 0 && isUrlTerminalPunct(candidate[i]!)) i -= 1;
+  if (i < 0) return false;
+  const ch = candidate[i]!;
+  return ch === ')' || ch === ']' || ch === "'";
+}
+
+/**
+ * Peel trailing prose from a bounded candidate [0, length): `.,;?`, conditional
+ * trailing `!`, unbalanced trailing `)`/`]`, and trailing `'`.
+ * - Terminal `?` peels like `.`/`,`/`;` (empty query ≈ no query; sentence `?`
+ *   is common). Mid-URL `?query` is never trailing and stays put.
+ * - Terminal `!` peels only with closer context (`)!` / `]!` / `'!` / `).!`),
+ *   so bare `…/token!` keeps the bang (F90 + F92). Mid-URL `!` stays put.
  * - openQuoted false: peel `'` only while the remaining apostrophe count is odd.
  * - openQuoted true (span started after prose `'`): peel exactly one closing
  *   `'` via a one-shot flag (F61/F63) — odd-parity must not fire as well, or a
@@ -448,9 +468,17 @@ function peelTrailingProse(
   let end = candidate.length;
   while (end > 0) {
     const ch = candidate[end - 1]!;
-    if (ch === '.' || ch === ',' || ch === ';' || ch === '!' || ch === '?') {
+    if (ch === '.' || ch === ',' || ch === ';' || ch === '?') {
       end -= 1;
       continue;
+    }
+    // F92: peel `!` only when glued to ) ] ' (skip other terminal punct in between).
+    if (ch === '!') {
+      if (bangHasCloserContext(candidate, end)) {
+        end -= 1;
+        continue;
+      }
+      break;
     }
     if (ch === ')' && closeParen > openParen) {
       closeParen -= 1;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -79,7 +79,28 @@ function decodeEntities(s: string): string {
     .replace(/&#39;|&apos;/g, "'");
 }
 
-/** Extract 4–8 digit codes appearing near an OTP keyword. */
+/**
+ * Strong OTP cues for year-shaped continuous codes (F65) and delimited forms
+ * (F68). Broader CODE_KEYWORDS alone would false-positive on roadmap years and
+ * phone-like `555-1234` near "call".
+ */
+const STRONG_OTP_CUE = /\b(?:code|otp|passcode|pin)\b|验证码|动态码/;
+
+/**
+ * True when a continuous \d{4,8} run is one half of a delimited OTP shape
+ * (`1234-5678`). Only 3–4 digit sides participate in that shape (continuous
+ * matches are ≥4, so length must be exactly 4); longer runs like
+ * `123456-7890` stay continuous so they are not dropped without recovery.
+ */
+function isHalfOfDelimitedOtp(text: string, idx: number, digits: string): boolean {
+  if (digits.length < 3 || digits.length > 4) return false;
+  const after = text.slice(idx + digits.length);
+  if (/^[-–—. ]\d{3,4}\b/.test(after)) return true;
+  const before = text.slice(Math.max(0, idx - 6), idx);
+  return /\b\d{3,4}[-–—. ]$/.test(before);
+}
+
+/** Extract 4–8 digit codes (continuous or delimited) near an OTP keyword. */
 export function extractCodes(text: string): string[] {
   const lower = text.toLowerCase();
   const codes: string[] = [];
@@ -88,6 +109,8 @@ export function extractCodes(text: string): string[] {
   for (const match of text.matchAll(/\b(\d{4,8})\b/g)) {
     const digits = match[1];
     const idx = match.index ?? 0;
+    // Leave `1234-5678` halves to the delimited pass (F68).
+    if (isHalfOfDelimitedOtp(text, idx, digits)) continue;
     const window = lower.slice(
       Math.max(0, idx - KEYWORD_WINDOW),
       Math.min(lower.length, idx + digits.length + KEYWORD_WINDOW),
@@ -96,15 +119,29 @@ export function extractCodes(text: string): string[] {
     // Years need a strong OTP cue (not mere "verification"/"identity") so
     // roadmap copy like "for 2026" does not fire false OTP alerts (F65).
     // "verification PIN is 2026" still matches \bpin\b.
-    if (
-      /^(19|20)\d{2}$/.test(digits) &&
-      !/\b(?:code|otp|passcode|pin)\b|验证码|动态码/.test(window)
-    ) {
+    if (/^(19|20)\d{2}$/.test(digits) && !STRONG_OTP_CUE.test(window)) {
       continue;
     }
     if (!seen.has(digits)) {
       seen.add(digits);
       codes.push(digits);
+    }
+  }
+
+  // F68: `123-456` / `1234–5678` only with a strong cue (not phone/roadmap).
+  // Separators: hyphen, en dash, em dash, period, space. Keep original spelling
+  // so maskSensitiveFragments can match the span.
+  for (const match of text.matchAll(/\b(\d{3,4}[-–—. ]\d{3,4})\b/g)) {
+    const form = match[1]!;
+    const idx = match.index ?? 0;
+    const window = lower.slice(
+      Math.max(0, idx - KEYWORD_WINDOW),
+      Math.min(lower.length, idx + form.length + KEYWORD_WINDOW),
+    );
+    if (!STRONG_OTP_CUE.test(window)) continue;
+    if (!seen.has(form)) {
+      seen.add(form);
+      codes.push(form);
     }
   }
   return codes;
@@ -312,7 +349,8 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
  * an unbalanced closer is a hard cut when (1) the next scheme is a proven
  * Markdown chain (tight `)(`, `](`, `)[`, `][`, or `)[label](` / `][label](`),
  * or (2) the span opened after `](` / prose `(` (first free `)` closes the
- * wrapper — F59/F64). Bare URLs keep free `)` in-path (e.g. F48 `confirm)[token=`).
+ * wrapper — F59/F64) or after prose `[` (first free `]` closes — F67; not
+ * `][` chain glue). Bare URLs keep free `)` in-path (e.g. F48 `confirm)[token=`).
  * openQuoted spans also cut before a closing `'` when the next char is prose
  * close context (F64). Nested redirects stay inside the URL when no cut applies.
  * Bounded tail peel removes free trailers without re-matching.
@@ -342,6 +380,11 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
       text[start - 1] === '(' &&
       (start < 2 || text[start - 2] !== ']');
     const cutOnFreeParen = markdownLinkOpen || proseParenOpen;
+    // F67: prose `[https://…]` — not `][` (Markdown/reference chain glue).
+    const proseBracketOpen =
+      start >= 1 &&
+      text[start - 1] === '[' &&
+      (start < 2 || text[start - 2] !== ']');
     // F61/F63: span opened after a prose apostrophe.
     const openQuoted = start >= 1 && text[start - 1] === "'";
     // True when F64 cut left the outer closer outside the raw span — peel must
@@ -413,6 +456,11 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
         if (isMarkdownChainGlue(text, i, nextScheme)) {
           end = i;
           glueCut = { closer: i, nextScheme: nextScheme! };
+          break;
+        }
+        // After glue: prose `[` opener cuts at first free closer (F67).
+        if (proseBracketOpen) {
+          end = i;
           break;
         }
         continue;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -410,8 +410,11 @@ function findSchemePositions(text: string): number[] {
 }
 
 /**
- * Peel trailing prose from a bounded candidate [0, length): `.,;`, unbalanced
+ * Peel trailing prose from a bounded candidate [0, length): `.,;!?`, unbalanced
  * trailing `)`/`]`, and trailing `'`.
+ * - Terminal `!`/`?` peel like `.`/`,`/`;` so non-adjacent wrappers that leave
+ *   `)!` / `]!` / `'!` on the candidate can then expose the unbalanced closer
+ *   (F90). Mid-URL `!`/`?` are never trailing and stay put.
  * - openQuoted false: peel `'` only while the remaining apostrophe count is odd.
  * - openQuoted true (span started after prose `'`): peel exactly one closing
  *   `'` via a one-shot flag (F61/F63) — odd-parity must not fire as well, or a
@@ -440,12 +443,12 @@ function peelTrailingProse(
     else if (ch === "'") apostrophes += 1;
   }
 
-  // openQuoted: authorize exactly one outer closer peel (after any .,;).
+  // openQuoted: authorize exactly one outer closer peel (after any .,;!?).
   let peelOpenQuote = openQuoted;
   let end = candidate.length;
   while (end > 0) {
     const ch = candidate[end - 1]!;
-    if (ch === '.' || ch === ',' || ch === ';') {
+    if (ch === '.' || ch === ',' || ch === ';' || ch === '!' || ch === '?') {
       end -= 1;
       continue;
     }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -153,43 +153,52 @@ export function validatedHttpUrl(candidate: string): string | null {
 
 /**
  * Split a bare-URL regex match into the real URL (`clean`) and prose tail
- * (`trail`). One O(n) count of brackets/apostrophes, then one right-to-left pass:
- * strip trailing `.,;`; strip trailing `)`/`]` only while closers outnumber
- * openers; strip a trailing `'` while the remaining apostrophe count is odd
- * (prose closer `'…url'` → peel one; even count or mid-string `it's` stays).
- * Must stay O(n) — never re-count on each trim (that reintroduces O(n²)).
+ * (`trail`). O(n):
+ * 1) Left-to-right depth scan — first `)`/`]` that makes its depth negative is
+ *    a hard cut (covers free trailers and mid-string boundaries like
+ *    `…/verify)[Confirm](https://…` between adjacent Markdown links).
+ * 2) On the remaining clean prefix, right-to-left peel of trailing `.,;` and
+ *    of a trailing `'` while the remaining apostrophe count is odd; peeled
+ *    chars are prepended onto trail to preserve order.
+ * Balanced nested `()`/`[]` never go negative and stay on the URL.
  */
 export function splitBareUrlCandidate(candidate: string): { clean: string; trail: string } {
   if (!candidate) return { clean: '', trail: '' };
 
-  let openParen = 0;
-  let closeParen = 0;
-  let openBracket = 0;
-  let closeBracket = 0;
-  let apostrophes = 0;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let cut = candidate.length;
   for (let i = 0; i < candidate.length; i++) {
     const ch = candidate[i]!;
-    if (ch === '(') openParen += 1;
-    else if (ch === ')') closeParen += 1;
-    else if (ch === '[') openBracket += 1;
-    else if (ch === ']') closeBracket += 1;
-    else if (ch === "'") apostrophes += 1;
+    if (ch === '(') parenDepth += 1;
+    else if (ch === ')') {
+      parenDepth -= 1;
+      if (parenDepth < 0) {
+        cut = i;
+        break;
+      }
+    } else if (ch === '[') bracketDepth += 1;
+    else if (ch === ']') {
+      bracketDepth -= 1;
+      if (bracketDepth < 0) {
+        cut = i;
+        break;
+      }
+    }
   }
 
-  let end = candidate.length;
+  let clean = candidate.slice(0, cut);
+  let trail = candidate.slice(cut);
+
+  let apostrophes = 0;
+  for (let i = 0; i < clean.length; i++) {
+    if (clean[i] === "'") apostrophes += 1;
+  }
+
+  let end = clean.length;
   while (end > 0) {
-    const ch = candidate[end - 1]!;
+    const ch = clean[end - 1]!;
     if (ch === '.' || ch === ',' || ch === ';') {
-      end -= 1;
-      continue;
-    }
-    if (ch === ')' && closeParen > openParen) {
-      closeParen -= 1;
-      end -= 1;
-      continue;
-    }
-    if (ch === ']' && closeBracket > openBracket) {
-      closeBracket -= 1;
       end -= 1;
       continue;
     }
@@ -202,13 +211,54 @@ export function splitBareUrlCandidate(candidate: string): { clean: string; trail
     break;
   }
 
-  return { clean: candidate.slice(0, end), trail: candidate.slice(end) };
+  if (end < clean.length) {
+    trail = clean.slice(end) + trail;
+    clean = clean.slice(0, end);
+  }
+
+  return { clean, trail };
+}
+
+/** One prose URL span after splitBareUrlCandidate (indices into the full text). */
+export type BareUrlSpan = {
+  /** Start index of `clean` in the full text. */
+  start: number;
+  /** Exclusive end index of `clean` in the full text. */
+  end: number;
+  clean: string;
+};
+
+/**
+ * Walk prose for bare URL cleans. After each hit, resume scanning at
+ * matchStart + clean.length so trail (e.g. `)[Confirm](https://…`) re-enters
+ * the scan and adjacent Markdown links split correctly.
+ */
+export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
+  if (!text) return;
+  const re = new RegExp(BARE_URL_RE.source, BARE_URL_RE.flags);
+  let pos = 0;
+  while (pos < text.length) {
+    re.lastIndex = pos;
+    const match = re.exec(text);
+    if (!match) break;
+    const matchStart = match.index;
+    const { clean } = splitBareUrlCandidate(match[0]);
+    if (clean.length === 0) {
+      // Avoid an infinite loop on a pathological zero-length clean.
+      pos = matchStart + Math.max(1, match[0].length);
+      continue;
+    }
+    // clean is always a prefix of the regex match under splitBareUrlCandidate.
+    yield { start: matchStart, end: matchStart + clean.length, clean };
+    pos = matchStart + clean.length;
+  }
 }
 
 /**
  * Replace bare URLs in `text` whose validatedHttpUrl form is in `normalizedLinks`
  * with `placeholder`, keeping the original spelling span as the match (so
  * EXAMPLE.com:443 still redacts when the needle is https://example.com/...).
+ * Each adjacent link is a separate span so Markdown chains mask fully.
  */
 export function maskNormalizedHttpUrls(
   text: string,
@@ -218,12 +268,16 @@ export function maskNormalizedHttpUrls(
   if (!text || normalizedLinks.length === 0) return text;
   const targets = new Set(normalizedLinks.filter(Boolean));
   if (targets.size === 0) return text;
-  return text.replace(BARE_URL_RE, (raw) => {
-    const { clean, trail } = splitBareUrlCandidate(raw);
-    const validated = validatedHttpUrl(clean);
-    if (validated && targets.has(validated)) return `${placeholder}${trail}`;
-    return raw;
-  });
+  let out = '';
+  let cursor = 0;
+  for (const span of bareUrlSpans(text)) {
+    out += text.slice(cursor, span.start);
+    const validated = validatedHttpUrl(span.clean);
+    out += validated && targets.has(validated) ? placeholder : span.clean;
+    cursor = span.end;
+  }
+  out += text.slice(cursor);
+  return out;
 }
 
 /**
@@ -234,9 +288,8 @@ export function maskNormalizedHttpUrls(
 export function extractLinks(text: string, html?: string): string[] {
   const links: string[] = [];
   const seen = new Set<string>();
-  const push = (url: string) => {
-    const { clean } = splitBareUrlCandidate(url);
-    const validated = validatedHttpUrl(clean);
+  const pushValidated = (candidate: string) => {
+    const validated = validatedHttpUrl(candidate);
     if (validated && !seen.has(validated)) {
       seen.add(validated);
       links.push(validated);
@@ -244,12 +297,15 @@ export function extractLinks(text: string, html?: string): string[] {
   };
 
   if (html) {
+    // Anchor hrefs are attribute-delimited — never prose-trim their tails.
     for (const a of extractAnchors(html)) {
-      if (/^https?:\/\//i.test(a.url) && looksLikeActionLink(a.url, a.anchorText)) push(a.url);
+      if (/^https?:\/\//i.test(a.url) && looksLikeActionLink(a.url, a.anchorText)) {
+        pushValidated(a.url);
+      }
     }
   }
-  for (const m of text.matchAll(BARE_URL_RE)) {
-    if (looksLikeActionLink(m[0])) push(m[0]);
+  for (const span of bareUrlSpans(text)) {
+    if (looksLikeActionLink(span.clean)) pushValidated(span.clean);
   }
   return links;
 }
@@ -274,9 +330,8 @@ export function extractOtp(text: string, html?: string): OtpExtraction {
 export function extractHttpLinks(text: string, html?: string): string[] {
   const links: string[] = [];
   const seen = new Set<string>();
-  const push = (candidate: string) => {
-    const { clean } = splitBareUrlCandidate(candidate);
-    const validated = validatedHttpUrl(clean);
+  const pushValidated = (candidate: string) => {
+    const validated = validatedHttpUrl(candidate);
     if (validated && !seen.has(validated)) {
       seen.add(validated);
       links.push(validated);
@@ -284,9 +339,10 @@ export function extractHttpLinks(text: string, html?: string): string[] {
   };
 
   if (html) {
-    for (const anchor of extractAnchors(html)) push(anchor.url);
+    // Anchor hrefs are attribute-delimited — never prose-trim their tails.
+    for (const anchor of extractAnchors(html)) pushValidated(anchor.url);
   }
   const visibleText = [text, html ? htmlToText(html) : ''].join('\n');
-  for (const match of visibleText.matchAll(BARE_URL_RE)) push(match[0]);
+  for (const span of bareUrlSpans(visibleText)) pushValidated(span.clean);
   return links;
 }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -239,13 +239,37 @@ export type BareUrlSpan = {
 };
 
 /**
+ * True when an unbalanced closer at `i` is proven Markdown-chain glue to the
+ * next scheme (O(1)): `)(scheme`, `](scheme`, `)[scheme`, `][scheme`, or
+ * `)[label](scheme` / `][label](scheme`. Bare `)[token=…` is a legal URL path
+ * and must not cut.
+ */
+function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undefined): boolean {
+  if (nextScheme === undefined) return false;
+  const next = text[i + 1];
+  if (next === '(' && nextScheme === i + 2) return true;
+  if (next === '[') {
+    if (nextScheme === i + 2) return true;
+    // )[label](https://…  — scheme is immediately after "]("
+    if (
+      nextScheme >= 2 &&
+      text[nextScheme - 2] === ']' &&
+      text[nextScheme - 1] === '('
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
  * Single-pass bare URL tokenizer. O(n) over the full text:
  * pre-scan scheme positions, then for each start scan once with depth tracking;
- * an unbalanced closer is a hard cut only when immediately followed by `[` or
- * `(` (Markdown chain glue: `)[`, `)(`, `][`, `](`). Nested redirects like
- * `)token=…?next=https://` keep the closer inside the URL (WHATWG); the inner
- * scheme is skipped by the post-span scheme advance. Bounded tail peel removes
- * free trailers without re-matching the remainder.
+ * an unbalanced closer is a hard cut only when the next scheme is a proven
+ * Markdown chain (tight `)(`, `](`, `)[`, `][`, or `)[label](` / `][label](`).
+ * Nested redirects and path segments like `)[token=` stay inside the URL
+ * (WHATWG); inner schemes are skipped by the post-span scheme advance.
+ * Bounded tail peel removes free trailers without re-matching the remainder.
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
@@ -277,10 +301,7 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           parenDepth -= 1;
           continue;
         }
-        // Unbalanced closer: hard-cut only for tightly adjacent Markdown chain
-        // openers. `?next=https://` after `)token=…` is not a chain — keep ) in URL.
-        const next = text[i + 1];
-        if (next === '[' || next === '(') {
+        if (isMarkdownChainGlue(text, i, schemePos[schemeIdx + 1])) {
           end = i;
           break;
         }
@@ -291,8 +312,7 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           bracketDepth -= 1;
           continue;
         }
-        const next = text[i + 1];
-        if (next === '[' || next === '(') {
+        if (isMarkdownChainGlue(text, i, schemePos[schemeIdx + 1])) {
           end = i;
           break;
         }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -87,17 +87,58 @@ function decodeEntities(s: string): string {
 const STRONG_OTP_CUE = /\b(?:code|otp|passcode|pin)\b|验证码|动态码/;
 
 /**
+ * Single separator class for delimited OTP (F68/F70): hyphen, en/em dash,
+ * period, ASCII space/tab, and common Unicode spaces (NBSP, NNBSP, em space,
+ * ideographic space, BOM as space, …).
+ *
+ * Newlines (\n \r \u2028 \u2029) are intentionally excluded: maskTier2Metadata
+ * joins from/subject with `\n`, and allowing line breaks would glue digits
+ * across fields into a fake delimited form.
+ */
+export const DELIMITED_OTP_SEP_CLASS =
+  '[-–—.\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
+
+/** Non-global: continuous run followed by sep + 3–4 digits (half of delimited). */
+const HALF_OF_DELIMITED_AFTER = new RegExp(
+  `^${DELIMITED_OTP_SEP_CLASS}\\d{3,4}\\b`,
+);
+/** Non-global: 3–4 digits + sep immediately before a continuous run. */
+const HALF_OF_DELIMITED_BEFORE = new RegExp(
+  `\\b\\d{3,4}${DELIMITED_OTP_SEP_CLASS}$`,
+);
+
+/**
+ * Fresh global regex for one delimited OTP form (capture group 1 = full form).
+ * Callers must not share a single global instance across concurrent scans.
+ */
+export function delimitedOtpCaptureRe(): RegExp {
+  return new RegExp(`\\b(\\d{3,4}${DELIMITED_OTP_SEP_CLASS}\\d{3,4})\\b`, 'g');
+}
+
+/**
+ * Fresh global regex for continuous 4–8 digit runs and delimited OTP forms.
+ * Delimited alternative is first so `1234-5678` / `1234\u00A05678` is one span.
+ * Shared by extract half-suppression consumers and tier-2 mask scans (F70).
+ */
+export function otpCodeRunRe(): RegExp {
+  return new RegExp(
+    `\\b\\d{3,4}${DELIMITED_OTP_SEP_CLASS}\\d{3,4}\\b|\\b\\d{4,8}\\b`,
+    'g',
+  );
+}
+
+/**
  * True when a continuous \d{4,8} run is one half of a delimited OTP shape
- * (`1234-5678`). Only 3–4 digit sides participate in that shape (continuous
+ * (`1234-5678` / `1234\u00A05678`). Only 3–4 digit sides participate (continuous
  * matches are ≥4, so length must be exactly 4); longer runs like
  * `123456-7890` stay continuous so they are not dropped without recovery.
  */
 function isHalfOfDelimitedOtp(text: string, idx: number, digits: string): boolean {
   if (digits.length < 3 || digits.length > 4) return false;
   const after = text.slice(idx + digits.length);
-  if (/^[-–—. ]\d{3,4}\b/.test(after)) return true;
+  if (HALF_OF_DELIMITED_AFTER.test(after)) return true;
   const before = text.slice(Math.max(0, idx - 6), idx);
-  return /\b\d{3,4}[-–—. ]$/.test(before);
+  return HALF_OF_DELIMITED_BEFORE.test(before);
 }
 
 /** Extract 4–8 digit codes (continuous or delimited) near an OTP keyword. */
@@ -109,7 +150,7 @@ export function extractCodes(text: string): string[] {
   for (const match of text.matchAll(/\b(\d{4,8})\b/g)) {
     const digits = match[1];
     const idx = match.index ?? 0;
-    // Leave `1234-5678` halves to the delimited pass (F68).
+    // Leave `1234-5678` / Unicode-space halves to the delimited pass (F68/F70).
     if (isHalfOfDelimitedOtp(text, idx, digits)) continue;
     const window = lower.slice(
       Math.max(0, idx - KEYWORD_WINDOW),
@@ -128,10 +169,9 @@ export function extractCodes(text: string): string[] {
     }
   }
 
-  // F68: `123-456` / `1234–5678` only with a strong cue (not phone/roadmap).
-  // Separators: hyphen, en dash, em dash, period, space. Keep original spelling
-  // so maskSensitiveFragments can match the span.
-  for (const match of text.matchAll(/\b(\d{3,4}[-–—. ]\d{3,4})\b/g)) {
+  // F68/F70: `123-456` / `1234\u00A05678` only with a strong cue (not phone/roadmap).
+  // Keep original spelling (including NBSP) so maskSensitiveFragments can match.
+  for (const match of text.matchAll(delimitedOtpCaptureRe())) {
     const form = match[1]!;
     const idx = match.index ?? 0;
     const window = lower.slice(

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -281,6 +281,9 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     let parenDepth = 0;
     let bracketDepth = 0;
     let end = text.length;
+    // First scheme strictly after the current closer; skips nested schemes that
+    // fell inside this span (e.g. ?next=https:// before a Markdown )[label]().
+    let probeIdx = schemeIdx + 1;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -301,7 +304,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           parenDepth -= 1;
           continue;
         }
-        if (isMarkdownChainGlue(text, i, schemePos[schemeIdx + 1])) {
+        while (probeIdx < schemePos.length && schemePos[probeIdx]! <= i) probeIdx += 1;
+        if (isMarkdownChainGlue(text, i, schemePos[probeIdx])) {
           end = i;
           break;
         }
@@ -312,7 +316,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           bracketDepth -= 1;
           continue;
         }
-        if (isMarkdownChainGlue(text, i, schemePos[schemeIdx + 1])) {
+        while (probeIdx < schemePos.length && schemePos[probeIdx]! <= i) probeIdx += 1;
+        if (isMarkdownChainGlue(text, i, schemePos[probeIdx])) {
           end = i;
           break;
         }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -131,16 +131,31 @@ function decodeEntities(s: string): string {
 }
 
 /**
- * Single separator class for delimited OTP (F68/F70): hyphen, en/em dash,
- * period, ASCII space/tab, and common Unicode spaces (NBSP, NNBSP, em space,
- * ideographic space, BOM as space, …).
+ * Unicode decimal digit (F75). JS `\d` is ASCII-only; fullwidth / Arabic-Indic
+ * / etc. need `\p{Nd}` with the `u` flag on every consuming pattern.
+ */
+const ND = '\\p{Nd}';
+
+/**
+ * OTP token edges (F75). Equivalent to classic `\b` for ASCII `\w` text, but
+ * treats any `\p{Nd}` as a "word" char so fullwidth/Arabic runs get edges.
+ * **Must not** use `\p{L}` — CJK letters would then glue to ASCII digits and
+ * break `验证码是123456` (CJK is non-word under old `\b` and must stay that way).
+ */
+const OTP_BOUND_LEFT = `(?<![A-Za-z0-9_${ND}])`;
+const OTP_BOUND_RIGHT = `(?![A-Za-z0-9_${ND}])`;
+
+/**
+ * Single separator class for delimited OTP (F68/F70/F75): hyphen, en/em dash,
+ * period, fullwidth hyphen/period, ASCII space/tab, and common Unicode spaces
+ * (NBSP, NNBSP, em space, ideographic space, BOM as space, …).
  *
  * Newlines (\n \r \u2028 \u2029) are intentionally excluded: maskTier2Metadata
  * joins from/subject with `\n`, and allowing line breaks would glue digits
  * across fields into a fake delimited form.
  */
 export const DELIMITED_OTP_SEP_CLASS =
-  '[-–—.\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
+  '[-–—.\uFF0D\uFF0E\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
 
 /**
  * One to three separator chars between digit groups (F72). Covers ` - `,
@@ -151,40 +166,90 @@ const DELIMITED_OTP_SEP_MAX = 3;
 const DELIMITED_OTP_SEP_RUN = `(?:${DELIMITED_OTP_SEP_CLASS}){1,${DELIMITED_OTP_SEP_MAX}}`;
 
 /**
- * One digit group of a delimited OTP (F73/F74): 2–4 digits. Full form is 2–4
- * such groups joined by SEP_RUN:
- * `\d{2,4}(?:SEP_RUN\d{2,4}){1,3}` → e.g. `12 34 56`, `12 34 56 78`,
- * `12-34-56-78`, classic two-group `123-456`.
+ * One digit group of a delimited OTP (F73–F75): 2–4 Unicode decimal digits.
+ * Full form is 2–4 such groups joined by SEP_RUN.
  *
  * End guards (F74, shared by capture + run) reject 5+ group chains without
- * taking a 3–4 group prefix/suffix: trailing `(?!SEP_RUN\d)` and leading
- * `(?<!\d SEP_RUN)` so engines cannot leave a partial match. Total digits may
- * reach 4–16 (privacy-safe over-mask of long labeled number strings).
- * Partial forms like `code 123-456-7` (trailing single digit after sep) no
- * longer extract a 2-group prefix — full-run integrity wins.
+ * taking a 3–4 group prefix/suffix. Total digits may reach 4–16 (privacy-safe
+ * over-mask). Partial forms like `code 123-456-7` no longer extract a 2-group
+ * prefix — full-run integrity wins.
  */
-const DELIMITED_OTP_GROUP = '\\d{2,4}';
+const DELIMITED_OTP_GROUP = `${ND}{2,4}`;
 const DELIMITED_OTP_FORM = `${DELIMITED_OTP_GROUP}(?:${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}){1,3}`;
 /**
  * Leading guard: not immediately after digit+sep (blocks mid-chain starts).
  * Tradeoff: a valid form glued after e.g. `1 12 34 56` is also refused — rare in OTP mail.
  */
-const DELIMITED_OTP_LEAD_GUARD = `(?<!\\d${DELIMITED_OTP_SEP_RUN})`;
+const DELIMITED_OTP_LEAD_GUARD = `(?<!${ND}${DELIMITED_OTP_SEP_RUN})`;
 /** Trailing guard: not immediately before sep+digit (blocks short prefixes). */
-const DELIMITED_OTP_TAIL_GUARD = `(?!${DELIMITED_OTP_SEP_RUN}\\d)`;
-const DELIMITED_OTP_BOUNDED = `${DELIMITED_OTP_LEAD_GUARD}\\b${DELIMITED_OTP_FORM}\\b${DELIMITED_OTP_TAIL_GUARD}`;
+const DELIMITED_OTP_TAIL_GUARD = `(?!${DELIMITED_OTP_SEP_RUN}${ND})`;
+const DELIMITED_OTP_BOUNDED = `${DELIMITED_OTP_LEAD_GUARD}${OTP_BOUND_LEFT}${DELIMITED_OTP_FORM}${OTP_BOUND_RIGHT}${DELIMITED_OTP_TAIL_GUARD}`;
 
 /** Lookbehind for half-suppress: max group digits + max seps + small margin. */
 const HALF_OF_DELIMITED_BEFORE_CHARS = 4 + DELIMITED_OTP_SEP_MAX + 3;
 
 /** Non-global: continuous run followed by sep-run + 2–4 digit group. */
 const HALF_OF_DELIMITED_AFTER = new RegExp(
-  `^${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}\\b`,
+  `^${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}${OTP_BOUND_RIGHT}`,
+  'u',
 );
 /** Non-global: 2–4 digit group + sep-run immediately before a continuous run. */
 const HALF_OF_DELIMITED_BEFORE = new RegExp(
-  `\\b${DELIMITED_OTP_GROUP}${DELIMITED_OTP_SEP_RUN}$`,
+  `${OTP_BOUND_LEFT}${DELIMITED_OTP_GROUP}${DELIMITED_OTP_SEP_RUN}$`,
+  'u',
 );
+
+/**
+ * Starts of contiguous 10-wide Nd decades (F75). Fullwidth/math digits usually
+ * NFKC to ASCII; these cover common scripts that do not. Keep in sync when
+ * adding extract languages — unmapped Nd fail closed to raw Nd sequence below.
+ */
+const ND_BLOCK_STARTS = [
+  0x0660, 0x06f0, 0x07c0, 0x0966, 0x09e6, 0x0a66, 0x0ae6, 0x0b66, 0x0be6, 0x0c66,
+  0x0ce6, 0x0d66, 0x0de6, 0x0e50, 0x0ed0, 0x0f20, 0x1040, 0x1090, 0x17e0, 0x1810,
+  0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40, 0x1c50, 0xa620, 0xa8d0,
+  0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0, 0x104a0, 0x10d30, 0x11066, 0x110f0,
+  0x11136, 0x111d0, 0x112f0, 0x11450, 0x114d0, 0x11650, 0x116c0, 0x11730, 0x118e0,
+  0x11950, 0x11c50, 0x11d50, 0x11da0, 0x16a60, 0x16b50, 0x16d70, 0x1d7ce, 0x1d7d8,
+  0x1d7e2, 0x1d7ec, 0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e950, 0x1fbf0,
+] as const;
+
+function mapNdToAscii(ch: string): string | null {
+  if (ch >= '0' && ch <= '9') return ch;
+  if (!/\p{Nd}/u.test(ch)) return null;
+  const nfkc = ch.normalize('NFKC');
+  if (nfkc.length === 1 && nfkc >= '0' && nfkc <= '9') return nfkc;
+  const cp = ch.codePointAt(0)!;
+  for (const start of ND_BLOCK_STARTS) {
+    if (cp >= start && cp < start + 10) return String(cp - start);
+  }
+  // Last resort: NFKC may expand to ASCII digits for some forms.
+  const only = nfkc.replace(/\D/g, '');
+  return only.length === 1 ? only : null;
+}
+
+/**
+ * Digit-only form for cross-script OTP equality (F69/F75): body `123456` and
+ * subject `１２３４５６` / `١٢٣٤٥٦` compare equal after mapping to ASCII.
+ * Non-digits are stripped. If any Nd cannot be mapped, fall back to the raw
+ * Nd sequence (same-script mask still works; avoids empty-canon fail-open).
+ */
+export function canonicalDigits(s: string): string {
+  let out = '';
+  let rawNd = '';
+  let unmapped = false;
+  for (const ch of s) {
+    if (!/\p{Nd}/u.test(ch)) continue;
+    rawNd += ch;
+    const mapped = mapNdToAscii(ch);
+    if (mapped === null) {
+      unmapped = true;
+    } else if (!unmapped) {
+      out += mapped;
+    }
+  }
+  return unmapped ? rawNd : out;
+}
 
 /**
  * Fresh global regex for one delimited OTP form (capture group 1 = full form).
@@ -192,33 +257,43 @@ const HALF_OF_DELIMITED_BEFORE = new RegExp(
  */
 export function delimitedOtpCaptureRe(): RegExp {
   return new RegExp(
-    `${DELIMITED_OTP_LEAD_GUARD}\\b(${DELIMITED_OTP_FORM})\\b${DELIMITED_OTP_TAIL_GUARD}`,
-    'g',
+    `${DELIMITED_OTP_LEAD_GUARD}${OTP_BOUND_LEFT}(${DELIMITED_OTP_FORM})${OTP_BOUND_RIGHT}${DELIMITED_OTP_TAIL_GUARD}`,
+    'gu',
   );
 }
 
 /**
  * Fresh global regex for continuous 4–8 digit runs and delimited OTP forms.
  * Delimited alternative is first so `12 34 56 78` / `1234-5678` is one span.
- * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70–F74);
+ * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70–F75);
  * half-suppress uses HALF_OF_DELIMITED_* built from the same SEP_RUN/GROUP.
  */
 export function otpCodeRunRe(): RegExp {
-  return new RegExp(`${DELIMITED_OTP_BOUNDED}|\\b\\d{4,8}\\b`, 'g');
+  return new RegExp(
+    `${DELIMITED_OTP_BOUNDED}|${OTP_BOUND_LEFT}${ND}{4,8}${OTP_BOUND_RIGHT}`,
+    'gu',
+  );
 }
 
 /**
- * True when a continuous \d{4,8} run is one side of a delimited OTP shape
+ * True when a continuous 4–8 Nd run is one side of a delimited OTP shape
  * (`1234-5678` / `1234 - 56`). Continuous extract only yields 4–8 digit runs,
- * and only a **4-digit** run can be a delimited group (`\d{2,4}`); longer runs
- * like `123456-7890` stay continuous so they are not dropped without recovery.
+ * and only a **4-digit** run can be a delimited group; longer runs like
+ * `123456-7890` stay continuous so they are not dropped without recovery.
  */
 function isHalfOfDelimitedOtp(text: string, idx: number, digits: string): boolean {
-  if (digits.length !== 4) return false;
+  // Continuous matches are 4–8 Nd code points; only a 4-digit run is a group half.
+  // BMP Nd (fullwidth/Arabic/…) have length === code-point count.
+  if ([...digits].length !== 4) return false;
   const after = text.slice(idx + digits.length);
   if (HALF_OF_DELIMITED_AFTER.test(after)) return true;
   const before = text.slice(Math.max(0, idx - HALF_OF_DELIMITED_BEFORE_CHARS), idx);
   return HALF_OF_DELIMITED_BEFORE.test(before);
+}
+
+/** Continuous 4–8 Nd run with OTP bounds (capture group 1 = run). */
+function continuousOtpCaptureRe(): RegExp {
+  return new RegExp(`${OTP_BOUND_LEFT}(${ND}{4,8})${OTP_BOUND_RIGHT}`, 'gu');
 }
 
 /** Extract 4–8 digit codes (continuous or delimited) near an OTP keyword. */
@@ -227,8 +302,8 @@ export function extractCodes(text: string): string[] {
   const codes: string[] = [];
   const seen = new Set<string>();
 
-  for (const match of text.matchAll(/\b(\d{4,8})\b/g)) {
-    const digits = match[1];
+  for (const match of text.matchAll(continuousOtpCaptureRe())) {
+    const digits = match[1]!;
     const idx = match.index ?? 0;
     // Leave `1234-5678` / Unicode-space halves to the delimited pass (F68/F70).
     if (isHalfOfDelimitedOtp(text, idx, digits)) continue;
@@ -239,8 +314,9 @@ export function extractCodes(text: string): string[] {
     if (!CODE_KEYWORDS.some((kw) => window.includes(kw))) continue;
     // Years need a strong OTP cue (not mere "verification"/"identity") so
     // roadmap copy like "for 2026" does not fire false OTP alerts (F65).
-    // "verification PIN is 2026" still matches \bpin\b.
-    if (/^(19|20)\d{2}$/.test(digits) && !STRONG_OTP_CUE.test(window)) {
+    // Compare on ASCII-mapped digits so fullwidth years get the same guard.
+    const yearCanon = canonicalDigits(digits);
+    if (/^(19|20)\d{2}$/.test(yearCanon) && !STRONG_OTP_CUE.test(window)) {
       continue;
     }
     if (!seen.has(digits)) {

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -167,9 +167,11 @@ function findSchemePositions(text: string): number[] {
 
 /**
  * Peel trailing prose from a bounded candidate [0, length): `.,;`, unbalanced
- * trailing `)`/`]`, and trailing `'` when the apostrophe count is odd — or when
- * the span opened after a prose `'` (outer quote; F61) so even counts still
- * drop one closing quote after an internal apostrophe (e.g. o'brien').
+ * trailing `)`/`]`, and trailing `'`.
+ * - openQuoted false: peel `'` only while the remaining apostrophe count is odd.
+ * - openQuoted true (span started after prose `'`): peel exactly one closing
+ *   `'` via a one-shot flag (F61/F63) — odd-parity must not fire as well, or a
+ *   legal URL-terminal `'` would be stripped after the outer closer (F63).
  * O(length).
  */
 function peelTrailingProse(
@@ -192,7 +194,7 @@ function peelTrailingProse(
     else if (ch === "'") apostrophes += 1;
   }
 
-  // At most one openQuoted peel, after any trailing .,; (not only original EOS).
+  // openQuoted: authorize exactly one outer closer peel (after any .,;).
   let peelOpenQuote = openQuoted;
   let end = candidate.length;
   while (end > 0) {
@@ -211,13 +213,20 @@ function peelTrailingProse(
       end -= 1;
       continue;
     }
-    if (ch === "'" && (apostrophes % 2 === 1 || peelOpenQuote)) {
-      // Odd count: classic prose closer. openQuoted: peel one outer closer even
-      // when an internal apostrophe made the total even (F61), including after .,;
-      apostrophes -= 1;
-      end -= 1;
-      peelOpenQuote = false;
-      continue;
+    if (ch === "'") {
+      if (openQuoted) {
+        // F63: only the one-shot flag; parity never stacks a second peel.
+        if (!peelOpenQuote) break;
+        peelOpenQuote = false;
+        apostrophes -= 1;
+        end -= 1;
+        continue;
+      }
+      if (apostrophes % 2 === 1) {
+        apostrophes -= 1;
+        end -= 1;
+        continue;
+      }
     }
     break;
   }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -243,6 +243,14 @@ export type BareUrlSpan = {
    * maskNormalizedHttpUrls redacts it with the adjacent URLs.
    */
   glueAfter?: { start: number; end: number };
+  /**
+   * When this span ended on a `"`, `<`, or `>` hard cut with a glued non-whitespace
+   * tail (e.g. `"token=secret` or `>token=secret`), the half-open range from the
+   * boundary char through that tail (stops before the next scheme if one sits
+   * inside the tail). Extractors ignore this; maskNormalizedHttpUrls redacts it
+   * when the URL itself is a redaction target.
+   */
+  tailAfter?: { start: number; end: number };
 };
 
 /**
@@ -293,11 +301,35 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     let probeIdx = schemeIdx + 1;
     // Set when we hard-cut on Markdown chain glue (closer index + next scheme).
     let glueCut: { closer: number; nextScheme: number } | undefined;
+    // Set when we hard-cut on " < > with a glued non-whitespace tail (F55).
+    let tailCut: { start: number; end: number } | undefined;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
       if (isJsWhitespace(ch) || ch === '<' || ch === '>' || ch === '"') {
         end = i;
+        // Quote/angle hard cut: glued non-ws tail may hold secrets (e.g. "token=).
+        // Whitespace cuts never record a tail (balanced "url" / <url> keep delimiters).
+        if (
+          (ch === '<' || ch === '>' || ch === '"') &&
+          i + 1 < text.length &&
+          !isJsWhitespace(text[i + 1]!)
+        ) {
+          let tailEnd = i + 1;
+          while (tailEnd < text.length && !isJsWhitespace(text[tailEnd]!)) {
+            tailEnd += 1;
+          }
+          while (probeIdx < schemePos.length && schemePos[probeIdx]! <= i) {
+            probeIdx += 1;
+          }
+          const nextScheme = schemePos[probeIdx];
+          if (nextScheme !== undefined && nextScheme < tailEnd) {
+            tailEnd = nextScheme;
+          }
+          if (tailEnd > i) {
+            tailCut = { start: i, end: tailEnd };
+          }
+        }
         break;
       }
       if (ch === '(') {
@@ -350,6 +382,10 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     if (glueCut) {
       span.glueAfter = { start: glueCut.closer, end: glueCut.nextScheme };
     }
+    // Tail is [boundary, tailEnd); independent of peel (boundary was never in raw).
+    if (tailCut) {
+      span.tailAfter = tailCut;
+    }
     yield span;
 
     // Skip schemes that fell inside this span (e.g. nested ?next=https://…).
@@ -365,6 +401,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
  * EXAMPLE.com:443 still redacts when the needle is https://example.com/...).
  * Markdown-chain glue (span.glueAfter) adjacent to a target URL on either side
  * is redacted too so labels like `)[token=secret](` cannot leak between spans.
+ * Quote/angle tails (span.tailAfter) are redacted when this URL is a target so
+ * `"token=secret` / `>token=secret` cannot leak after a hard cut (F55).
  */
 export function maskNormalizedHttpUrls(
   text: string,
@@ -386,18 +424,26 @@ export function maskNormalizedHttpUrls(
     cursor = span.end;
 
     const glue = span.glueAfter;
-    if (!glue || glue.end <= glue.start) continue;
-    // Mask glue when either adjacent URL is a redaction target (label may hold secrets).
-    let maskNext = false;
-    const next = spans[i + 1];
-    if (next) {
-      const nextValidated = validatedHttpUrl(next.clean);
-      maskNext = Boolean(nextValidated && targets.has(nextValidated));
+    if (glue && glue.end > glue.start) {
+      // Mask glue when either adjacent URL is a redaction target (label may hold secrets).
+      let maskNext = false;
+      const next = spans[i + 1];
+      if (next) {
+        const nextValidated = validatedHttpUrl(next.clean);
+        maskNext = Boolean(nextValidated && targets.has(nextValidated));
+      }
+      if (maskThis || maskNext) {
+        // Skip any peel gap before the closer, then redact [closer, nextScheme).
+        out += placeholder;
+        cursor = glue.end;
+      }
     }
-    if (maskThis || maskNext) {
-      // Skip any peel gap before the closer, then redact [closer, nextScheme).
+
+    const tail = span.tailAfter;
+    if (maskThis && tail && tail.end > tail.start && tail.end > cursor) {
+      // URL was redacted: redact glued " / < / > tail so secrets cannot stick.
       out += placeholder;
-      cursor = glue.end;
+      cursor = tail.end;
     }
   }
   out += text.slice(cursor);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -236,6 +236,13 @@ export type BareUrlSpan = {
   /** Exclusive end index of `clean` in the full text. */
   end: number;
   clean: string;
+  /**
+   * When this span ended on a proven Markdown-chain cut, the glue between the
+   * unbalanced closer and the next scheme (e.g. `)[token=secret](`). Indices
+   * into the full text, half-open [start, end). Extractors ignore this; only
+   * maskNormalizedHttpUrls redacts it with the adjacent URLs.
+   */
+  glueAfter?: { start: number; end: number };
 };
 
 /**
@@ -284,6 +291,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     // First scheme strictly after the current closer; skips nested schemes that
     // fell inside this span (e.g. ?next=https:// before a Markdown )[label]().
     let probeIdx = schemeIdx + 1;
+    // Set when we hard-cut on Markdown chain glue (closer index + next scheme).
+    let glueCut: { closer: number; nextScheme: number } | undefined;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -305,8 +314,10 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           continue;
         }
         while (probeIdx < schemePos.length && schemePos[probeIdx]! <= i) probeIdx += 1;
-        if (isMarkdownChainGlue(text, i, schemePos[probeIdx])) {
+        const nextScheme = schemePos[probeIdx];
+        if (isMarkdownChainGlue(text, i, nextScheme)) {
           end = i;
+          glueCut = { closer: i, nextScheme: nextScheme! };
           break;
         }
         continue;
@@ -317,8 +328,10 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           continue;
         }
         while (probeIdx < schemePos.length && schemePos[probeIdx]! <= i) probeIdx += 1;
-        if (isMarkdownChainGlue(text, i, schemePos[probeIdx])) {
+        const nextScheme = schemePos[probeIdx];
+        if (isMarkdownChainGlue(text, i, nextScheme)) {
           end = i;
+          glueCut = { closer: i, nextScheme: nextScheme! };
           break;
         }
         continue;
@@ -332,7 +345,12 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
       continue;
     }
     const cleanEnd = start + clean.length;
-    yield { start, end: cleanEnd, clean };
+    const span: BareUrlSpan = { start, end: cleanEnd, clean };
+    // Glue is always [closer, nextScheme) even if peel shortened cleanEnd.
+    if (glueCut) {
+      span.glueAfter = { start: glueCut.closer, end: glueCut.nextScheme };
+    }
+    yield span;
 
     // Skip schemes that fell inside this span (e.g. nested ?next=https://…).
     while (schemeIdx < schemePos.length && schemePos[schemeIdx]! < cleanEnd) {
@@ -345,7 +363,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
  * Replace bare URLs in `text` whose validatedHttpUrl form is in `normalizedLinks`
  * with `placeholder`, keeping the original spelling span as the match (so
  * EXAMPLE.com:443 still redacts when the needle is https://example.com/...).
- * Each adjacent link is a separate span so Markdown chains mask fully.
+ * Markdown-chain glue (span.glueAfter) adjacent to a target URL on either side
+ * is redacted too so labels like `)[token=secret](` cannot leak between spans.
  */
 export function maskNormalizedHttpUrls(
   text: string,
@@ -355,13 +374,31 @@ export function maskNormalizedHttpUrls(
   if (!text || normalizedLinks.length === 0) return text;
   const targets = new Set(normalizedLinks.filter(Boolean));
   if (targets.size === 0) return text;
+  const spans = [...bareUrlSpans(text)];
   let out = '';
   let cursor = 0;
-  for (const span of bareUrlSpans(text)) {
+  for (let i = 0; i < spans.length; i++) {
+    const span = spans[i]!;
     out += text.slice(cursor, span.start);
     const validated = validatedHttpUrl(span.clean);
-    out += validated && targets.has(validated) ? placeholder : span.clean;
+    const maskThis = Boolean(validated && targets.has(validated));
+    out += maskThis ? placeholder : span.clean;
     cursor = span.end;
+
+    const glue = span.glueAfter;
+    if (!glue || glue.end <= glue.start) continue;
+    // Mask glue when either adjacent URL is a redaction target (label may hold secrets).
+    let maskNext = false;
+    const next = spans[i + 1];
+    if (next) {
+      const nextValidated = validatedHttpUrl(next.clean);
+      maskNext = Boolean(nextValidated && targets.has(nextValidated));
+    }
+    if (maskThis || maskNext) {
+      // Skip any peel gap before the closer, then redact [closer, nextScheme).
+      out += placeholder;
+      cursor = glue.end;
+    }
   }
   out += text.slice(cursor);
   return out;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -308,13 +308,17 @@ function continuousOtpCaptureRe(): RegExp {
 
 /**
  * Keyword window around a match: slice the **original** text at original
- * offsets, then lowercase only the window (F99). Whole-string `toLowerCase()`
- * shifts later indices when case-fold expands (Turkish `İ` → `i`+combining
- * dot), so a pre-lowercased buffer must not be sliced with source indices.
+ * offsets, then NFKC + lowercase only the window (F99/F104). Whole-string
+ * `toLowerCase()` shifts later indices when case-fold expands (Turkish `İ` →
+ * `i`+combining dot), so a pre-lowercased buffer must not be sliced with
+ * source indices. NFKC lets compatibility-form keywords (fullwidth `ｃｏｄｅ`)
+ * match CODE_KEYWORDS / STRONG_OTP_CUE inside the window; the window feeds
+ * keyword search only, never extraction offsets, so NFKC length drift is safe.
  */
 function keywordWindow(text: string, idx: number, matchLen: number): string {
   return text
     .slice(Math.max(0, idx - KEYWORD_WINDOW), Math.min(text.length, idx + matchLen + KEYWORD_WINDOW))
+    .normalize('NFKC')
     .toLowerCase();
 }
 

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -164,13 +164,16 @@ const OTP_BOUND_RIGHT = `(?![A-Za-z0-9_${ND}])`;
  * pure-digit groups, so this extractor is the only masking path. Dates
  * (`08/07/2026`) match exactly like the hyphen/dot forms already do — the
  * established privacy-over-readability tradeoff for cued digit runs.
+ * F129: colon (ASCII + fullwidth) joins for the same reason (`123:456`);
+ * clock forms (`12:30`) are the colon equivalent of the date tradeoff —
+ * delimited forms still require a strong cue outside metadata masking.
  *
  * Newlines (\n \r \u2028 \u2029) are intentionally excluded: maskTier2Metadata
  * joins from/subject with `\n`, and allowing line breaks would glue digits
  * across fields into a fake delimited form.
  */
 export const DELIMITED_OTP_SEP_CLASS =
-  '[-–—./\uFF0D\uFF0E\uFF0F\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
+  '[-–—./:：\uFF0D\uFF0E\uFF0F\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
 
 /**
  * One to three separator chars between digit groups (F72). Covers ` - `,
@@ -732,7 +735,8 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
  * Bounded tail peel removes free trailers without re-matching.
  * Smart-quoted spans (“…”/‘…’) likewise cut before the matching closing
  * smart quote in close context (F122) so the quote is not percent-encoded
- * into the published destination.
+ * into the published destination. Markdown-wrapped spans (`` ` ``/`*`/`**`)
+ * cut before the closing delimiter run in close context (F130).
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
@@ -779,6 +783,13 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
         : smartOpener === '\u2018'
           ? '\u2019'
           : undefined;
+    // F130: span opened after a Markdown inline-code/emphasis wrapper
+    // (`` ` `` or `*`/`**`) — the closing delimiter is markup, not URL
+    // content (`https://example.com/verify%60`, path trailing `**`).
+    const mdWrapper =
+      start >= 1 && (text[start - 1] === '`' || text[start - 1] === '*')
+        ? (text[start - 1] as '`' | '*')
+        : undefined;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -870,6 +881,25 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
       // context; anything else keeps the quote as (rare, invalid) URL content.
       if (openSmartQuote !== undefined && ch === openSmartQuote) {
         const next = i + 1 < text.length ? text[i + 1]! : '';
+        if (isProseCloseContext(next)) {
+          end = i;
+          break;
+        }
+        continue;
+      }
+      // F130: matching Markdown wrapper closer in close context ends the span.
+      // `*` closes on a 1–2 char run so a `**` closer never leaves one behind.
+      if (mdWrapper === '`' && ch === '`') {
+        const next = i + 1 < text.length ? text[i + 1]! : '';
+        if (isProseCloseContext(next)) {
+          end = i;
+          break;
+        }
+        continue;
+      }
+      if (mdWrapper === '*' && ch === '*') {
+        const runEnd = text[i + 1] === '*' ? i + 2 : i + 1;
+        const next = runEnd < text.length ? text[runEnd]! : '';
         if (isProseCloseContext(next)) {
           end = i;
           break;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -82,9 +82,14 @@ function buildStrongOtpCueRe(cues: readonly string[]): RegExp {
 
 const STRONG_OTP_CUE = buildStrongOtpCueRe(STRONG_OTP_CUES);
 
-/** True when text contains a strong OTP cue (F71 list; case-folded for Latin). */
+/**
+ * True when text contains a strong OTP cue (F71 list; case-folded for Latin).
+ * NFKC first so compatibility-form cues match: fullwidth `ｃｏｄｅ` lowercases
+ * to fullwidth, never to ASCII `code`, so a labeled fullwidth subject would
+ * otherwise bypass tier-2 masking entirely (F103).
+ */
 export function hasStrongOtpCue(text: string): boolean {
-  return STRONG_OTP_CUE.test(text.toLowerCase());
+  return STRONG_OTP_CUE.test(text.normalize('NFKC').toLowerCase());
 }
 
 export function htmlToText(html: string): string {

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -143,22 +143,34 @@ export const DELIMITED_OTP_SEP_CLASS =
   '[-–—.\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
 
 /**
- * One to three separator chars between digit halves (F72). Covers ` - `,
+ * One to three separator chars between digit groups (F72). Covers ` - `,
  * double space, ` – `; four+ seps (e.g. `123    456`) intentionally miss —
  * rare layout, prefer a bounded false-positive surface over open-ended sep runs.
  */
 const DELIMITED_OTP_SEP_MAX = 3;
 const DELIMITED_OTP_SEP_RUN = `(?:${DELIMITED_OTP_SEP_CLASS}){1,${DELIMITED_OTP_SEP_MAX}}`;
-/** Lookbehind for half-suppress: max half digits + max seps + small margin. */
+
+/**
+ * One digit group of a delimited OTP (F73): 2–4 digits. Full form is 2–3 such
+ * groups joined by SEP_RUN: `\d{2,4}(?:SEP_RUN\d{2,4}){1,2}` → e.g. `12 34 56`,
+ * `12-34-56`, `1234 - 56`, as well as classic two-group `123-456`.
+ *
+ * Not matched (intentional): 4+ groups (`1 2 3 4 5 6`); total digit count may
+ * reach 9–12 (privacy-safe over-mask of long labeled number strings).
+ */
+const DELIMITED_OTP_GROUP = '\\d{2,4}';
+const DELIMITED_OTP_FORM = `${DELIMITED_OTP_GROUP}(?:${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}){1,2}`;
+
+/** Lookbehind for half-suppress: max group digits + max seps + small margin. */
 const HALF_OF_DELIMITED_BEFORE_CHARS = 4 + DELIMITED_OTP_SEP_MAX + 3;
 
-/** Non-global: continuous run followed by sep-run + 3–4 digits (half of delimited). */
+/** Non-global: continuous run followed by sep-run + 2–4 digit group. */
 const HALF_OF_DELIMITED_AFTER = new RegExp(
-  `^${DELIMITED_OTP_SEP_RUN}\\d{3,4}\\b`,
+  `^${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}\\b`,
 );
-/** Non-global: 3–4 digits + sep-run immediately before a continuous run. */
+/** Non-global: 2–4 digit group + sep-run immediately before a continuous run. */
 const HALF_OF_DELIMITED_BEFORE = new RegExp(
-  `\\b\\d{3,4}${DELIMITED_OTP_SEP_RUN}$`,
+  `\\b${DELIMITED_OTP_GROUP}${DELIMITED_OTP_SEP_RUN}$`,
 );
 
 /**
@@ -166,30 +178,27 @@ const HALF_OF_DELIMITED_BEFORE = new RegExp(
  * Callers must not share a single global instance across concurrent scans.
  */
 export function delimitedOtpCaptureRe(): RegExp {
-  return new RegExp(`\\b(\\d{3,4}${DELIMITED_OTP_SEP_RUN}\\d{3,4})\\b`, 'g');
+  return new RegExp(`\\b(${DELIMITED_OTP_FORM})\\b`, 'g');
 }
 
 /**
  * Fresh global regex for continuous 4–8 digit runs and delimited OTP forms.
- * Delimited alternative is first so `1234-5678` / `1234 - 5678` is one span.
- * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70/F72);
- * half-suppress uses HALF_OF_DELIMITED_* built from the same SEP_RUN.
+ * Delimited alternative is first so `12 34 56` / `1234-5678` is one span.
+ * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70–F73);
+ * half-suppress uses HALF_OF_DELIMITED_* built from the same SEP_RUN/GROUP.
  */
 export function otpCodeRunRe(): RegExp {
-  return new RegExp(
-    `\\b\\d{3,4}${DELIMITED_OTP_SEP_RUN}\\d{3,4}\\b|\\b\\d{4,8}\\b`,
-    'g',
-  );
+  return new RegExp(`\\b${DELIMITED_OTP_FORM}\\b|\\b\\d{4,8}\\b`, 'g');
 }
 
 /**
- * True when a continuous \d{4,8} run is one half of a delimited OTP shape
- * (`1234-5678` / `1234 - 5678`). Only 3–4 digit sides participate (continuous
- * matches are ≥4, so length must be exactly 4); longer runs like
- * `123456-7890` stay continuous so they are not dropped without recovery.
+ * True when a continuous \d{4,8} run is one side of a delimited OTP shape
+ * (`1234-5678` / `1234 - 56`). Continuous extract only yields 4–8 digit runs,
+ * and only a **4-digit** run can be a delimited group (`\d{2,4}`); longer runs
+ * like `123456-7890` stay continuous so they are not dropped without recovery.
  */
 function isHalfOfDelimitedOtp(text: string, idx: number, digits: string): boolean {
-  if (digits.length < 3 || digits.length > 4) return false;
+  if (digits.length !== 4) return false;
   const after = text.slice(idx + digits.length);
   if (HALF_OF_DELIMITED_AFTER.test(after)) return true;
   const before = text.slice(Math.max(0, idx - HALF_OF_DELIMITED_BEFORE_CHARS), idx);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -151,15 +151,28 @@ const DELIMITED_OTP_SEP_MAX = 3;
 const DELIMITED_OTP_SEP_RUN = `(?:${DELIMITED_OTP_SEP_CLASS}){1,${DELIMITED_OTP_SEP_MAX}}`;
 
 /**
- * One digit group of a delimited OTP (F73): 2–4 digits. Full form is 2–3 such
- * groups joined by SEP_RUN: `\d{2,4}(?:SEP_RUN\d{2,4}){1,2}` → e.g. `12 34 56`,
- * `12-34-56`, `1234 - 56`, as well as classic two-group `123-456`.
+ * One digit group of a delimited OTP (F73/F74): 2–4 digits. Full form is 2–4
+ * such groups joined by SEP_RUN:
+ * `\d{2,4}(?:SEP_RUN\d{2,4}){1,3}` → e.g. `12 34 56`, `12 34 56 78`,
+ * `12-34-56-78`, classic two-group `123-456`.
  *
- * Not matched (intentional): 4+ groups (`1 2 3 4 5 6`); total digit count may
- * reach 9–12 (privacy-safe over-mask of long labeled number strings).
+ * End guards (F74, shared by capture + run) reject 5+ group chains without
+ * taking a 3–4 group prefix/suffix: trailing `(?!SEP_RUN\d)` and leading
+ * `(?<!\d SEP_RUN)` so engines cannot leave a partial match. Total digits may
+ * reach 4–16 (privacy-safe over-mask of long labeled number strings).
+ * Partial forms like `code 123-456-7` (trailing single digit after sep) no
+ * longer extract a 2-group prefix — full-run integrity wins.
  */
 const DELIMITED_OTP_GROUP = '\\d{2,4}';
-const DELIMITED_OTP_FORM = `${DELIMITED_OTP_GROUP}(?:${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}){1,2}`;
+const DELIMITED_OTP_FORM = `${DELIMITED_OTP_GROUP}(?:${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}){1,3}`;
+/**
+ * Leading guard: not immediately after digit+sep (blocks mid-chain starts).
+ * Tradeoff: a valid form glued after e.g. `1 12 34 56` is also refused — rare in OTP mail.
+ */
+const DELIMITED_OTP_LEAD_GUARD = `(?<!\\d${DELIMITED_OTP_SEP_RUN})`;
+/** Trailing guard: not immediately before sep+digit (blocks short prefixes). */
+const DELIMITED_OTP_TAIL_GUARD = `(?!${DELIMITED_OTP_SEP_RUN}\\d)`;
+const DELIMITED_OTP_BOUNDED = `${DELIMITED_OTP_LEAD_GUARD}\\b${DELIMITED_OTP_FORM}\\b${DELIMITED_OTP_TAIL_GUARD}`;
 
 /** Lookbehind for half-suppress: max group digits + max seps + small margin. */
 const HALF_OF_DELIMITED_BEFORE_CHARS = 4 + DELIMITED_OTP_SEP_MAX + 3;
@@ -178,17 +191,20 @@ const HALF_OF_DELIMITED_BEFORE = new RegExp(
  * Callers must not share a single global instance across concurrent scans.
  */
 export function delimitedOtpCaptureRe(): RegExp {
-  return new RegExp(`\\b(${DELIMITED_OTP_FORM})\\b`, 'g');
+  return new RegExp(
+    `${DELIMITED_OTP_LEAD_GUARD}\\b(${DELIMITED_OTP_FORM})\\b${DELIMITED_OTP_TAIL_GUARD}`,
+    'g',
+  );
 }
 
 /**
  * Fresh global regex for continuous 4–8 digit runs and delimited OTP forms.
- * Delimited alternative is first so `12 34 56` / `1234-5678` is one span.
- * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70–F73);
+ * Delimited alternative is first so `12 34 56 78` / `1234-5678` is one span.
+ * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70–F74);
  * half-suppress uses HALF_OF_DELIMITED_* built from the same SEP_RUN/GROUP.
  */
 export function otpCodeRunRe(): RegExp {
-  return new RegExp(`\\b${DELIMITED_OTP_FORM}\\b|\\b\\d{4,8}\\b`, 'g');
+  return new RegExp(`${DELIMITED_OTP_BOUNDED}|\\b\\d{4,8}\\b`, 'g');
 }
 
 /**

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -124,8 +124,12 @@ function extractAnchors(html: string): Anchor[] {
   return anchors;
 }
 
-/** Bare http(s) URLs in plain text; scheme is case-insensitive (RFC 3986). */
-export const BARE_URL_RE = /https?:\/\/[^\s<>"')\]]+/gi;
+/**
+ * Bare http(s) URLs in plain text; scheme is case-insensitive (RFC 3986).
+ * Allows a balanced `[...]` host segment (IPv6 literals) but still stops before
+ * a free trailing `]` / `)` so `[see https://x.example]` keeps the outer bracket.
+ */
+export const BARE_URL_RE = /https?:\/\/(?:\[[^\s\]]+\]|[^\s<>"')\]])+/gi;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -499,6 +499,9 @@ function trailerForcesQuestionPeel(trailer: string): boolean {
  * - openQuoted true (span started after prose `'`): peel exactly one closing
  *   `'` via a one-shot flag (F61/F63) — odd-parity must not fire as well, or a
  *   legal URL-terminal `'` would be stripped after the outer closer (F63).
+ * - Terminal `'s` (F108): an English possessive at the candidate end peels
+ *   (`verify's` → `verify`); internal apostrophes (`don't/verify`) are never
+ *   trailing and stay put. Skipped under preserveApostrophes.
  *
  * F98: closer-context look-back is cached per contiguous terminal-punct run so
  * a long `!!!!` / `::::` / `????` suffix is O(length), not O(length²).
@@ -540,6 +543,20 @@ function peelTrailingProse(
       // Unconditional peel may exit/enter a conditional run — drop cache.
       cachedBoundary = null;
       end -= 1;
+      continue;
+    }
+    // F108: English possessive at candidate end (`verify's`) peels `'s`;
+    // internal apostrophes (`don't/verify`) are never trailing and stay put.
+    if (
+      !preserveApostrophes &&
+      ch === 's' &&
+      end >= 3 &&
+      candidate[end - 2] === "'" &&
+      /[A-Za-z0-9]/.test(candidate[end - 3]!)
+    ) {
+      apostrophes -= 1;
+      cachedBoundary = null;
+      end -= 2;
       continue;
     }
     // F100: conditional `?` — keep first bare empty-query; peel later / prose.

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -422,8 +422,8 @@ function isJsWhitespace(ch: string): boolean {
 
 /**
  * Prose close-context after a quote closer (F64/F122): end of text,
- * whitespace, or terminal punctuation — an internal apostrophe (`o'brien`)
- * or quote-joined URL content sees anything else.
+ * whitespace, or terminal punctuation (ASCII plus CJK, F131) — an internal
+ * apostrophe (`o'brien`) or quote-joined URL content sees anything else.
  */
 function isProseCloseContext(next: string): boolean {
   return (
@@ -437,7 +437,16 @@ function isProseCloseContext(next: string): boolean {
     next === '?' ||
     next === ')' ||
     next === ']' ||
-    next === '}'
+    next === '}' ||
+    // CJK terminal punctuation plays the same prose-closing role (F131).
+    next === '\u3001' ||
+    next === '\u3002' ||
+    next === '\uFF01' ||
+    next === '\uFF0C' ||
+    next === '\uFF1A' ||
+    next === '\uFF1B' ||
+    next === '\uFF1F' ||
+    next === '\uFF09'
   );
 }
 
@@ -723,6 +732,28 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
 }
 
 /**
+ * F122/F131: paired Unicode prose quotes that may wrap a bare URL. When a
+ * span opens right after one of these openers, the matching closer in prose
+ * close context ends the span — the closer is prose punctuation, not URL
+ * content (the WHATWG parser percent-encodes it into a different, unusable
+ * destination). Covers smart quotes, guillemets, German low-9 quotes, and
+ * the CJK bracket family.
+ */
+const PAIRED_URL_QUOTES: Record<string, string> = {
+  '\u201C': '\u201D', // curly double quotes
+  '\u2018': '\u2019', // curly single quotes
+  '\u201E': '\u201C', // German low-9 double quote
+  '\u201A': '\u2018', // German low-9 single quote
+  '\u00AB': '\u00BB', // guillemets
+  '\u2039': '\u203A', // single guillemets
+  '\u300C': '\u300D', // CJK corner brackets
+  '\u300E': '\u300F', // CJK double corner brackets
+  '\u3008': '\u3009', // CJK angle brackets
+  '\u300A': '\u300B', // CJK double angle brackets
+  '\u3010': '\u3011', // CJK lenticular brackets
+};
+
+/**
  * Single-pass bare URL tokenizer. O(n) over the full text:
  * pre-scan scheme positions, then for each start scan once with depth tracking;
  * an unbalanced closer is a hard cut when (1) the next scheme is a proven
@@ -733,8 +764,9 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
  * openQuoted spans also cut before a closing `'` when the next char is prose
  * close context (F64). Nested redirects stay inside the URL when no cut applies.
  * Bounded tail peel removes free trailers without re-matching.
- * Smart-quoted spans (“…”/‘…’) likewise cut before the matching closing
- * smart quote in close context (F122) so the quote is not percent-encoded
+ * Spans wrapped in paired Unicode prose quotes (smart quotes, guillemets,
+ * CJK brackets — PAIRED_URL_QUOTES) likewise cut before the matching closer
+ * in close context (F122/F131) so the quote is not percent-encoded
  * into the published destination. Markdown-wrapped spans (`` ` ``/`*`/`**`)
  * cut before the closing delimiter run in close context (F130).
  */
@@ -773,16 +805,11 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     // True when F64 cut left the outer closer outside the raw span — peel must
     // not also strip a legal URL-terminal ' (F63).
     let openQuotedCut = false;
-    // F122: span opened after a smart-quote opener (“…”/‘…’) — the matching
-    // closing quote is prose context, not URL content (the WHATWG parser
+    // F122/F131: span opened after a paired-quote opener — the matching
+    // closer is prose context, not URL content (the WHATWG parser
     // percent-encodes it into a different, unusable destination).
-    const smartOpener = start >= 1 ? text[start - 1]! : '';
-    const openSmartQuote =
-      smartOpener === '\u201C'
-        ? '\u201D'
-        : smartOpener === '\u2018'
-          ? '\u2019'
-          : undefined;
+    const openSmartQuote: string | undefined =
+      start >= 1 ? PAIRED_URL_QUOTES[text[start - 1]!] : undefined;
     // F130: span opened after a Markdown inline-code/emphasis wrapper
     // (`` ` `` or `*`/`**`) — the closing delimiter is markup, not URL
     // content (`https://example.com/verify%60`, path trailing `**`).
@@ -877,8 +904,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
         }
         continue;
       }
-      // F122: matching smart closer closes a smart-quoted span in close
-      // context; anything else keeps the quote as (rare, invalid) URL content.
+      // F122/F131: the matching paired-quote closer closes a quoted span
+      // in close context; anything else keeps it as (rare, invalid) content.
       if (openSmartQuote !== undefined && ch === openSmartQuote) {
         const next = i + 1 < text.length ? text[i + 1]! : '';
         if (isProseCloseContext(next)) {

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -82,6 +82,11 @@ function buildStrongOtpCueRe(cues: readonly string[]): RegExp {
 
 const STRONG_OTP_CUE = buildStrongOtpCueRe(STRONG_OTP_CUES);
 
+/** True when text contains a strong OTP cue (F71 list; case-folded for Latin). */
+export function hasStrongOtpCue(text: string): boolean {
+  return STRONG_OTP_CUE.test(text.toLowerCase());
+}
+
 export function htmlToText(html: string): string {
   let s = html;
   // Drop non-content blocks entirely.

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -159,13 +159,18 @@ const OTP_BOUND_RIGHT = `(?![A-Za-z0-9_${ND}])`;
  * Single separator class for delimited OTP (F68/F70/F75): hyphen, en/em dash,
  * period, fullwidth hyphen/period, ASCII space/tab, and common Unicode spaces
  * (NBSP, NNBSP, em space, ideographic space, BOM as space, …).
+ * F128: slash (ASCII + fullwidth) joins — providers format numeric codes as
+ * `123/456`, and the metadata alnum slash matcher deliberately rejects
+ * pure-digit groups, so this extractor is the only masking path. Dates
+ * (`08/07/2026`) match exactly like the hyphen/dot forms already do — the
+ * established privacy-over-readability tradeoff for cued digit runs.
  *
  * Newlines (\n \r \u2028 \u2029) are intentionally excluded: maskTier2Metadata
  * joins from/subject with `\n`, and allowing line breaks would glue digits
  * across fields into a fake delimited form.
  */
 export const DELIMITED_OTP_SEP_CLASS =
-  '[-–—.\uFF0D\uFF0E\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
+  '[-–—./\uFF0D\uFF0E\uFF0F\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
 
 /**
  * One to three separator chars between digit groups (F72). Covers ` - `,

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -126,11 +126,12 @@ function extractAnchors(html: string): Anchor[] {
 
 /**
  * Bare http(s) URL *candidates* in plain text (scheme case-insensitive).
- * Intentionally greedy and linear — nested/paired delimiters are not expressed
- * in the regex. Call splitBareUrlCandidate() to peel free trailing `)].,;`
- * while keeping balanced brackets (IPv6 hosts, wiki paths, confirm(foo(bar))).
+ * Intentionally greedy and linear. `'` is kept (RFC 3986 sub-delim / path
+ * apostrophes); only whitespace, `<`, `>`, `"` stay excluded — those never
+ * appear unencoded in a legal URL. Call splitBareUrlCandidate() to peel free
+ * trailing prose delimiters while keeping balanced brackets and in-URL `'`.
  */
-export const BARE_URL_RE = /https?:\/\/[^\s<>"']+/gi;
+export const BARE_URL_RE = /https?:\/\/[^\s<>"]+/gi;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);
@@ -152,10 +153,10 @@ export function validatedHttpUrl(candidate: string): string | null {
 
 /**
  * Split a bare-URL regex match into the real URL (`clean`) and prose tail
- * (`trail`). One O(n) count of brackets, then one right-to-left pass:
- * strip trailing `.,;`, and strip a trailing `)`/`]` only while closers
- * outnumber openers. Balanced nested `()`/`[]` stay on the URL; free outer
- * brackets and trailing punctuation stay in `trail` for the caller to reattach.
+ * (`trail`). One O(n) count of brackets/apostrophes, then one right-to-left pass:
+ * strip trailing `.,;`; strip trailing `)`/`]` only while closers outnumber
+ * openers; strip a trailing `'` while the remaining apostrophe count is odd
+ * (prose closer `'…url'` → peel one; even count or mid-string `it's` stays).
  * Must stay O(n) — never re-count on each trim (that reintroduces O(n²)).
  */
 export function splitBareUrlCandidate(candidate: string): { clean: string; trail: string } {
@@ -165,12 +166,14 @@ export function splitBareUrlCandidate(candidate: string): { clean: string; trail
   let closeParen = 0;
   let openBracket = 0;
   let closeBracket = 0;
+  let apostrophes = 0;
   for (let i = 0; i < candidate.length; i++) {
     const ch = candidate[i]!;
     if (ch === '(') openParen += 1;
     else if (ch === ')') closeParen += 1;
     else if (ch === '[') openBracket += 1;
     else if (ch === ']') closeBracket += 1;
+    else if (ch === "'") apostrophes += 1;
   }
 
   let end = candidate.length;
@@ -187,6 +190,12 @@ export function splitBareUrlCandidate(candidate: string): { clean: string; trail
     }
     if (ch === ']' && closeBracket > openBracket) {
       closeBracket -= 1;
+      end -= 1;
+      continue;
+    }
+    // Odd remaining apostrophe count ⇒ peel a free prose closer; even ⇒ keep.
+    if (ch === "'" && apostrophes % 2 === 1) {
+      apostrophes -= 1;
       end -= 1;
       continue;
     }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -8,7 +8,11 @@
  *   URL or anchor text matches verif|confirm|activate|reset|signin|login.
  */
 
-const CODE_KEYWORDS = [
+/**
+ * Keywords that unlock continuous 4–8 digit extraction (any nearby match).
+ * Exported so alignment tests can keep STRONG_OTP_CUES in sync (F71).
+ */
+export const CODE_KEYWORDS = [
   'code',
   'verification',
   'verify',
@@ -24,12 +28,59 @@ const CODE_KEYWORDS = [
   '校验码',
   '確認コード',
   '認証コード',
-];
+] as const;
+
+/**
+ * Strong cues for year-shaped continuous codes (F65) and delimited forms
+ * (F68/F71). Only terms that *themselves* mean "a code" / PIN / OTP.
+ *
+ * Not listed as array entries (weak / action / generic — still in
+ * CODE_KEYWORDS for continuous non-year extract): verification, verify,
+ * confirmation, one-time, one time. Those alone must not unlock year PIN or
+ * delimited OTP. The phrase "security code" is also kept out of this array
+ * as a whole, but bare `\bcode\b` still matches inside it — intentional so
+ * Microsoft/Discord-style "security code" mail keeps strong paths.
+ */
+export const STRONG_OTP_CUES = [
+  'code',
+  'otp',
+  'passcode',
+  'pin',
+  '验证码',
+  '动态码',
+  '校验码',
+  '確認コード',
+  '認証コード',
+] as const;
 
 const LINK_INTENT = /verif|confirm|activate|reset|signin|sign-in|login|log-in/i;
 
 /** How many characters around a digit run to scan for a keyword. */
 const KEYWORD_WINDOW = 80;
+
+/** Escape a literal for embedding in a RegExp source. */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Built from STRONG_OTP_CUES so Latin tokens keep word boundaries and CJK/JP
+ * tokens match as substrings (same surface as the former hand-written re).
+ */
+function buildStrongOtpCueRe(cues: readonly string[]): RegExp {
+  const latin: string[] = [];
+  const other: string[] = [];
+  for (const cue of cues) {
+    if (/^[a-z]+(?:-[a-z]+)*$/i.test(cue)) latin.push(escapeRegExp(cue));
+    else other.push(escapeRegExp(cue));
+  }
+  const parts: string[] = [];
+  if (latin.length > 0) parts.push(`\\b(?:${latin.join('|')})\\b`);
+  parts.push(...other);
+  return new RegExp(parts.join('|'));
+}
+
+const STRONG_OTP_CUE = buildStrongOtpCueRe(STRONG_OTP_CUES);
 
 export function htmlToText(html: string): string {
   let s = html;
@@ -80,13 +131,6 @@ function decodeEntities(s: string): string {
 }
 
 /**
- * Strong OTP cues for year-shaped continuous codes (F65) and delimited forms
- * (F68). Broader CODE_KEYWORDS alone would false-positive on roadmap years and
- * phone-like `555-1234` near "call".
- */
-const STRONG_OTP_CUE = /\b(?:code|otp|passcode|pin)\b|验证码|动态码/;
-
-/**
  * Single separator class for delimited OTP (F68/F70): hyphen, en/em dash,
  * period, ASCII space/tab, and common Unicode spaces (NBSP, NNBSP, em space,
  * ideographic space, BOM as space, …).
@@ -98,13 +142,23 @@ const STRONG_OTP_CUE = /\b(?:code|otp|passcode|pin)\b|验证码|动态码/;
 export const DELIMITED_OTP_SEP_CLASS =
   '[-–—.\t \u00A0\u1680\u2000-\u200A\u202F\u205F\u3000\uFEFF]';
 
-/** Non-global: continuous run followed by sep + 3–4 digits (half of delimited). */
+/**
+ * One to three separator chars between digit halves (F72). Covers ` - `,
+ * double space, ` – `; four+ seps (e.g. `123    456`) intentionally miss —
+ * rare layout, prefer a bounded false-positive surface over open-ended sep runs.
+ */
+const DELIMITED_OTP_SEP_MAX = 3;
+const DELIMITED_OTP_SEP_RUN = `(?:${DELIMITED_OTP_SEP_CLASS}){1,${DELIMITED_OTP_SEP_MAX}}`;
+/** Lookbehind for half-suppress: max half digits + max seps + small margin. */
+const HALF_OF_DELIMITED_BEFORE_CHARS = 4 + DELIMITED_OTP_SEP_MAX + 3;
+
+/** Non-global: continuous run followed by sep-run + 3–4 digits (half of delimited). */
 const HALF_OF_DELIMITED_AFTER = new RegExp(
-  `^${DELIMITED_OTP_SEP_CLASS}\\d{3,4}\\b`,
+  `^${DELIMITED_OTP_SEP_RUN}\\d{3,4}\\b`,
 );
-/** Non-global: 3–4 digits + sep immediately before a continuous run. */
+/** Non-global: 3–4 digits + sep-run immediately before a continuous run. */
 const HALF_OF_DELIMITED_BEFORE = new RegExp(
-  `\\b\\d{3,4}${DELIMITED_OTP_SEP_CLASS}$`,
+  `\\b\\d{3,4}${DELIMITED_OTP_SEP_RUN}$`,
 );
 
 /**
@@ -112,24 +166,25 @@ const HALF_OF_DELIMITED_BEFORE = new RegExp(
  * Callers must not share a single global instance across concurrent scans.
  */
 export function delimitedOtpCaptureRe(): RegExp {
-  return new RegExp(`\\b(\\d{3,4}${DELIMITED_OTP_SEP_CLASS}\\d{3,4})\\b`, 'g');
+  return new RegExp(`\\b(\\d{3,4}${DELIMITED_OTP_SEP_RUN}\\d{3,4})\\b`, 'g');
 }
 
 /**
  * Fresh global regex for continuous 4–8 digit runs and delimited OTP forms.
- * Delimited alternative is first so `1234-5678` / `1234\u00A05678` is one span.
- * Shared by extract half-suppression consumers and tier-2 mask scans (F70).
+ * Delimited alternative is first so `1234-5678` / `1234 - 5678` is one span.
+ * Shared by extractCodes output shapes and tier-2 mask/meta scans (F70/F72);
+ * half-suppress uses HALF_OF_DELIMITED_* built from the same SEP_RUN.
  */
 export function otpCodeRunRe(): RegExp {
   return new RegExp(
-    `\\b\\d{3,4}${DELIMITED_OTP_SEP_CLASS}\\d{3,4}\\b|\\b\\d{4,8}\\b`,
+    `\\b\\d{3,4}${DELIMITED_OTP_SEP_RUN}\\d{3,4}\\b|\\b\\d{4,8}\\b`,
     'g',
   );
 }
 
 /**
  * True when a continuous \d{4,8} run is one half of a delimited OTP shape
- * (`1234-5678` / `1234\u00A05678`). Only 3–4 digit sides participate (continuous
+ * (`1234-5678` / `1234 - 5678`). Only 3–4 digit sides participate (continuous
  * matches are ≥4, so length must be exactly 4); longer runs like
  * `123456-7890` stay continuous so they are not dropped without recovery.
  */
@@ -137,7 +192,7 @@ function isHalfOfDelimitedOtp(text: string, idx: number, digits: string): boolea
   if (digits.length < 3 || digits.length > 4) return false;
   const after = text.slice(idx + digits.length);
   if (HALF_OF_DELIMITED_AFTER.test(after)) return true;
-  const before = text.slice(Math.max(0, idx - 6), idx);
+  const before = text.slice(Math.max(0, idx - HALF_OF_DELIMITED_BEFORE_CHARS), idx);
   return HALF_OF_DELIMITED_BEFORE.test(before);
 }
 

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -301,9 +301,20 @@ function continuousOtpCaptureRe(): RegExp {
   return new RegExp(`${OTP_BOUND_LEFT}(${ND}{4,8})${OTP_BOUND_RIGHT}`, 'gu');
 }
 
+/**
+ * Keyword window around a match: slice the **original** text at original
+ * offsets, then lowercase only the window (F99). Whole-string `toLowerCase()`
+ * shifts later indices when case-fold expands (Turkish `İ` → `i`+combining
+ * dot), so a pre-lowercased buffer must not be sliced with source indices.
+ */
+function keywordWindow(text: string, idx: number, matchLen: number): string {
+  return text
+    .slice(Math.max(0, idx - KEYWORD_WINDOW), Math.min(text.length, idx + matchLen + KEYWORD_WINDOW))
+    .toLowerCase();
+}
+
 /** Extract 4–8 digit codes (continuous or delimited) near an OTP keyword. */
 export function extractCodes(text: string): string[] {
-  const lower = text.toLowerCase();
   const codes: string[] = [];
   const seen = new Set<string>();
 
@@ -312,10 +323,7 @@ export function extractCodes(text: string): string[] {
     const idx = match.index ?? 0;
     // Leave `1234-5678` / Unicode-space halves to the delimited pass (F68/F70).
     if (isHalfOfDelimitedOtp(text, idx, digits)) continue;
-    const window = lower.slice(
-      Math.max(0, idx - KEYWORD_WINDOW),
-      Math.min(lower.length, idx + digits.length + KEYWORD_WINDOW),
-    );
+    const window = keywordWindow(text, idx, digits.length);
     if (!CODE_KEYWORDS.some((kw) => window.includes(kw))) continue;
     // Years need a strong OTP cue (not mere "verification"/"identity") so
     // roadmap copy like "for 2026" does not fire false OTP alerts (F65).
@@ -335,10 +343,7 @@ export function extractCodes(text: string): string[] {
   for (const match of text.matchAll(delimitedOtpCaptureRe())) {
     const form = match[1]!;
     const idx = match.index ?? 0;
-    const window = lower.slice(
-      Math.max(0, idx - KEYWORD_WINDOW),
-      Math.min(lower.length, idx + form.length + KEYWORD_WINDOW),
-    );
+    const window = keywordWindow(text, idx, form.length);
     if (!STRONG_OTP_CUE.test(window)) continue;
     if (!seen.has(form)) {
       seen.add(form);
@@ -426,17 +431,21 @@ function isUrlTerminalPunct(ch: string): boolean {
 }
 
 /**
- * Whether a trailing `!` or `:` at candidate[end-1] is prose punctuation glued
- * to a closer `)`/`]`/`'` (possibly with other terminal punct in between), not
- * a legal URL-final bang/colon (F92/F96). Look-back is O(length) over the suffix.
+ * Look-back from candidate[end-1]: skip terminal punct, return the index of the
+ * first non-punct char (or -1) and whether it is a closer `)`/`]`/`'` (F92/F96).
  */
-function terminalPunctHasCloserContext(candidate: string, end: number): boolean {
-  // Skip the terminal char itself, then any run of terminal punct, then require a closer.
+function scanTerminalPunctCloserContext(
+  candidate: string,
+  end: number,
+): { boundary: number; verdict: boolean } {
   let i = end - 2;
   while (i >= 0 && isUrlTerminalPunct(candidate[i]!)) i -= 1;
-  if (i < 0) return false;
+  if (i < 0) return { boundary: -1, verdict: false };
   const ch = candidate[i]!;
-  return ch === ')' || ch === ']' || ch === "'";
+  return {
+    boundary: i,
+    verdict: ch === ')' || ch === ']' || ch === "'",
+  };
 }
 
 /**
@@ -446,14 +455,16 @@ function terminalPunctHasCloserContext(candidate: string, end: number): boolean 
  *   is common). Mid-URL `?query` is never trailing and stays put.
  * - Terminal `!` peels only with closer context (`)!` / `]!` / `'!` / `).!`),
  *   so bare `…/token!` keeps the bang (F90 + F92). Mid-URL `!` stays put.
- * - Terminal `:` peels only with closer context (`)!` form twin: `):` / `]:` /
- *   `':` / `):.`), so bare `…/v:` keeps the colon (F96). Port/mid-URL `:` are
- *   never trailing and stay put.
+ * - Terminal `:` peels only with closer context (`):` / `]:` / `':` / `):.`),
+ *   so bare `…/v:` keeps the colon (F96). Port/mid-URL `:` are never trailing.
  * - openQuoted false: peel `'` only while the remaining apostrophe count is odd.
  * - openQuoted true (span started after prose `'`): peel exactly one closing
  *   `'` via a one-shot flag (F61/F63) — odd-parity must not fire as well, or a
  *   legal URL-terminal `'` would be stripped after the outer closer (F63).
- * O(length).
+ *
+ * F98: closer-context look-back is cached per contiguous terminal-punct run so
+ * a long `!!!!` / `::::` suffix is O(length), not O(length²). Verdicts are
+ * bit-identical to rescanning every iteration.
  */
 function peelTrailingProse(
   candidate: string,
@@ -480,15 +491,26 @@ function peelTrailingProse(
   // openQuoted: authorize exactly one outer closer peel (after any .,;!?:).
   let peelOpenQuote = openQuoted;
   let end = candidate.length;
+  // F98: cache look-back for one contiguous `!`/`:` (and mixed terminal) run.
+  let cachedBoundary: number | null = null;
+  let cachedVerdict = false;
   while (end > 0) {
     const ch = candidate[end - 1]!;
     if (ch === '.' || ch === ',' || ch === ';' || ch === '?') {
+      // Unconditional peel may exit/enter a conditional run — drop cache.
+      cachedBoundary = null;
       end -= 1;
       continue;
     }
     // F92/F96: peel `!` or `:` only when glued to ) ] ' (skip other terminal punct).
     if (ch === '!' || ch === ':') {
-      if (terminalPunctHasCloserContext(candidate, end)) {
+      // Same run while end-2 is still strictly after the first non-punct char.
+      if (cachedBoundary === null || !(end - 2 > cachedBoundary)) {
+        const scan = scanTerminalPunctCloserContext(candidate, end);
+        cachedBoundary = scan.boundary;
+        cachedVerdict = scan.verdict;
+      }
+      if (cachedVerdict) {
         end -= 1;
         continue;
       }
@@ -496,11 +518,13 @@ function peelTrailingProse(
     }
     if (ch === ')' && closeParen > openParen) {
       closeParen -= 1;
+      cachedBoundary = null;
       end -= 1;
       continue;
     }
     if (ch === ']' && closeBracket > openBracket) {
       closeBracket -= 1;
+      cachedBoundary = null;
       end -= 1;
       continue;
     }
@@ -510,11 +534,13 @@ function peelTrailingProse(
         if (!peelOpenQuote) break;
         peelOpenQuote = false;
         apostrophes -= 1;
+        cachedBoundary = null;
         end -= 1;
         continue;
       }
       if (apostrophes % 2 === 1) {
         apostrophes -= 1;
+        cachedBoundary = null;
         end -= 1;
         continue;
       }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -280,11 +280,13 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
 /**
  * Single-pass bare URL tokenizer. O(n) over the full text:
  * pre-scan scheme positions, then for each start scan once with depth tracking;
- * an unbalanced closer is a hard cut only when the next scheme is a proven
- * Markdown chain (tight `)(`, `](`, `)[`, `][`, or `)[label](` / `][label](`).
- * Nested redirects and path segments like `)[token=` stay inside the URL
- * (WHATWG); inner schemes are skipped by the post-span scheme advance.
- * Bounded tail peel removes free trailers without re-matching the remainder.
+ * an unbalanced closer is a hard cut when (1) the next scheme is a proven
+ * Markdown chain (tight `)(`, `](`, `)[`, `][`, or `)[label](` / `][label](`),
+ * or (2) the span opened as Markdown `](https://…)` (first free `)` closes the
+ * link even without a following scheme — F59). Bare URLs keep free `)` in-path
+ * (e.g. F48 `confirm)[token=`). Nested redirects and path segments stay inside
+ * the URL when neither cut applies; inner schemes are skipped by post-span
+ * advance. Bounded tail peel removes free trailers without re-matching.
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
@@ -303,6 +305,10 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     let glueCut: { closer: number; nextScheme: number } | undefined;
     // Set when we hard-cut on " < > with a glued non-whitespace tail (F55).
     let tailCut: { start: number; end: number } | undefined;
+    // F59: URL opened as Markdown `](https://…)` — first free `)` closes the link,
+    // even with no following scheme / whitespace (bare URLs keep free `)` in-path).
+    const markdownLinkOpen =
+      start >= 2 && text[start - 1] === '(' && text[start - 2] === ']';
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -350,6 +356,11 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
         if (isMarkdownChainGlue(text, i, nextScheme)) {
           end = i;
           glueCut = { closer: i, nextScheme: nextScheme! };
+          break;
+        }
+        // After glue check: MD link openers cut at the first free closer (no glue/tail meta).
+        if (markdownLinkOpen) {
+          end = i;
           break;
         }
         continue;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -449,10 +449,39 @@ function scanTerminalPunctCloserContext(
 }
 
 /**
- * Peel trailing prose from a bounded candidate [0, length): `.,;?`, conditional
- * trailing `!`/`:`, unbalanced trailing `)`/`]`, and trailing `'`.
- * - Terminal `?` peels like `.`/`,`/`;` (empty query ≈ no query; sentence `?`
- *   is common). Mid-URL `?query` is never trailing and stays put.
+ * Whether an already-peeled trailer forces peeling a structural first `?` (F100).
+ * Closers / quotes / non-`?` terminal punct after the `?` mean sentence context
+ * (`verify?)`, `verify?).`). A trailer of only extra `?` does **not** force peel
+ * of the first (`??` → keep one empty-query `?`).
+ */
+function trailerForcesQuestionPeel(trailer: string): boolean {
+  for (let i = 0; i < trailer.length; i++) {
+    const ch = trailer[i]!;
+    if (
+      ch === ')' ||
+      ch === ']' ||
+      ch === "'" ||
+      ch === '.' ||
+      ch === ',' ||
+      ch === ';' ||
+      ch === '!'
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Peel trailing prose from a bounded candidate [0, length): `.,;`, conditional
+ * trailing `?`/`!`/`:`, unbalanced trailing `)`/`]`, and trailing `'`.
+ * - Terminal `.`/`,`/`;` peel unconditionally.
+ * - Terminal `?` (F100): **keep** the first bare `?` (WHATWG empty query is
+ *   significant for strict servers; usually same route as no-query). **Peel**
+ *   a later `?` (query already started — prose question mark wins), or a first
+ *   `?` followed by peeled closers/quotes/`!.,;` (`verify?)`), or a first `?`
+ *   with closer-context look-back (`)!?` stacked prose). Mid-URL `?query` is
+ *   never trailing.
  * - Terminal `!` peels only with closer context (`)!` / `]!` / `'!` / `).!`),
  *   so bare `…/token!` keeps the bang (F90 + F92). Mid-URL `!` stays put.
  * - Terminal `:` peels only with closer context (`):` / `]:` / `':` / `):.`),
@@ -463,8 +492,7 @@ function scanTerminalPunctCloserContext(
  *   legal URL-terminal `'` would be stripped after the outer closer (F63).
  *
  * F98: closer-context look-back is cached per contiguous terminal-punct run so
- * a long `!!!!` / `::::` suffix is O(length), not O(length²). Verdicts are
- * bit-identical to rescanning every iteration.
+ * a long `!!!!` / `::::` / `????` suffix is O(length), not O(length²).
  */
 function peelTrailingProse(
   candidate: string,
@@ -488,19 +516,43 @@ function peelTrailingProse(
     else if (ch === "'") apostrophes += 1;
   }
 
+  // O(1) later-`?` checks for F100 (single scan budget per peel call).
+  const firstQuestionIdx = candidate.indexOf('?');
+
   // openQuoted: authorize exactly one outer closer peel (after any .,;!?:).
   let peelOpenQuote = openQuoted;
   let end = candidate.length;
-  // F98: cache look-back for one contiguous `!`/`:` (and mixed terminal) run.
+  // F98: cache look-back for one contiguous `!`/`:`/`?` (mixed terminal) run.
   let cachedBoundary: number | null = null;
   let cachedVerdict = false;
   while (end > 0) {
     const ch = candidate[end - 1]!;
-    if (ch === '.' || ch === ',' || ch === ';' || ch === '?') {
+    if (ch === '.' || ch === ',' || ch === ';') {
       // Unconditional peel may exit/enter a conditional run — drop cache.
       cachedBoundary = null;
       end -= 1;
       continue;
+    }
+    // F100: conditional `?` — keep first bare empty-query; peel later / prose.
+    if (ch === '?') {
+      const laterQuestion = firstQuestionIdx >= 0 && firstQuestionIdx < end - 1;
+      if (laterQuestion || trailerForcesQuestionPeel(candidate.slice(end))) {
+        cachedBoundary = null;
+        end -= 1;
+        continue;
+      }
+      // First `?` with empty/only-`?` trailer: peel only with closer context
+      // (stacked `)!?` / `]?`); otherwise keep structural empty query.
+      if (cachedBoundary === null || !(end - 2 > cachedBoundary)) {
+        const scan = scanTerminalPunctCloserContext(candidate, end);
+        cachedBoundary = scan.boundary;
+        cachedVerdict = scan.verdict;
+      }
+      if (cachedVerdict) {
+        end -= 1;
+        continue;
+      }
+      break;
     }
     // F92/F96: peel `!` or `:` only when glued to ) ] ' (skip other terminal punct).
     if (ch === '!' || ch === ':') {

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -409,18 +409,29 @@ function findSchemePositions(text: string): number[] {
   return positions;
 }
 
-/** Prose terminal punctuation that may trail a URL (peel loop / F90–F92). */
+/**
+ * Prose terminal punctuation that may trail a URL (peel loop / F90–F96).
+ * Includes `:` for look-back over stacked trailers (e.g. `):.`) but bare `:`
+ * peels only with closer context (F96) — never unconditional.
+ */
 function isUrlTerminalPunct(ch: string): boolean {
-  return ch === '.' || ch === ',' || ch === ';' || ch === '!' || ch === '?';
+  return (
+    ch === '.' ||
+    ch === ',' ||
+    ch === ';' ||
+    ch === '!' ||
+    ch === '?' ||
+    ch === ':'
+  );
 }
 
 /**
- * Whether a trailing `!` at candidate[end-1] is prose punctuation glued to a
- * closer `)`/`]`/`'` (possibly with other terminal punct in between), not a
- * legal URL-final bang (F92). Look-back is O(length) over the suffix only.
+ * Whether a trailing `!` or `:` at candidate[end-1] is prose punctuation glued
+ * to a closer `)`/`]`/`'` (possibly with other terminal punct in between), not
+ * a legal URL-final bang/colon (F92/F96). Look-back is O(length) over the suffix.
  */
-function bangHasCloserContext(candidate: string, end: number): boolean {
-  // Skip the `!` itself, then any run of terminal punct, then require a closer.
+function terminalPunctHasCloserContext(candidate: string, end: number): boolean {
+  // Skip the terminal char itself, then any run of terminal punct, then require a closer.
   let i = end - 2;
   while (i >= 0 && isUrlTerminalPunct(candidate[i]!)) i -= 1;
   if (i < 0) return false;
@@ -430,11 +441,14 @@ function bangHasCloserContext(candidate: string, end: number): boolean {
 
 /**
  * Peel trailing prose from a bounded candidate [0, length): `.,;?`, conditional
- * trailing `!`, unbalanced trailing `)`/`]`, and trailing `'`.
+ * trailing `!`/`:`, unbalanced trailing `)`/`]`, and trailing `'`.
  * - Terminal `?` peels like `.`/`,`/`;` (empty query ≈ no query; sentence `?`
  *   is common). Mid-URL `?query` is never trailing and stays put.
  * - Terminal `!` peels only with closer context (`)!` / `]!` / `'!` / `).!`),
  *   so bare `…/token!` keeps the bang (F90 + F92). Mid-URL `!` stays put.
+ * - Terminal `:` peels only with closer context (`)!` form twin: `):` / `]:` /
+ *   `':` / `):.`), so bare `…/v:` keeps the colon (F96). Port/mid-URL `:` are
+ *   never trailing and stay put.
  * - openQuoted false: peel `'` only while the remaining apostrophe count is odd.
  * - openQuoted true (span started after prose `'`): peel exactly one closing
  *   `'` via a one-shot flag (F61/F63) — odd-parity must not fire as well, or a
@@ -463,7 +477,7 @@ function peelTrailingProse(
     else if (ch === "'") apostrophes += 1;
   }
 
-  // openQuoted: authorize exactly one outer closer peel (after any .,;!?).
+  // openQuoted: authorize exactly one outer closer peel (after any .,;!?:).
   let peelOpenQuote = openQuoted;
   let end = candidate.length;
   while (end > 0) {
@@ -472,9 +486,9 @@ function peelTrailingProse(
       end -= 1;
       continue;
     }
-    // F92: peel `!` only when glued to ) ] ' (skip other terminal punct in between).
-    if (ch === '!') {
-      if (bangHasCloserContext(candidate, end)) {
+    // F92/F96: peel `!` or `:` only when glued to ) ] ' (skip other terminal punct).
+    if (ch === '!' || ch === ':') {
+      if (terminalPunctHasCloserContext(candidate, end)) {
         end -= 1;
         continue;
       }

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -92,10 +92,16 @@ export function extractCodes(text: string): string[] {
       Math.max(0, idx - KEYWORD_WINDOW),
       Math.min(lower.length, idx + digits.length + KEYWORD_WINDOW),
     );
-    // No separate year guard: 19xx/20xx next to any CODE_KEYWORDS token is
-    // treated as an OTP (prefer over-mask to leaking "verification PIN is 2026").
-    // Without a keyword in the window the run is skipped here.
     if (!CODE_KEYWORDS.some((kw) => window.includes(kw))) continue;
+    // Years need a strong OTP cue (not mere "verification"/"identity") so
+    // roadmap copy like "for 2026" does not fire false OTP alerts (F65).
+    // "verification PIN is 2026" still matches \bpin\b.
+    if (
+      /^(19|20)\d{2}$/.test(digits) &&
+      !/\b(?:code|otp|passcode|pin)\b|验证码|动态码/.test(window)
+    ) {
+      continue;
+    }
     if (!seen.has(digits)) {
       seen.add(digits);
       codes.push(digits);
@@ -177,6 +183,8 @@ function findSchemePositions(text: string): number[] {
 function peelTrailingProse(
   candidate: string,
   openQuoted = false,
+  /** When true, never peel `'` (outer closer already left outside the span; F64 cut). */
+  preserveApostrophes = false,
 ): { clean: string; trail: string } {
   if (!candidate) return { clean: '', trail: '' };
 
@@ -213,7 +221,7 @@ function peelTrailingProse(
       end -= 1;
       continue;
     }
-    if (ch === "'") {
+    if (ch === "'" && !preserveApostrophes) {
       if (openQuoted) {
         // F63: only the one-shot flag; parity never stacks a second peel.
         if (!peelOpenQuote) break;
@@ -303,11 +311,11 @@ function isMarkdownChainGlue(text: string, i: number, nextScheme: number | undef
  * pre-scan scheme positions, then for each start scan once with depth tracking;
  * an unbalanced closer is a hard cut when (1) the next scheme is a proven
  * Markdown chain (tight `)(`, `](`, `)[`, `][`, or `)[label](` / `][label](`),
- * or (2) the span opened as Markdown `](https://…)` (first free `)` closes the
- * link even without a following scheme — F59). Bare URLs keep free `)` in-path
- * (e.g. F48 `confirm)[token=`). Nested redirects and path segments stay inside
- * the URL when neither cut applies; inner schemes are skipped by post-span
- * advance. Bounded tail peel removes free trailers without re-matching.
+ * or (2) the span opened after `](` / prose `(` (first free `)` closes the
+ * wrapper — F59/F64). Bare URLs keep free `)` in-path (e.g. F48 `confirm)[token=`).
+ * openQuoted spans also cut before a closing `'` when the next char is prose
+ * close context (F64). Nested redirects stay inside the URL when no cut applies.
+ * Bounded tail peel removes free trailers without re-matching.
  */
 export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
   if (!text) return;
@@ -326,13 +334,19 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     let glueCut: { closer: number; nextScheme: number } | undefined;
     // Set when we hard-cut on " < > with a glued non-whitespace tail (F55).
     let tailCut: { start: number; end: number } | undefined;
-    // F59: URL opened as Markdown `](https://…)` — first free `)` closes the link,
-    // even with no following scheme / whitespace (bare URLs keep free `)` in-path).
+    // F59: Markdown `](https://…)`. F64: prose `(https://…)` — not `](`.
     const markdownLinkOpen =
       start >= 2 && text[start - 1] === '(' && text[start - 2] === ']';
-    // F61: span opened after a prose apostrophe — peel one trailing ' even if
-    // internal apostrophes made the count even (e.g. '…o'brien').
+    const proseParenOpen =
+      start >= 1 &&
+      text[start - 1] === '(' &&
+      (start < 2 || text[start - 2] !== ']');
+    const cutOnFreeParen = markdownLinkOpen || proseParenOpen;
+    // F61/F63: span opened after a prose apostrophe.
     const openQuoted = start >= 1 && text[start - 1] === "'";
+    // True when F64 cut left the outer closer outside the raw span — peel must
+    // not also strip a legal URL-terminal ' (F63).
+    let openQuotedCut = false;
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -382,8 +396,8 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
           glueCut = { closer: i, nextScheme: nextScheme! };
           break;
         }
-        // After glue check: MD link openers cut at the first free closer (no glue/tail meta).
-        if (markdownLinkOpen) {
+        // After glue: MD `](` or prose `(` openers cut at first free closer.
+        if (cutOnFreeParen) {
           end = i;
           break;
         }
@@ -403,10 +417,39 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
         }
         continue;
       }
+      // F64: outer prose quote closes when ' is followed by close-context.
+      // Internal apostrophes (o'brien) and URL-terminal ' before another '
+      // (token'' + space → cut only the outer closer) stay in the URL.
+      if (ch === "'" && openQuoted) {
+        const next = i + 1 < text.length ? text[i + 1]! : '';
+        const closes =
+          next === '' ||
+          isJsWhitespace(next) ||
+          next === '!' ||
+          next === '.' ||
+          next === ',' ||
+          next === ';' ||
+          next === ':' ||
+          next === '?' ||
+          next === ')' ||
+          next === ']' ||
+          next === '}';
+        if (closes) {
+          end = i;
+          openQuotedCut = true;
+          break;
+        }
+        continue;
+      }
     }
 
     const raw = text.slice(start, end);
-    const { clean } = peelTrailingProse(raw, openQuoted);
+    // F64 cut left outer closer outside the span: keep any URL-terminal ' (F63).
+    const { clean } = peelTrailingProse(
+      raw,
+      openQuoted && !openQuotedCut,
+      openQuotedCut,
+    );
     if (clean.length === 0) {
       schemeIdx += 1;
       continue;

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -124,19 +124,47 @@ function extractAnchors(html: string): Anchor[] {
   return anchors;
 }
 
-const BARE_URL_RE = /https?:\/\/[^\s<>"')\]]+/g;
+/** Bare http(s) URLs in plain text; shared by extractors and tier-2 masking. */
+export const BARE_URL_RE = /https?:\/\/[^\s<>"')\]]+/g;
 
 function looksLikeActionLink(url: string, anchorText = ''): boolean {
   return LINK_INTENT.test(url) || LINK_INTENT.test(anchorText);
 }
 
-function validatedHttpUrl(candidate: string): string | null {
+/**
+ * Canonical WHATWG form for http(s) candidates (hostname lowercased, default
+ * ports dropped). Returns null for non-http(s) or unparseable input.
+ * Shared by extractLinks and tier-2 URL masking so both use one normalizer.
+ */
+export function validatedHttpUrl(candidate: string): string | null {
   try {
     const url = new URL(candidate);
     return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : null;
   } catch {
     return null;
   }
+}
+
+/**
+ * Replace bare URLs in `text` whose validatedHttpUrl form is in `normalizedLinks`
+ * with `placeholder`, keeping the original spelling span as the match (so
+ * EXAMPLE.com:443 still redacts when the needle is https://example.com/...).
+ */
+export function maskNormalizedHttpUrls(
+  text: string,
+  normalizedLinks: string[],
+  placeholder = '•••',
+): string {
+  if (!text || normalizedLinks.length === 0) return text;
+  const targets = new Set(normalizedLinks.filter(Boolean));
+  if (targets.size === 0) return text;
+  return text.replace(BARE_URL_RE, (raw) => {
+    const clean = raw.replace(/[.,;]+$/, '');
+    const trail = raw.slice(clean.length);
+    const validated = validatedHttpUrl(clean);
+    if (validated && targets.has(validated)) return `${placeholder}${trail}`;
+    return raw;
+  });
 }
 
 /**

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -185,7 +185,8 @@ const DELIMITED_OTP_SEP_RUN = `(?:${DELIMITED_OTP_SEP_CLASS}){1,${DELIMITED_OTP_
 
 /**
  * One digit group of a delimited OTP (F73–F75): 2–4 Unicode decimal digits.
- * Full form is 2–4 such groups joined by SEP_RUN.
+ * Full form is 2–4 such groups joined by SEP_RUN — or, since F132, a
+ * single-digit chain of 4–8 one-digit groups (`1 2 3 4 5 6`).
  *
  * End guards (F74, shared by capture + run) reject 5+ group chains without
  * taking a 3–4 group prefix/suffix. Total digits may reach 4–16 (privacy-safe
@@ -193,7 +194,11 @@ const DELIMITED_OTP_SEP_RUN = `(?:${DELIMITED_OTP_SEP_CLASS}){1,${DELIMITED_OTP_
  * prefix — full-run integrity wins.
  */
 const DELIMITED_OTP_GROUP = `${ND}{2,4}`;
-const DELIMITED_OTP_FORM = `${DELIMITED_OTP_GROUP}(?:${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}){1,3}`;
+// F132: single-digit chains (`1 2 3 4 5 6`) — providers render codes
+// spaced for readability. 4–8 one-digit groups across the same bounded
+// separators; the shared lead/tail guards refuse 9+ chains whole.
+const DELIMITED_OTP_SINGLE_FORM = `${ND}(?:${DELIMITED_OTP_SEP_RUN}${ND}){3,7}`;
+const DELIMITED_OTP_FORM = `(?:${DELIMITED_OTP_GROUP}(?:${DELIMITED_OTP_SEP_RUN}${DELIMITED_OTP_GROUP}){1,3}|${DELIMITED_OTP_SINGLE_FORM})`;
 /**
  * Leading guard: not immediately after digit+sep (blocks mid-chain starts).
  * Tradeoff: a valid form glued after e.g. `1 12 34 56` is also refused — rare in OTP mail.
@@ -751,6 +756,9 @@ const PAIRED_URL_QUOTES: Record<string, string> = {
   '\u3008': '\u3009', // CJK angle brackets
   '\u300A': '\u300B', // CJK double angle brackets
   '\u3010': '\u3011', // CJK lenticular brackets
+  '\uFF62': '\uFF63', // halfwidth CJK corner brackets (F133)
+  '\uFF08': '\uFF09', // fullwidth parentheses (F133)
+  '\uFF1C': '\uFF1E', // fullwidth angle brackets (F133)
 };
 
 /**

--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -92,9 +92,10 @@ export function extractCodes(text: string): string[] {
       Math.max(0, idx - KEYWORD_WINDOW),
       Math.min(lower.length, idx + digits.length + KEYWORD_WINDOW),
     );
+    // No separate year guard: 19xx/20xx next to any CODE_KEYWORDS token is
+    // treated as an OTP (prefer over-mask to leaking "verification PIN is 2026").
+    // Without a keyword in the window the run is skipped here.
     if (!CODE_KEYWORDS.some((kw) => window.includes(kw))) continue;
-    // Skip obvious years that merely sit next to a keyword.
-    if (/^(19|20)\d{2}$/.test(digits) && !/code|otp|passcode|验证码|动态码/.test(window)) continue;
     if (!seen.has(digits)) {
       seen.add(digits);
       codes.push(digits);
@@ -166,9 +167,15 @@ function findSchemePositions(text: string): number[] {
 
 /**
  * Peel trailing prose from a bounded candidate [0, length): `.,;`, unbalanced
- * trailing `)`/`]`, and an odd trailing `'`. O(length).
+ * trailing `)`/`]`, and trailing `'` when the apostrophe count is odd — or when
+ * the span opened after a prose `'` (outer quote; F61) so even counts still
+ * drop one closing quote after an internal apostrophe (e.g. o'brien').
+ * O(length).
  */
-function peelTrailingProse(candidate: string): { clean: string; trail: string } {
+function peelTrailingProse(
+  candidate: string,
+  openQuoted = false,
+): { clean: string; trail: string } {
   if (!candidate) return { clean: '', trail: '' };
 
   let openParen = 0;
@@ -185,6 +192,8 @@ function peelTrailingProse(candidate: string): { clean: string; trail: string } 
     else if (ch === "'") apostrophes += 1;
   }
 
+  // At most one openQuoted peel, after any trailing .,; (not only original EOS).
+  let peelOpenQuote = openQuoted;
   let end = candidate.length;
   while (end > 0) {
     const ch = candidate[end - 1]!;
@@ -202,9 +211,12 @@ function peelTrailingProse(candidate: string): { clean: string; trail: string } 
       end -= 1;
       continue;
     }
-    if (ch === "'" && apostrophes % 2 === 1) {
+    if (ch === "'" && (apostrophes % 2 === 1 || peelOpenQuote)) {
+      // Odd count: classic prose closer. openQuoted: peel one outer closer even
+      // when an internal apostrophe made the total even (F61), including after .,;
       apostrophes -= 1;
       end -= 1;
+      peelOpenQuote = false;
       continue;
     }
     break;
@@ -309,6 +321,9 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     // even with no following scheme / whitespace (bare URLs keep free `)` in-path).
     const markdownLinkOpen =
       start >= 2 && text[start - 1] === '(' && text[start - 2] === ']';
+    // F61: span opened after a prose apostrophe — peel one trailing ' even if
+    // internal apostrophes made the count even (e.g. '…o'brien').
+    const openQuoted = start >= 1 && text[start - 1] === "'";
 
     for (let i = start; i < text.length; i++) {
       const ch = text[i]!;
@@ -382,7 +397,7 @@ export function* bareUrlSpans(text: string): Generator<BareUrlSpan> {
     }
 
     const raw = text.slice(start, end);
-    const { clean } = peelTrailingProse(raw);
+    const { clean } = peelTrailingProse(raw, openQuoted);
     if (clean.length === 0) {
       schemeIdx += 1;
       continue;

--- a/packages/api/src/routes/identities.ts
+++ b/packages/api/src/routes/identities.ts
@@ -4,9 +4,15 @@ import { z } from 'zod';
 import {
   createIdentity,
   deleteIdentity,
+  findIdentity,
   listIdentities,
   rotateIdentityToken,
+  resolvePushContentTier,
+  setIdentityPushContentTier,
   LOCALPART_RE,
+  PUSH_TIER3_WARNING,
+  type Identity,
+  type PushContentTier,
 } from '../lib/identities.ts';
 import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
 import { getAuth } from '../lib/auth.ts';
@@ -19,6 +25,14 @@ const createSchema = z.object({
   canNotifyUser: z.boolean().optional(),
 });
 
+const pushTierSchema = z
+  .object({
+    pushContentTier: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+    // Tier 3 ships body/OTP off-box via ntfy; require an explicit ack.
+    confirm_risk: z.boolean().optional(),
+  })
+  .strict();
+
 // Identity management is admin-only: identity tokens may not mint, list or
 // delete identities (that would let a leaked token escalate sideways).
 function requireAdmin(c: Context) {
@@ -26,6 +40,26 @@ function requireAdmin(c: Context) {
     return c.json({ error: 'forbidden: admin key required' }, 403);
   }
   return null;
+}
+
+function pushTierResponse(address: string, tier: PushContentTier) {
+  return {
+    address,
+    pushContentTier: tier,
+    ...(tier === 3 ? { warning: PUSH_TIER3_WARNING } : {}),
+  };
+}
+
+function publicIdentity(identity: Identity) {
+  const tier = resolvePushContentTier(identity);
+  return {
+    address: identity.address,
+    ...(identity.name ? { name: identity.name } : {}),
+    createdAt: identity.createdAt,
+    ...(identity.canNotifyUser ? { canNotifyUser: true } : {}),
+    pushContentTier: tier,
+    ...(tier === 3 ? { pushContentTierWarning: PUSH_TIER3_WARNING } : {}),
+  };
 }
 
 export const identitiesRoute = new Hono()
@@ -64,6 +98,7 @@ export const identitiesRoute = new Hono()
           address: identity.address,
           ...(identity.name ? { name: identity.name } : {}),
           ...(identity.canNotifyUser ? { canNotifyUser: true } : {}),
+          pushContentTier: resolvePushContentTier(identity),
           // Shown exactly once — store it now. Only its hash persists.
           token,
         },
@@ -79,7 +114,47 @@ export const identitiesRoute = new Hono()
   .get('/', (c) => {
     const denied = requireAdmin(c);
     if (denied) return denied;
-    return c.json({ identities: listIdentities() });
+    return c.json({
+      identities: listIdentities().map((identity) => publicIdentity(identity)),
+    });
+  })
+  .get('/:address/push-tier', (c) => {
+    const address = c.req.param('address').toLowerCase();
+    const auth = getAuth(c);
+    // Identity tokens may read their own tier; only admins may read others.
+    if (auth.kind === 'identity' && auth.address !== address) {
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+    const identity = findIdentity(address);
+    if (!identity) return c.json({ error: 'not_found' }, 404);
+    return c.json(pushTierResponse(address, resolvePushContentTier(identity)));
+  })
+  .put('/:address/push-tier', async (c) => {
+    const denied = requireAdmin(c);
+    if (denied) return denied;
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400);
+    }
+    const parsed = pushTierSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+    const { pushContentTier: tier, confirm_risk: confirmRisk } = parsed.data;
+    if (tier === 3 && confirmRisk !== true) {
+      return c.json(
+        {
+          error: 'confirm_risk_required',
+          message: PUSH_TIER3_WARNING,
+        },
+        400,
+      );
+    }
+    const updated = setIdentityPushContentTier(c.req.param('address'), tier);
+    if (!updated) return c.json({ error: 'not_found' }, 404);
+    return c.json(pushTierResponse(updated.address, resolvePushContentTier(updated)));
   })
   .post('/:address/token', (c) => {
     const denied = requireAdmin(c);

--- a/packages/api/src/routes/notify.ts
+++ b/packages/api/src/routes/notify.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { z } from 'zod';
 import { getAuth } from '../lib/auth.ts';
-import { config } from '../lib/config.ts';
+import { config, normalizeUrl } from '../lib/config.ts';
 import { findIdentity } from '../lib/identities.ts';
 import {
   NotifyError,
@@ -85,7 +85,8 @@ export function createNotifyRoutes(options: NotifyRouteOptions = {}) {
   const service = options.service ?? notificationService();
   const find = options.findIdentity ?? findIdentity;
   const createDevice = options.createDevice ?? createNotificationDevice;
-  const activePublicUrl = options.publicUrl ?? config.ntfy.publicUrl;
+  // Same normalizer as config (pathname trailing slash, not string-end slash).
+  const activePublicUrl = normalizeUrl(options.publicUrl ?? config.ntfy.publicUrl);
 
   return new Hono()
     .post('/', async (c) => {
@@ -155,7 +156,7 @@ export function createNotifyRoutes(options: NotifyRouteOptions = {}) {
       if (requestedPublicUrl.protocol !== 'https:') {
         return c.json({ error: 'invalid_request: publicUrl must use https' }, 400);
       }
-      if (requestedPublicUrl.href.replace(/\/$/, '') !== activePublicUrl) {
+      if (normalizeUrl(parsed.data.publicUrl) !== activePublicUrl) {
         return c.json({ error: 'notify_public_url_mismatch: set NOTIFY_PUBLIC_URL and restart the stack first' }, 409);
       }
       try {

--- a/packages/api/src/routes/notify.ts
+++ b/packages/api/src/routes/notify.ts
@@ -6,6 +6,7 @@ import { config, normalizeUrl } from '../lib/config.ts';
 import { findIdentity } from '../lib/identities.ts';
 import {
   NotifyError,
+  NTFY_REQUEST_MAX_BYTES,
   createNotificationDevice,
   type NotificationDevice,
   type NotifyLevel,
@@ -53,6 +54,17 @@ function notificationError(c: Context, err: unknown) {
     return c.json({ error: err.code }, 503);
   }
   if (err.code === 'unknown_agent') return c.json({ error: err.code }, 404);
+  if (err.code === 'message_too_large') {
+    // 413: payload exceeds the ntfy request budget after framing (F76).
+    return c.json(
+      {
+        error: err.code,
+        maxRequestBytes: err.details?.maxRequestBytes ?? NTFY_REQUEST_MAX_BYTES,
+        availableMessageBytes: err.details?.availableMessageBytes ?? 0,
+      },
+      413,
+    );
+  }
   return c.json({ error: err.code }, 502);
 }
 

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -8,7 +8,10 @@ import {
   findIdentity,
   listIdentities,
   LOCALPART_RE,
+  PUSH_TIER3_WARNING,
+  resolvePushContentTier,
   rotateIdentityToken,
+  setIdentityPushContentTier,
   type Identity,
 } from '../lib/identities.ts';
 import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
@@ -80,13 +83,23 @@ const seenBodySchema = z
   .strict();
 
 function identityProjection(identity: Identity) {
+  const pushContentTier = resolvePushContentTier(identity);
   return {
     address: identity.address,
     ...(identity.name ? { name: identity.name } : {}),
     createdAt: identity.createdAt,
     hasToken: Boolean(identity.tokenHash),
+    pushContentTier,
+    ...(pushContentTier === 3 ? { pushContentTierWarning: PUSH_TIER3_WARNING } : {}),
   };
 }
+
+const pushTierBodySchema = z
+  .object({
+    pushContentTier: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+    confirm_risk: z.boolean().optional(),
+  })
+  .strict();
 
 function requireUiAdmin(c: Context): Response | null {
   if (getAuth(c).kind !== 'admin') {
@@ -272,6 +285,39 @@ export function createUiApiRoutes(
     const token = rotateIdentityToken(c.req.param('address'));
     if (!token) return c.json({ error: 'not_found' }, 404);
     return c.json({ address: c.req.param('address').toLowerCase(), token });
+  });
+
+  routes.put('/identities/:address/push-tier', async (c) => {
+    const denied = requireUiAdmin(c);
+    if (denied) return denied;
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400);
+    }
+    const parsed = pushTierBodySchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+    const { pushContentTier: tier, confirm_risk: confirmRisk } = parsed.data;
+    if (tier === 3 && confirmRisk !== true) {
+      return c.json(
+        {
+          error: 'confirm_risk_required',
+          message: PUSH_TIER3_WARNING,
+        },
+        400,
+      );
+    }
+    const updated = setIdentityPushContentTier(c.req.param('address'), tier);
+    if (!updated) return c.json({ error: 'not_found' }, 404);
+    const resolved = resolvePushContentTier(updated);
+    return c.json({
+      address: updated.address,
+      pushContentTier: resolved,
+      ...(resolved === 3 ? { warning: PUSH_TIER3_WARNING } : {}),
+    });
   });
 
   routes.delete('/identities/:address', (c) => {

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -13,6 +13,7 @@ import {
   rotateIdentityToken,
   setIdentityPushContentTier,
   type Identity,
+  type PushContentTier,
 } from '../lib/identities.ts';
 import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
 import {
@@ -47,6 +48,8 @@ export type UiApiDependencies = {
     refresh: boolean;
     identityAddresses: string[];
   }) => Promise<ScanOutcome>;
+  /** Persist an identity's mail-arrival push content tier (admin UI). */
+  setPushContentTier: (address: string, tier: PushContentTier) => Identity | null;
 };
 
 /** 进程内单例：快照与会话一样活在进程里，重启后第一次 Overview 是冷启动。 */
@@ -61,6 +64,7 @@ const defaultDependencies: UiApiDependencies = {
   getMessage,
   setMessageSeen,
   getMailboxScan: (opts) => overviewCache.getOverview(opts),
+  setPushContentTier: setIdentityPushContentTier,
 };
 
 /** 「最近活跃」的窗口长度（小时）。 */
@@ -310,7 +314,7 @@ export function createUiApiRoutes(
         400,
       );
     }
-    const updated = setIdentityPushContentTier(c.req.param('address'), tier);
+    const updated = dependencies.setPushContentTier(c.req.param('address'), tier);
     if (!updated) return c.json({ error: 'not_found' }, 404);
     const resolved = resolvePushContentTier(updated);
     return c.json({

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -490,8 +490,26 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   padding: 12px 10px;
   text-align: left;
 }
+/* Nav hit-target spans identity…created (cols 1–6); tier/actions stay siblings (F66). */
+.overview-row-nav {
+  grid-column: 1 / span 6;
+  display: grid;
+  grid-template-columns: subgrid;
+  gap: 10px;
+  align-items: baseline;
+  min-width: 0;
+  margin: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
 .overview-row:hover, .overview-row[aria-current="true"] { background: var(--gold-dim); }
-.overview-row:focus-visible { outline: 3px solid var(--gold); outline-offset: -3px; }
+.overview-row-nav:focus-visible { outline: 3px solid var(--gold); outline-offset: -3px; }
 .overview-row .cell { display: block; overflow: hidden; text-overflow: ellipsis; }
 .overview-row .cell-label { display: none; color: var(--ink-dim); font-size: 12px; }
 .cell-value { font-variant-numeric: tabular-nums; }
@@ -686,6 +704,7 @@ button:disabled { cursor: not-allowed; opacity: .55; }
     gap: 6px;
     grid-template-columns: minmax(0, 1fr) 58px 60px 58px 80px 66px 100px 58px;
   }
+  .overview-row-nav { gap: 6px; }
   .session-label { display: none; }
 }
 
@@ -716,6 +735,11 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   .overview-heading { flex-wrap: wrap; }
   .overview-header { display: none; }
   .overview-row { display: block; min-height: 44px; }
+  .overview-row-nav {
+    display: block;
+    grid-column: auto;
+    grid-template-columns: none;
+  }
   .overview-row .cell { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; min-height: 24px; }
   .overview-row .cell-label { display: inline; }
   .overview-row .cell-unit { display: none; }
@@ -1618,9 +1642,13 @@ export const UI_JS = `(function () {
       var rowNode = document.createElement('div');
       rowNode.className = 'overview-row';
       rowNode.dataset.address = model.identity.address;
-      rowNode.tabIndex = 0;
-      rowNode.setAttribute('role', 'button');
       rowNode.setAttribute('aria-current', 'false');
+
+      // F66: navigation is a sibling of tier/actions, not an ancestor of <select>.
+      var navNode = document.createElement('div');
+      navNode.className = 'overview-row-nav';
+      navNode.setAttribute('role', 'button');
+      navNode.tabIndex = 0;
 
       var identityCell = document.createElement('span');
       identityCell.className = 'cell';
@@ -1637,7 +1665,7 @@ export const UI_JS = `(function () {
         note.textContent = '(no mail in the current window)';
         identityCell.append(note);
       }
-      rowNode.append(identityCell);
+      navNode.append(identityCell);
 
       var tokenCell = document.createElement('span');
       tokenCell.className = 'cell token-cell';
@@ -1650,10 +1678,10 @@ export const UI_JS = `(function () {
       tokenDot.className = 'token-dot' + (model.identity.hasToken ? ' has-token' : '');
       tokenStatus.append(tokenDot, document.createTextNode(model.identity.hasToken ? 'Set' : 'None'));
       tokenCell.append(tokenLabel, tokenStatus);
-      rowNode.append(tokenCell);
+      navNode.append(tokenCell);
 
-      var countText = appendCell(rowNode, 'Messages', countParts(row, 'count'));
-      var unseenText = appendCell(rowNode, 'Unseen', countParts(row, 'unseen'));
+      var countText = appendCell(navNode, 'Messages', countParts(row, 'count'));
+      var unseenText = appendCell(navNode, 'Unseen', countParts(row, 'unseen'));
 
       var dot = null;
       if (isActiveRow(row)) {
@@ -1663,13 +1691,34 @@ export const UI_JS = `(function () {
       var lastParts = row && row.lastReceivedAt
         ? { text: formatAgo(row.lastReceivedAt) }
         : { text: row ? '—' : 'Unavailable', flat: true };
-      var lastText = appendCell(rowNode, 'Last', lastParts, dot);
-      var createdText = appendCell(rowNode, 'Created', { text: formatDay(model.identity.createdAt) });
+      var lastText = appendCell(navNode, 'Last', lastParts, dot);
+      var createdText = appendCell(navNode, 'Created', { text: formatDay(model.identity.createdAt) });
+
+      var currentTier = model.identity.pushContentTier === 2 || model.identity.pushContentTier === 3
+        ? model.identity.pushContentTier
+        : 1;
+      var ariaParts = [
+        model.identity.name || model.identity.address,
+        model.identity.address,
+        model.identity.hasToken ? 'token set' : 'no token',
+        countText,
+        unseenText,
+        'last ' + lastText,
+        'created ' + createdText,
+        'push tier ' + currentTier
+      ];
+      navNode.setAttribute('aria-label', ariaParts.join(', '));
+      navNode.addEventListener('click', function () {
+        openAddress(model.identity.address);
+      });
+      navNode.addEventListener('keydown', function (event) {
+        if (event.target !== navNode || (event.key !== 'Enter' && event.key !== ' ')) return;
+        event.preventDefault();
+        openAddress(model.identity.address);
+      });
+      rowNode.append(navNode);
 
       if (isAdmin()) {
-        var currentTier = model.identity.pushContentTier === 2 || model.identity.pushContentTier === 3
-          ? model.identity.pushContentTier
-          : 1;
         var tierCell = document.createElement('span');
         tierCell.className = 'cell push-tier-cell';
         var tierLabelNode = document.createElement('span');
@@ -1735,26 +1784,6 @@ export const UI_JS = `(function () {
         rowNode.append(actionsCell);
       }
 
-      rowNode.setAttribute(
-        'aria-label',
-        [
-          model.identity.name || model.identity.address,
-          model.identity.address,
-          model.identity.hasToken ? 'token set' : 'no token',
-          countText,
-          unseenText,
-          'last ' + lastText,
-          'created ' + createdText
-        ].join(', ')
-      );
-      rowNode.addEventListener('click', function () {
-        openAddress(model.identity.address);
-      });
-      rowNode.addEventListener('keydown', function (event) {
-        if (event.target !== rowNode || (event.key !== 'Enter' && event.key !== ' ')) return;
-        event.preventDefault();
-        openAddress(model.identity.address);
-      });
       overviewRows.append(rowNode);
     });
   }
@@ -1785,9 +1814,12 @@ export const UI_JS = `(function () {
   }
 
   function rowButtonFor(address) {
-    var buttons = overviewRows.children;
-    for (var index = 0; index < buttons.length; index += 1) {
-      if (buttons[index].dataset.address === address) return buttons[index];
+    // Focus the row's nav hit-target (role=button), not the neutral outer row (F66).
+    var rows = overviewRows.children;
+    for (var index = 0; index < rows.length; index += 1) {
+      if (rows[index].dataset.address === address) {
+        return rows[index].querySelector('.overview-row-nav') || rows[index];
+      }
     }
     return null;
   }

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1068,9 +1068,11 @@ export const UI_JS = `(function () {
         selectEl.dataset.currentTier = String(tier);
         announce('Push content set to tier ' + tier + ' for ' + address + '.');
         renderOverviewRows();
-        // Restart overview so bumpIdentityEpoch cannot leave overviewPending stuck
-        // after a superseded in-flight /overview response skips clearing it.
-        loadOverviewCycle({ refresh: false });
+        // Restart overview only while still on Overview: unstick Refresh after
+        // bumpIdentityEpoch, but do not revive overview polling after openAddress.
+        if (state.scope === 'overview') {
+          loadOverviewCycle({ refresh: false });
+        }
       } catch (error) {
         restore();
         if (

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -765,7 +765,9 @@ export const UI_JS = `(function () {
     overviewRetryAt: 0,
     overviewPending: false,
     overviewLoadingSince: 0,
-    returnAddress: ''
+    returnAddress: '',
+    /* address -> true while a push-tier PUT is in flight (survives re-render). */
+    tierPending: {}
   };
   var refreshTask = null;
   var refreshController = null;
@@ -1059,6 +1061,7 @@ export const UI_JS = `(function () {
     }
 
     async function apply(tier, confirmRisk) {
+      state.tierPending[address] = true;
       selectEl.disabled = true;
       try {
         await savePushContentTier(address, tier, confirmRisk);
@@ -1080,7 +1083,10 @@ export const UI_JS = `(function () {
           announce('Could not update push content tier. Try again.');
         }
       } finally {
+        delete state.tierPending[address];
         selectEl.disabled = false;
+        // Re-render so a select recreated mid-flight drops disabled correctly.
+        if (state.scope === 'overview') renderOverviewRows();
       }
     }
 
@@ -1634,6 +1640,9 @@ export const UI_JS = `(function () {
         tierSelect.className = 'push-tier-select';
         tierSelect.setAttribute('aria-label', 'Push content tier for ' + model.identity.address);
         tierSelect.dataset.currentTier = String(currentTier);
+        if (state.tierPending[model.identity.address]) {
+          tierSelect.disabled = true;
+        }
         [
           { value: 1, label: '1 · interrupt only' },
           { value: 2, label: '2 · + subject / from' },

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -674,7 +674,11 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   border: 0;
 }
 
-/* Desktop overview fixed tracks+gaps ≈724px + 240px sidebar + panel pad ≈1044px; compact (≈812px) covers that band. */
+/*
+ * Desktop overview fixed tracks+gaps ≈724px + 240 sidebar + panel pad ≈1044px → compact to 1100px.
+ * Compact fixed tracks+gaps+row pad ≈542px + 210 sidebar + panel pad ≈800px → stack below 820px
+ * so portrait tablets (720–800) do not collapse the identity track.
+ */
 @media (max-width: 1100px) {
   .inbox-layout { grid-template-columns: 210px minmax(0, 1fr); }
   .inbox-main { grid-template-columns: 320px minmax(0, 1fr); }
@@ -685,7 +689,7 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   .session-label { display: none; }
 }
 
-@media (max-width: 719px) {
+@media (max-width: 820px) {
   .topbar { height: 66px; padding: 0 14px; gap: 10px; }
   .topbar h1 { font-size: 18px; }
   /* 375 px 下品牌名让位给 scope 标题与 Sign out，logo 与按钮都不许换行溢出 */
@@ -995,6 +999,7 @@ export const UI_JS = `(function () {
         await apiJson('/ui/api/identities/' + encodeURIComponent(address), {
           method: 'DELETE'
         });
+        bumpIdentityEpoch();
         state.identities = state.identities.filter(function (identity) {
           return identity.address !== address;
         });
@@ -1013,6 +1018,12 @@ export const UI_JS = `(function () {
     confirmModalConfirm.focus();
   }
 
+  /* Invalidate in-flight overview identity loads so a stale /identities
+     response cannot overwrite a local mutation (tier save, delete, …). */
+  function bumpIdentityEpoch() {
+    state.overviewGen += 1;
+  }
+
   async function savePushContentTier(address, tier, confirmRisk) {
     var body = { pushContentTier: tier };
     if (confirmRisk) body.confirm_risk = true;
@@ -1024,6 +1035,7 @@ export const UI_JS = `(function () {
         body: JSON.stringify(body)
       }
     );
+    bumpIdentityEpoch();
     state.identities = state.identities.map(function (identity) {
       if (identity.address !== address) return identity;
       return Object.assign({}, identity, {

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1074,15 +1074,48 @@ export const UI_JS = `(function () {
           loadOverviewCycle({ refresh: false });
         }
       } catch (error) {
-        restore();
         if (
           error.status === 400 &&
           error.body &&
           error.body.error === 'confirm_risk_required'
         ) {
+          // Server rejected — no ambiguous state.
+          restore();
           announce('Tier 3 requires explicit risk confirmation.');
-        } else if (error.message !== 'session_expired') {
-          announce('Could not update push content tier. Try again.');
+        } else if (error.message === 'session_expired') {
+          restore();
+        } else {
+          // Fuzzy failure (network/parse/5xx): PUT may already have persisted.
+          // Re-fetch authoritative identities so UI matches server tier.
+          try {
+            var payload = await apiJson('/ui/api/identities');
+            state.identities = Array.isArray(payload.identities) ? payload.identities : [];
+            var row = state.identities.find(function (identity) {
+              return identity.address === address;
+            });
+            if (!row) {
+              restore();
+              announce('Could not update push content tier. Try again.');
+            } else {
+              var authoritative =
+                row.pushContentTier === 2 || row.pushContentTier === 3
+                  ? row.pushContentTier
+                  : 1;
+              selectEl.value = String(authoritative);
+              selectEl.dataset.currentTier = String(authoritative);
+              announce(
+                'Push content tier is tier ' +
+                  authoritative +
+                  ' for ' +
+                  address +
+                  ' (refreshed).',
+              );
+              renderOverviewRows();
+            }
+          } catch (_refreshErr) {
+            restore();
+            announce('Could not update push content tier. Try again.');
+          }
         }
       } finally {
         delete state.tierPending[address];

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1088,6 +1088,11 @@ export const UI_JS = `(function () {
 
   function handlePushTierChange(address, selectEl) {
     if (!isAdmin()) return;
+    // F126: a tier PUT is already in flight for this address (an overview
+    // rerender can replace the selector while the tier-3 dialog waits) —
+    // reject the competing change so the persisted tier follows the user's
+    // choice, not request timing.
+    if (state.tierPending[address]) return;
     var previous = Number(selectEl.dataset.currentTier || '1');
     var next = Number(selectEl.value);
     if (next === previous) return;
@@ -1099,6 +1104,10 @@ export const UI_JS = `(function () {
     async function apply(tier, confirmRisk) {
       state.tierPending[address] = true;
       selectEl.disabled = true;
+      // F126: render the pending state immediately — the modal background is
+      // not inert, so a row recreated mid-flight must come back disabled, or
+      // keyboard users can start a competing PUT on the replacement select.
+      if (state.scope === 'overview') renderOverviewRows();
       try {
         await savePushContentTier(address, tier, confirmRisk);
         selectEl.dataset.currentTier = String(tier);

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1086,9 +1086,12 @@ export const UI_JS = `(function () {
           restore();
         } else {
           // Fuzzy failure (network/parse/5xx): PUT may already have persisted.
-          // Re-fetch authoritative identities so UI matches server tier.
+          // Invalidate in-flight overview identity loads, then re-fetch.
+          bumpIdentityEpoch();
+          var recoveryGen = state.overviewGen;
           try {
             var payload = await apiJson('/ui/api/identities');
+            if (recoveryGen !== state.overviewGen) return;
             state.identities = Array.isArray(payload.identities) ? payload.identities : [];
             var row = state.identities.find(function (identity) {
               return identity.address === address;
@@ -1113,6 +1116,7 @@ export const UI_JS = `(function () {
               renderOverviewRows();
             }
           } catch (_refreshErr) {
+            if (recoveryGen !== state.overviewGen) return;
             restore();
             announce('Could not update push content tier. Try again.');
           }

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -674,7 +674,8 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   border: 0;
 }
 
-@media (max-width: 900px) {
+/* Desktop overview fixed tracks+gaps ≈724px + 240px sidebar + panel pad ≈1044px; compact (≈812px) covers that band. */
+@media (max-width: 1100px) {
   .inbox-layout { grid-template-columns: 210px minmax(0, 1fr); }
   .inbox-main { grid-template-columns: 320px minmax(0, 1fr); }
   .overview-header, .overview-row {

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1877,8 +1877,12 @@ export const UI_JS = `(function () {
   /* inbox 里触发身份刷新的时机：admin 每次手动 Refresh。停在 inbox 时 Overview
      周期是停掉的（cancelOverview），所以这是"活动地址被删"能被发现的那一刻。 */
   function refreshInboxIdentities() {
+    // Same epoch as loadOverviewCycle: a tier save mid-flight must not be
+    // overwritten by a slower inbox identity refresh.
+    var generation = state.overviewGen;
     apiJson('/ui/api/identities').then(function (payload) {
       if (state.scope !== 'inbox') return;
+      if (generation !== state.overviewGen) return;
       state.identities = Array.isArray(payload.identities) ? payload.identities : [];
       renderIdentities();
       reconcileActiveAddress();

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -885,10 +885,19 @@ export const UI_JS = `(function () {
     if (!response.ok) {
       var failure = new Error('request_failed');
       failure.status = response.status;
+      failure.body = null;
+      try {
+        failure.body = await response.json();
+      } catch (_parseError) {
+        /* body optional */
+      }
       throw failure;
     }
     return response.json();
   }
+
+  /* Optional cancel side-effect (e.g. restore a select) — run once on Cancel. */
+  var confirmModalOnCancel = null;
 
   function closeAllModals() {
     tokenModal.hidden = true;
@@ -903,6 +912,7 @@ export const UI_JS = `(function () {
     confirmModalRisk.hidden = true;
     confirmModalConfirm.textContent = 'Confirm';
     confirmModalConfirm.onclick = null;
+    confirmModalOnCancel = null;
   }
 
   function showTokenModal(token, title) {
@@ -1042,7 +1052,11 @@ export const UI_JS = `(function () {
         renderOverviewRows();
       } catch (error) {
         restore();
-        if (error.status === 400) {
+        if (
+          error.status === 400 &&
+          error.body &&
+          error.body.error === 'confirm_risk_required'
+        ) {
           announce('Tier 3 requires explicit risk confirmation.');
         } else if (error.message !== 'session_expired') {
           announce('Could not update push content tier. Try again.');
@@ -1065,6 +1079,10 @@ export const UI_JS = `(function () {
     confirmModalRisk.hidden = false;
     confirmModalConfirm.textContent = 'Enable tier 3';
     confirmModal.hidden = false;
+    // Restore the previous tier once on Cancel; closeAllModals clears this.
+    confirmModalOnCancel = function () {
+      restore();
+    };
     confirmModalConfirm.onclick = async function () {
       confirmModalConfirm.disabled = true;
       try {
@@ -1073,12 +1091,6 @@ export const UI_JS = `(function () {
       } finally {
         confirmModalConfirm.disabled = false;
       }
-    };
-    var previousCancel = confirmModalCancel.onclick;
-    confirmModalCancel.onclick = function () {
-      restore();
-      closeAllModals();
-      confirmModalCancel.onclick = previousCancel;
     };
     confirmModalConfirm.focus();
   }
@@ -2377,7 +2389,13 @@ export const UI_JS = `(function () {
     copyValue(tokenValue.textContent, tokenValue, tokenCopyButton);
   });
   tokenModalClose.addEventListener('click', closeAllModals);
-  confirmModalCancel.addEventListener('click', closeAllModals);
+  confirmModalCancel.addEventListener('click', function () {
+    // Run cancel side-effect (e.g. restore tier select) before clearing state.
+    var onCancel = confirmModalOnCancel;
+    confirmModalOnCancel = null;
+    if (onCancel) onCancel();
+    closeAllModals();
+  });
   createModalCancel.addEventListener('click', closeAllModals);
   backToOverview.addEventListener('click', function () {
     enterOverview({ returnTo: state.returnAddress, announce: 'Back to overview' });

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1102,6 +1102,14 @@ export const UI_JS = `(function () {
     }
 
     async function apply(tier, confirmRisk) {
+      // F127: the tier-3 dialog can outlive an overview rerender — the user may
+      // have started a competing change on the replacement selector before this
+      // confirmation ran. apply() bypasses the handlePushTierChange entry lock,
+      // so recheck here: the in-flight change wins, this stale one is dropped.
+      if (state.tierPending[address]) {
+        announce('Another push content change is already in progress for ' + address + '.');
+        return;
+      }
       state.tierPending[address] = true;
       selectEl.disabled = true;
       // F126: render the pending state immediately — the modal background is

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -161,7 +161,13 @@ export const UI_HTML = `<!doctype html>
     </div>
 
     <div class="modal-overlay" id="confirm-modal" hidden>
-      <div class="modal-card">
+      <div
+        class="modal-card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-modal-title"
+        aria-describedby="confirm-modal-text confirm-modal-risk"
+      >
         <h2 id="confirm-modal-title">Confirm</h2>
         <p id="confirm-modal-text"></p>
         <p id="confirm-modal-risk" class="modal-warn" hidden></p>

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -935,7 +935,8 @@ export const UI_JS = `(function () {
     return response.json();
   }
 
-  /* Optional cancel side-effect (e.g. restore a select) — run once on Cancel. */
+  /* Optional cancel side-effect (e.g. restore a select) — run once when the
+     dialog closes unconfirmed (Cancel button or indirect close; F107). */
   var confirmModalOnCancel = null;
 
   function closeAllModals() {
@@ -951,7 +952,12 @@ export const UI_JS = `(function () {
     confirmModalRisk.hidden = true;
     confirmModalConfirm.textContent = 'Confirm';
     confirmModalConfirm.onclick = null;
+    // F107: an indirect close (background action opening another modal) must
+    // still run the pending cancel side-effect (restore tier select) — the
+    // callback is consumed exactly once either way.
+    var onCancel = confirmModalOnCancel;
     confirmModalOnCancel = null;
+    if (onCancel) onCancel();
   }
 
   function showTokenModal(token, title) {
@@ -1172,7 +1178,8 @@ export const UI_JS = `(function () {
     confirmModalRisk.hidden = false;
     confirmModalConfirm.textContent = 'Enable tier 3';
     confirmModal.hidden = false;
-    // Restore the previous tier once on Cancel; closeAllModals clears this.
+    // Restore the previous tier if the dialog closes unconfirmed (Cancel or an
+    // indirect close runs it via closeAllModals); the success path clears it.
     confirmModalOnCancel = function () {
       restore();
     };
@@ -1183,6 +1190,9 @@ export const UI_JS = `(function () {
       confirmModalCancel.disabled = true;
       try {
         await apply(3, true);
+        // F107: confirmed — consume the pending restore before closeAllModals
+        // would run it and drop the select back to the old tier.
+        confirmModalOnCancel = null;
         closeAllModals();
       } finally {
         confirmModalConfirm.disabled = false;
@@ -2517,10 +2527,7 @@ export const UI_JS = `(function () {
   });
   tokenModalClose.addEventListener('click', closeAllModals);
   confirmModalCancel.addEventListener('click', function () {
-    // Run cancel side-effect (e.g. restore tier select) before clearing state.
-    var onCancel = confirmModalOnCancel;
-    confirmModalOnCancel = null;
-    if (onCancel) onCancel();
+    // closeAllModals consumes the pending cancel side-effect exactly once (F107).
     closeAllModals();
   });
   createModalCancel.addEventListener('click', closeAllModals);

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -759,6 +759,8 @@ export const UI_JS = `(function () {
     overviewFilter: '',
     overviewSort: { key: 'last', dir: 'desc' },
     overviewGen: 0,
+    /* Generation of the in-flight loadOverviewCycle (0 when none owns pending). */
+    overviewCycleGen: 0,
     overviewPolls: 0,
     overviewRetryAt: 0,
     overviewPending: false,
@@ -1063,6 +1065,9 @@ export const UI_JS = `(function () {
         selectEl.dataset.currentTier = String(tier);
         announce('Push content set to tier ' + tier + ' for ' + address + '.');
         renderOverviewRows();
+        // Restart overview so bumpIdentityEpoch cannot leave overviewPending stuck
+        // after a superseded in-flight /overview response skips clearing it.
+        loadOverviewCycle({ refresh: false });
       } catch (error) {
         restore();
         if (
@@ -1097,12 +1102,16 @@ export const UI_JS = `(function () {
       restore();
     };
     confirmModalConfirm.onclick = async function () {
+      // Disable both actions for the in-flight PUT so Cancel cannot restore
+      // the select while a successful response still enables tier 3.
       confirmModalConfirm.disabled = true;
+      confirmModalCancel.disabled = true;
       try {
         await apply(3, true);
         closeAllModals();
       } finally {
         confirmModalConfirm.disabled = false;
+        confirmModalCancel.disabled = false;
       }
     };
     confirmModalConfirm.focus();
@@ -1877,6 +1886,7 @@ export const UI_JS = `(function () {
     overviewController = new AbortController();
     var signal = overviewController.signal;
     state.overviewPending = true;
+    state.overviewCycleGen = generation;
     updateOverviewRefreshButton();
 
     var identitiesPromise = apiJson('/ui/api/identities', { signal: signal });
@@ -1898,12 +1908,26 @@ export const UI_JS = `(function () {
     });
 
     overviewPromise.then(function (payload) {
-      if (generation !== state.overviewGen) return;
+      if (generation !== state.overviewGen) {
+        // Superseded by bumpIdentityEpoch or a newer cycle: never write data,
+        // but if no live cycle owns the current gen, clear a stuck Refresh.
+        if (state.overviewPending && state.overviewCycleGen !== state.overviewGen) {
+          state.overviewPending = false;
+          updateOverviewRefreshButton();
+        }
+        return;
+      }
       state.overviewPending = false;
       applyOverviewPayload(payload);
       renderOverview();
     }).catch(function (error) {
-      if (generation !== state.overviewGen) return;
+      if (generation !== state.overviewGen) {
+        if (state.overviewPending && state.overviewCycleGen !== state.overviewGen) {
+          state.overviewPending = false;
+          updateOverviewRefreshButton();
+        }
+        return;
+      }
       state.overviewPending = false;
       if (error.name === 'AbortError') return;
       applyOverviewError(error);

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -113,6 +113,7 @@ export const UI_HTML = `<!doctype html>
           <span>Unseen</span>
           <span>Last</span>
           <span>Created</span>
+          <span>Push</span>
           <span>Actions</span>
         </div>
         <div id="overview-rows" class="overview-rows"></div>
@@ -161,11 +162,12 @@ export const UI_HTML = `<!doctype html>
 
     <div class="modal-overlay" id="confirm-modal" hidden>
       <div class="modal-card">
-        <h2>Delete Identity</h2>
+        <h2 id="confirm-modal-title">Confirm</h2>
         <p id="confirm-modal-text"></p>
+        <p id="confirm-modal-risk" class="modal-warn" hidden></p>
         <div class="modal-actions">
           <button class="quiet" id="confirm-modal-cancel" type="button">Cancel</button>
-          <button class="primary" id="confirm-modal-confirm" type="button">Delete</button>
+          <button class="primary" id="confirm-modal-confirm" type="button">Confirm</button>
         </div>
       </div>
     </div>
@@ -465,7 +467,7 @@ button:disabled { cursor: not-allowed; opacity: .55; }
 .overview-header {
   display: grid;
   gap: 10px;
-  grid-template-columns: minmax(0,1fr) 80px 96px 80px 120px 96px 72px;
+  grid-template-columns: minmax(0,1fr) 80px 96px 80px 120px 96px minmax(110px, 130px) 72px;
   padding: 8px 10px;
   color: var(--ink-dim);
   font-size: 11px;
@@ -479,7 +481,7 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   display: grid;
   align-items: baseline;
   gap: 10px;
-  grid-template-columns: minmax(0,1fr) 80px 96px 80px 120px 96px 72px;
+  grid-template-columns: minmax(0,1fr) 80px 96px 80px 120px 96px minmax(110px, 130px) 72px;
   min-height: 56px;
   border: 0;
   border-bottom: 1px solid var(--line);
@@ -520,6 +522,16 @@ button:disabled { cursor: not-allowed; opacity: .55; }
 .row-actions { display: grid !important; gap: 4px; align-self: center; overflow: visible !important; }
 .row-action { min-height: 26px; padding: 2px 6px; font-size: 11px; }
 .delete-action { color: var(--red); }
+.push-tier-cell { display: grid !important; gap: 4px; align-self: center; overflow: visible !important; }
+.push-tier-select {
+  min-height: 28px;
+  width: 100%;
+  max-width: 118px;
+  padding: 2px 6px;
+  font-size: 11px;
+  border-radius: 8px;
+}
+.push-tier-hint { color: var(--ink-faint); font-size: 11px; line-height: 1.3; }
 .overview-panel.is-error .overview-rows, .overview-panel.is-error .overview-stats { opacity: .8; }
 .modal-overlay {
   position: fixed;
@@ -667,7 +679,7 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   .inbox-main { grid-template-columns: 320px minmax(0, 1fr); }
   .overview-header, .overview-row {
     gap: 6px;
-    grid-template-columns: minmax(0, 1fr) 58px 60px 58px 80px 66px 58px;
+    grid-template-columns: minmax(0, 1fr) 58px 60px 58px 80px 66px 100px 58px;
   }
   .session-label { display: none; }
 }
@@ -800,9 +812,13 @@ export const UI_JS = `(function () {
   var tokenCopyButton = byId('token-copy-button');
   var tokenModalClose = byId('token-modal-close');
   var confirmModal = byId('confirm-modal');
+  var confirmModalTitle = byId('confirm-modal-title');
   var confirmModalText = byId('confirm-modal-text');
+  var confirmModalRisk = byId('confirm-modal-risk');
   var confirmModalCancel = byId('confirm-modal-cancel');
   var confirmModalConfirm = byId('confirm-modal-confirm');
+  var PUSH_TIER3_WARNING =
+    'Tier 3 includes message body previews and OTP codes/links in push notifications. That content leaves this server for the ntfy channel.';
   var createModal = byId('create-modal');
   var createName = byId('create-name');
   var createLocalpart = byId('create-localpart');
@@ -881,7 +897,11 @@ export const UI_JS = `(function () {
     tokenValue.textContent = '';
     tokenModalTitle.textContent = 'Token';
     tokenCopyButton.classList.remove('copied');
+    confirmModalTitle.textContent = 'Confirm';
     confirmModalText.textContent = '';
+    confirmModalRisk.textContent = '';
+    confirmModalRisk.hidden = true;
+    confirmModalConfirm.textContent = 'Confirm';
     confirmModalConfirm.onclick = null;
   }
 
@@ -953,7 +973,10 @@ export const UI_JS = `(function () {
   function handleDeleteIdentity(address) {
     if (!isAdmin()) return;
     closeAllModals();
+    confirmModalTitle.textContent = 'Delete Identity';
     confirmModalText.textContent = 'Delete ' + address + '? This cannot be undone.';
+    confirmModalRisk.hidden = true;
+    confirmModalConfirm.textContent = 'Delete';
     confirmModal.hidden = false;
     confirmModalConfirm.onclick = async function () {
       confirmModalConfirm.disabled = true;
@@ -975,6 +998,87 @@ export const UI_JS = `(function () {
       } finally {
         confirmModalConfirm.disabled = false;
       }
+    };
+    confirmModalConfirm.focus();
+  }
+
+  async function savePushContentTier(address, tier, confirmRisk) {
+    var body = { pushContentTier: tier };
+    if (confirmRisk) body.confirm_risk = true;
+    var payload = await apiJson(
+      '/ui/api/identities/' + encodeURIComponent(address) + '/push-tier',
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body)
+      }
+    );
+    state.identities = state.identities.map(function (identity) {
+      if (identity.address !== address) return identity;
+      return Object.assign({}, identity, {
+        pushContentTier: payload.pushContentTier,
+        pushContentTierWarning: payload.warning
+      });
+    });
+    return payload;
+  }
+
+  function handlePushTierChange(address, selectEl) {
+    if (!isAdmin()) return;
+    var previous = Number(selectEl.dataset.currentTier || '1');
+    var next = Number(selectEl.value);
+    if (next === previous) return;
+
+    function restore() {
+      selectEl.value = String(previous);
+    }
+
+    async function apply(tier, confirmRisk) {
+      selectEl.disabled = true;
+      try {
+        await savePushContentTier(address, tier, confirmRisk);
+        selectEl.dataset.currentTier = String(tier);
+        announce('Push content set to tier ' + tier + ' for ' + address + '.');
+        renderOverviewRows();
+      } catch (error) {
+        restore();
+        if (error.status === 400) {
+          announce('Tier 3 requires explicit risk confirmation.');
+        } else if (error.message !== 'session_expired') {
+          announce('Could not update push content tier. Try again.');
+        }
+      } finally {
+        selectEl.disabled = false;
+      }
+    }
+
+    if (next !== 3) {
+      apply(next, false);
+      return;
+    }
+
+    closeAllModals();
+    confirmModalTitle.textContent = 'Enable sensitive push content';
+    confirmModalText.textContent =
+      'Enable tier 3 for ' + address + '? Body previews and OTP codes/links will leave this server.';
+    confirmModalRisk.textContent = PUSH_TIER3_WARNING;
+    confirmModalRisk.hidden = false;
+    confirmModalConfirm.textContent = 'Enable tier 3';
+    confirmModal.hidden = false;
+    confirmModalConfirm.onclick = async function () {
+      confirmModalConfirm.disabled = true;
+      try {
+        await apply(3, true);
+        closeAllModals();
+      } finally {
+        confirmModalConfirm.disabled = false;
+      }
+    };
+    var previousCancel = confirmModalCancel.onclick;
+    confirmModalCancel.onclick = function () {
+      restore();
+      closeAllModals();
+      confirmModalCancel.onclick = previousCancel;
     };
     confirmModalConfirm.focus();
   }
@@ -1484,6 +1588,46 @@ export const UI_JS = `(function () {
       var createdText = appendCell(rowNode, 'Created', { text: formatDay(model.identity.createdAt) });
 
       if (isAdmin()) {
+        var currentTier = model.identity.pushContentTier === 2 || model.identity.pushContentTier === 3
+          ? model.identity.pushContentTier
+          : 1;
+        var tierCell = document.createElement('span');
+        tierCell.className = 'cell push-tier-cell';
+        var tierLabelNode = document.createElement('span');
+        tierLabelNode.className = 'cell-label';
+        tierLabelNode.textContent = 'Push content';
+        var tierSelect = document.createElement('select');
+        tierSelect.className = 'push-tier-select';
+        tierSelect.setAttribute('aria-label', 'Push content tier for ' + model.identity.address);
+        tierSelect.dataset.currentTier = String(currentTier);
+        [
+          { value: 1, label: '1 · interrupt only' },
+          { value: 2, label: '2 · + subject / from' },
+          { value: 3, label: '3 · + body / OTP (sensitive)' }
+        ].forEach(function (optionDef) {
+          var option = document.createElement('option');
+          option.value = String(optionDef.value);
+          option.textContent = optionDef.label;
+          if (optionDef.value === currentTier) option.selected = true;
+          tierSelect.append(option);
+        });
+        tierSelect.addEventListener('click', function (event) {
+          event.stopPropagation();
+        });
+        tierSelect.addEventListener('change', function (event) {
+          event.stopPropagation();
+          handlePushTierChange(model.identity.address, tierSelect);
+        });
+        tierCell.append(tierLabelNode, tierSelect);
+        if (currentTier === 3) {
+          var riskHint = document.createElement('span');
+          riskHint.className = 'push-tier-hint';
+          riskHint.textContent = 'Body/OTP leave server';
+          riskHint.title = model.identity.pushContentTierWarning || PUSH_TIER3_WARNING;
+          tierCell.append(riskHint);
+        }
+        rowNode.append(tierCell);
+
         var actionsCell = document.createElement('span');
         actionsCell.className = 'cell row-actions';
         var actionsLabel = document.createElement('span');

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -105,6 +105,33 @@ describe('notification URL configuration', () => {
     ).toBe('http://127.0.0.1:2586');
   });
 
+  test('envUrl rejects non-http(s) schemes', () => {
+    for (const bad of [
+      'ftp://example.com',
+      'file:///tmp/x',
+      'mailto:user@example.com',
+    ]) {
+      expect(() =>
+        parseConfig({ ...requiredEnv, DASHBOARD_PUBLIC_URL: bad }),
+      ).toThrow(/http or https/i);
+      expect(() =>
+        parseConfig({ ...requiredEnv, NOTIFY_PUBLIC_URL: bad }),
+      ).toThrow(/http or https/i);
+    }
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'http://dash.example.com/ui',
+      }).dashboardPublicUrl,
+    ).toBe('http://dash.example.com/ui');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        NOTIFY_PUBLIC_URL: 'https://notify.example.com',
+      }).ntfy.publicUrl,
+    ).toBe('https://notify.example.com');
+  });
+
   test('normalizeUrl only strips pathname trailing slashes, not query or fragment', () => {
     expect(
       parseConfig({

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -82,6 +82,29 @@ describe('notification URL configuration', () => {
     ).toBe('https://mail.example.com/ui');
   });
 
+  test('empty or whitespace optional URL env values are treated as unset', () => {
+    // Compose ${DASHBOARD_PUBLIC_URL:-} injects "" when the var is absent.
+    expect(() =>
+      parseConfig({ ...requiredEnv, DASHBOARD_PUBLIC_URL: '' }),
+    ).not.toThrow();
+    expect(
+      parseConfig({ ...requiredEnv, DASHBOARD_PUBLIC_URL: '' }).dashboardPublicUrl,
+    ).toBeUndefined();
+    expect(
+      parseConfig({ ...requiredEnv, DASHBOARD_PUBLIC_URL: '   ' }).dashboardPublicUrl,
+    ).toBeUndefined();
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://dash.example.com/ui',
+      }).dashboardPublicUrl,
+    ).toBe('https://dash.example.com/ui');
+    // Same empty-string safety for defaulted URL fields (fall through to default).
+    expect(
+      parseConfig({ ...requiredEnv, NOTIFY_PUBLIC_URL: '' }).ntfy.publicUrl,
+    ).toBe('http://127.0.0.1:2586');
+  });
+
   test('normalizeUrl only strips pathname trailing slashes, not query or fragment', () => {
     expect(
       parseConfig({

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -81,4 +81,25 @@ describe('notification URL configuration', () => {
       }).dashboardPublicUrl,
     ).toBe('https://mail.example.com/ui');
   });
+
+  test('normalizeUrl only strips pathname trailing slashes, not query or fragment', () => {
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui?next=/',
+      }).dashboardPublicUrl,
+    ).toBe('https://mail.example.com/ui?next=/');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui#/',
+      }).dashboardPublicUrl,
+    ).toBe('https://mail.example.com/ui#/');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        NOTIFY_PUBLIC_URL: 'https://NTFY.EXAMPLE.COM/',
+      }).ntfy.publicUrl,
+    ).toBe('https://ntfy.example.com');
+  });
 });

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -132,6 +132,35 @@ describe('notification URL configuration', () => {
     ).toBe('https://notify.example.com');
   });
 
+  test('DASHBOARD_PUBLIC_URL rejects userinfo credentials (F80)', () => {
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://admin:secret@mail.example/ui',
+      }),
+    ).toThrow(/credentials|userinfo/i);
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://admin@mail.example/ui',
+      }),
+    ).toThrow(/credentials|userinfo/i);
+    // Plain public origin still accepted.
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui',
+      }).dashboardPublicUrl,
+    ).toBe('https://mail.example.com/ui');
+    // Internal ntfy URL may still carry credentials (private network auth).
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        NTFY_INTERNAL_URL: 'http://publisher:secret@ntfy.internal',
+      }).ntfy.internalUrl,
+    ).toMatch(/publisher:secret@ntfy\.internal/);
+  });
+
   test('normalizeUrl root path keeps userinfo credentials (F60)', () => {
     expect(normalizeUrl('https://publisher:secret@ntfy.example/')).toBe(
       'https://publisher:secret@ntfy.example',

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -71,4 +71,14 @@ describe('notification URL configuration', () => {
     });
     expect(config.ntfy.publicUrl).toBe('https://ntfy.example.com');
   });
+
+  test('DASHBOARD_PUBLIC_URL is optional and normalized when present', () => {
+    expect(parseConfig(requiredEnv).dashboardPublicUrl).toBeUndefined();
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://MAIL.EXAMPLE.COM/ui/',
+      }).dashboardPublicUrl,
+    ).toBe('https://mail.example.com/ui');
+  });
 });

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -161,6 +161,28 @@ describe('notification URL configuration', () => {
     ).toMatch(/publisher:secret@ntfy\.internal/);
   });
 
+  test('DASHBOARD_PUBLIC_URL rejects query and fragment secrets (F114)', () => {
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui?token=secret',
+      }),
+    ).toThrow(/credentials|userinfo|query|fragment/i);
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui#session=abc',
+      }),
+    ).toThrow(/credentials|userinfo|query|fragment/i);
+    // Plain path (with or without trailing slash) still accepted.
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui/',
+      }).dashboardPublicUrl,
+    ).toBe('https://mail.example.com/ui');
+  });
+
   test('normalizeUrl root path keeps userinfo credentials (F60)', () => {
     expect(normalizeUrl('https://publisher:secret@ntfy.example/')).toBe(
       'https://publisher:secret@ntfy.example',
@@ -174,18 +196,20 @@ describe('notification URL configuration', () => {
   });
 
   test('normalizeUrl only strips pathname trailing slashes, not query or fragment', () => {
+    // Vehicle: NOTIFY_PUBLIC_URL — DASHBOARD_PUBLIC_URL rejects query/fragment
+    // outright (F114), so it can no longer carry this normalizeUrl contract.
     expect(
       parseConfig({
         ...requiredEnv,
-        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui?next=/',
-      }).dashboardPublicUrl,
-    ).toBe('https://mail.example.com/ui?next=/');
+        NOTIFY_PUBLIC_URL: 'https://ntfy.example.com/ui?next=/',
+      }).ntfy.publicUrl,
+    ).toBe('https://ntfy.example.com/ui?next=/');
     expect(
       parseConfig({
         ...requiredEnv,
-        DASHBOARD_PUBLIC_URL: 'https://mail.example.com/ui#/',
-      }).dashboardPublicUrl,
-    ).toBe('https://mail.example.com/ui#/');
+        NOTIFY_PUBLIC_URL: 'https://ntfy.example.com/ui#/',
+      }).ntfy.publicUrl,
+    ).toBe('https://ntfy.example.com/ui#/');
     expect(
       parseConfig({
         ...requiredEnv,

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -8,7 +8,7 @@ process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
 
 import { describe, expect, test } from 'bun:test';
-import { parseConfig } from '../src/lib/config.ts';
+import { normalizeUrl, parseConfig } from '../src/lib/config.ts';
 
 const requiredEnv: NodeJS.ProcessEnv = {
   DOMAIN: 'example.com',
@@ -130,6 +130,18 @@ describe('notification URL configuration', () => {
         NOTIFY_PUBLIC_URL: 'https://notify.example.com',
       }).ntfy.publicUrl,
     ).toBe('https://notify.example.com');
+  });
+
+  test('normalizeUrl root path keeps userinfo credentials (F60)', () => {
+    expect(normalizeUrl('https://publisher:secret@ntfy.example/')).toBe(
+      'https://publisher:secret@ntfy.example',
+    );
+    expect(normalizeUrl('https://ntfy.example/')).toBe('https://ntfy.example');
+    expect(normalizeUrl('https://ntfy.example:8443/')).toBe('https://ntfy.example:8443');
+    // Non-root still keeps credentials (href branch).
+    expect(normalizeUrl('https://publisher:secret@ntfy.example/v1/path/')).toBe(
+      'https://publisher:secret@ntfy.example/v1/path',
+    );
   });
 
   test('normalizeUrl only strips pathname trailing slashes, not query or fragment', () => {

--- a/packages/api/test/identities.test.ts
+++ b/packages/api/test/identities.test.ts
@@ -1,6 +1,15 @@
 // Identity-store tests. config.ts parses env at import time, so set the
 // required variables BEFORE importing anything that pulls it in.
-import { chmodSync, mkdtempSync, readFileSync, statSync, utimesSync, writeFileSync } from 'node:fs';
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -387,5 +396,57 @@ describe('identity store mtime cache + address index (F41)', () => {
     const tier1Body = bodies[1];
     expect(tier1Body).not.toContain('Subject:');
     expect(tier1Body).not.toContain('Codes:');
+  });
+});
+
+describe('identity store save failure drops cache (F42)', () => {
+  /**
+   * Force save() to throw after invalidateStoreCache(). save() re-chmods the
+   * data dir to 0o700 before writing, so a read-only data dir is not a reliable
+   * fault injection; blocking the identities.json.tmp write path is.
+   */
+  function withBlockedSaveTmp(run: () => void): void {
+    const tmpPath = `${storeFile()}.tmp`;
+    rmSync(tmpPath, { recursive: true, force: true });
+    mkdirSync(tmpPath);
+    try {
+      run();
+    } finally {
+      rmSync(tmpPath, { recursive: true, force: true });
+      try {
+        chmodSync(storeDir(), 0o700);
+      } catch {
+        // best effort restore
+      }
+    }
+  }
+
+  test('failed rotateIdentityToken keeps the old token hash after reload', () => {
+    const created = createIdentity({ localpart: 'save-fail-rotate' })!;
+    const address = created.identity.address;
+    const oldToken = created.token;
+    const oldHash = findIdentity(address)!.tokenHash;
+    expect(oldHash).toBeDefined();
+    expect(findIdentityByToken(oldToken)?.address).toBe(address);
+
+    withBlockedSaveTmp(() => {
+      expect(() => rotateIdentityToken(address)).toThrow();
+    });
+
+    // Cache was dropped before the failed write; disk still has the old hash.
+    expect(findIdentity(address)?.tokenHash).toBe(oldHash);
+    expect(findIdentityByToken(oldToken)?.address).toBe(address);
+  });
+
+  test('failed createIdentity leaves no ghost identity after reload', () => {
+    const ghost = 'ghost-save-fail@test.example';
+    expect(findIdentity(ghost)).toBeUndefined();
+
+    withBlockedSaveTmp(() => {
+      expect(() => createIdentity({ localpart: 'ghost-save-fail' })).toThrow();
+    });
+
+    expect(findIdentity(ghost)).toBeUndefined();
+    expect(listIdentities().some((i) => i.address === ghost)).toBe(false);
   });
 });

--- a/packages/api/test/identities.test.ts
+++ b/packages/api/test/identities.test.ts
@@ -1,6 +1,6 @@
 // Identity-store tests. config.ts parses env at import time, so set the
 // required variables BEFORE importing anything that pulls it in.
-import { chmodSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, readFileSync, statSync, utimesSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -27,6 +27,7 @@ const {
   PUSH_TIER3_WARNING,
 } = await import('../src/lib/identities.ts');
 const { identitiesRoute } = await import('../src/routes/identities.ts');
+const { processWatchedMessage } = await import('../src/lib/notification-watcher.ts');
 
 /** Always use the process-wide config path (other files may race on DATA_DIR env). */
 const storeDir = () => config.dataDir;
@@ -280,5 +281,111 @@ describe('push content tier store and REST', () => {
     expect(findIdentity(other.identity.address)?.pushContentTier).toBeUndefined();
     // Sibling entry keeps its valid tier.
     expect(findIdentity(good.identity.address)?.pushContentTier).toBe(2);
+  });
+});
+
+describe('identity store mtime cache + address index (F41)', () => {
+  /** External rewrite that must miss the mtime cache even within the same ms. */
+  function writeStoreExternal(entries: Array<Record<string, unknown>>): void {
+    writeFileSync(storeFile(), JSON.stringify(entries, null, 2), { mode: 0o600 });
+    const bumped = Date.now() / 1000 + 2;
+    utimesSync(storeFile(), bumped, bumped);
+  }
+
+  test('findIdentity matches a full list scan (index correctness)', () => {
+    createIdentity({ localpart: 'idx-alpha' });
+    createIdentity({ localpart: 'idx-beta' });
+    setIdentityPushContentTier('idx-beta@test.example', 2);
+
+    const listed = listIdentities();
+    for (const row of listed) {
+      const found = findIdentity(row.address);
+      expect(found?.address).toBe(row.address);
+      expect(found?.pushContentTier).toBe(row.pushContentTier);
+      // Case-insensitive lookup.
+      expect(findIdentity(row.address.toUpperCase())?.address).toBe(row.address);
+    }
+    expect(findIdentity('missing-index@test.example')).toBeUndefined();
+  });
+
+  test('save invalidates cache so same-ms rewrites are visible without mtime help', () => {
+    const address = createIdentity({ localpart: 'same-ms-cache' })!.identity.address;
+    // Populate cache at current mtime.
+    expect(resolvePushContentTier(findIdentity(address)!)).toBe(1);
+
+    // In-process save path (explicit invalidate) must surface the new tier immediately.
+    setIdentityPushContentTier(address, 3);
+    expect(findIdentity(address)?.pushContentTier).toBe(3);
+    expect(resolvePushContentTier(findIdentity(address)!)).toBe(3);
+
+    // Second write in the same tick path: still visible after save.
+    setIdentityPushContentTier(address, 2);
+    expect(findIdentity(address)?.pushContentTier).toBe(2);
+  });
+
+  test('processWatchedMessage with findIdentity refresh stays under 1s on 5k store / 50 recipients', async () => {
+    const createdAt = '2026-08-02T00:00:00.000Z';
+    const bulk = Array.from({ length: 5_000 }, (_, i) => ({
+      address: `bulk${i}@test.example`,
+      createdAt,
+      // Mix tiers so refreshIdentity actually resolves something meaningful.
+      ...(i % 5 === 0 ? { pushContentTier: 2 as const } : {}),
+    }));
+    writeStoreExternal(bulk);
+
+    // Spot-check the indexed store loaded the bulk file.
+    expect(findIdentity('bulk0@test.example')?.address).toBe('bulk0@test.example');
+    expect(findIdentity('bulk4999@test.example')?.address).toBe('bulk4999@test.example');
+    expect(listIdentities()).toHaveLength(5_000);
+
+    // bulk0..bulk49: store has tier 2 when index % 5 === 0, else default tier 1.
+    // Snapshot pretends tier 3 so a working refreshIdentity is required for correctness.
+    const recipients = Array.from({ length: 50 }, (_, i) => ({
+      address: `bulk${i}@test.example`,
+      createdAt,
+      pushContentTier: 3 as const,
+    }));
+
+    const calls: unknown[] = [];
+    const started = performance.now();
+    await processWatchedMessage(
+      {
+        envelope: {
+          from: [{ name: 'auth', address: 'auth@example.net' }],
+          to: recipients.map((r) => ({ address: r.address })),
+          subject: 'Hello',
+        },
+        headers: Buffer.from(
+          recipients.map((r) => `Delivered-To: ${r.address}`).join('\r\n') + '\r\n',
+        ),
+        source: Buffer.from(
+          'From: auth@example.net\r\nSubject: Hello\r\n\r\nYour verification code is 482731\r\n',
+        ),
+      } as any,
+      recipients,
+      'otp',
+      {
+        publish: async (payload) => {
+          calls.push(payload);
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+      {
+        // Production path after F41: O(1) indexed lookup + mtime/invalidate cache.
+        refreshIdentity: (address) => findIdentity(address),
+      },
+    );
+    expect(performance.now() - started).toBeLessThan(1_000);
+    expect(calls).toHaveLength(50);
+
+    const bodies = calls.map((c) => (c as { message: string }).message);
+    // Store tier 2 (index % 5 === 0): subject/from, no Codes (not snapshot tier 3).
+    const tier2Body = bodies[0];
+    expect(tier2Body).toContain('Subject:');
+    expect(tier2Body).not.toContain('Codes:');
+    // Store default tier 1: interrupt only.
+    const tier1Body = bodies[1];
+    expect(tier1Body).not.toContain('Subject:');
+    expect(tier1Body).not.toContain('Codes:');
   });
 });

--- a/packages/api/test/identities.test.ts
+++ b/packages/api/test/identities.test.ts
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  renameSync,
   rmSync,
   statSync,
   utimesSync,
@@ -448,5 +449,86 @@ describe('identity store save failure drops cache (F42)', () => {
 
     expect(findIdentity(ghost)).toBeUndefined();
     expect(listIdentities().some((i) => i.address === ghost)).toBe(false);
+  });
+});
+
+describe('identity store composite cache version (F56)', () => {
+  /** Pin mtime to whole milliseconds so utimes can reproduce the cached value. */
+  function stabilizeMtimeAndRecache(address: string) {
+    const st = statSync(storeFile());
+    const ms = Math.floor(st.mtimeMs);
+    utimesSync(storeFile(), new Date(ms), new Date(ms));
+    // Composite key sees ctime change → reload with rounded mtime in cache.
+    findIdentity(address);
+    return statSync(storeFile());
+  }
+
+  test('atomic replace with forced same mtime reloads new content', () => {
+    const created = createIdentity({ localpart: 'f56-atomic' })!;
+    const address = created.identity.address;
+    const oldToken = created.token;
+    const oldHash = findIdentity(address)!.tokenHash!;
+    expect(oldHash.length).toBe(64);
+    expect(findIdentityByToken(oldToken)?.address).toBe(address);
+
+    const before = stabilizeMtimeAndRecache(address);
+    const raw = readFileSync(storeFile(), 'utf8');
+    // Same-size body: only swap the 64-hex hash so size stays put.
+    const nextRaw = raw.replace(oldHash, 'a'.repeat(64));
+    expect(nextRaw).not.toBe(raw);
+    expect(Buffer.byteLength(nextRaw)).toBe(Buffer.byteLength(raw));
+
+    const tmp = `${storeFile()}.f56-atomic.tmp`;
+    writeFileSync(tmp, nextRaw, { mode: 0o600 });
+    renameSync(tmp, storeFile());
+    utimesSync(storeFile(), new Date(before.mtimeMs), new Date(before.mtimeMs));
+
+    const after = statSync(storeFile());
+    // Prove mtime-only would still hit; composite must see ino.
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(after.size).toBe(before.size);
+    expect(after.ino).not.toBe(before.ino);
+
+    expect(findIdentityByToken(oldToken)).toBeUndefined();
+    expect(findIdentity(address)?.tokenHash).toBe('a'.repeat(64));
+  });
+
+  test('in-place rewrite with same size and mtime reloads new content', () => {
+    const created = createIdentity({ localpart: 'f56-inplace' })!;
+    const address = created.identity.address;
+    setIdentityPushContentTier(address, 3);
+    expect(findIdentity(address)?.pushContentTier).toBe(3);
+
+    const before = stabilizeMtimeAndRecache(address);
+    const raw = readFileSync(storeFile(), 'utf8');
+    // Same byte length: swap tier 3 → tier 1 in place without size change.
+    expect(raw).toContain('"pushContentTier": 3');
+    const rewritten = raw.replace('"pushContentTier": 3', '"pushContentTier": 1');
+    expect(Buffer.byteLength(rewritten)).toBe(Buffer.byteLength(raw));
+
+    writeFileSync(storeFile(), rewritten, { mode: 0o600 });
+    utimesSync(storeFile(), new Date(before.mtimeMs), new Date(before.mtimeMs));
+
+    const after = statSync(storeFile());
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(after.ino).toBe(before.ino);
+    expect(after.size).toBe(before.size);
+    // ctimeMs must diverge so a composite key misses (mtime-only would hit).
+    expect(after.ctimeMs).not.toBe(before.ctimeMs);
+
+    expect(findIdentity(address)?.pushContentTier).toBe(1);
+    expect(resolvePushContentTier(findIdentity(address)!)).toBe(1);
+  });
+
+  test('unchanged file returns the same cached identity object', () => {
+    createIdentity({ localpart: 'f56-stable' });
+    const first = listIdentities();
+    // Same Map value object ⇒ storeCache was not rebuilt between loads.
+    const a = findIdentity('f56-stable@test.example');
+    const b = findIdentity('f56-stable@test.example');
+    expect(a).toBe(b);
+    expect(listIdentities().map((i) => i.address).sort()).toEqual(
+      first.map((i) => i.address).sort(),
+    );
   });
 });

--- a/packages/api/test/identities.test.ts
+++ b/packages/api/test/identities.test.ts
@@ -262,4 +262,23 @@ describe('push content tier store and REST', () => {
     const row = body.identities.find((i) => i.address === fresh.address);
     expect(row?.pushContentTier).toBe(resolvePushContentTier(findIdentity(fresh.address)!));
   });
+
+  test('invalid persisted pushContentTier normalizes to tier 1 without corrupting the store', () => {
+    const good = createIdentity({ localpart: 'compat-good' })!;
+    setIdentityPushContentTier(good.identity.address, 2);
+    const other = createIdentity({ localpart: 'compat-bad-tier' })!;
+
+    const raw = JSON.parse(readFileSync(storeFile(), 'utf8')) as Array<Record<string, unknown>>;
+    const bad = raw.find((entry) => entry.address === other.identity.address);
+    expect(bad).toBeDefined();
+    bad!.pushContentTier = 99;
+    writeFileSync(storeFile(), JSON.stringify(raw, null, 2));
+
+    // Store still loads; invalid enum is stripped to default tier 1.
+    expect(listIdentities().some((i) => i.address === good.identity.address)).toBe(true);
+    expect(resolvePushContentTier(findIdentity(other.identity.address)!)).toBe(1);
+    expect(findIdentity(other.identity.address)?.pushContentTier).toBeUndefined();
+    // Sibling entry keeps its valid tier.
+    expect(findIdentity(good.identity.address)?.pushContentTier).toBe(2);
+  });
 });

--- a/packages/api/test/identities.test.ts
+++ b/packages/api/test/identities.test.ts
@@ -13,14 +13,34 @@ process.env.SMTP_PASS = 'x';
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-identities-'));
 
 const { describe, expect, test } = await import('bun:test');
+const { Hono } = await import('hono');
+const { config } = await import('../src/lib/config.ts');
 const {
   createIdentity,
   deleteIdentity,
   findIdentity,
   findIdentityByToken,
   listIdentities,
+  resolvePushContentTier,
   rotateIdentityToken,
+  setIdentityPushContentTier,
+  PUSH_TIER3_WARNING,
 } = await import('../src/lib/identities.ts');
+const { identitiesRoute } = await import('../src/routes/identities.ts');
+
+/** Always use the process-wide config path (other files may race on DATA_DIR env). */
+const storeDir = () => config.dataDir;
+const storeFile = () => join(config.dataDir, 'identities.json');
+
+function appFor(auth: { kind: 'admin' } | { kind: 'identity'; address: string }) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', auth);
+    await next();
+  });
+  app.route('/v1/identities', identitiesRoute);
+  return app;
+}
 
 describe('identity tokens', () => {
   test('create returns a plaintext token once; store keeps only the hash', () => {
@@ -73,7 +93,7 @@ describe('identity tokens', () => {
 
   // 身份库里存着所有身份的令牌哈希，别的本地用户不该读得到。
   test('store file and data dir are not readable by other users', () => {
-    const dir = process.env.DATA_DIR!;
+    const dir = storeDir();
     // 模拟"目录已经存在且权限宽松"——mkdirSync 的 mode 对已存在目录不生效，
     // 只测 mkdtemp 造出来的 0700 目录等于没测（Codex 复核指出的盲点）。
     chmodSync(dir, 0o755);
@@ -83,11 +103,9 @@ describe('identity tokens', () => {
   });
 });
 
-// 身份库损坏时绝不能"当成空库继续跑"：随便一次创建/轮换都会把损坏文件
+// 身份库损坏时绝不能"当成空库继续跑"：随便一次 create/轮换都会把损坏文件
 // 覆盖成"空库 + 新身份"，所有既有身份和令牌一次性丢光。
 describe('identity store 损坏时 fail closed', () => {
-  const storeFile = () => join(process.env.DATA_DIR!, 'identities.json');
-
   test('截断的 JSON：读取直接抛错，而不是静默返回空库', () => {
     createIdentity({ localpart: 'before-corrupt' });
     const good = readFileSync(storeFile(), 'utf8');
@@ -116,5 +134,132 @@ describe('identity store 损坏时 fail closed', () => {
 
   test('修好之后一切照常', () => {
     expect(listIdentities().some((i) => i.address === 'before-corrupt@test.example')).toBe(true);
+  });
+});
+
+describe('push content tier store and REST', () => {
+  function ensureTierAddress(): string {
+    const existing = findIdentity('tier-agent@test.example');
+    if (existing) return existing.address;
+    return createIdentity({ localpart: 'tier-agent' })!.identity.address;
+  }
+
+  test('unset tier resolves to interrupt-only (1)', () => {
+    expect(resolvePushContentTier({})).toBe(1);
+    const address = ensureTierAddress();
+    // Reset to absent/default for this assertion when possible.
+    setIdentityPushContentTier(address, 1);
+    expect(resolvePushContentTier(findIdentity(address)!)).toBe(1);
+  });
+
+  test('setIdentityPushContentTier persists and list surfaces the value', () => {
+    const address = ensureTierAddress();
+    expect(setIdentityPushContentTier(address, 2)?.pushContentTier).toBe(2);
+    expect(findIdentity(address)?.pushContentTier).toBe(2);
+    const listed = listIdentities().find((i) => i.address === address);
+    expect(listed?.pushContentTier).toBe(2);
+    expect(setIdentityPushContentTier('missing@test.example', 1)).toBeNull();
+  });
+
+  test('identity token cannot set its own tier (403)', async () => {
+    const address = ensureTierAddress();
+    const response = await appFor({ kind: 'identity', address }).request(
+      `/v1/identities/${encodeURIComponent(address)}/push-tier`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pushContentTier: 1 }),
+      },
+    );
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: 'forbidden: admin key required' });
+  });
+
+  test('identity token may read its own tier', async () => {
+    const address = ensureTierAddress();
+    setIdentityPushContentTier(address, 2);
+    const response = await appFor({ kind: 'identity', address }).request(
+      `/v1/identities/${encodeURIComponent(address)}/push-tier`,
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      address,
+      pushContentTier: 2,
+    });
+  });
+
+  test('identity token cannot read another identity tier', async () => {
+    const address = ensureTierAddress();
+    const other =
+      findIdentity('other-tier-read@test.example') ??
+      createIdentity({ localpart: 'other-tier-read' })!.identity;
+    const response = await appFor({ kind: 'identity', address }).request(
+      `/v1/identities/${encodeURIComponent(other.address)}/push-tier`,
+    );
+    expect(response.status).toBe(403);
+  });
+
+  test('admin can set non-tier-3 without confirm_risk', async () => {
+    const address = ensureTierAddress();
+    const response = await appFor({ kind: 'admin' }).request(
+      `/v1/identities/${encodeURIComponent(address)}/push-tier`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pushContentTier: 1 }),
+      },
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      address,
+      pushContentTier: 1,
+    });
+  });
+
+  test('tier 3 requires confirm_risk: true and returns the risk warning', async () => {
+    const address = ensureTierAddress();
+    setIdentityPushContentTier(address, 1);
+    const denied = await appFor({ kind: 'admin' }).request(
+      `/v1/identities/${encodeURIComponent(address)}/push-tier`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pushContentTier: 3 }),
+      },
+    );
+    expect(denied.status).toBe(400);
+    const deniedBody = (await denied.json()) as { error: string; message: string };
+    expect(deniedBody.error).toBe('confirm_risk_required');
+    expect(deniedBody.message).toBe(PUSH_TIER3_WARNING);
+    expect(resolvePushContentTier(findIdentity(address)!)).toBe(1);
+
+    const allowed = await appFor({ kind: 'admin' }).request(
+      `/v1/identities/${encodeURIComponent(address)}/push-tier`,
+      {
+        method: 'PUT',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ pushContentTier: 3, confirm_risk: true }),
+      },
+    );
+    expect(allowed.status).toBe(200);
+    expect(await allowed.json()).toEqual({
+      address,
+      pushContentTier: 3,
+      warning: PUSH_TIER3_WARNING,
+    });
+    expect(findIdentity(address)?.pushContentTier).toBe(3);
+  });
+
+  test('GET list includes pushContentTier for every identity', async () => {
+    const fresh =
+      findIdentity('unset-tier-list@test.example') ??
+      createIdentity({ localpart: 'unset-tier-list' })!.identity;
+    const response = await appFor({ kind: 'admin' }).request('/v1/identities');
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as {
+      identities: Array<{ address: string; pushContentTier: number }>;
+    };
+    const row = body.identities.find((i) => i.address === fresh.address);
+    expect(row?.pushContentTier).toBe(resolvePushContentTier(findIdentity(fresh.address)!));
   });
 });

--- a/packages/api/test/identities.test.ts
+++ b/packages/api/test/identities.test.ts
@@ -36,6 +36,7 @@ const {
   setIdentityPushContentTier,
   PUSH_TIER3_WARNING,
 } = await import('../src/lib/identities.ts');
+type Identity = import('../src/lib/identities.ts').Identity;
 const { identitiesRoute } = await import('../src/routes/identities.ts');
 const { processWatchedMessage } = await import('../src/lib/notification-watcher.ts');
 
@@ -285,12 +286,43 @@ describe('push content tier store and REST', () => {
     bad!.pushContentTier = 99;
     writeFileSync(storeFile(), JSON.stringify(raw, null, 2));
 
-    // Store still loads; invalid enum is stripped to default tier 1.
+    // Store still loads; unknown enum resolves as tier 1 but is preserved on disk/object (F94).
     expect(listIdentities().some((i) => i.address === good.identity.address)).toBe(true);
     expect(resolvePushContentTier(findIdentity(other.identity.address)!)).toBe(1);
-    expect(findIdentity(other.identity.address)?.pushContentTier).toBeUndefined();
+    expect((findIdentity(other.identity.address) as { pushContentTier?: unknown })?.pushContentTier).toBe(
+      99,
+    );
     // Sibling entry keeps its valid tier.
     expect(findIdentity(good.identity.address)?.pushContentTier).toBe(2);
+  });
+
+  test('coerceIdentity preserves unknown fields and future tier across rewrite (F94)', () => {
+    const normal = createIdentity({ localpart: 'f94-normal' })!;
+    const future = createIdentity({ localpart: 'f94-future' })!;
+
+    const seeded = JSON.parse(readFileSync(storeFile(), 'utf8')) as Array<Record<string, unknown>>;
+    const futureRow = seeded.find((entry) => entry.address === future.identity.address)!;
+    futureRow.pushContentTier = 4;
+    futureRow.futureField = { nested: true, note: 'from-newer-binary' };
+    writeFileSync(storeFile(), JSON.stringify(seeded, null, 2));
+
+    // Load: future tier resolves as 1; raw value kept.
+    const loaded = findIdentity(future.identity.address) as Identity & {
+      futureField?: { nested: boolean; note: string };
+      pushContentTier?: number;
+    };
+    expect(resolvePushContentTier(loaded)).toBe(1);
+    expect(loaded.pushContentTier).toBe(4);
+    expect(loaded.futureField).toEqual({ nested: true, note: 'from-newer-binary' });
+
+    // Mutate a different identity and save — future row must not be stripped.
+    setIdentityPushContentTier(normal.identity.address, 2);
+    const after = JSON.parse(readFileSync(storeFile(), 'utf8')) as Array<Record<string, unknown>>;
+    const still = after.find((entry) => entry.address === future.identity.address)!;
+    expect(still.pushContentTier).toBe(4);
+    expect(still.futureField).toEqual({ nested: true, note: 'from-newer-binary' });
+    const normalRow = after.find((entry) => entry.address === normal.identity.address)!;
+    expect(normalRow.pushContentTier).toBe(2);
   });
 });
 

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -934,6 +934,35 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('78');
   });
 
+  test('maskSensitiveFragments masks Unicode digits via canonicalDigits (F75)', () => {
+    expect(maskSensitiveFragments('验证码 １２３４５６', ['123456'], [])).toBe('验证码 •••');
+    expect(maskSensitiveFragments('code ١٢٣٤٥٦', ['123456'], [])).toBe('code •••');
+    expect(maskSensitiveFragments('code ۱۲۳۴۵۶', ['123456'], [])).toBe('code •••');
+  });
+
+  test('tier 2 masks fullwidth OTP in subject under policy=all (F75)', async () => {
+    const subject = '您的验证码是 １２３４５６';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('１２３４５６');
+    expect(body).not.toContain('123456');
+  });
+
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
     const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
       // 6-digit distinct codes that do not appear in the short subject.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -812,7 +812,7 @@ describe('mail-arrival notification watcher', () => {
     expect(calls[0].message).not.toContain('Codes:');
   });
 
-  test('beforeSend aborts when tier is downgraded after build (F47)', async () => {
+  test('beforeSend downgrade rebuilds at lower tier and sends (F49)', async () => {
     const address = 'target@test.example';
     let reads = 0;
     const calls: any[] = [];
@@ -826,9 +826,9 @@ describe('mail-arrival notification watcher', () => {
       'otp',
       { publish: publishWithBeforeSend(calls) },
       {
+        // build: tier3 → beforeSend: tier1 (cancel) → retry build/beforeSend: tier1 (send)
         refreshIdentity: () => {
           reads += 1;
-          // First read: build tier-3 body; beforeSend re-read: privacy tightened to tier 1.
           if (reads === 1) {
             return { address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 as const };
           }
@@ -836,8 +836,115 @@ describe('mail-arrival notification watcher', () => {
         },
       },
     );
-    expect(reads).toBe(2);
+    // 1 build + 1 beforeSend + 1 rebuild + 1 beforeSend = 4 reads
+    expect(reads).toBe(4);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).not.toContain('Codes:');
+    expect(calls[0].message).not.toContain('Subject:');
+  });
+
+  test('beforeSend gives up after three cancelled attempts when tier keeps dropping', async () => {
+    const address = 'target@test.example';
+    let publishAttempts = 0;
+    let reads = 0;
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        'Verify',
+      ),
+      [{ address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 }],
+      'otp',
+      {
+        publish: async () => {
+          publishAttempts += 1;
+          // Always cancel (skip beforeSend) so retry path is exercised by re-read tier drops.
+          throw new NotifyError('notify_cancelled');
+        },
+      },
+      {
+        refreshIdentity: () => {
+          reads += 1;
+          // init build3 → cancel → re-read2 → build2 → cancel → re-read1 → build1 → cancel → re-read1 stop
+          const tier = reads === 1 ? 3 : reads === 2 ? 2 : 1;
+          return {
+            address,
+            createdAt: '2026-08-02T00:00:00.000Z',
+            pushContentTier: tier as 1 | 2 | 3,
+          };
+        },
+      },
+    );
+    expect(publishAttempts).toBe(3);
     expect(calls).toHaveLength(0);
+  });
+
+  test('tier-2 metadata mask is shared across recipients (F50)', async () => {
+    const a = {
+      address: 'a@test.example',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 2 as const,
+    };
+    const b = {
+      address: 'b@test.example',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 2 as const,
+    };
+    const calls: any[] = [];
+    await processWatchedMessage(
+      {
+        envelope: {
+          from: [{ name: 'auth', address: 'auth@example.net' }],
+          to: [{ address: a.address }, { address: b.address }],
+          subject: 'Code 482731',
+        },
+        headers: Buffer.from(
+          `Delivered-To: ${a.address}\r\nDelivered-To: ${b.address}\r\n`,
+        ),
+        source: Buffer.from(
+          'From: auth@example.net\r\nSubject: Code 482731\r\n\r\nYour verification code is 482731\r\n',
+        ),
+      } as any,
+      [a, b],
+      'otp',
+      { publish: publishWithBeforeSend(calls) },
+    );
+    expect(calls).toHaveLength(2);
+    const stripAddr = (body: string) => body.replace(/^.*received new email[^\n]*/m, 'ADDR');
+    expect(stripAddr(calls[0].message)).toBe(stripAddr(calls[1].message));
+    expect(calls[0].message).toContain('•••');
+  });
+
+  test('many tier-2 recipients with large subject stay under 1s (F50)', async () => {
+    const subject = `code 482731 ${'x'.repeat(500_000)}`;
+    const recipients = Array.from({ length: 50 }, (_, i) => ({
+      address: `r${i}@test.example`,
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 2 as const,
+    }));
+    const calls: any[] = [];
+    const started = performance.now();
+    await processWatchedMessage(
+      {
+        envelope: {
+          from: [{ name: 'auth', address: 'auth@example.net' }],
+          to: recipients.map((r) => ({ address: r.address })),
+          subject,
+        },
+        headers: Buffer.from(
+          recipients.map((r) => `Delivered-To: ${r.address}`).join('\r\n') + '\r\n',
+        ),
+        source: Buffer.from(
+          `From: auth@example.net\r\nSubject: ${subject.slice(0, 200)}\r\n\r\nYour verification code is 482731\r\n`,
+        ),
+      } as any,
+      recipients,
+      'otp',
+      { publish: publishWithBeforeSend(calls) },
+    );
+    expect(performance.now() - started).toBeLessThan(1_000);
+    expect(calls).toHaveLength(50);
   });
 
   test('beforeSend keeps lower-tier body when tier is upgraded mid-flight', async () => {
@@ -893,7 +1000,8 @@ describe('mail-arrival notification watcher', () => {
         },
       },
     );
-    expect(reads).toBe(2);
+    // build read + beforeSend delete + catch re-read delete
+    expect(reads).toBe(3);
     expect(calls).toHaveLength(0);
   });
 

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -524,6 +524,28 @@ describe('mail-arrival notification watcher', () => {
     }
   });
 
+  test('tier 2 masks a year-shaped PIN next to verification keywords (F62)', async () => {
+    const subject = 'Your verification PIN is 2026';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('2026');
+  });
+
   test('tier 2 masks URLs that contain a legal apostrophe before the token', async () => {
     // BARE_URL_RE used to exclude '; match stopped at confirm? and leaked 'token=secret.
     const subject = "Reset https://example.com/confirm?'token=secret";

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1316,6 +1316,50 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toContain('WX-YZ');
   });
 
+  test('tier 2 masks space single-char chain OTP under strong cue (F106)', () => {
+    // Mixed space single-char chain: extract + mask.
+    expect(extractMetaAlnumCodes('Your verification code is A 1 B 2')).toContain('A 1 B 2');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A 1 B 2',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('A 1 B 2');
+    // Fullwidth chain (NFKC single chars).
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ １ Ｂ ２')).toContain('Ａ １ Ｂ ２');
+    // Lowercase mixed chain.
+    expect(extractMetaAlnumCodes('Your verification code is a 1 b 2')).toContain('a 1 b 2');
+    // Longer chain within 4–8 total.
+    expect(extractMetaAlnumCodes('Your verification code is A 1 B 2 C 3')).toContain('A 1 B 2 C 3');
+    // Run stops before a following word: only the chain masks; a 9+-letter
+    // word (outside the F101 continuous length) stays fully intact — proves
+    // the run did not eat its first char (F106 boundary guard).
+    const prose = maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Your verification code is A 1 B 2 yesterday',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(prose.subject).toContain('yesterday');
+    expect(prose.subject).not.toContain('A 1 B 2');
+    // Shape locks: 3-group too short; 9-group rejected whole.
+    expect(extractMetaAlnumCodes('Your verification code is A 1 B')).not.toContain('A 1 B');
+    expect(extractMetaAlnumCodes('Your verification code is A 1 B 2 C 3 D 4 E')).not.toContain('A 1 B 2 C 3 D 4 E');
+    // Letter-only single chains stay rejected (F97 letter policy).
+    expect(extractMetaAlnumCodes('Your verification code is A B C D')).not.toContain('A B C D');
+    // Pure-digit chain stays on the digit path.
+    expect(extractMetaAlnumCodes('Your verification code is 1 2 3 4')).not.toContain('1 2 3 4');
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference A 1 B 2 attached')).toEqual([]);
+    // F85/F84 space path regressions.
+    expect(extractMetaAlnumCodes('Your verification code is A1 B2 C3')).toContain('A1 B2 C3');
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toContain('ABC 123');
+  });
+
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
     expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toContain('A1B-2C3');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -99,9 +99,10 @@ describe('mail-arrival notification watcher', () => {
     expect(watermark.uidValidity).toBe(1000n);
     // Same generation: only strictly newer UIDs are unseen.
     expect(unseenWatcherUids([10, 11, 12], watermark, 1000n)).toEqual([12]);
-    // INBOX recreated (new UIDVALIDITY): UIDs restart below the old watermark;
-    // re-anchor on the replacement generation instead of rejecting all of it.
-    expect(unseenWatcherUids([1, 2, 3], watermark, 2000n)).toEqual([]);
+    // INBOX recreated (new UIDVALIDITY) on an already-observed mailbox: mail
+    // may have landed during the disconnect, so every current UID is pending
+    // (F115); the watermark still re-anchors on the replacement generation.
+    expect(unseenWatcherUids([1, 2, 3], watermark, 2000n)).toEqual([1, 2, 3]);
     expect(watermark.uid).toBe(3);
     expect(watermark.uidValidity).toBe(2000n);
     // Mail delivered after the re-anchor flows again.
@@ -201,6 +202,47 @@ describe('mail-arrival notification watcher', () => {
       'otp',
     );
     expect(none).toEqual([]);
+  });
+
+  test('tier 3 carries subject-only codes and links into the payload (F116)', async () => {
+    // The only credential is a long signed URL in the subject with a plain
+    // body: tier 3 must publish the full link, not a subject line truncated
+    // at the metadata cap.
+    const longUrl = `https://example.com/verify?token=${'a'.repeat(600)}`;
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: verify ${longUrl}\r\n\r\nplain body, no credentials`,
+        `verify ${longUrl}`,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Links:');
+    expect(body).toContain(longUrl);
+
+    // Subject-only code lands on the Codes line too.
+    const codeCalls = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Your verification code is 123456\r\n\r\nplain body',
+        'Your verification code is 123456',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(codeCalls).toHaveLength(1);
+    expect(codeCalls[0].message).toContain('Codes: 123456');
   });
 
   test('default push content tier is interrupt-only when unset', async () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -419,6 +419,37 @@ describe('mail-arrival notification watcher', () => {
     expect(far).toEqual([]);
   });
 
+  test('otp policy scans the HTML alternative for alnum codes (F140)', async () => {
+    // Stub plain-text part, credential only in the HTML part: extractCodes
+    // (digits only) finds nothing, so only the alnum pass can classify.
+    const raw = [
+      'From: auth@example.net',
+      'Subject: Sign in',
+      'MIME-Version: 1.0',
+      'Content-Type: multipart/alternative; boundary="alt"',
+      '',
+      '--alt',
+      'Content-Type: text/plain; charset=utf-8',
+      '',
+      'Open this message in an HTML-capable mail client.',
+      '',
+      '--alt',
+      'Content-Type: text/html; charset=utf-8',
+      '',
+      '<p>Your verification code is A1B2C3, use it soon.</p>',
+      '',
+      '--alt--',
+      '',
+    ].join('\r\n');
+    const calls = await dispatches(message('auth@example.net', raw), 'otp', [{
+      address: 'target@test.example',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 3,
+    }]);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toContain('Codes: A1B2C3');
+  });
+
   test('tier 3 merges subject credentials even when the body also matches (F119)', async () => {
     // Body has its own code while the subject carries a long signed URL: both
     // must reach the payload — the subject is truncated at the metadata cap,

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -9,6 +9,7 @@ const { describe, expect, test } = await import('bun:test');
 const {
   boundPushMessage,
   buildMailArrivalMessage,
+  maskSensitiveFragments,
   processWatchedMessage,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
@@ -535,6 +536,57 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('confirm');
     expect(body).not.toContain('token=secret');
     expect(body).not.toContain('https://');
+  });
+
+  test('tier 2 masks a subject code even when the body has many unrelated codes', () => {
+    const bodyCodes = Array.from({ length: 100 }, (_, i) => String(100000 + i));
+    const bodyText = bodyCodes.map((code) => `Your verification code is ${code}.`).join(' ');
+    // Direct builder: extras.codes is huge, subject holds only 654321.
+    const body = buildMailArrivalMessage('a@test.example', 2, true, {
+      subject: 'Your login code is 654321',
+      from: 'auth@example.com',
+      preview: bodyText.slice(0, 280),
+      codes: [...bodyCodes, '654321'],
+      links: [],
+    });
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('654321');
+    // Unrelated body codes must not appear either (they are not in subject).
+    expect(body).not.toContain('100000');
+  });
+
+  test('maskSensitiveFragments uses one-pass code replace and handles empty needles', () => {
+    expect(maskSensitiveFragments('plain subject', [], [])).toBe('plain subject');
+    expect(maskSensitiveFragments('code 112233 and 445566', ['112233', '445566'], [])).toBe(
+      'code ••• and •••',
+    );
+    // Longest-first: overlapping would prefer longer if both listed.
+    expect(maskSensitiveFragments('code 11223399', ['1122', '112233'], [])).toBe('code •••99');
+    expect(maskSensitiveFragments('dup 1111 and 1111', ['1111', '1111'], [])).toBe(
+      'dup ••• and •••',
+    );
+  });
+
+  test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
+    const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
+      // 6-digit distinct codes that do not appear in the short subject.
+      return String(200000 + (i % 800_000)).padStart(6, '0');
+    });
+    // Folded-looking subject with many digit runs that are not the body codes.
+    const subjectDigits = Array.from({ length: 2_000 }, (_, i) => String(900000 + (i % 1000)).padStart(6, '0'));
+    const subject = `codes ${subjectDigits.join(' ')} and secret 654321`;
+    const started = performance.now();
+    const body = buildMailArrivalMessage('a@test.example', 2, true, {
+      subject,
+      from: 'auth@example.com',
+      preview: 'x'.repeat(280),
+      codes: bodyCodes,
+      links: [],
+    });
+    expect(performance.now() - started).toBeLessThan(1_000);
+    expect(body).toContain('•••');
+    expect(body).not.toContain('654321');
   });
 
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -566,6 +566,31 @@ describe('mail-arrival notification watcher', () => {
     expect(body).toContain('[Verify](•••)[Confirm](•••)');
   });
 
+  test('tier 2 masks a full URL that contains an unbalanced ) mid-path', async () => {
+    // WHATWG accepts confirm)foo; must not hard-cut and leak ?token=.
+    const subject = 'Reset https://example.com/confirm)foo?token=secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('•••');
+    expect(body).not.toContain('confirm)foo');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('https://');
+  });
+
   test('tier 2 masks a subject code even when the body has many unrelated codes', () => {
     const bodyCodes = Array.from({ length: 100 }, (_, i) => String(100000 + i));
     const bodyText = bodyCodes.map((code) => `Your verification code is ${code}.`).join(' ');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -24,7 +24,11 @@ const {
   PUSH_OTP_ENTRY_CHARS,
   PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
-const { NotifyError, jsonEscapedByteLength } = await import('../src/lib/notify.ts');
+const {
+  NotifyError,
+  jsonEscapedByteLength,
+  notifyAvailableMessageBytes,
+} = await import('../src/lib/notify.ts');
 
 /** Mock publish that honors beforeSend like NtfyNotificationService. */
 function publishWithBeforeSend(calls: any[]) {
@@ -1798,7 +1802,12 @@ describe('mail-arrival notification watcher', () => {
 
     expect(calls).toHaveLength(1);
     const body = calls[0].message as string;
-    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    const tier3Budget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+    });
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(tier3Budget);
     // At most PUSH_OTP_ITEM_MAX codes appear after "Codes: ".
     const codesLine = body.split('\n').find((line) => line.startsWith('Codes: '));
     if (codesLine) {
@@ -1830,9 +1839,11 @@ describe('mail-arrival notification watcher', () => {
       codes: Array.from({ length: 40 }, (_, i) => `${'1'.repeat(300)}${i}`),
       links: Array.from({ length: 40 }, (_, i) => `https://example.com/${'x'.repeat(300)}/${i}`),
     });
-    expect(Buffer.byteLength(huge, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    expect(jsonEscapedByteLength(huge)).toBeLessThanOrEqual(tier3Budget);
     expect(
-      huge.endsWith('…') || Buffer.byteLength(huge, 'utf8') < PUSH_MESSAGE_MAX_BYTES || huge.includes('more links'),
+      huge.endsWith('…') ||
+        jsonEscapedByteLength(huge) < tier3Budget ||
+        huge.includes('more links'),
     ).toBe(true);
   });
 
@@ -1922,13 +1933,13 @@ describe('mail-arrival notification watcher', () => {
   });
 
   test('tier 3 packs full link before preview remainder (F88 order)', () => {
-    // Coordinator repro: 2500-char verify link + 200 backslash subject + 500 preview
-    // under the 3500 escaped-byte local cap. Link must stay whole; preview shrinks.
+    // Long verify link + backslash-heavy subject + large preview under the ntfy
+    // residual: link must stay whole; preview shrinks to the remainder.
     const prefix = 'https://example.com/verify?token=';
     const longLink = `${prefix}${'a'.repeat(2500 - prefix.length)}`;
     expect(longLink.length).toBe(2500);
     const slashSubject = '\\'.repeat(200);
-    const fullPreview = 'p'.repeat(500);
+    const fullPreview = 'p'.repeat(2000);
 
     const body = buildMailArrivalMessage('a@test.example', 3, true, {
       subject: slashSubject,
@@ -1941,13 +1952,18 @@ describe('mail-arrival notification watcher', () => {
     expect(body).toContain(longLink);
     expect(body).not.toMatch(/https:\/\/example\.com\/verify[^\n]*…/);
     expect(body).not.toMatch(/\(\+\d+ more links/);
-    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    const noClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+    });
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(noClickBudget);
 
     const previewLine = body.split('\n').find((line) => line.startsWith('Preview: '));
     expect(previewLine).toBeDefined();
     const previewText = previewLine!.slice('Preview: '.length);
     expect(previewText.length).toBeGreaterThan(0);
-    expect(previewText.length).toBeLessThan(500);
+    expect(previewText.length).toBeLessThan(2000);
     // Assembly order: meta → Preview → Links
     const previewIdx = body.indexOf('\nPreview: ');
     const linksIdx = body.indexOf('\nLinks:\n');
@@ -1956,11 +1972,11 @@ describe('mail-arrival notification watcher', () => {
   });
 
   test('tier 3 omits whole link with note when base alone leaves no room (F88)', () => {
-    // 2900-char link + 400-backslash subject: escaped subject (~800) + framing + link
-    // exceed the 3500 cap even without preview → honest +N note, no half URL.
+    // Oversized link + backslash-heavy subject: even no-click residual cannot keep
+    // the full URL → honest +N note, no half URL. Preview may still fill remainder.
     const prefix = 'https://example.com/verify?token=';
-    const longLink = `${prefix}${'a'.repeat(2900 - prefix.length)}`;
-    expect(longLink.length).toBe(2900);
+    const longLink = `${prefix}${'a'.repeat(3700 - prefix.length)}`;
+    expect(longLink.length).toBe(3700);
     const slashSubject = '\\'.repeat(400);
     const fullPreview = 'p'.repeat(200);
 
@@ -1976,7 +1992,12 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('https://example.com/verify?token=');
     expect(body).not.toMatch(/https:\/\/example\.com\/verify[^\n]*…/);
     expect(body).toMatch(/\(\+1 more links, open the dashboard to view\)/);
-    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    const noClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+    });
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(noClickBudget);
     // Preview still fills remainder after the note-only Links block.
     const previewLine = body.split('\n').find((line) => line.startsWith('Preview: '));
     expect(previewLine).toBeDefined();
@@ -2003,6 +2024,102 @@ describe('mail-arrival notification watcher', () => {
     expect(previewIdx).toBeGreaterThan(0);
     expect(codesIdx).toBeGreaterThan(previewIdx);
     expect(linksIdx).toBeGreaterThan(codesIdx);
+  });
+
+  test('tier 3 prefers no-click budget over link eviction (F93)', () => {
+    // Coordinator repro: long dashboard click + ~3483-byte verify link. With-click
+    // residual (~3400) evicts the link; no-click residual (~3846) keeps it whole.
+    const clickUrl = `https://dash.example/ui/${'c'.repeat(400)}`;
+    const prefix = 'https://example.com/verify?token=';
+    const longLink = `${prefix}${'a'.repeat(3483 - prefix.length)}`;
+    expect(longLink.length).toBe(3483);
+
+    const withClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+      click: clickUrl,
+    });
+    const noClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+    });
+    expect(withClickBudget).toBeLessThan(noClickBudget);
+    expect(withClickBudget).toBeLessThan(3483);
+
+    const body = buildMailArrivalMessage(
+      'a@test.example',
+      3,
+      true,
+      {
+        subject: '',
+        from: '',
+        preview: '',
+        codes: [],
+        links: [longLink],
+      },
+      undefined,
+      { clickUrl },
+    );
+    expect(body).toContain(longLink);
+    expect(body).not.toMatch(/\(\+\d+ more links/);
+    const escaped = jsonEscapedByteLength(body);
+    expect(escaped).toBeGreaterThan(withClickBudget);
+    expect(escaped).toBeLessThanOrEqual(noClickBudget);
+  });
+
+  test('tier 3 keeps with-click packing when short link fits (F93 regression)', () => {
+    const clickUrl = 'https://dash.example/ui';
+    const shortLink = 'https://example.com/verify?token=abc';
+    const body = buildMailArrivalMessage(
+      'a@test.example',
+      3,
+      true,
+      {
+        subject: 'Verify',
+        from: 'auth@example.com',
+        preview: 'hi',
+        codes: [],
+        links: [shortLink],
+      },
+      undefined,
+      { clickUrl },
+    );
+    expect(body).toContain(shortLink);
+    expect(body).not.toMatch(/\(\+\d+ more links/);
+    // Fits under with-click residual → no need for no-click packing.
+    const withClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+      click: clickUrl,
+    });
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(withClickBudget);
+  });
+
+  test('tier 3 keeps with-click packing when eviction is equal under both budgets (F93)', () => {
+    // Two enormous links: neither budget can keep either full URL → equal drops
+    // → prefer with-click packing path (honest note, no half URL).
+    const clickUrl = `https://dash.example/ui/${'c'.repeat(400)}`;
+    const huge = (i: number) =>
+      `https://example.com/verify?token=${'z'.repeat(3900)}&i=${i}`;
+    const body = buildMailArrivalMessage(
+      'a@test.example',
+      3,
+      true,
+      {
+        subject: '',
+        from: '',
+        preview: '',
+        codes: [],
+        links: [huge(0), huge(1)],
+      },
+      undefined,
+      { clickUrl },
+    );
+    expect(body).not.toContain('https://example.com/verify?token=');
+    expect(body).toMatch(/\(\+\d+ more links, open the dashboard to view\)/);
   });
 
   test('tier 3 drops tail links with +N note under budget (F79)', () => {
@@ -2065,7 +2182,12 @@ describe('mail-arrival notification watcher', () => {
       links: ['https://example.com/verify?token=abc'],
     });
 
-    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    const tier3Budget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+    });
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(tier3Budget);
     expect(body).toContain('Codes: 112233');
     expect(body).toContain('https://example.com/verify?token=abc');
     expect(body).toContain('Subject:');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -13,6 +13,7 @@ const {
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
   PUSH_MESSAGE_MAX_BYTES,
+  PUSH_META_FIELD_MAX_BYTES,
   PUSH_OTP_ENTRY_CHARS,
   PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
@@ -276,5 +277,30 @@ describe('mail-arrival notification watcher', () => {
 
     // Walked body must re-encode cleanly (round-trip through UTF-8).
     expect(Buffer.from(capped, 'utf8').toString('utf8')).toBe(capped);
+  });
+
+  test('tier 3 keeps Codes/Links when subject would otherwise exhaust the byte budget', () => {
+    // ~4000 UTF-8 bytes of CJK subject (each char 3 bytes) without field caps
+    // would starve Preview/Codes/Links under the shared body limit.
+    const hugeSubject = '验'.repeat(1400);
+    expect(Buffer.byteLength(hugeSubject, 'utf8')).toBeGreaterThan(4000);
+
+    const body = buildMailArrivalMessage('a@test.example', 3, true, {
+      subject: hugeSubject,
+      from: 'sender@example.com',
+      preview: 'Your verification code is 112233',
+      codes: ['112233'],
+      links: ['https://example.com/verify?token=abc'],
+    });
+
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    expect(body).toContain('Codes: 112233');
+    expect(body).toContain('https://example.com/verify?token=abc');
+    expect(body).toContain('Subject:');
+    const subjectLine = body.split('\n').find((line) => line.startsWith('Subject: '))!;
+    expect(subjectLine.endsWith('…')).toBe(true);
+    expect(Buffer.byteLength(subjectLine.slice('Subject: '.length), 'utf8')).toBeLessThanOrEqual(
+      PUSH_META_FIELD_MAX_BYTES,
+    );
   });
 });

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -313,6 +313,41 @@ describe('mail-arrival notification watcher', () => {
     expect(JSON.stringify(tier2[0])).not.toContain('1 2 3 4 5 6');
   });
 
+  test('tier 2 masks and otp policy classifies letter-only single-char chains (F135)', async () => {
+    // All-caps letter chain is the only credential (subject-only).
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A B C D',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('A B C D');
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Your verification code is A-B-C-D\r\n\r\nplain body, no credentials',
+      ),
+      'otp',
+    );
+    expect(calls).toHaveLength(1);
+    expect(JSON.stringify(calls[0])).not.toContain('A-B-C-D');
+  });
+
+  test('otp policy ignores cue-word-only subjects (F136)', async () => {
+    // `Error`/`code`/`expired` over-extract for masking, but none is a
+    // code-shaped token: no classification, no misleading OTP alert.
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Error code has expired\r\n\r\nordinary body, nothing sensitive',
+      ),
+      'otp',
+    );
+    expect(calls).toEqual([]);
+  });
+
   test('tier 3 merges subject credentials even when the body also matches (F119)', async () => {
     // Body has its own code while the subject carries a long signed URL: both
     // must reach the payload — the subject is truncated at the metadata cap,
@@ -1610,8 +1645,10 @@ describe('mail-arrival notification watcher', () => {
     // Shape locks: 3-group chain too short; 9-group chain rejected whole.
     expect(extractMetaAlnumCodes('Your verification code is A-1-B')).not.toContain('A-1-B');
     expect(extractMetaAlnumCodes('Your verification code is A-1-B-2-C-3-D-4-E')).not.toContain('A-1-B-2-C-3-D-4-E');
-    // Letter-only single chains stay rejected (delimited letter-only = F97 groups of 2–4).
-    expect(extractMetaAlnumCodes('Your verification code is A-B-C-D')).not.toContain('A-B-C-D');
+    // F135: all-caps letter-only single chains extract (shouted letter codes).
+    expect(extractMetaAlnumCodes('Your verification code is A-B-C-D')).toContain('A-B-C-D');
+    // Lowercase letter-only chains stay rejected (prose protection, mirrors F97).
+    expect(extractMetaAlnumCodes('Your verification code is a-b-c-d')).not.toContain('a-b-c-d');
     // Pure-digit chain stays on the digit path (not alnum extract).
     expect(extractMetaAlnumCodes('Your verification code is 1-2-3-4')).not.toContain('1-2-3-4');
     // No cue: rejected.
@@ -1654,8 +1691,9 @@ describe('mail-arrival notification watcher', () => {
     // Shape locks: 3-group too short; 9-group rejected whole.
     expect(extractMetaAlnumCodes('Your verification code is A 1 B')).not.toContain('A 1 B');
     expect(extractMetaAlnumCodes('Your verification code is A 1 B 2 C 3 D 4 E')).not.toContain('A 1 B 2 C 3 D 4 E');
-    // Letter-only single chains stay rejected (F97 letter policy).
-    expect(extractMetaAlnumCodes('Your verification code is A B C D')).not.toContain('A B C D');
+    // F135: all-caps letter-only space chains extract; lowercase stays rejected.
+    expect(extractMetaAlnumCodes('Your verification code is A B C D')).toContain('A B C D');
+    expect(extractMetaAlnumCodes('Your verification code is a b c d')).not.toContain('a b c d');
     // Pure-digit chain stays on the digit path.
     expect(extractMetaAlnumCodes('Your verification code is 1 2 3 4')).not.toContain('1 2 3 4');
     // No cue: rejected.
@@ -1698,8 +1736,8 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is A 1-B 2 C-3 D 4 E-5')).not.toContain(
       'A 1-B 2 C-3 D 4 E-5',
     );
-    // Letter-only / pure-digit mixed chains stay rejected (F105/F106 policy).
-    expect(extractMetaAlnumCodes('Your verification code is A B-C D')).not.toContain('A B-C D');
+    // F135: all-caps letter-only mixed-sep chains extract; pure-digit stays rejected.
+    expect(extractMetaAlnumCodes('Your verification code is A B-C D')).toContain('A B-C D');
     expect(extractMetaAlnumCodes('Your verification code is 1 2-3 4')).not.toContain('1 2-3 4');
     // No cue: rejected.
     expect(extractMetaAlnumCodes('Reference A 1-B 2 attached')).toEqual([]);

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1090,6 +1090,26 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is 123-456')).toEqual([]);
   });
 
+  test('mixed space+punctuation alnum seps mask under strong cue (F87)', () => {
+    expect(extractMetaAlnumCodes('Your verification code is ABC - 123')).toEqual(['ABC - 123']);
+    expect(extractMetaAlnumCodes('Your code is A1 - B2 - C3')).toEqual(['A1 - B2 - C3']);
+    expect(extractMetaAlnumCodes('Your code is ABC--123')).toEqual(['ABC--123']);
+    expect(extractMetaAlnumCodes('Your code is ABC－ 123')).toEqual(['ABC－ 123']);
+    expect(extractMetaAlnumCodes('Ref ABC - 123 attached')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your code is word - another')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is Mar - 2026')).toEqual([]);
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is ABC - 123',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    // Prior tight/space paths still work.
+    expect(extractMetaAlnumCodes('Your code is ABC-123')).toEqual(['ABC-123']);
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
+  });
+
   test('tier 2 masks fullwidth alnum OTP under strong cue (F86)', () => {
     // Fullwidth mixed continuous.
     expect(extractMetaAlnumCodes('您的验证码是 Ａ１Ｂ２Ｃ３')).toEqual(['Ａ１Ｂ２Ｃ３']);
@@ -1759,6 +1779,76 @@ describe('mail-arrival notification watcher', () => {
     });
     expect(body).toContain(longLink);
     expect(body).not.toContain(`${longLink.slice(0, PUSH_OTP_ENTRY_CHARS)}…`);
+  });
+
+  test('JSON-escape packing keeps long signed links whole (F88)', async () => {
+    // Backslash-heavy subject expands under JSON.stringify; link must stay complete.
+    const longLink = `https://example.com/verify?token=${'a'.repeat(2800)}&sig=${'b'.repeat(80)}`;
+    const slashSubject = `${'\\'.repeat(400)}verify`;
+    const body = buildMailArrivalMessage(
+      'a@test.example',
+      3,
+      true,
+      {
+        subject: slashSubject,
+        from: 'auth@example.com',
+        preview: 'x'.repeat(500),
+        codes: [],
+        links: [longLink],
+      },
+      undefined,
+      { clickUrl: 'https://dash.example/ui' },
+    );
+    // Full link present or honest omit — never mid-truncated with ….
+    if (body.includes('https://example.com/verify')) {
+      expect(body).toContain(longLink);
+      expect(body).not.toMatch(/https:\/\/example\.com\/verify[^\n]*…/);
+    } else {
+      expect(body).toMatch(/\(\+\d+ more links, open the dashboard to view\)/);
+      expect(body).not.toContain('https://example.com/verify?token=');
+    }
+
+    // Through publish(overflow=truncate): link still complete in ntfy JSON.
+    const { NtfyNotificationService, NTFY_REQUEST_MAX_BYTES, jsonEscapedByteLength } =
+      await import('../src/lib/notify.ts');
+    const { config } = await import('../src/lib/config.ts');
+    const previousNtfy = { ...config.ntfy };
+    Object.assign(config.ntfy as { enabled: boolean; adminPassword?: string; publicUrl: string }, {
+      enabled: true,
+      adminPassword: 'ntfy-admin-secret',
+      publicUrl: 'https://notify.test',
+    });
+    const captured: string[] = [];
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (_input, init) => {
+      captured.push(String(init?.body ?? ''));
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+    try {
+      await new NtfyNotificationService().publish({
+        target: 'user',
+        title: 'openagent.email new mail',
+        message: body,
+        level: 'urgent',
+        tags: ['email'],
+        click: 'https://dash.example/ui',
+        overflow: 'truncate',
+      });
+      expect(captured).toHaveLength(1);
+      expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+      const parsed = JSON.parse(captured[0]!) as { message: string };
+      if (parsed.message.includes('https://example.com/verify')) {
+        expect(parsed.message).toContain(longLink);
+        expect(parsed.message).not.toMatch(/https:\/\/example\.com\/verify[^\n]*…/);
+      } else {
+        expect(parsed.message).toMatch(/more links/);
+      }
+      // Packed body already under escaped budget for typical framing.
+      expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+    } finally {
+      globalThis.fetch = originalFetch;
+      Object.assign(config.ntfy, previousNtfy);
+    }
   });
 
   test('tier 3 drops tail links with +N note under budget (F79)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -29,6 +29,7 @@ const {
   jsonEscapedByteLength,
   notifyAvailableMessageBytes,
 } = await import('../src/lib/notify.ts');
+const { hasStrongOtpCue } = await import('../src/lib/otp.ts');
 
 /** Mock publish that honors beforeSend like NtfyNotificationService. */
 function publishWithBeforeSend(calls: any[]) {
@@ -1419,6 +1420,46 @@ describe('mail-arrival notification watcher', () => {
     // Exact original spelling: fullwidth extract does not mask halfwidth form.
     expect(maskSensitiveFragments('code A1B2C3', ['Ａ１Ｂ２Ｃ３'], [])).toBe('code A1B2C3');
     expect(maskSensitiveFragments('code Ａ１Ｂ２Ｃ３', ['Ａ１Ｂ２Ｃ３'], [])).toBe('code •••');
+  });
+
+  test('tier 2 masks OTP under fullwidth Latin cue (F103)', () => {
+    // Fullwidth cue words: lowercasing alone never reaches ASCII `code`.
+    expect(hasStrongOtpCue('Ｙｏｕｒ ｖｅｒｉｆｉｃａｔｉｏｎ ｃｏｄｅ ｉｓ Ａ１Ｂ２')).toBe(true);
+    // Fullwidth cue + fullwidth alnum code masks.
+    expect(extractMetaAlnumCodes('Ｙｏｕｒ ｖｅｒｉｆｉｃａｔｉｏｎ ｃｏｄｅ ｉｓ Ａ１Ｂ２')).toContain('Ａ１Ｂ２');
+    const alnum = maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Ｙｏｕｒ ｖｅｒｉｆｉｃａｔｉｏｎ ｃｏｄｅ ｉｓ Ａ１Ｂ２',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(alnum.subject).toContain('•••');
+    expect(alnum.subject).not.toContain('Ａ１Ｂ２');
+    // Fullwidth cue + fullwidth numeric code masks (F102 digit-run path).
+    const numeric = maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Ｙｏｕｒ ｖｅｒｉｆｉｃａｔｉｏｎ ｃｏｄｅ ｉｓ １２３４５６',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(numeric.subject).toContain('•••');
+    expect(numeric.subject).not.toContain('１２３４５６');
+    // Halfwidth cue-only mix: cue fullwidth, code ASCII.
+    const half = maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'ｃｏｄｅ A1B2',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(half.subject).toContain('•••');
+    expect(half.subject).not.toContain('A1B2');
+    // ASCII and CJK cue regressions.
+    expect(hasStrongOtpCue('Your verification code is A1B2')).toBe(true);
+    expect(hasStrongOtpCue('您的验证码是 123456')).toBe(true);
+    expect(hasStrongOtpCue('Ｙｏｕｒ ｏｒｄｅｒ ｓｈｉｐｐｅｄ')).toBe(false);
   });
 
   test('space-separated alnum runs mask whole chain not halves (F85)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1284,6 +1284,38 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('WX');
   });
 
+  test('tier 2 masks tight single-char chain OTP under strong cue (F105)', () => {
+    // Mixed single-char chain: extract + mask.
+    expect(extractMetaAlnumCodes('Your verification code is A-1-B-2')).toContain('A-1-B-2');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A-1-B-2',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('A-1-B-2');
+    // Fullwidth chain (NFKC single chars).
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ-１-Ｂ-２')).toContain('Ａ-１-Ｂ-２');
+    // Lowercase mixed chain (mixed is case-insensitive).
+    expect(extractMetaAlnumCodes('Your verification code is a-1-b-2')).toContain('a-1-b-2');
+    // Longer chain within 4–8 total.
+    expect(extractMetaAlnumCodes('Your verification code is A-1-B-2-C-3')).toContain('A-1-B-2-C-3');
+    // Shape locks: 3-group chain too short; 9-group chain rejected whole.
+    expect(extractMetaAlnumCodes('Your verification code is A-1-B')).not.toContain('A-1-B');
+    expect(extractMetaAlnumCodes('Your verification code is A-1-B-2-C-3-D-4-E')).not.toContain('A-1-B-2-C-3-D-4-E');
+    // Letter-only single chains stay rejected (delimited letter-only = F97 groups of 2–4).
+    expect(extractMetaAlnumCodes('Your verification code is A-B-C-D')).not.toContain('A-B-C-D');
+    // Pure-digit chain stays on the digit path (not alnum extract).
+    expect(extractMetaAlnumCodes('Your verification code is 1-2-3-4')).not.toContain('1-2-3-4');
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference A-1-B-2 attached')).toEqual([]);
+    // 2-4-char group regression (F84/F97 paths unaffected).
+    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
+    expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toContain('WX-YZ');
+  });
+
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
     expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toContain('A1B-2C3');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1090,6 +1090,63 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is 123-456')).toEqual([]);
   });
 
+  test('space-separated alnum runs mask whole chain not halves (F85)', () => {
+    // Bug repro: 3-group must not leave leading A1 unmasked as B2 C3 only.
+    expect(extractMetaAlnumCodes('Your verification code is A1 B2 C3')).toEqual(['A1 B2 C3']);
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A1 B2 C3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    const three = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A1 B2 C3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject;
+    expect(three).not.toContain('A1');
+    expect(three).not.toContain('B2');
+    expect(three).not.toContain('C3');
+
+    // 4 groups, every group has a digit.
+    expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4')).toEqual(['A1 B2 C3 D4']);
+    expect(maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Your code is A1 B2 C3 D4',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your code is •••');
+
+    // No digits → reject whole run (no mid-chain letter-only halves).
+    expect(extractMetaAlnumCodes('Your code is AB CD EF GH')).toEqual([]);
+    expect(maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Your code is AB CD EF GH',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your code is AB CD EF GH');
+
+    // 5+ groups rejected whole.
+    expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4 E5')).toEqual([]);
+    expect(maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Your code is A1 B2 C3 D4 E5',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your code is A1 B2 C3 D4 E5');
+
+    // 2-group regressions.
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
+    expect(extractMetaAlnumCodes('Your code is to A1B2')).not.toContain('to A1B2');
+    expect(extractMetaAlnumCodes('Your verification code expires Mar 2026')).toEqual([]);
+  });
+
   test('alnum mask uses one alternation regex (F83)', () => {
     const forms = ['A1B2C3', 'XY99ZZ', 'Ab12'];
     const re = buildAlnumMaskRe(forms);

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -24,7 +24,7 @@ const {
   PUSH_OTP_ENTRY_CHARS,
   PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
-const { NotifyError } = await import('../src/lib/notify.ts');
+const { NotifyError, jsonEscapedByteLength } = await import('../src/lib/notify.ts');
 
 /** Mock publish that honors beforeSend like NtfyNotificationService. */
 function publishWithBeforeSend(calls: any[]) {
@@ -1809,8 +1809,7 @@ describe('mail-arrival notification watcher', () => {
     }
 
     // Through publish(overflow=truncate): link still complete in ntfy JSON.
-    const { NtfyNotificationService, NTFY_REQUEST_MAX_BYTES, jsonEscapedByteLength } =
-      await import('../src/lib/notify.ts');
+    const { NtfyNotificationService, NTFY_REQUEST_MAX_BYTES } = await import('../src/lib/notify.ts');
     const { config } = await import('../src/lib/config.ts');
     const previousNtfy = { ...config.ntfy };
     Object.assign(config.ntfy as { enabled: boolean; adminPassword?: string; publicUrl: string }, {
@@ -1849,6 +1848,90 @@ describe('mail-arrival notification watcher', () => {
       globalThis.fetch = originalFetch;
       Object.assign(config.ntfy, previousNtfy);
     }
+  });
+
+  test('tier 3 packs full link before preview remainder (F88 order)', () => {
+    // Coordinator repro: 2500-char verify link + 200 backslash subject + 500 preview
+    // under the 3500 escaped-byte local cap. Link must stay whole; preview shrinks.
+    const prefix = 'https://example.com/verify?token=';
+    const longLink = `${prefix}${'a'.repeat(2500 - prefix.length)}`;
+    expect(longLink.length).toBe(2500);
+    const slashSubject = '\\'.repeat(200);
+    const fullPreview = 'p'.repeat(500);
+
+    const body = buildMailArrivalMessage('a@test.example', 3, true, {
+      subject: slashSubject,
+      from: 'auth@example.com',
+      preview: fullPreview,
+      codes: [],
+      links: [longLink],
+    });
+
+    expect(body).toContain(longLink);
+    expect(body).not.toMatch(/https:\/\/example\.com\/verify[^\n]*…/);
+    expect(body).not.toMatch(/\(\+\d+ more links/);
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+
+    const previewLine = body.split('\n').find((line) => line.startsWith('Preview: '));
+    expect(previewLine).toBeDefined();
+    const previewText = previewLine!.slice('Preview: '.length);
+    expect(previewText.length).toBeGreaterThan(0);
+    expect(previewText.length).toBeLessThan(500);
+    // Assembly order: meta → Preview → Links
+    const previewIdx = body.indexOf('\nPreview: ');
+    const linksIdx = body.indexOf('\nLinks:\n');
+    expect(previewIdx).toBeGreaterThan(0);
+    expect(linksIdx).toBeGreaterThan(previewIdx);
+  });
+
+  test('tier 3 omits whole link with note when base alone leaves no room (F88)', () => {
+    // 2900-char link + 400-backslash subject: escaped subject (~800) + framing + link
+    // exceed the 3500 cap even without preview → honest +N note, no half URL.
+    const prefix = 'https://example.com/verify?token=';
+    const longLink = `${prefix}${'a'.repeat(2900 - prefix.length)}`;
+    expect(longLink.length).toBe(2900);
+    const slashSubject = '\\'.repeat(400);
+    const fullPreview = 'p'.repeat(200);
+
+    const body = buildMailArrivalMessage('a@test.example', 3, true, {
+      subject: slashSubject,
+      from: 'auth@example.com',
+      preview: fullPreview,
+      codes: [],
+      links: [longLink],
+    });
+
+    expect(body).not.toContain(longLink);
+    expect(body).not.toContain('https://example.com/verify?token=');
+    expect(body).not.toMatch(/https:\/\/example\.com\/verify[^\n]*…/);
+    expect(body).toMatch(/\(\+1 more links, open the dashboard to view\)/);
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    // Preview still fills remainder after the note-only Links block.
+    const previewLine = body.split('\n').find((line) => line.startsWith('Preview: '));
+    expect(previewLine).toBeDefined();
+    expect(previewLine!.slice('Preview: '.length).length).toBeGreaterThan(0);
+    expect(previewLine!.slice('Preview: '.length).length).toBeLessThanOrEqual(fullPreview.length);
+  });
+
+  test('tier 3 keeps small link preview and codes under budget (F88 regression)', () => {
+    const body = buildMailArrivalMessage('a@test.example', 3, true, {
+      subject: 'Your login code',
+      from: 'auth@example.com',
+      preview: 'Use the code below to finish signing in.',
+      codes: ['123456'],
+      links: ['https://example.com/verify?token=abc'],
+    });
+    expect(body).toContain('Codes: 123456');
+    expect(body).toContain('https://example.com/verify?token=abc');
+    expect(body).toContain('Preview: Use the code below to finish signing in.');
+    expect(body).toContain('Subject: Your login code');
+    expect(jsonEscapedByteLength(body)).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    const previewIdx = body.indexOf('\nPreview: ');
+    const codesIdx = body.indexOf('\nCodes: ');
+    const linksIdx = body.indexOf('\nLinks:\n');
+    expect(previewIdx).toBeGreaterThan(0);
+    expect(codesIdx).toBeGreaterThan(previewIdx);
+    expect(linksIdx).toBeGreaterThan(codesIdx);
   });
 
   test('tier 3 drops tail links with +N note under budget (F79)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -149,6 +149,53 @@ describe('mail-arrival notification watcher', () => {
     expect(calls[0].level).toBe('urgent');
   });
 
+  test('tier 2 masks OTP codes that appear in the subject line', async () => {
+    const subject = 'Your login code is 654321';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: Auth <auth@example.net>\r\nSubject: ${subject}\r\n\r\nYour verification code is 654321`,
+        subject,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).not.toContain('654321');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('Preview:');
+    expect(body).not.toContain('Codes:');
+  });
+
+  test('tier 3 still exposes Codes when the subject also contains the OTP', async () => {
+    const subject = 'Your login code is 654321';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nYour verification code is 654321`,
+        subject,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject: Your login code is 654321');
+    expect(body).toContain('Codes: 654321');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -677,6 +677,28 @@ describe('mail-arrival notification watcher', () => {
     expect(maskSensitiveFragments('code 1234-5678', ['12345678'], [])).toBe('code •••');
   });
 
+  test('maskSensitiveFragments masks full alnum before digit sub-runs (F91)', () => {
+    // Both forms in the code set: alnum first so `ABC-` is not left after digit pass.
+    expect(
+      maskSensitiveFragments('Your verification code is ABC-1234', ['1234', 'ABC-1234'], []),
+    ).toBe('Your verification code is •••');
+    expect(
+      maskSensitiveFragments('Your verification code is ABC-1234', ['1234', 'ABC-1234'], []),
+    ).not.toContain('ABC');
+    // Numeric-only / alnum-only / mixed+separate digit still work.
+    expect(maskSensitiveFragments('Your code is 1234', ['1234'], [])).toBe('Your code is •••');
+    expect(maskSensitiveFragments('Your code is ABC-1234', ['ABC-1234'], [])).toBe(
+      'Your code is •••',
+    );
+    expect(maskSensitiveFragments('codes ABC-1234 and 5678', ['ABC-1234', '5678'], [])).toBe(
+      'codes ••• and •••',
+    );
+    // Digit-only in codes against mixed text still half-masks (by design).
+    expect(maskSensitiveFragments('Your code is ABC-1234', ['1234'], [])).toBe(
+      'Your code is ABC-•••',
+    );
+  });
+
   test('maskTier2Metadata redacts delimited OTP in subject (F68)', () => {
     const masked = maskTier2Metadata({
       from: 'auth@example.net',
@@ -1108,6 +1130,30 @@ describe('mail-arrival notification watcher', () => {
     // Prior tight/space paths still work.
     expect(extractMetaAlnumCodes('Your code is ABC-123')).toEqual(['ABC-123']);
     expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
+  });
+
+  test('tier 2 push redacts full ABC-1234 when body also has 1234 (F91)', async () => {
+    // Body continuous digits + subject mixed alnum: both enter mask list; alnum
+    // must win so the subject does not publish an `ABC-` prefix leak.
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Your verification code is ABC-1234\r\n\r\nYour code is 1234. Thanks.',
+        'Your verification code is ABC-1234',
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('ABC');
+    expect(body).not.toContain('1234');
   });
 
   test('tier 2 masks fullwidth alnum OTP under strong cue (F86)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -18,6 +18,18 @@ const {
   PUSH_OTP_ENTRY_CHARS,
   PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
+const { NotifyError } = await import('../src/lib/notify.ts');
+
+/** Mock publish that honors beforeSend like NtfyNotificationService. */
+function publishWithBeforeSend(calls: any[]) {
+  return async (payload: any) => {
+    if (payload.beforeSend && !payload.beforeSend()) {
+      throw new NotifyError('notify_cancelled');
+    }
+    calls.push(payload);
+    return { target: payload.target, title: payload.title, level: payload.level };
+  };
+}
 
 const baseIdentities = [
   { address: 'target@test.example', createdAt: '2026-08-02T00:00:00.000Z' },
@@ -789,12 +801,7 @@ describe('mail-arrival notification watcher', () => {
       } as any,
       [alive, deleted],
       'otp',
-      {
-        publish: async (payload) => {
-          calls.push(payload);
-          return { target: payload.target, title: payload.title, level: payload.level };
-        },
-      },
+      { publish: publishWithBeforeSend(calls) },
       {
         // First recipient still live; second deleted mid-flight (after prior publish).
         refreshIdentity: (address) => (address === alive.address ? alive : undefined),
@@ -803,6 +810,91 @@ describe('mail-arrival notification watcher', () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].message).toContain('Subject:');
     expect(calls[0].message).not.toContain('Codes:');
+  });
+
+  test('beforeSend aborts when tier is downgraded after build (F47)', async () => {
+    const address = 'target@test.example';
+    let reads = 0;
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        'Verify',
+      ),
+      [{ address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 }],
+      'otp',
+      { publish: publishWithBeforeSend(calls) },
+      {
+        refreshIdentity: () => {
+          reads += 1;
+          // First read: build tier-3 body; beforeSend re-read: privacy tightened to tier 1.
+          if (reads === 1) {
+            return { address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 as const };
+          }
+          return { address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 1 as const };
+        },
+      },
+    );
+    expect(reads).toBe(2);
+    expect(calls).toHaveLength(0);
+  });
+
+  test('beforeSend keeps lower-tier body when tier is upgraded mid-flight', async () => {
+    const address = 'target@test.example';
+    let reads = 0;
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        'Verify',
+      ),
+      [{ address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 1 }],
+      'otp',
+      { publish: publishWithBeforeSend(calls) },
+      {
+        refreshIdentity: () => {
+          reads += 1;
+          if (reads === 1) {
+            return { address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 1 as const };
+          }
+          return { address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 as const };
+        },
+      },
+    );
+    expect(reads).toBe(2);
+    expect(calls).toHaveLength(1);
+    // Already-built tier-1 body is still safe under a higher floor.
+    expect(calls[0].message).not.toContain('Codes:');
+    expect(calls[0].message).not.toContain('Subject:');
+  });
+
+  test('beforeSend aborts when identity is deleted after build', async () => {
+    const address = 'target@test.example';
+    let reads = 0;
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        'Verify',
+      ),
+      [{ address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 }],
+      'otp',
+      { publish: publishWithBeforeSend(calls) },
+      {
+        refreshIdentity: () => {
+          reads += 1;
+          if (reads === 1) {
+            return { address, createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 3 as const };
+          }
+          return undefined;
+        },
+      },
+    );
+    expect(reads).toBe(2);
+    expect(calls).toHaveLength(0);
   });
 
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -302,6 +302,32 @@ describe('mail-arrival notification watcher', () => {
     expect(body.toLowerCase()).not.toContain('https://');
   });
 
+  test('tier 2 masks subject URLs when LINK_INTENT is only adjacent text', async () => {
+    // extractOtp requires intent in the URL itself; "Verify here:" is outside the URL.
+    const subject = 'Verify here: https://x.example/t/secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('x.example');
+    expect(body).not.toContain('/t/secret');
+    expect(body).not.toContain('https://');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1826,6 +1826,29 @@ describe('mail-arrival notification watcher', () => {
     expect(linksBlock).not.toMatch(/verify\?token=abc\)!/);
   });
 
+  test('tier 3 push keeps clean URL from closer-colon wrapper (F96)', async () => {
+    const mailBody =
+      'See this link (secure: https://example.com/verify?token=abc): Finish setup.';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: Verify\r\n\r\n${mailBody}`,
+        'Verify',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    const linksBlock = body.split('\nLinks:\n')[1] ?? '';
+    expect(linksBlock.split('\n')[0]).toBe('https://example.com/verify?token=abc');
+    expect(linksBlock).not.toMatch(/verify\?token=abc\):/);
+  });
+
   test('click field is present only when clickUrl is provided', async () => {
     const mail = message(
       'stranger@example.net',

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -781,6 +781,65 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('123456');
   });
 
+  test('maskSensitiveFragments masks NBSP-delimited OTP (F70)', () => {
+    const nbsp = '\u00A0';
+    const form = `123${nbsp}456`;
+    // Same spelling in the code set.
+    expect(maskSensitiveFragments(`code ${form}`, [form], [])).toBe('code •••');
+    // F69 canonical cross-form: continuous needle masks Unicode-space run.
+    expect(maskSensitiveFragments(`code ${form}`, ['123456'], [])).toBe('code •••');
+  });
+
+  test('maskTier2Metadata does not glue digits across from\\nsubject (F70)', () => {
+    // metaText is from + '\\n' + subject; newlines must not act as OTP separators.
+    // 4+4 across \\n would become one delimited form if \\n were a sep.
+    const masked = maskTier2Metadata({
+      from: 'user 1234',
+      subject: '5678 提醒',
+      codes: ['12345678'],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toBe('5678 提醒');
+    expect(masked.from).toBe('user 1234');
+  });
+
+  test('maskTier2Metadata masks subject NBSP form from body continuous (F70×F69)', () => {
+    const nbsp = '\u00A0';
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: `123${nbsp}456`,
+      codes: ['123456'],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toBe('•••');
+  });
+
+  test('tier 2 masks NBSP-delimited OTP in subject under policy=all (F70)', async () => {
+    const nbsp = '\u00A0';
+    const subject = `Your verification code is 123${nbsp}456`;
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('123');
+    expect(body).not.toContain(`${nbsp}456`);
+  });
+
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
     const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
       // 6-digit distinct codes that do not appear in the short subject.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1502,6 +1502,32 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is ABC.123')).toContain('ABC.123');
   });
 
+  test('tier 2 masks compatibility-form alnum OTP beyond fullwidth (F113)', () => {
+    // Circled letters/digits NFKC-normalize to A1B2: extract original spelling + mask.
+    expect(extractMetaAlnumCodes('Your verification code is Ⓐ①Ⓑ②')).toContain('Ⓐ①Ⓑ②');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is Ⓐ①Ⓑ②',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('Ⓐ①Ⓑ②');
+    // Lowercase circled + superscript digits (¹² NFKC → 12).
+    expect(extractMetaAlnumCodes('Your verification code is ⓐ¹ⓑ²')).toContain('ⓐ¹ⓑ²');
+    // Mathematical bold (surrogate-pair source) maps back to the right span.
+    expect(extractMetaAlnumCodes('Your verification code is 𝐀𝟏𝐁𝟐')).toContain('𝐀𝟏𝐁𝟐');
+    // Delimited compatibility form via the tight path.
+    expect(extractMetaAlnumCodes('Your verification code is Ⓐ①-Ⓑ②')).toContain('Ⓐ①-Ⓑ②');
+    // Multi-unit NFKC expansion (⑳ → 20) recovers the original span.
+    expect(extractMetaAlnumCodes('Your verification code is Ⓐ⑳Ⓑ')).toContain('Ⓐ⑳Ⓑ');
+    // Fullwidth fast path regression (same spelling, deduped across passes).
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ１Ｂ２')).toEqual(['Ａ１Ｂ２']);
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference Ⓐ①Ⓑ② attached')).toEqual([]);
+  });
+
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
     expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toContain('A1B-2C3');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -11,6 +11,9 @@ const {
   processWatchedMessage,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
+  PUSH_MESSAGE_MAX_CHARS,
+  PUSH_OTP_ENTRY_CHARS,
+  PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
 
 const baseIdentities = [
@@ -196,5 +199,59 @@ describe('mail-arrival notification watcher', () => {
         links: ['https://example.com'],
       }),
     ).toBe('a@test.example received new email');
+  });
+
+  test('tier 3 caps codes/links count, entry length, and total body size', async () => {
+    const longCode = '9'.repeat(PUSH_OTP_ENTRY_CHARS + 80);
+    const longLink = `https://example.com/verify?token=${'a'.repeat(PUSH_OTP_ENTRY_CHARS + 80)}`;
+    // Many keyword-adjacent codes so extractOtp returns a long list.
+    const codeLines = Array.from({ length: 20 }, (_, i) => {
+      const digits = String(100000 + i);
+      return `Your verification code is ${digits}`;
+    }).join('\n');
+    const linkLines = Array.from({ length: 20 }, (_, i) =>
+      `https://example.com/verify-login-${i}?token=${'z'.repeat(50)}`,
+    ).join('\n');
+    const calls = await dispatches(
+      message(
+        'flood@example.net',
+        `From: flood@example.net\r\nSubject: Flood\r\n\r\n${codeLines}\n${linkLines}\ncode ${longCode}\n${longLink}`,
+        'Flood',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body.length).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_CHARS);
+    // At most PUSH_OTP_ITEM_MAX codes appear after "Codes: ".
+    const codesLine = body.split('\n').find((line) => line.startsWith('Codes: '));
+    if (codesLine) {
+      const listed = codesLine.slice('Codes: '.length).split(', ');
+      expect(listed.length).toBeLessThanOrEqual(PUSH_OTP_ITEM_MAX);
+      for (const entry of listed) {
+        // Truncated entries end with …; raw length never exceeds cap+ellipsis.
+        expect(entry.replace(/…$/, '').length).toBeLessThanOrEqual(PUSH_OTP_ENTRY_CHARS);
+      }
+    }
+    const linkSection = body.includes('Links:\n') ? body.split('Links:\n')[1]! : '';
+    const linkEntries = linkSection.split('\n').filter(Boolean);
+    expect(linkEntries.length).toBeLessThanOrEqual(PUSH_OTP_ITEM_MAX);
+
+    // Direct builder path with deliberately huge inputs.
+    const huge = buildMailArrivalMessage('a@test.example', 3, true, {
+      subject: 'S'.repeat(500),
+      from: 'f'.repeat(500),
+      preview: 'p'.repeat(PUSH_BODY_PREVIEW_CHARS),
+      codes: Array.from({ length: 40 }, (_, i) => `${'1'.repeat(300)}${i}`),
+      links: Array.from({ length: 40 }, (_, i) => `https://example.com/${'x'.repeat(300)}/${i}`),
+    });
+    expect(huge.length).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_CHARS);
+    expect(huge.endsWith('…') || huge.length < PUSH_MESSAGE_MAX_CHARS).toBe(true);
   });
 });

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -348,6 +348,47 @@ describe('mail-arrival notification watcher', () => {
     expect(calls).toEqual([]);
   });
 
+  test('otp policy classifies strongly cued alphanumeric body codes (F137)', async () => {
+    // The only credential is an alnum code in the BODY (plain subject).
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Hello there\r\n\r\nYour verification code is A1B2C3, use it soon.',
+      ),
+      'otp',
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('urgent');
+    // Tier 1 (default): the code does not enter the payload.
+    expect(JSON.stringify(calls[0])).not.toContain('A1B2C3');
+
+    // Tier 3 lists the body code on the Codes line.
+    const tier3 = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Hello\r\n\r\nYour verification code is A1B2C3, use it soon.',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(tier3).toHaveLength(1);
+    expect(tier3[0].message).toContain('Codes: A1B2C3');
+
+    // Shouted words without any strong cue do not classify.
+    const prose = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: NOTES\r\n\r\nMEETING at noon, bring NOTES.',
+      ),
+      'otp',
+    );
+    expect(prose).toEqual([]);
+  });
+
   test('tier 3 merges subject credentials even when the body also matches (F119)', async () => {
     // Body has its own code while the subject carries a long signed URL: both
     // must reach the payload — the subject is truncated at the metadata cap,

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -538,6 +538,34 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('https://');
   });
 
+  test('tier 2 masks every link in an adjacent Markdown chain in the subject', async () => {
+    const subject =
+      '[Verify](https://a.example/verify)[Confirm](https://b.example/confirm)';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('a.example');
+    expect(body).not.toContain('b.example');
+    expect(body).not.toContain('https://');
+    // Markdown structure may remain between placeholders; URLs must not.
+    expect(body).toContain('[Verify](•••)[Confirm](•••)');
+  });
+
   test('tier 2 masks a subject code even when the body has many unrelated codes', () => {
     const bodyCodes = Array.from({ length: 100 }, (_, i) => String(100000 + i));
     const bodyText = bodyCodes.map((code) => `Your verification code is ${code}.`).join(' ');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1079,8 +1079,6 @@ describe('mail-arrival notification watcher', () => {
     // Prose locks: lowercase / title case must not extract.
     expect(extractMetaAlnumCodes('Your verification code is wxyz')).toEqual([]);
     expect(extractMetaAlnumCodes('Your verification code is Pending')).toEqual([]);
-    // Delimited letter-only remains out of scope.
-    expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toEqual([]);
     // Mixed regression anchor.
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toEqual(['ABC-123']);
 
@@ -1143,6 +1141,61 @@ describe('mail-arrival notification watcher', () => {
     expect(body).toContain('Subject:');
     expect(body).toContain('•••');
     expect(body).not.toContain('WXYZ');
+  });
+
+  test('tier 2 masks delimited letter-only OTP under strong cue (F97)', async () => {
+    expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toEqual(['WX-YZ']);
+    expect(extractMetaAlnumCodes('Your verification code is WX YZ')).toEqual(['WX YZ']);
+    expect(extractMetaAlnumCodes('Your verification code is AB-CD-EF')).toEqual(['AB-CD-EF']);
+    // Fullwidth letter-only delimited (NFKC uppercase groups).
+    expect(extractMetaAlnumCodes('您的验证码是 ＷＸ ＹＺ')).toEqual(['ＷＸ ＹＺ']);
+    expect(extractMetaAlnumCodes('您的验证码是 ＷＸ－ＹＺ')).toEqual(['ＷＸ－ＹＺ']);
+    // Continuous F95 anchor still works.
+    expect(extractMetaAlnumCodes('Your verification code is WXYZ')).toEqual(['WXYZ']);
+    // Prose / shape locks.
+    expect(extractMetaAlnumCodes('Your verification code is Wx-Yz')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is W-XYZ')).toEqual([]); // group <2
+    expect(extractMetaAlnumCodes('Your verification code is ABCDEFGHI-JK')).toEqual([]); // group >4
+    // 5-group space/tight runs rejected whole (F85 doctrine).
+    expect(extractMetaAlnumCodes('Your verification code is AB CD EF GH IJ')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is AB-CD-EF-GH-IJ')).toEqual([]);
+    expect(maskSensitiveFragments('Your verification code is WX-YZ', ['WX-YZ'], [])).toBe(
+      'Your verification code is •••',
+    );
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is WX-YZ',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is WX YZ',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+
+    const subject = 'Your verification code is WX-YZ';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('•••');
+    expect(body).not.toContain('WX-YZ');
+    expect(body).not.toContain('WX');
   });
 
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
@@ -1314,17 +1367,19 @@ describe('mail-arrival notification watcher', () => {
       preview: '',
     }).subject).toBe('Your code is •••');
 
-    // No digits → reject whole run (no mid-chain letter-only halves).
-    expect(extractMetaAlnumCodes('Your code is AB CD EF GH')).toEqual([]);
+    // F97: pure letter space runs (2–4 all-caps groups) are now accepted under cue.
+    expect(extractMetaAlnumCodes('Your code is AB CD EF GH')).toEqual(['AB CD EF GH']);
     expect(maskTier2Metadata({
       from: 'a@b.c',
       subject: 'Your code is AB CD EF GH',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your code is AB CD EF GH');
+    }).subject).toBe('Your code is •••');
+    // 5+ letter groups still rejected whole (same F85 consume-full-run doctrine).
+    expect(extractMetaAlnumCodes('Your code is AB CD EF GH IJ')).toEqual([]);
 
-    // 5+ groups rejected whole.
+    // 5+ digit-bearing groups rejected whole.
     expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4 E5')).toEqual([]);
     expect(maskTier2Metadata({
       from: 'a@b.c',

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -328,6 +328,59 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('https://');
   });
 
+  test('tier 2 masks bracketed IPv6 host URLs in the subject', async () => {
+    const subject = 'Verify https://[2001:db8::1]/confirm?token=secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('2001:db8::1');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('https://');
+  });
+
+  test('tier 2 masks a URL inside free brackets without swallowing the trailing ]', async () => {
+    // Outer [ ... ] is prose; only the bare URL is redacted.
+    const subject = 'Note [see https://example.com/verify?token=a]';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).toContain('[');
+    expect(body).toContain(']');
+    expect(body).not.toContain('example.com');
+    expect(body).not.toContain('token=a');
+    expect(body).not.toContain('https://');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -91,6 +91,27 @@ describe('mail-arrival notification watcher', () => {
     expect(unseenWatcherUids([10, 11, 12], watermark)).toEqual([12]);
   });
 
+  test('uidvalidity change re-anchors the watermark instead of starving mail (F111)', () => {
+    const watermark: { uid?: number; uidValidity?: bigint } = {};
+    // First sight of the mailbox: anchor at high-water, no replay.
+    expect(unseenWatcherUids([10, 11], watermark, 1000n)).toEqual([]);
+    expect(watermark.uid).toBe(11);
+    expect(watermark.uidValidity).toBe(1000n);
+    // Same generation: only strictly newer UIDs are unseen.
+    expect(unseenWatcherUids([10, 11, 12], watermark, 1000n)).toEqual([12]);
+    // INBOX recreated (new UIDVALIDITY): UIDs restart below the old watermark;
+    // re-anchor on the replacement generation instead of rejecting all of it.
+    expect(unseenWatcherUids([1, 2, 3], watermark, 2000n)).toEqual([]);
+    expect(watermark.uid).toBe(3);
+    expect(watermark.uidValidity).toBe(2000n);
+    // Mail delivered after the re-anchor flows again.
+    expect(unseenWatcherUids([1, 2, 3, 4], watermark, 2000n)).toEqual([4]);
+    // Legacy callers without uidValidity keep numeric-only behavior.
+    const legacy: { uid?: number } = {};
+    expect(unseenWatcherUids([5], legacy)).toEqual([]);
+    expect(unseenWatcherUids([5, 6], legacy)).toEqual([6]);
+  });
+
   test('external OTP mail alerts the user but can never wake an agent', async () => {
     const subject = 'private subject from outside';
     const calls = await dispatches(
@@ -130,6 +151,56 @@ describe('mail-arrival notification watcher', () => {
     expect(await dispatches(ordinary, 'otp')).toEqual([]);
     expect((await dispatches(ordinary, 'all')).map((call) => call.target)).toEqual(['user']);
     expect(await dispatches(ordinary, 'none')).toEqual([]);
+  });
+
+  test('otp policy classifies subject-only codes and links (F110)', async () => {
+    // Subject carries the code while the body is plain: must still alert.
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Your verification code is 123456\r\n\r\nHello there, no code in this body.',
+      ),
+      'otp',
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toBe('target@test.example received new email (contains OTP or verification link)');
+    expect(calls[0].level).toBe('urgent');
+    // Tier 1 (default): the subject code still does not enter the payload.
+    expect(JSON.stringify(calls[0])).not.toContain('123456');
+
+    // Envelope-subject fallback (no parseable source) classifies too.
+    const envelopeOnly = await dispatches(
+      {
+        envelope: {
+          from: [{ address: 'stranger@example.net' }],
+          to: [{ address: 'target@test.example' }],
+          subject: 'Your verification code is 654321',
+        },
+        headers: Buffer.from('Delivered-To: target@test.example\r\n'),
+      } as any,
+      'otp',
+    );
+    expect(envelopeOnly).toHaveLength(1);
+
+    // Subject verify-link without a body link alerts as well.
+    const linkCalls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: verify https://example.com/verify?token=abc123\r\n\r\nplain body',
+      ),
+      'otp',
+    );
+    expect(linkCalls).toHaveLength(1);
+
+    // No OTP in subject or body: still gated out.
+    const none = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: lunch tomorrow?\r\n\r\nsee you at noon',
+      ),
+      'otp',
+    );
+    expect(none).toEqual([]);
   });
 
   test('default push content tier is interrupt-only when unset', async () => {
@@ -1358,6 +1429,49 @@ describe('mail-arrival notification watcher', () => {
     // F85/F84 space path regressions.
     expect(extractMetaAlnumCodes('Your verification code is A1 B2 C3')).toContain('A1 B2 C3');
     expect(extractMetaAlnumCodes('Your code is ABC 123')).toContain('ABC 123');
+  });
+
+  test('tier 2 masks mixed-separator single-char chain OTP under strong cue (F109)', () => {
+    // Alternating space/tight chain bypasses both F105 and F106: extract + mask.
+    expect(extractMetaAlnumCodes('Your verification code is A 1-B 2')).toContain('A 1-B 2');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A 1-B 2',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('A 1-B 2');
+    // Alternating styles across the whole chain.
+    expect(extractMetaAlnumCodes('Your verification code is A-1 B-2 C-3')).toContain('A-1 B-2 C-3');
+    // Lowercase + fullwidth mixtures.
+    expect(extractMetaAlnumCodes('Your verification code is a 1-b 2')).toContain('a 1-b 2');
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ １-Ｂ ２')).toContain('Ａ １-Ｂ ２');
+    // Run stops before a following word: chain masks, word stays intact.
+    const prose = maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Your verification code is A 1-B 2 yesterday',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(prose.subject).toContain('yesterday');
+    expect(prose.subject).not.toContain('A 1-B 2');
+    // Shape locks: 3-group too short; 9+-group chain rejected whole (embedded
+    // pure-space 4-group runs may still extract via F106 — pre-existing).
+    expect(extractMetaAlnumCodes('Your verification code is A 1-B')).not.toContain('A 1-B');
+    expect(extractMetaAlnumCodes('Your verification code is A 1-B 2 C-3 D 4 E-5')).not.toContain(
+      'A 1-B 2 C-3 D 4 E-5',
+    );
+    // Letter-only / pure-digit mixed chains stay rejected (F105/F106 policy).
+    expect(extractMetaAlnumCodes('Your verification code is A B-C D')).not.toContain('A B-C D');
+    expect(extractMetaAlnumCodes('Your verification code is 1 2-3 4')).not.toContain('1 2-3 4');
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference A 1-B 2 attached')).toEqual([]);
+    // F105/F106 regressions: pure tight and pure space chains still extract.
+    expect(extractMetaAlnumCodes('Your verification code is A-1-B-2')).toContain('A-1-B-2');
+    expect(extractMetaAlnumCodes('Your verification code is A 1 B 2')).toContain('A 1 B 2');
   });
 
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -836,6 +836,44 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('100000');
   });
 
+  test('tier 1/2 prefers dropping the click over truncating the alert (F123)', () => {
+    // A ~3800-char DASHBOARD_PUBLIC_URL shrinks the with-click budget below
+    // the interrupt text; the click must go, not the alert.
+    const hugeClick = `https://dashboard.example.com/${'p'.repeat(3800)}`;
+    const tier1 = buildMailArrivalMessage(
+      'fox@example.com',
+      1,
+      false,
+      { subject: '', from: '', preview: '', codes: [], links: [] },
+      undefined,
+      { clickUrl: hugeClick },
+    );
+    expect(tier1).toBe('fox@example.com received new email');
+
+    const tier2 = buildMailArrivalMessage(
+      'fox@example.com',
+      2,
+      true,
+      { subject: 'hi', from: 'auth@example.com', preview: '', codes: [], links: [] },
+      undefined,
+      { clickUrl: hugeClick },
+    );
+    expect(tier2).toContain('fox@example.com received new email (contains OTP or verification link)');
+    expect(tier2).toContain('From: auth@example.com');
+    expect(tier2).not.toContain('…');
+
+    // Short click still fits alongside the body — no behavior change.
+    const withClick = buildMailArrivalMessage(
+      'fox@example.com',
+      1,
+      false,
+      { subject: '', from: '', preview: '', codes: [], links: [] },
+      undefined,
+      { clickUrl: 'https://dash.example.com' },
+    );
+    expect(withClick).toBe('fox@example.com received new email');
+  });
+
   test('maskSensitiveFragments masks digit runs present in the code set only', () => {
     expect(maskSensitiveFragments('plain subject', [], [])).toBe('plain subject');
     expect(maskSensitiveFragments('code 112233 and 445566', ['112233', '445566'], [])).toBe(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1042,6 +1042,54 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('A1B2C3');
   });
 
+  test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
+    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toEqual(['ABC-123']);
+    expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toEqual(['A1B-2C3']);
+    expect(extractMetaAlnumCodes('Your code is A1-B2-C3')).toEqual(['A1-B2-C3']);
+    expect(extractMetaAlnumCodes('Ref ABC-123 attached')).toEqual([]);
+    // 5+ groups rejected whole (no prefix half).
+    expect(extractMetaAlnumCodes('Your code is AB-12-CD-34-EF')).toEqual([]);
+    // Short English glue / year-ish space forms must not extract.
+    expect(extractMetaAlnumCodes('Your code is to A1B2')).toEqual(['A1B2']); // continuous only
+    expect(extractMetaAlnumCodes('Your code is to A1B2')).not.toContain('to A1B2');
+    expect(extractMetaAlnumCodes('Your verification code expires Mar 2026')).toEqual([]);
+    // Separator variants.
+    expect(extractMetaAlnumCodes('Your code is ABC.123')).toEqual(['ABC.123']);
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
+    expect(extractMetaAlnumCodes('Your code is ABC\uFF0D123')).toEqual(['ABC\uFF0D123']);
+
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is ABC-123',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '您的校验码是A1B-2C3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('您的校验码是•••');
+    expect(maskTier2Metadata({
+      from: 'shop@example.net',
+      subject: 'Ref ABC-123 attached',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Ref ABC-123 attached');
+    // Pure digit delimited still masks via digit path (not alnum channel).
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is 123-456',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(extractMetaAlnumCodes('Your verification code is 123-456')).toEqual([]);
+  });
+
   test('alnum mask uses one alternation regex (F83)', () => {
     const forms = ['A1B2C3', 'XY99ZZ', 'Ab12'];
     const re = buildAlnumMaskRe(forms);

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -381,6 +381,59 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('https://');
   });
 
+  test('tier 2 masks URLs that contain balanced parentheses before the query', async () => {
+    // Without paired-() support the match stops at confirm(foo and leaves )?token=secret.
+    const subject = 'Reset https://example.com/confirm(foo)?token=secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('confirm(foo');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('https://');
+  });
+
+  test('tier 2 masks a URL inside free parentheses without swallowing outer parens', async () => {
+    const subject = 'Note (see https://example.com/verify?token=a)';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).toContain('(');
+    expect(body).toContain(')');
+    expect(body).not.toContain('example.com');
+    expect(body).not.toContain('token=a');
+    expect(body).not.toContain('https://');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -874,6 +874,30 @@ describe('mail-arrival notification watcher', () => {
     expect(withClick).toBe('fox@example.com received new email');
   });
 
+  test('tier 3 repacks the preview when the click cannot survive the payload (F125)', () => {
+    // Head (address + capped From/Subject) alone exceeds the with-click
+    // budget, so publish() will drop the click regardless — the preview must
+    // be packed under the roomier no-click budget instead of being omitted.
+    const hugeClick = `https://dashboard.example.com/${'p'.repeat(3800)}`;
+    const body = buildMailArrivalMessage(
+      'fox@example.com',
+      3,
+      true,
+      {
+        subject: 'Your login code is 654321',
+        from: 'auth@example.com',
+        preview: 'Your verification code is 654321 — it expires in 10 minutes.',
+        codes: ['654321'],
+        links: [],
+      },
+      undefined,
+      { clickUrl: hugeClick },
+    );
+    expect(body).toContain('From: auth@example.com');
+    expect(body).toContain('Preview:');
+    expect(body).toContain('Codes: 654321');
+  });
+
   test('maskSensitiveFragments masks digit runs present in the code set only', () => {
     expect(maskSensitiveFragments('plain subject', [], [])).toBe('plain subject');
     expect(maskSensitiveFragments('code 112233 and 445566', ['112233', '445566'], [])).toBe(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -556,13 +556,14 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('100000');
   });
 
-  test('maskSensitiveFragments uses one-pass code replace and handles empty needles', () => {
+  test('maskSensitiveFragments masks digit runs present in the code set only', () => {
     expect(maskSensitiveFragments('plain subject', [], [])).toBe('plain subject');
     expect(maskSensitiveFragments('code 112233 and 445566', ['112233', '445566'], [])).toBe(
       'code ••• and •••',
     );
-    // Longest-first: overlapping would prefer longer if both listed.
-    expect(maskSensitiveFragments('code 11223399', ['1122', '112233'], [])).toBe('code •••99');
+    // Whole \b\d{4,8}\b run must be in the set — partial needles do not mask.
+    expect(maskSensitiveFragments('code 11223399', ['1122', '112233'], [])).toBe('code 11223399');
+    expect(maskSensitiveFragments('code 11223399', ['11223399'], [])).toBe('code •••');
     expect(maskSensitiveFragments('dup 1111 and 1111', ['1111', '1111'], [])).toBe(
       'dup ••• and •••',
     );
@@ -587,6 +588,97 @@ describe('mail-arrival notification watcher', () => {
     expect(performance.now() - started).toBeLessThan(1_000);
     expect(body).toContain('•••');
     expect(body).not.toContain('654321');
+  });
+
+  test('tier-2 build stays linear on a large subject full of keyword-adjacent codes', () => {
+    // 8000 distinct meta codes (~96KB folded subject) must not build a huge alternation.
+    const metaCodes = Array.from({ length: 8_000 }, (_, i) => String(100000 + i));
+    const subject = metaCodes.map((code) => `code ${code}`).join(' ');
+    expect(subject.length).toBeGreaterThan(80_000);
+    const started = performance.now();
+    const body = buildMailArrivalMessage('a@test.example', 2, true, {
+      subject,
+      from: 'auth@example.com',
+      preview: 'x'.repeat(280),
+      codes: ['654321'],
+      links: [],
+    });
+    expect(performance.now() - started).toBeLessThan(1_000);
+    expect(body).toContain('•••');
+    // Every 6-digit meta code should be masked; non-code digits would stay.
+    expect(body).not.toContain('100000');
+    expect(body).not.toContain('107999');
+  });
+
+  test('refreshIdentity is consulted after parsing so a tier downgrade is applied', async () => {
+    let reads = 0;
+    const snapshot = {
+      address: 'target@test.example',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 3 as const,
+    };
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\nVisit https://example.com/verify?token=abc\r\n',
+        'Verify',
+      ),
+      [snapshot],
+      'otp',
+      {
+        publish: async (payload) => {
+          calls.push(payload);
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+      {
+        refreshIdentity: () => {
+          reads += 1;
+          // First read after parse: still elevated; second path unused for one identity.
+          // Simulate admin downgrade completed during simpleParser await.
+          return {
+            address: 'target@test.example',
+            createdAt: '2026-08-02T00:00:00.000Z',
+            pushContentTier: 2 as const,
+          };
+        },
+      },
+    );
+    expect(reads).toBe(1);
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    // Tier 2: subject/from only, no preview/codes/links content.
+    expect(body).toContain('Subject:');
+    expect(body).not.toContain('Preview:');
+    expect(body).not.toContain('Codes:');
+    expect(body).not.toContain('Links:');
+    expect(body).not.toContain('482731');
+    expect(body).not.toContain('https://example.com/verify');
+  });
+
+  test('without refreshIdentity the snapshot tier is used unchanged', async () => {
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        'Verify',
+      ),
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+      'otp',
+      {
+        publish: async (payload) => {
+          calls.push(payload);
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+    );
+    expect(calls[0].message).toContain('Codes: 482731');
   });
 
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -656,11 +656,18 @@ describe('mail-arrival notification watcher', () => {
     expect(maskSensitiveFragments('dup 1111 and 1111', ['1111', '1111'], [])).toBe(
       'dup ••• and •••',
     );
-    // F68: delimited form only when the full original spelling is in the set.
+    // Full run's digit sequence must match the set — half-codes do not mask.
     expect(maskSensitiveFragments('Your verification code is 123-456', ['123-456'], [])).toBe(
       'Your verification code is •••',
     );
     expect(maskSensitiveFragments('code 123-456', ['123', '456'], [])).toBe('code 123-456');
+    // F69: same OTP across continuous vs delimited spelling (digit-only match).
+    expect(maskSensitiveFragments('code 123-456', ['123456'], [])).toBe('code •••');
+    expect(maskSensitiveFragments('code 123 456', ['123456'], [])).toBe('code •••');
+    expect(maskSensitiveFragments('code 123-789', ['123456'], [])).toBe('code 123-789');
+    // Reverse cross-form + 8-digit continuous ↔ 4+4 delimited.
+    expect(maskSensitiveFragments('code 123456', ['123-456'], [])).toBe('code •••');
+    expect(maskSensitiveFragments('code 1234-5678', ['12345678'], [])).toBe('code •••');
   });
 
   test('maskTier2Metadata redacts delimited OTP in subject (F68)', () => {
@@ -673,6 +680,31 @@ describe('mail-arrival notification watcher', () => {
     });
     expect(masked.subject).toBe('Your verification code is •••');
     expect(masked.subject).not.toContain('123-456');
+  });
+
+  test('maskTier2Metadata masks subject delimited form from body continuous (F69)', () => {
+    // Body extractCodes yields continuous; subject has separator and no keyword.
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '123-456',
+      codes: ['123456'],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toBe('•••');
+    expect(masked.subject).not.toContain('123-456');
+    expect(masked.subject).not.toContain('123456');
+  });
+
+  test('maskTier2Metadata masks subject continuous form from body delimited (F69)', () => {
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '123456',
+      codes: ['123-456'],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toBe('•••');
   });
 
   test('tier 2 masks delimited OTP in subject under policy=all (F68)', async () => {
@@ -698,6 +730,55 @@ describe('mail-arrival notification watcher', () => {
     expect(body).toContain('•••');
     expect(body).not.toContain('123-456');
     expect(body).toContain('(contains OTP or verification link)');
+  });
+
+  test('tier 2 masks subject delimited OTP from continuous body under otp policy (F69)', async () => {
+    // Body continuous with keyword → extractCodes ['123456']; subject is bare
+    // delimited with no cue (meta extractOtp empty). Canonical intersect must mask.
+    const subject = '123-456';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nYour verification code is 123456`,
+        subject,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('urgent');
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('123-456');
+    expect(body).not.toContain('123456');
+  });
+
+  test('tier 2 masks subject delimited OTP from continuous body under policy=all (F69)', async () => {
+    const subject = '123-456';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nYour verification code is 123456`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('123-456');
+    expect(body).not.toContain('123456');
   });
 
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -101,11 +101,14 @@ describe('mail-arrival notification watcher', () => {
     expect(unseenWatcherUids([10, 11, 12], watermark, 1000n)).toEqual([12]);
     // INBOX recreated (new UIDVALIDITY) on an already-observed mailbox: mail
     // may have landed during the disconnect, so every current UID is pending
-    // (F115); the watermark still re-anchors on the replacement generation.
+    // (F115); the new generation starts BELOW the pending UIDs and the watcher
+    // loop advances the watermark only after each message is processed (F118),
+    // so a transient failure retries the remainder instead of losing it.
     expect(unseenWatcherUids([1, 2, 3], watermark, 2000n)).toEqual([1, 2, 3]);
-    expect(watermark.uid).toBe(3);
+    expect(watermark.uid).toBe(0);
     expect(watermark.uidValidity).toBe(2000n);
-    // Mail delivered after the re-anchor flows again.
+    // Simulate the watcher loop's per-message advancement, then new mail flows.
+    watermark.uid = 3;
     expect(unseenWatcherUids([1, 2, 3, 4], watermark, 2000n)).toEqual([4]);
     // Legacy callers without uidValidity keep numeric-only behavior.
     const legacy: { uid?: number } = {};
@@ -243,6 +246,68 @@ describe('mail-arrival notification watcher', () => {
     );
     expect(codeCalls).toHaveLength(1);
     expect(codeCalls[0].message).toContain('Codes: 123456');
+  });
+
+  test('tier 3 merges subject credentials even when the body also matches (F119)', async () => {
+    // Body has its own code while the subject carries a long signed URL: both
+    // must reach the payload — the subject is truncated at the metadata cap,
+    // so a Links entry is the only usable form.
+    const subjectUrl = `https://example.com/verify?token=${'b'.repeat(500)}`;
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: also verify ${subjectUrl}\r\n\r\nYour verification code is 654321`,
+        `also verify ${subjectUrl}`,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Codes: 654321');
+    expect(body).toContain('Links:');
+    expect(body).toContain(subjectUrl);
+
+    // Duplicate subject/body credentials are not repeated in the payload.
+    const dupe = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Your verification code is 654321\r\n\r\nYour verification code is 654321',
+        'Your verification code is 654321',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(dupe).toHaveLength(1);
+    // Subject + Preview + Codes: the merged credential is not repeated on the
+    // Codes line even though subject and body extracted the same code.
+    expect(dupe[0].message.match(/654321/g)).toHaveLength(3);
+    expect(dupe[0].message.match(/Codes:/g)).toHaveLength(1);
+  });
+
+  test('tier 2 masking bounds metadata before compiling the alternation (F120)', () => {
+    // Strong cue + thousands of distinct tokens: extraction/masking runs on
+    // the publish-window prefix only, so output stays bounded (and fast —
+    // unfixed this compiled a ~5000-branch alternation per message).
+    const tokens = Array.from({ length: 5000 }, (_, i) => `tk${i.toString(36)}x`).join(' ');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: `Your verification code is 123456 ${tokens}`,
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('123456');
+    expect(masked.subject.length).toBeLessThanOrEqual(464);
   });
 
   test('default push content tier is interrupt-only when unset', async () => {
@@ -1542,6 +1607,32 @@ describe('mail-arrival notification watcher', () => {
     // Regression: hyphen/dot tight forms still extract.
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
     expect(extractMetaAlnumCodes('Your verification code is ABC.123')).toContain('ABC.123');
+  });
+
+  test('tier 2 masks colon-delimited alnum OTP under strong cue (F117)', () => {
+    // Colon-joined mixed groups: extract + mask.
+    expect(extractMetaAlnumCodes('Your verification code is AB:12:CD')).toContain('AB:12:CD');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is AB:12:CD',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('AB:12:CD');
+    // Fullwidth colon; colon single-char chain (4–8 groups).
+    expect(extractMetaAlnumCodes('您的验证码是 ＡＢ：１２')).toContain('ＡＢ：１２');
+    expect(extractMetaAlnumCodes('Your verification code is A:1:B:2')).toContain('A:1:B:2');
+    // Pure-digit colon forms (times) stay unextracted — no letter.
+    expect(extractMetaAlnumCodes('Your verification code is 12:30')).not.toContain('12:30');
+    // Letter-only lowercase colon words stay rejected.
+    expect(extractMetaAlnumCodes('Your verification code is ab:cd')).not.toContain('ab:cd');
+    // Regression: a tight form after a single `label:` still extracts
+    // (colon must not join the tight-class mid-chain guard).
+    expect(extractMetaAlnumCodes('code: ABC-123')).toContain('ABC-123');
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference AB:12:CD attached')).toEqual([]);
   });
 
   test('tier 2 masks compatibility-form alnum OTP beyond fullwidth (F113)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -247,6 +247,34 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('Codes:');
   });
 
+  test('tier 2 masks subject URLs whose original spelling differs from validatedHttpUrl form', async () => {
+    // extractOtp returns https://example.com/verify?token=secret (lower host, no :443);
+    // the subject keeps EXAMPLE.com:443 — exact string replace would miss it.
+    const subject = 'Confirm at https://EXAMPLE.com:443/verify?token=secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('EXAMPLE.com');
+    expect(body).not.toContain('example.com');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('https://');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1664,6 +1664,16 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is 08/07')).not.toContain('08/07');
     // Letter-only lowercase slash words stay rejected.
     expect(extractMetaAlnumCodes('Your verification code is and/or')).not.toContain('and/or');
+    // F128: pure-digit slash forms mask via the numeric extractor path.
+    const digitMasked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is 123/456',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(digitMasked.subject).toContain('•••');
+    expect(digitMasked.subject).not.toContain('123/456');
     // No cue: rejected.
     expect(extractMetaAlnumCodes('Reference A1/B2 attached')).toEqual([]);
     // Regression: hyphen/dot tight forms still extract.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1685,6 +1685,30 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Reference AB:12:CD attached')).toEqual([]);
   });
 
+  test('tier 2 masks underscore-delimited alnum OTP under strong cue (F124)', () => {
+    // Underscore-joined mixed groups: extract + mask.
+    expect(extractMetaAlnumCodes('Your verification code is AB_12')).toContain('AB_12');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is AB_12',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('AB_12');
+    // Three groups; single-char chain; fullwidth underscore.
+    expect(extractMetaAlnumCodes('Your verification code is AB_12_CD')).toContain('AB_12_CD');
+    expect(extractMetaAlnumCodes('Your verification code is A_1_B_2')).toContain('A_1_B_2');
+    expect(extractMetaAlnumCodes('您的验证码是 ＡＢ＿１２')).toContain('ＡＢ＿１２');
+    // snake_case words stay unextracted — letter-only joins drop.
+    expect(extractMetaAlnumCodes('Your verification code is otp_code')).not.toContain('otp_code');
+    // Pure-digit underscore forms (ids) stay unextracted — no letter.
+    expect(extractMetaAlnumCodes('Your verification code is 12_30')).not.toContain('12_30');
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference AB_12 attached')).toEqual([]);
+  });
+
   test('tier 2 masks compatibility-form alnum OTP beyond fullwidth (F113)', () => {
     // Circled letters/digits NFKC-normalize to A1B2: extract original spelling + mask.
     expect(extractMetaAlnumCodes('Your verification code is Ⓐ①Ⓑ②')).toContain('Ⓐ①Ⓑ②');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1674,6 +1674,31 @@ describe('mail-arrival notification watcher', () => {
     expect(calls[0].level).toBe('urgent');
   });
 
+  test('tier 3 push keeps clean URL from non-adjacent prose wrapper (F90)', async () => {
+    const mailBody =
+      'See this link (secure: https://example.com/verify?token=abc)! Finish setup.';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: Verify\r\n\r\n${mailBody}`,
+        'Verify',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    const linksBlock = body.split('\nLinks:\n')[1] ?? '';
+    expect(linksBlock).toContain('https://example.com/verify?token=abc');
+    // Links entry is clean; prose `)!` may still appear only in Preview (raw body).
+    expect(linksBlock.split('\n')[0]).toBe('https://example.com/verify?token=abc');
+    expect(linksBlock).not.toMatch(/verify\?token=abc\)!/);
+  });
+
   test('click field is present only when clickUrl is provided', async () => {
     const mail = message(
       'stranger@example.net',

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -434,6 +434,83 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('https://');
   });
 
+  test('tier 2 masks nested-parenthesis URLs whole (no truncated tail leak)', async () => {
+    const subject = 'Reset https://example.com/confirm(foo(bar))?token=secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('confirm');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('https://');
+  });
+
+  test('tier 2 masks Wikipedia-style paths with balanced underscores parens', async () => {
+    const subject = 'See https://en.wikipedia.org/wiki/Foo_(bar)';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('•••');
+    expect(body).not.toContain('wikipedia.org');
+    expect(body).not.toContain('Foo_');
+    expect(body).not.toContain('https://');
+  });
+
+  test('tier 2 peels free trailing ). and .) without leaving the URL half-masked', async () => {
+    for (const subject of [
+      'See https://example.com/verify?token=a).',
+      'See https://example.com/verify?token=a.)',
+    ]) {
+      const calls = await dispatches(
+        message(
+          'auth@example.net',
+          `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+          subject,
+        ),
+        'all',
+        [{
+          address: 'target@test.example',
+          createdAt: '2026-08-02T00:00:00.000Z',
+          pushContentTier: 2,
+        }],
+      );
+      expect(calls).toHaveLength(1);
+      const body = calls[0].message as string;
+      expect(body).toContain('•••');
+      expect(body).toContain(')');
+      expect(body).not.toContain('example.com');
+      expect(body).not.toContain('token=a');
+      expect(body).not.toContain('https://');
+    }
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -7,10 +7,13 @@ process.env.SMTP_PASS = 'smtp-secret';
 
 const { describe, expect, test } = await import('bun:test');
 const {
+  boundPushLinkEntries,
   boundPushMessage,
   buildMailArrivalMessage,
+  extractMetaAlnumCodes,
   maskSensitiveFragments,
   maskTier2Metadata,
+  packPushLinkLines,
   processWatchedMessage,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
@@ -965,6 +968,52 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('123456');
   });
 
+  test('tier 2 masks alnum OTP in subject with strong cue only (F77)', async () => {
+    expect(extractMetaAlnumCodes('Your verification code is A1B2C3')).toEqual(['A1B2C3']);
+    expect(extractMetaAlnumCodes('Order ABC12345 shipped')).toEqual([]);
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A1B2C3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'shop@example.net',
+      subject: 'Order ABC12345 shipped',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Order ABC12345 shipped');
+    // CJK strong cue glued to alnum (bounds are ASCII-alnum only).
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '您的校验码是A1B2C3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('您的校验码是•••');
+
+    const subject = 'Your verification code is A1B2C3';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('•••');
+    expect(body).not.toContain('A1B2C3');
+  });
+
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
     const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
       // 6-digit distinct codes that do not appear in the short subject.
@@ -1424,13 +1473,22 @@ describe('mail-arrival notification watcher', () => {
       const listed = codesLine.slice('Codes: '.length).split(', ');
       expect(listed.length).toBeLessThanOrEqual(PUSH_OTP_ITEM_MAX);
       for (const entry of listed) {
-        // Truncated entries end with …; raw length never exceeds cap+ellipsis.
+        // Truncated code entries end with …; raw length never exceeds cap+ellipsis.
         expect(entry.replace(/…$/, '').length).toBeLessThanOrEqual(PUSH_OTP_ENTRY_CHARS);
       }
     }
     const linkSection = body.includes('Links:\n') ? body.split('Links:\n')[1]! : '';
-    const linkEntries = linkSection.split('\n').filter(Boolean);
+    const linkEntries = linkSection
+      .split('\n')
+      .filter((line) => line && !line.startsWith('(+'));
     expect(linkEntries.length).toBeLessThanOrEqual(PUSH_OTP_ITEM_MAX);
+    // Links are never mid-truncated with … (F79); long verify links stay whole.
+    for (const entry of linkEntries) {
+      expect(entry.endsWith('…')).toBe(false);
+    }
+    if (body.includes(longLink.slice(0, 40))) {
+      expect(body).toContain(longLink);
+    }
 
     // Direct builder path with deliberately huge inputs.
     const huge = buildMailArrivalMessage('a@test.example', 3, true, {
@@ -1442,8 +1500,50 @@ describe('mail-arrival notification watcher', () => {
     });
     expect(Buffer.byteLength(huge, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
     expect(
-      huge.endsWith('…') || Buffer.byteLength(huge, 'utf8') < PUSH_MESSAGE_MAX_BYTES,
+      huge.endsWith('…') || Buffer.byteLength(huge, 'utf8') < PUSH_MESSAGE_MAX_BYTES || huge.includes('more links'),
     ).toBe(true);
+  });
+
+  test('tier 3 keeps full verification links over 200 chars (F79)', () => {
+    const longLink = `https://example.com/verify?token=${'a'.repeat(PUSH_OTP_ENTRY_CHARS + 80)}&sig=${'b'.repeat(40)}`;
+    expect(longLink.length).toBeGreaterThan(PUSH_OTP_ENTRY_CHARS);
+    expect(boundPushLinkEntries([longLink])).toEqual([longLink]);
+
+    const body = buildMailArrivalMessage('a@test.example', 3, true, {
+      subject: 'Verify',
+      from: 'auth@example.com',
+      preview: 'hi',
+      codes: [],
+      links: [longLink],
+    });
+    expect(body).toContain(longLink);
+    expect(body).not.toContain(`${longLink.slice(0, PUSH_OTP_ENTRY_CHARS)}…`);
+  });
+
+  test('tier 3 drops tail links with +N note under budget (F79)', () => {
+    const links = Array.from(
+      { length: 12 },
+      (_, i) => `https://example.com/verify?token=${'z'.repeat(180)}&i=${i}`,
+    );
+    const packed = packPushLinkLines(
+      'a@test.example received new email\nFrom: x\nSubject: y\nPreview: p',
+      links,
+    );
+    const linksBlock = packed.find((line) => line.startsWith('Links:\n'));
+    expect(linksBlock).toBeDefined();
+    const keptUrls = linksBlock!.slice('Links:\n'.length).split('\n').filter(Boolean);
+    expect(keptUrls.length).toBeGreaterThan(0);
+    expect(keptUrls.length).toBeLessThanOrEqual(PUSH_OTP_ITEM_MAX);
+    for (const url of keptUrls) {
+      expect(links).toContain(url);
+      expect(url.endsWith('…')).toBe(false);
+      expect(url.startsWith('https://example.com/verify?token=')).toBe(true);
+    }
+    const note = packed.find((line) => line.startsWith('(+'));
+    expect(note).toMatch(/\(\+\d+ more links, open the dashboard to view\)/);
+    const n = Number(note!.match(/\+(\d+)/)?.[1]);
+    expect(n).toBe(links.length - keptUrls.length);
+    expect(n).toBeGreaterThan(0);
   });
 
   test('boundPushMessage caps UTF-8 bytes and truncates on a code-point boundary', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -511,6 +511,32 @@ describe('mail-arrival notification watcher', () => {
     }
   });
 
+  test('tier 2 masks URLs that contain a legal apostrophe before the token', async () => {
+    // BARE_URL_RE used to exclude '; match stopped at confirm? and leaked 'token=secret.
+    const subject = "Reset https://example.com/confirm?'token=secret";
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('confirm');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('https://');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -389,6 +389,36 @@ describe('mail-arrival notification watcher', () => {
     expect(prose).toEqual([]);
   });
 
+  test('tier 2 masks metadata repeats of body-derived alnum codes (F138)', async () => {
+    // The body-derived code repeats in a cue-less subject: no cue, no digit
+    // run, so the digit-canon filter alone published the subject unchanged.
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Reference A1B2\r\n\r\nYour verification code is A1B2.',
+        'Reference A1B2',
+      ),
+      'otp',
+      [{ address: 'target@test.example', createdAt: '2026-08-02T00:00:00.000Z', pushContentTier: 2 }],
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toContain('•••');
+    expect(calls[0].message).not.toContain('A1B2');
+  });
+
+  test('body codes beyond the cue window do not classify (F139)', async () => {
+    // One cue near the start of a huge body: extraction is bounded to cue
+    // windows, so a code-shaped token far past the window is not a signal.
+    const far = await dispatches(
+      message(
+        'stranger@example.net',
+        `From: stranger@example.net\r\nSubject: hi\r\n\r\nYour verification code expires soon. ${'x'.repeat(2000)} A1B2C3`,
+      ),
+      'otp',
+    );
+    expect(far).toEqual([]);
+  });
+
   test('tier 3 merges subject credentials even when the body also matches (F119)', async () => {
     // Body has its own code while the subject carries a long signed URL: both
     // must reach the payload — the subject is truncated at the metadata cap,

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1013,7 +1013,7 @@ describe('mail-arrival notification watcher', () => {
       links: [],
       preview: '',
     }).subject).toBe('Order AB12 shipped');
-    // CJK strong cue glued to alnum (bounds are ASCII-alnum only).
+    // CJK strong cue glued to alnum (bounds exclude CJK; fullwidth Latin is in-class).
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: '您的校验码是A1B2C3',
@@ -1088,6 +1088,52 @@ describe('mail-arrival notification watcher', () => {
       preview: '',
     }).subject).toBe('Your verification code is •••');
     expect(extractMetaAlnumCodes('Your verification code is 123-456')).toEqual([]);
+  });
+
+  test('tier 2 masks fullwidth alnum OTP under strong cue (F86)', () => {
+    // Fullwidth mixed continuous.
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ１Ｂ２Ｃ３')).toEqual(['Ａ１Ｂ２Ｃ３']);
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '您的验证码是 Ａ１Ｂ２Ｃ３',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('您的验证码是 •••');
+    // Half/fullwidth mixed run (same char class).
+    expect(extractMetaAlnumCodes('您的验证码是 A1Ｂ2Ｃ3')).toEqual(['A1Ｂ2Ｃ3']);
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '您的验证码是 A1Ｂ2Ｃ3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('您的验证码是 •••');
+    // English cue + fullwidth.
+    expect(extractMetaAlnumCodes('Your verification code is ＡＢＣ１２３')).toEqual(['ＡＢＣ１２３']);
+    expect(maskTier2Metadata({
+      from: 'a@b.c',
+      subject: 'Your verification code is ＡＢＣ１２３',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    // No strong cue.
+    expect(extractMetaAlnumCodes('编号 Ａ１Ｂ２Ｃ３ 见附')).toEqual([]);
+    // Pure fullwidth digits stay on digit path (not alnum extract).
+    expect(extractMetaAlnumCodes('您的验证码是 １２３４５６')).toEqual([]);
+    expect(maskTier2Metadata({
+      from: 'a@b.c',
+      subject: '您的验证码是 １２３４５６',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('您的验证码是 •••');
+    // CJK red line: no alnum extract from pure Chinese.
+    expect(extractMetaAlnumCodes('验证码是您发的')).toEqual([]);
+    // Exact original spelling: fullwidth extract does not mask halfwidth form.
+    expect(maskSensitiveFragments('code A1B2C3', ['Ａ１Ｂ２Ｃ３'], [])).toBe('code A1B2C3');
+    expect(maskSensitiveFragments('code Ａ１Ｂ２Ｃ３', ['Ａ１Ｂ２Ｃ３'], [])).toBe('code •••');
   });
 
   test('space-separated alnum runs mask whole chain not halves (F85)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -7,11 +7,12 @@ process.env.SMTP_PASS = 'smtp-secret';
 
 const { describe, expect, test } = await import('bun:test');
 const {
+  boundPushMessage,
   buildMailArrivalMessage,
   processWatchedMessage,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
-  PUSH_MESSAGE_MAX_CHARS,
+  PUSH_MESSAGE_MAX_BYTES,
   PUSH_OTP_ENTRY_CHARS,
   PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
@@ -228,7 +229,7 @@ describe('mail-arrival notification watcher', () => {
 
     expect(calls).toHaveLength(1);
     const body = calls[0].message as string;
-    expect(body.length).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_CHARS);
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
     // At most PUSH_OTP_ITEM_MAX codes appear after "Codes: ".
     const codesLine = body.split('\n').find((line) => line.startsWith('Codes: '));
     if (codesLine) {
@@ -251,7 +252,29 @@ describe('mail-arrival notification watcher', () => {
       codes: Array.from({ length: 40 }, (_, i) => `${'1'.repeat(300)}${i}`),
       links: Array.from({ length: 40 }, (_, i) => `https://example.com/${'x'.repeat(300)}/${i}`),
     });
-    expect(huge.length).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_CHARS);
-    expect(huge.endsWith('…') || huge.length < PUSH_MESSAGE_MAX_CHARS).toBe(true);
+    expect(Buffer.byteLength(huge, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    expect(
+      huge.endsWith('…') || Buffer.byteLength(huge, 'utf8') < PUSH_MESSAGE_MAX_BYTES,
+    ).toBe(true);
+  });
+
+  test('boundPushMessage caps UTF-8 bytes and truncates on a code-point boundary', () => {
+    // ~2000 CJK (3 bytes each) + emoji (4 bytes) far exceed 3500 bytes while
+    // looking "short" under String.length.
+    const multiByte = `${'验证码通知'.repeat(400)}${'😀'.repeat(50)}`;
+    expect(multiByte.length).toBeLessThan(PUSH_MESSAGE_MAX_BYTES);
+    expect(Buffer.byteLength(multiByte, 'utf8')).toBeGreaterThan(PUSH_MESSAGE_MAX_BYTES);
+
+    const capped = boundPushMessage(multiByte);
+    expect(Buffer.byteLength(capped, 'utf8')).toBeLessThanOrEqual(PUSH_MESSAGE_MAX_BYTES);
+    expect(capped.endsWith('…')).toBe(true);
+    expect(capped).not.toContain('\uFFFD');
+    // No dangling high/low surrogates after truncation.
+    expect(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(capped)).toBe(
+      false,
+    );
+
+    // Walked body must re-encode cleanly (round-trip through UTF-8).
+    expect(Buffer.from(capped, 'utf8').toString('utf8')).toBe(capped);
   });
 });

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -196,6 +196,57 @@ describe('mail-arrival notification watcher', () => {
     expect(body).toContain('Codes: 654321');
   });
 
+  test('tier 2 masks a code that appears only in the subject (policy=all, plain body)', async () => {
+    // Body has no OTP — extras.codes is empty; needles must come from meta extractOtp.
+    const subject = 'Your login code is 654321';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).not.toContain('654321');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('Codes:');
+  });
+
+  test('tier 2 masks a subject-only code when body only has a verification link', async () => {
+    // otp policy fires because of the link; the code lives only in the subject.
+    const subject = 'Your login code is 654321';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nVisit https://example.com/verify?token=abc to continue.`,
+        subject,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).not.toContain('654321');
+    expect(body).toContain('•••');
+    // Link may also appear in subject only if it was there; body link is not in Subject.
+    expect(body).not.toContain('Codes:');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -868,6 +868,33 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('123');
   });
 
+  test('maskSensitiveFragments masks three-group OTP via canonical digits (F73)', () => {
+    expect(maskSensitiveFragments('code 12 34 56', ['123456'], [])).toBe('code •••');
+    expect(maskSensitiveFragments('code 12 34 99', ['123456'], [])).toBe('code 12 34 99');
+  });
+
+  test('tier 2 masks three-group OTP in subject under policy=all (F73)', async () => {
+    const subject = 'Your code is 12 34 56';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('12 34 56');
+  });
+
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
     const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
       // 6-digit distinct codes that do not appear in the short subject.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -895,6 +895,45 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('12 34 56');
   });
 
+  test('maskSensitiveFragments masks full four-group form only (F74)', () => {
+    expect(maskSensitiveFragments('code 12 34 56 78', ['12345678'], [])).toBe('code •••');
+    // Shorter canonical must not partial-mask a four-group run.
+    expect(maskSensitiveFragments('code 12 34 56 78', ['123456'], [])).toBe('code 12 34 56 78');
+    expect(maskSensitiveFragments('code 12 34 56 78', ['123456'], [])).not.toContain('•••');
+    // Five+ groups are not a code run at all (including prefix-canon needles).
+    expect(maskSensitiveFragments('code 12 34 56 78 90', ['1234567890'], [])).toBe(
+      'code 12 34 56 78 90',
+    );
+    expect(maskSensitiveFragments('code 12 34 56 78 90', ['12345678'], [])).toBe(
+      'code 12 34 56 78 90',
+    );
+    expect(maskSensitiveFragments('code 12 34 56 78 90', ['12345678'], [])).not.toContain('•••');
+  });
+
+  test('tier 2 masks four-group OTP in subject under policy=all (F74)', async () => {
+    const subject = 'Your verification code is 12 34 56 78';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('12 34 56 78');
+    expect(body).not.toContain('12 34 56');
+    expect(body).not.toContain('78');
+  });
+
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
     const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
       // 6-digit distinct codes that do not appear in the short subject.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -574,8 +574,9 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('a.example');
     expect(body).not.toContain('b.example');
     expect(body).not.toContain('https://');
-    // Markdown structure may remain between placeholders; URLs must not.
-    expect(body).toContain('[Verify](•••)[Confirm](•••)');
+    // F54: chain glue (including label) is redacted with the URLs.
+    expect(body).toContain('[Verify](•••••••••)');
+    expect(body).not.toContain('Confirm');
   });
 
   test('tier 2 masks a full URL that contains an unbalanced ) mid-path', async () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1624,6 +1624,18 @@ describe('mail-arrival notification watcher', () => {
     // Fullwidth colon; colon single-char chain (4–8 groups).
     expect(extractMetaAlnumCodes('您的验证码是 ＡＢ：１２')).toContain('ＡＢ：１２');
     expect(extractMetaAlnumCodes('Your verification code is A:1:B:2')).toContain('A:1:B:2');
+    // F121: nonbreaking hyphen (U+2011) and its NFKC form (U+2010) mask too.
+    expect(extractMetaAlnumCodes('Your verification code is AB\u201112')).toContain('AB\u201112');
+    expect(extractMetaAlnumCodes('Your verification code is AB\u201012')).toContain('AB\u201012');
+    const nbMasked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is AB\u201112',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(nbMasked.subject).not.toContain('AB\u201112');
+    expect(nbMasked.subject).toContain('•••');
     // Pure-digit colon forms (times) stay unextracted — no letter.
     expect(extractMetaAlnumCodes('Your verification code is 12:30')).not.toContain('12:30');
     // Letter-only lowercase colon words stay rejected.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -7,8 +7,10 @@ process.env.SMTP_PASS = 'smtp-secret';
 
 const { describe, expect, test } = await import('bun:test');
 const {
+  boundPreviewChars,
   boundPushLinkEntries,
   boundPushMessage,
+  buildAlnumMaskRe,
   buildMailArrivalMessage,
   extractMetaAlnumCodes,
   maskSensitiveFragments,
@@ -968,12 +970,31 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('123456');
   });
 
-  test('tier 2 masks alnum OTP in subject with strong cue only (F77)', async () => {
+  test('tier 2 masks alnum OTP in subject with strong cue only (F77/F81)', async () => {
     expect(extractMetaAlnumCodes('Your verification code is A1B2C3')).toEqual(['A1B2C3']);
     expect(extractMetaAlnumCodes('Order ABC12345 shipped')).toEqual([]);
+    // F81: 4–5 char mixed alnum under strong cue; 3-char stays out.
+    expect(extractMetaAlnumCodes('Your verification code is A1B2')).toEqual(['A1B2']);
+    expect(extractMetaAlnumCodes('Your verification code is AB12')).toEqual(['AB12']);
+    expect(extractMetaAlnumCodes('Your verification code is A1B')).toEqual([]);
+    expect(extractMetaAlnumCodes('Order AB12 shipped')).toEqual([]);
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is A1B2C3',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A1B2',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is AB12',
       codes: [],
       links: [],
       preview: '',
@@ -985,6 +1006,13 @@ describe('mail-arrival notification watcher', () => {
       links: [],
       preview: '',
     }).subject).toBe('Order ABC12345 shipped');
+    expect(maskTier2Metadata({
+      from: 'shop@example.net',
+      subject: 'Order AB12 shipped',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Order AB12 shipped');
     // CJK strong cue glued to alnum (bounds are ASCII-alnum only).
     expect(maskTier2Metadata({
       from: 'auth@example.net',
@@ -1012,6 +1040,68 @@ describe('mail-arrival notification watcher', () => {
     const body = calls[0].message as string;
     expect(body).toContain('•••');
     expect(body).not.toContain('A1B2C3');
+  });
+
+  test('alnum mask uses one alternation regex (F83)', () => {
+    const forms = ['A1B2C3', 'XY99ZZ', 'Ab12'];
+    const re = buildAlnumMaskRe(forms);
+    expect(re).not.toBeNull();
+    // Single pattern with all three forms (longest-first).
+    expect(re!.source).toContain('A1B2C3');
+    expect(re!.source).toContain('XY99ZZ');
+    expect(re!.source).toContain('Ab12');
+    expect(re!.source.indexOf('A1B2C3')).toBeLessThan(re!.source.indexOf('Ab12'));
+    // Exactly one alnum alternation replace (not one pass per token).
+    const text = 'code A1B2C3 and XY99ZZ and Ab12 again A1B2C3';
+    let alnumReplaceCalls = 0;
+    const originalReplace = String.prototype.replace;
+    String.prototype.replace = function (
+      this: string,
+      searchValue: string | RegExp,
+      ...rest: unknown[]
+    ) {
+      if (
+        searchValue instanceof RegExp &&
+        searchValue.source.includes('(?:') &&
+        searchValue.source.includes('A1B2C3') &&
+        searchValue.source.includes('XY99ZZ')
+      ) {
+        alnumReplaceCalls += 1;
+      }
+      return (originalReplace as (s: string | RegExp, ...r: unknown[]) => string).apply(
+        this,
+        [searchValue, ...rest],
+      );
+    };
+    let masked: string;
+    try {
+      masked = maskSensitiveFragments(text, forms, []);
+    } finally {
+      String.prototype.replace = originalReplace;
+    }
+    expect(alnumReplaceCalls).toBe(1);
+    expect(masked).toBe('code ••• and ••• and ••• again •••');
+    // Case-sensitive exact spelling (AB12 ≠ Ab12).
+    expect(maskSensitiveFragments('code AB12', ['Ab12'], [])).toBe('code AB12');
+    expect(maskSensitiveFragments('code Ab12', ['Ab12'], [])).toBe('code •••');
+    expect(buildAlnumMaskRe([])).toBeNull();
+  });
+
+  test('preview truncates on code-point boundaries (F82)', () => {
+    const emoji = '😀'; // one code point, two UTF-16 units
+    expect(emoji.length).toBe(2);
+    // 279 ASCII + emoji → maxChars=280 keeps the full emoji (no lone surrogate).
+    const text = `${'a'.repeat(279)}${emoji}${'b'.repeat(10)}`;
+    const preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
+    expect([...preview].length).toBe(PUSH_BODY_PREVIEW_CHARS);
+    expect(preview.endsWith(emoji)).toBe(true);
+    expect(preview).not.toMatch(/[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/);
+    // Short text unchanged.
+    expect(boundPreviewChars('hi', PUSH_BODY_PREVIEW_CHARS)).toBe('hi');
+    // Cap mid-string still code-point safe when cut falls before emoji.
+    const cutBefore = boundPreviewChars(`${'a'.repeat(280)}${emoji}`, PUSH_BODY_PREVIEW_CHARS);
+    expect(cutBefore).toBe('a'.repeat(280));
+    expect(cutBefore).not.toContain(emoji);
   });
 
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -734,6 +734,77 @@ describe('mail-arrival notification watcher', () => {
     expect(calls[0].message).toContain('Codes: 482731');
   });
 
+  test('refreshIdentity undefined skips deleted recipient (F46)', async () => {
+    const calls: any[] = [];
+    await processWatchedMessage(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        'Verify',
+      ),
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+      'otp',
+      {
+        publish: async (payload) => {
+          calls.push(payload);
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+      {
+        refreshIdentity: () => undefined,
+      },
+    );
+    expect(calls).toHaveLength(0);
+  });
+
+  test('refreshIdentity skip is per-recipient; live sibling still publishes', async () => {
+    const alive = {
+      address: 'alive@test.example',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 2 as const,
+    };
+    const deleted = {
+      address: 'deleted@test.example',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      pushContentTier: 3 as const,
+    };
+    const calls: any[] = [];
+    await processWatchedMessage(
+      {
+        envelope: {
+          from: [{ name: 'auth', address: 'auth@example.net' }],
+          to: [{ address: alive.address }, { address: deleted.address }],
+          subject: 'Verify',
+        },
+        headers: Buffer.from(
+          `Delivered-To: ${alive.address}\r\nDelivered-To: ${deleted.address}\r\n`,
+        ),
+        source: Buffer.from(
+          'From: auth@example.net\r\nSubject: Verify\r\n\r\nYour verification code is 482731\r\n',
+        ),
+      } as any,
+      [alive, deleted],
+      'otp',
+      {
+        publish: async (payload) => {
+          calls.push(payload);
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+      {
+        // First recipient still live; second deleted mid-flight (after prior publish).
+        refreshIdentity: (address) => (address === alive.address ? alive : undefined),
+      },
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toContain('Subject:');
+    expect(calls[0].message).not.toContain('Codes:');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -6,32 +6,49 @@ process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
 
 const { describe, expect, test } = await import('bun:test');
-const { processWatchedMessage, unseenWatcherUids } = await import('../src/lib/notification-watcher.ts');
+const {
+  buildMailArrivalMessage,
+  processWatchedMessage,
+  unseenWatcherUids,
+  PUSH_BODY_PREVIEW_CHARS,
+} = await import('../src/lib/notification-watcher.ts');
 
-const identities = [
+const baseIdentities = [
   { address: 'target@test.example', createdAt: '2026-08-02T00:00:00.000Z' },
   { address: 'sender@test.example', createdAt: '2026-08-02T00:00:00.000Z' },
 ];
 
-function message(from: string, source: string) {
+function message(from: string, source: string, subject = '') {
   return {
     envelope: {
-      from: [{ address: from }],
+      from: [{ name: from.includes('@') ? from.split('@')[0] : from, address: from }],
       to: [{ address: 'target@test.example' }],
+      subject,
     },
     headers: Buffer.from('Delivered-To: target@test.example\r\n'),
     source: Buffer.from(source),
   } as any;
 }
 
-async function dispatches(input: any, policy: 'otp' | 'all' | 'none') {
+async function dispatches(
+  input: any,
+  policy: 'otp' | 'all' | 'none',
+  identities = baseIdentities,
+  options: { clickUrl?: string } = {},
+) {
   const calls: any[] = [];
-  await processWatchedMessage(input, identities, policy, {
-    publish: async (payload) => {
-      calls.push(payload);
-      return { target: payload.target, title: payload.title, level: payload.level };
+  await processWatchedMessage(
+    input,
+    identities,
+    policy,
+    {
+      publish: async (payload) => {
+        calls.push(payload);
+        return { target: payload.target, title: payload.title, level: payload.level };
+      },
     },
-  });
+    options,
+  );
   return calls;
 }
 
@@ -48,15 +65,22 @@ describe('mail-arrival notification watcher', () => {
   test('external OTP mail alerts the user but can never wake an agent', async () => {
     const subject = 'private subject from outside';
     const calls = await dispatches(
-      message('stranger@example.net', `From: stranger@example.net\r\nSubject: ${subject}\r\n\r\nYour verification code is 482731`),
+      message(
+        'stranger@example.net',
+        `From: stranger@example.net\r\nSubject: ${subject}\r\n\r\nYour verification code is 482731`,
+        subject,
+      ),
       'otp',
     );
 
     expect(calls).toHaveLength(1);
     expect(calls[0].target).toBe('user');
     expect(calls[0].message).toBe('target@test.example received new email (contains OTP or verification link)');
+    expect(calls[0].level).toBe('urgent');
+    // Tier 1 (default): no subject, sender, or code content in the payload.
     expect(JSON.stringify(calls[0])).not.toContain(subject);
     expect(JSON.stringify(calls[0])).not.toContain('stranger@example.net');
+    expect(JSON.stringify(calls[0])).not.toContain('482731');
   });
 
   test('a forged local From header still cannot wake the target agent', async () => {
@@ -75,5 +99,102 @@ describe('mail-arrival notification watcher', () => {
     expect(await dispatches(ordinary, 'otp')).toEqual([]);
     expect((await dispatches(ordinary, 'all')).map((call) => call.target)).toEqual(['user']);
     expect(await dispatches(ordinary, 'none')).toEqual([]);
+  });
+
+  test('default push content tier is interrupt-only when unset', async () => {
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Secret\r\n\r\nYour verification code is 111222',
+        'Secret',
+      ),
+      'otp',
+      [{ address: 'target@test.example', createdAt: '2026-08-02T00:00:00.000Z' }],
+    );
+    expect(calls[0].message).toBe(
+      'target@test.example received new email (contains OTP or verification link)',
+    );
+    expect(calls[0].message).not.toContain('Subject:');
+    expect(calls[0].message).not.toContain('111222');
+  });
+
+  test('tier 2 adds subject and sender, still omits body and OTP', async () => {
+    const subject = 'Login code';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: Auth <auth@example.net>\r\nSubject: ${subject}\r\n\r\nYour verification code is 654321`,
+        subject,
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].message).toContain('target@test.example received new email (contains OTP or verification link)');
+    expect(calls[0].message).toContain('From:');
+    expect(calls[0].message).toContain('auth@example.net');
+    expect(calls[0].message).toContain(`Subject: ${subject}`);
+    expect(calls[0].message).not.toContain('654321');
+    expect(calls[0].message).not.toContain('Preview:');
+    expect(calls[0].level).toBe('urgent');
+  });
+
+  test('tier 3 adds bounded preview plus OTP codes and links', async () => {
+    const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: Verify\r\n\r\n${longBody}`,
+        'Verify',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject: Verify');
+    expect(body).toContain('From:');
+    expect(body).toContain('Preview:');
+    expect(body).toContain('Codes: 998877');
+    expect(body).toContain('https://example.com/verify?token=abc');
+    const previewLine = body.split('\n').find((line) => line.startsWith('Preview: '))!;
+    expect(previewLine.slice('Preview: '.length).length).toBeLessThanOrEqual(PUSH_BODY_PREVIEW_CHARS);
+    expect(calls[0].level).toBe('urgent');
+  });
+
+  test('click field is present only when clickUrl is provided', async () => {
+    const mail = message(
+      'stranger@example.net',
+      'From: stranger@example.net\r\n\r\nYour verification code is 482731',
+    );
+    const without = await dispatches(mail, 'otp');
+    expect(without[0].click).toBeUndefined();
+
+    const withClick = await dispatches(mail, 'otp', baseIdentities, {
+      clickUrl: 'https://mail.example.com/ui',
+    });
+    expect(withClick[0].click).toBe('https://mail.example.com/ui');
+  });
+
+  test('buildMailArrivalMessage stays interrupt-only at tier 1', () => {
+    expect(
+      buildMailArrivalMessage('a@test.example', 1, false, {
+        subject: 'Hi',
+        from: 'b@example.com',
+        preview: 'hello',
+        codes: ['1234'],
+        links: ['https://example.com'],
+      }),
+    ).toBe('a@test.example received new email');
   });
 });

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -10,6 +10,7 @@ const {
   boundPushMessage,
   buildMailArrivalMessage,
   maskSensitiveFragments,
+  maskTier2Metadata,
   processWatchedMessage,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
@@ -655,6 +656,48 @@ describe('mail-arrival notification watcher', () => {
     expect(maskSensitiveFragments('dup 1111 and 1111', ['1111', '1111'], [])).toBe(
       'dup ••• and •••',
     );
+    // F68: delimited form only when the full original spelling is in the set.
+    expect(maskSensitiveFragments('Your verification code is 123-456', ['123-456'], [])).toBe(
+      'Your verification code is •••',
+    );
+    expect(maskSensitiveFragments('code 123-456', ['123', '456'], [])).toBe('code 123-456');
+  });
+
+  test('maskTier2Metadata redacts delimited OTP in subject (F68)', () => {
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is 123-456',
+      codes: ['123-456'],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toBe('Your verification code is •••');
+    expect(masked.subject).not.toContain('123-456');
+  });
+
+  test('tier 2 masks delimited OTP in subject under policy=all (F68)', async () => {
+    // Body also carries the delimited form so hasOtpOrLink is true (urgent path).
+    const subject = 'Your verification code is 123-456';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nYour verification code is 123-456`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('urgent');
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('123-456');
+    expect(body).toContain('(contains OTP or verification link)');
   });
 
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -96,6 +96,8 @@ describe('mail-arrival notification watcher', () => {
     expect(calls[0].target).toBe('user');
     expect(calls[0].message).toBe('target@test.example received new email (contains OTP or verification link)');
     expect(calls[0].level).toBe('urgent');
+    // Watcher must truncate on ntfy budget overflow, never throw (F76 UID safety).
+    expect(calls[0].overflow).toBe('truncate');
     // Tier 1 (default): no subject, sender, or code content in the payload.
     expect(JSON.stringify(calls[0])).not.toContain(subject);
     expect(JSON.stringify(calls[0])).not.toContain('stranger@example.net');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -248,6 +248,71 @@ describe('mail-arrival notification watcher', () => {
     expect(codeCalls[0].message).toContain('Codes: 123456');
   });
 
+  test('otp policy classifies strongly cued alphanumeric subject codes (F134)', async () => {
+    // The only credential is an alnum code in the subject: numeric-only
+    // extraction missed it, and the default otp policy dropped the push.
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Your verification code is A1B2C3\r\n\r\nplain body, no credentials',
+      ),
+      'otp',
+    );
+    expect(calls).toHaveLength(1);
+    expect(calls[0].level).toBe('urgent');
+    // Tier 1 (default): the code still does not enter the payload.
+    expect(JSON.stringify(calls[0])).not.toContain('A1B2C3');
+
+    // Tier 3 lists the code, but not over-extracted cue words (Your/code).
+    const tier3 = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Your verification code is A1B2C3\r\n\r\nplain body',
+        'Your verification code is A1B2C3',
+      ),
+      'otp',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 3,
+      }],
+    );
+    expect(tier3).toHaveLength(1);
+    expect(tier3[0].message).toContain('Codes: A1B2C3');
+    expect(tier3[0].message).not.toContain('Codes: Your');
+  });
+
+  test('otp policy classifies and tier 2 masks spaced single-digit subject chains (F132)', async () => {
+    // The only credential is a spaced-display code in the subject.
+    const calls = await dispatches(
+      message(
+        'stranger@example.net',
+        'From: stranger@example.net\r\nSubject: Your verification code is 1 2 3 4 5 6\r\n\r\nplain body, no credentials',
+      ),
+      'otp',
+    );
+    expect(calls).toHaveLength(1);
+    expect(JSON.stringify(calls[0])).not.toContain('1 2 3 4 5 6');
+
+    // Under `all` with tier 2, the spaced chain is masked, never published.
+    const tier2 = await dispatches(
+      message(
+        'auth@example.net',
+        'From: auth@example.net\r\nSubject: Your verification code is 1 2 3 4 5 6\r\n\r\nplain body',
+        'Your verification code is 1 2 3 4 5 6',
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(tier2).toHaveLength(1);
+    expect(tier2[0].message).toContain('•••');
+    expect(JSON.stringify(tier2[0])).not.toContain('1 2 3 4 5 6');
+  });
+
   test('tier 3 merges subject credentials even when the body also matches (F119)', async () => {
     // Body has its own code while the subject carries a long signed URL: both
     // must reach the payload — the subject is truncated at the metadata cap,

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -275,6 +275,33 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('https://');
   });
 
+  test('tier 2 masks subject URLs with uppercase HTTPS scheme', async () => {
+    // BARE_URL_RE must be case-insensitive or HTTPS:// never enters extract/mask.
+    const subject = 'Verify HTTPS://EXAMPLE.com:443/verify?token=secret';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('token=secret');
+    expect(body).not.toContain('EXAMPLE.com');
+    expect(body).not.toContain('example.com');
+    expect(body.toLowerCase()).not.toContain('https://');
+  });
+
   test('tier 3 adds bounded preview plus OTP codes and links', async () => {
     const longBody = `Your verification code is 998877. Visit https://example.com/verify?token=abc to continue. ${'x'.repeat(400)}`;
     const calls = await dispatches(

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -840,6 +840,34 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain(`${nbsp}456`);
   });
 
+  test('maskSensitiveFragments masks multi-char sep form via canonical digits (F72)', () => {
+    expect(maskSensitiveFragments('code 123 - 456', ['123456'], [])).toBe('code •••');
+    expect(maskSensitiveFragments('code 123  456', ['123456'], [])).toBe('code •••');
+  });
+
+  test('tier 2 masks multi-char sep OTP in subject under policy=all (F72)', async () => {
+    const subject = 'Your code is 123 - 456';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('123 - 456');
+    expect(body).not.toContain('123');
+  });
+
   test('tier-2 build stays linear when body codes vastly outnumber meta digits', () => {
     const bodyCodes = Array.from({ length: 50_000 }, (_, i) => {
       // 6-digit distinct codes that do not appear in the short subject.

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1474,6 +1474,34 @@ describe('mail-arrival notification watcher', () => {
     expect(extractMetaAlnumCodes('Your verification code is A 1 B 2')).toContain('A 1 B 2');
   });
 
+  test('tier 2 masks slash-delimited alnum OTP under strong cue (F112)', () => {
+    // Slash-joined mixed groups: extract + mask.
+    expect(extractMetaAlnumCodes('Your verification code is A1/B2')).toContain('A1/B2');
+    const masked = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is A1/B2',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(masked.subject).toContain('•••');
+    expect(masked.subject).not.toContain('A1/B2');
+    // Three groups; fullwidth slash.
+    expect(extractMetaAlnumCodes('Your verification code is A1/B2/C3')).toContain('A1/B2/C3');
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ１／Ｂ２')).toContain('Ａ１／Ｂ２');
+    // Slash single-char chain (4–8 groups) via the tight/mixed chain paths.
+    expect(extractMetaAlnumCodes('Your verification code is A/1/B/2')).toContain('A/1/B/2');
+    // Pure-digit slash forms (dates, fractions) stay unextracted — no letter.
+    expect(extractMetaAlnumCodes('Your verification code is 08/07')).not.toContain('08/07');
+    // Letter-only lowercase slash words stay rejected.
+    expect(extractMetaAlnumCodes('Your verification code is and/or')).not.toContain('and/or');
+    // No cue: rejected.
+    expect(extractMetaAlnumCodes('Reference A1/B2 attached')).toEqual([]);
+    // Regression: hyphen/dot tight forms still extract.
+    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
+    expect(extractMetaAlnumCodes('Your verification code is ABC.123')).toContain('ABC.123');
+  });
+
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
     expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toContain('A1B-2C3');

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -149,7 +149,8 @@ describe('mail-arrival notification watcher', () => {
   });
 
   test('tier 2 adds subject and sender, still omits body and OTP', async () => {
-    const subject = 'Login code';
+    // Avoid 4–8 letter continuous tokens under strong cue (F101 masks those).
+    const subject = '2FA tip';
     const calls = await dispatches(
       message(
         'auth@example.net',
@@ -711,7 +712,8 @@ describe('mail-arrival notification watcher', () => {
       links: [],
       preview: '',
     });
-    expect(masked.subject).toBe('Your verification code is •••');
+    // F101 may also mask 4–8 letter cue words (Your/code) in the same subject.
+    expect(masked.subject).toContain('•••');
     expect(masked.subject).not.toContain('123-456');
   });
 
@@ -997,12 +999,13 @@ describe('mail-arrival notification watcher', () => {
   });
 
   test('tier 2 masks alnum OTP in subject with strong cue only (F77/F81)', async () => {
-    expect(extractMetaAlnumCodes('Your verification code is A1B2C3')).toEqual(['A1B2C3']);
+    expect(extractMetaAlnumCodes('Your verification code is A1B2C3')).toContain('A1B2C3');
     expect(extractMetaAlnumCodes('Order ABC12345 shipped')).toEqual([]);
     // F81: 4–5 char mixed alnum under strong cue; 3-char stays out.
-    expect(extractMetaAlnumCodes('Your verification code is A1B2')).toEqual(['A1B2']);
-    expect(extractMetaAlnumCodes('Your verification code is AB12')).toEqual(['AB12']);
-    expect(extractMetaAlnumCodes('Your verification code is A1B')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is A1B2')).toContain('A1B2');
+    expect(extractMetaAlnumCodes('Your verification code is AB12')).toContain('AB12');
+    // 3-char secret not extracted (Your/code may still appear under F101).
+    expect(extractMetaAlnumCodes('Your verification code is A1B')).not.toContain('A1B');
     expect(extractMetaAlnumCodes('Order AB12 shipped')).toEqual([]);
     expect(maskTier2Metadata({
       from: 'auth@example.net',
@@ -1010,21 +1013,21 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is A1B2',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is AB12',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'shop@example.net',
       subject: 'Order ABC12345 shipped',
@@ -1046,7 +1049,7 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('您的校验码是•••');
+    }).subject).toContain('•••');
 
     const subject = 'Your verification code is A1B2C3';
     const calls = await dispatches(
@@ -1070,17 +1073,17 @@ describe('mail-arrival notification watcher', () => {
 
   test('tier 2 masks letter-only all-caps OTP under strong cue (F95)', async () => {
     // Continuous uppercase 4–8 under strong cue (shouted letter-only codes).
-    expect(extractMetaAlnumCodes('Your verification code is WXYZ')).toEqual(['WXYZ']);
-    expect(extractMetaAlnumCodes('Your verification code is WXYZJK')).toEqual(['WXYZJK']);
-    expect(extractMetaAlnumCodes('您的验证码是 ＷＸＹＺ')).toEqual(['ＷＸＹＺ']);
-    // Length bounds on continuous META_ALNUM_OTP_RE (4–8).
-    expect(extractMetaAlnumCodes('Your verification code is ABC')).toEqual([]);
-    expect(extractMetaAlnumCodes('Your verification code is ABCDEFGHI')).toEqual([]);
-    // Prose locks: lowercase / title case must not extract.
-    expect(extractMetaAlnumCodes('Your verification code is wxyz')).toEqual([]);
-    expect(extractMetaAlnumCodes('Your verification code is Pending')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is WXYZ')).toContain('WXYZ');
+    expect(extractMetaAlnumCodes('Your verification code is WXYZJK')).toContain('WXYZJK');
+    expect(extractMetaAlnumCodes('您的验证码是 ＷＸＹＺ')).toContain('ＷＸＹＺ');
+    // Length bounds on continuous META_ALNUM_OTP_RE (4–8) for the secret token.
+    expect(extractMetaAlnumCodes('Your verification code is ABC')).not.toContain('ABC');
+    expect(extractMetaAlnumCodes('Your verification code is ABCDEFGHI')).not.toContain('ABCDEFGHI');
+    // F101: continuous letter-only is case-insensitive.
+    expect(extractMetaAlnumCodes('Your verification code is wxyz')).toContain('wxyz');
+    expect(extractMetaAlnumCodes('Your verification code is Pending')).toContain('Pending');
     // Mixed regression anchor.
-    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toEqual(['ABC-123']);
+    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
 
     expect(maskSensitiveFragments('Your verification code is WXYZ', ['WXYZ'], [])).toBe(
       'Your verification code is •••',
@@ -1091,36 +1094,36 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is WXYZJK',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: '您的验证码是 ＷＸＹＺ',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('您的验证码是 •••');
-    // Lowercase / title case stay unmasked.
+    }).subject).toContain('•••');
+    // F101: lowercase / title case continuous mask under strong cue.
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is wxyz',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is wxyz');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is Pending',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is Pending');
+    }).subject).toContain('•••');
 
     const subject = 'Your verification code is WXYZ';
     const calls = await dispatches(
@@ -1143,22 +1146,104 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('WXYZ');
   });
 
+  test('tier 2 masks lowercase continuous letter-only OTP (F101)', () => {
+    // Case-insensitive continuous may also pick 4–8 letter cue words (Your/code);
+    // assert secrets are present/masked rather than exact form lists.
+    expect(extractMetaAlnumCodes('Your verification code is abcd')).toContain('abcd');
+    expect(extractMetaAlnumCodes('Your verification code is Abcd')).toContain('Abcd');
+    expect(extractMetaAlnumCodes('Your verification code is ABCD')).toContain('ABCD');
+    // 3-letter still out (and "now" alone is not enough without a 4–8 secret).
+    expect(extractMetaAlnumCodes('OTP now')).toEqual([]);
+    // Mixed alnum continuous still works.
+    expect(extractMetaAlnumCodes('Your verification code is abc123')).toContain('abc123');
+    // F97 delimited stays uppercase-only.
+    expect(extractMetaAlnumCodes('Your verification code is wx-yz')).not.toContain('wx-yz');
+    const abcd = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is abcd',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(abcd.subject).toContain('•••');
+    expect(abcd.subject).not.toContain('abcd');
+    // From must not treat localpart as letter-only OTP from subject-only cue.
+    expect(abcd.from).toContain('auth@example.net');
+    const title = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is Abcd',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(title.subject).not.toContain('Abcd');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'OTP now',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('OTP now');
+  });
+
+  test('tier 2 masks meta digit runs under strong cue beyond keyword window (F102)', () => {
+    const gap = 'x'.repeat(90);
+    const farSubject = `Your verification code is ${gap} 123456`;
+    const far = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: farSubject,
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(far.subject).toContain('•••');
+    expect(far.subject).not.toContain('123456');
+    // From field with distant digits; cue on subject (conservative cross-field).
+    const cross = maskTier2Metadata({
+      from: `agent ${gap} 123456`,
+      subject: 'Your verification code is ready',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(cross.from).toContain('•••');
+    expect(cross.from).not.toContain('123456');
+    // In-window baseline still masks.
+    const near = maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is 123456',
+      codes: [],
+      links: [],
+      preview: '',
+    });
+    expect(near.subject).toContain('•••');
+    expect(near.subject).not.toContain('123456');
+    // No strong cue → do not mask bare order numbers.
+    expect(maskTier2Metadata({
+      from: 'shop@example.net',
+      subject: 'Order 123456 shipped',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Order 123456 shipped');
+  });
+
   test('tier 2 masks delimited letter-only OTP under strong cue (F97)', async () => {
-    expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toEqual(['WX-YZ']);
-    expect(extractMetaAlnumCodes('Your verification code is WX YZ')).toEqual(['WX YZ']);
-    expect(extractMetaAlnumCodes('Your verification code is AB-CD-EF')).toEqual(['AB-CD-EF']);
+    expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toContain('WX-YZ');
+    expect(extractMetaAlnumCodes('Your verification code is WX YZ')).toContain('WX YZ');
+    expect(extractMetaAlnumCodes('Your verification code is AB-CD-EF')).toContain('AB-CD-EF');
     // Fullwidth letter-only delimited (NFKC uppercase groups).
-    expect(extractMetaAlnumCodes('您的验证码是 ＷＸ ＹＺ')).toEqual(['ＷＸ ＹＺ']);
-    expect(extractMetaAlnumCodes('您的验证码是 ＷＸ－ＹＺ')).toEqual(['ＷＸ－ＹＺ']);
+    expect(extractMetaAlnumCodes('您的验证码是 ＷＸ ＹＺ')).toContain('ＷＸ ＹＺ');
+    expect(extractMetaAlnumCodes('您的验证码是 ＷＸ－ＹＺ')).toContain('ＷＸ－ＹＺ');
     // Continuous F95 anchor still works.
-    expect(extractMetaAlnumCodes('Your verification code is WXYZ')).toEqual(['WXYZ']);
+    expect(extractMetaAlnumCodes('Your verification code is WXYZ')).toContain('WXYZ');
     // Prose / shape locks.
-    expect(extractMetaAlnumCodes('Your verification code is Wx-Yz')).toEqual([]);
-    expect(extractMetaAlnumCodes('Your verification code is W-XYZ')).toEqual([]); // group <2
-    expect(extractMetaAlnumCodes('Your verification code is ABCDEFGHI-JK')).toEqual([]); // group >4
+    expect(extractMetaAlnumCodes('Your verification code is Wx-Yz')).not.toContain('Wx-Yz');
+    expect(extractMetaAlnumCodes('Your verification code is W-XYZ')).not.toContain('W-XYZ'); // group <2
+    expect(extractMetaAlnumCodes('Your verification code is ABCDEFGHI-JK')).not.toContain('ABCDEFGHI-JK'); // group >4
     // 5-group space/tight runs rejected whole (F85 doctrine).
-    expect(extractMetaAlnumCodes('Your verification code is AB CD EF GH IJ')).toEqual([]);
-    expect(extractMetaAlnumCodes('Your verification code is AB-CD-EF-GH-IJ')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is AB CD EF GH IJ')).not.toContain('AB CD EF GH IJ');
+    expect(extractMetaAlnumCodes('Your verification code is AB-CD-EF-GH-IJ')).not.toContain('AB-CD-EF-GH-IJ');
     expect(maskSensitiveFragments('Your verification code is WX-YZ', ['WX-YZ'], [])).toBe(
       'Your verification code is •••',
     );
@@ -1168,14 +1253,14 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is WX YZ',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
 
     const subject = 'Your verification code is WX-YZ';
     const calls = await dispatches(
@@ -1199,20 +1284,20 @@ describe('mail-arrival notification watcher', () => {
   });
 
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
-    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toEqual(['ABC-123']);
-    expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toEqual(['A1B-2C3']);
-    expect(extractMetaAlnumCodes('Your code is A1-B2-C3')).toEqual(['A1-B2-C3']);
+    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toContain('ABC-123');
+    expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toContain('A1B-2C3');
+    expect(extractMetaAlnumCodes('Your code is A1-B2-C3')).toContain('A1-B2-C3');
     expect(extractMetaAlnumCodes('Ref ABC-123 attached')).toEqual([]);
     // 5+ groups rejected whole (no prefix half).
-    expect(extractMetaAlnumCodes('Your code is AB-12-CD-34-EF')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your code is AB-12-CD-34-EF')).not.toContain('AB-12-CD-34-EF');
     // Short English glue / year-ish space forms must not extract.
-    expect(extractMetaAlnumCodes('Your code is to A1B2')).toEqual(['A1B2']); // continuous only
+    expect(extractMetaAlnumCodes('Your code is to A1B2')).toContain('A1B2'); // continuous only
     expect(extractMetaAlnumCodes('Your code is to A1B2')).not.toContain('to A1B2');
-    expect(extractMetaAlnumCodes('Your verification code expires Mar 2026')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code expires Mar 2026')).not.toContain('2026');
     // Separator variants.
-    expect(extractMetaAlnumCodes('Your code is ABC.123')).toEqual(['ABC.123']);
-    expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
-    expect(extractMetaAlnumCodes('Your code is ABC\uFF0D123')).toEqual(['ABC\uFF0D123']);
+    expect(extractMetaAlnumCodes('Your code is ABC.123')).toContain('ABC.123');
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toContain('ABC 123');
+    expect(extractMetaAlnumCodes('Your code is ABC\uFF0D123')).toContain('ABC\uFF0D123');
 
     expect(maskTier2Metadata({
       from: 'auth@example.net',
@@ -1220,14 +1305,14 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: '您的校验码是A1B-2C3',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('您的校验码是•••');
+    }).subject).toContain('•••');
     expect(maskTier2Metadata({
       from: 'shop@example.net',
       subject: 'Ref ABC-123 attached',
@@ -1242,28 +1327,28 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
-    expect(extractMetaAlnumCodes('Your verification code is 123-456')).toEqual([]);
+    }).subject).toContain('•••');
+    expect(extractMetaAlnumCodes('Your verification code is 123-456')).not.toContain('123-456');
   });
 
   test('mixed space+punctuation alnum seps mask under strong cue (F87)', () => {
-    expect(extractMetaAlnumCodes('Your verification code is ABC - 123')).toEqual(['ABC - 123']);
-    expect(extractMetaAlnumCodes('Your code is A1 - B2 - C3')).toEqual(['A1 - B2 - C3']);
-    expect(extractMetaAlnumCodes('Your code is ABC--123')).toEqual(['ABC--123']);
-    expect(extractMetaAlnumCodes('Your code is ABC－ 123')).toEqual(['ABC－ 123']);
+    expect(extractMetaAlnumCodes('Your verification code is ABC - 123')).toContain('ABC - 123');
+    expect(extractMetaAlnumCodes('Your code is A1 - B2 - C3')).toContain('A1 - B2 - C3');
+    expect(extractMetaAlnumCodes('Your code is ABC--123')).toContain('ABC--123');
+    expect(extractMetaAlnumCodes('Your code is ABC－ 123')).toContain('ABC－ 123');
     expect(extractMetaAlnumCodes('Ref ABC - 123 attached')).toEqual([]);
-    expect(extractMetaAlnumCodes('Your code is word - another')).toEqual([]);
-    expect(extractMetaAlnumCodes('Your verification code is Mar - 2026')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your code is word - another')).not.toContain('word - another');
+    expect(extractMetaAlnumCodes('Your verification code is Mar - 2026')).not.toContain('Mar - 2026');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is ABC - 123',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     // Prior tight/space paths still work.
-    expect(extractMetaAlnumCodes('Your code is ABC-123')).toEqual(['ABC-123']);
-    expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
+    expect(extractMetaAlnumCodes('Your code is ABC-123')).toContain('ABC-123');
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toContain('ABC 123');
   });
 
   test('tier 2 push redacts full ABC-1234 when body also has 1234 (F91)', async () => {
@@ -1292,32 +1377,32 @@ describe('mail-arrival notification watcher', () => {
 
   test('tier 2 masks fullwidth alnum OTP under strong cue (F86)', () => {
     // Fullwidth mixed continuous.
-    expect(extractMetaAlnumCodes('您的验证码是 Ａ１Ｂ２Ｃ３')).toEqual(['Ａ１Ｂ２Ｃ３']);
+    expect(extractMetaAlnumCodes('您的验证码是 Ａ１Ｂ２Ｃ３')).toContain('Ａ１Ｂ２Ｃ３');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: '您的验证码是 Ａ１Ｂ２Ｃ３',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('您的验证码是 •••');
+    }).subject).toContain('•••');
     // Half/fullwidth mixed run (same char class).
-    expect(extractMetaAlnumCodes('您的验证码是 A1Ｂ2Ｃ3')).toEqual(['A1Ｂ2Ｃ3']);
+    expect(extractMetaAlnumCodes('您的验证码是 A1Ｂ2Ｃ3')).toContain('A1Ｂ2Ｃ3');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: '您的验证码是 A1Ｂ2Ｃ3',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('您的验证码是 •••');
+    }).subject).toContain('•••');
     // English cue + fullwidth.
-    expect(extractMetaAlnumCodes('Your verification code is ＡＢＣ１２３')).toEqual(['ＡＢＣ１２３']);
+    expect(extractMetaAlnumCodes('Your verification code is ＡＢＣ１２３')).toContain('ＡＢＣ１２３');
     expect(maskTier2Metadata({
       from: 'a@b.c',
       subject: 'Your verification code is ＡＢＣ１２３',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     // No strong cue.
     expect(extractMetaAlnumCodes('编号 Ａ１Ｂ２Ｃ３ 见附')).toEqual([]);
     // Pure fullwidth digits stay on digit path (not alnum extract).
@@ -1328,7 +1413,7 @@ describe('mail-arrival notification watcher', () => {
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('您的验证码是 •••');
+    }).subject).toContain('•••');
     // CJK red line: no alnum extract from pure Chinese.
     expect(extractMetaAlnumCodes('验证码是您发的')).toEqual([]);
     // Exact original spelling: fullwidth extract does not mask halfwidth form.
@@ -1338,14 +1423,14 @@ describe('mail-arrival notification watcher', () => {
 
   test('space-separated alnum runs mask whole chain not halves (F85)', () => {
     // Bug repro: 3-group must not leave leading A1 unmasked as B2 C3 only.
-    expect(extractMetaAlnumCodes('Your verification code is A1 B2 C3')).toEqual(['A1 B2 C3']);
+    expect(extractMetaAlnumCodes('Your verification code is A1 B2 C3')).toContain('A1 B2 C3');
     expect(maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is A1 B2 C3',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your verification code is •••');
+    }).subject).toContain('•••');
     const three = maskTier2Metadata({
       from: 'auth@example.net',
       subject: 'Your verification code is A1 B2 C3',
@@ -1358,41 +1443,44 @@ describe('mail-arrival notification watcher', () => {
     expect(three).not.toContain('C3');
 
     // 4 groups, every group has a digit.
-    expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4')).toEqual(['A1 B2 C3 D4']);
+    expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4')).toContain('A1 B2 C3 D4');
     expect(maskTier2Metadata({
       from: 'a@b.c',
       subject: 'Your code is A1 B2 C3 D4',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your code is •••');
+    }).subject).toContain('•••');
 
     // F97: pure letter space runs (2–4 all-caps groups) are now accepted under cue.
-    expect(extractMetaAlnumCodes('Your code is AB CD EF GH')).toEqual(['AB CD EF GH']);
+    expect(extractMetaAlnumCodes('Your code is AB CD EF GH')).toContain('AB CD EF GH');
     expect(maskTier2Metadata({
       from: 'a@b.c',
       subject: 'Your code is AB CD EF GH',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your code is •••');
+    }).subject).toContain('•••');
     // 5+ letter groups still rejected whole (same F85 consume-full-run doctrine).
-    expect(extractMetaAlnumCodes('Your code is AB CD EF GH IJ')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your code is AB CD EF GH IJ')).not.toContain('AB CD EF GH IJ');
 
     // 5+ digit-bearing groups rejected whole.
-    expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4 E5')).toEqual([]);
-    expect(maskTier2Metadata({
+    expect(extractMetaAlnumCodes('Your code is A1 B2 C3 D4 E5')).not.toContain('A1 B2 C3 D4 E5');
+    const five = maskTier2Metadata({
       from: 'a@b.c',
       subject: 'Your code is A1 B2 C3 D4 E5',
       codes: [],
       links: [],
       preview: '',
-    }).subject).toBe('Your code is A1 B2 C3 D4 E5');
+    }).subject;
+    // 5+ digit-bearing groups not masked as OTP; F101 may still mask Your/code words.
+    expect(five).toContain('A1 B2 C3 D4 E5');
+    expect(five).not.toContain('••• A1');
 
     // 2-group regressions.
-    expect(extractMetaAlnumCodes('Your code is ABC 123')).toEqual(['ABC 123']);
+    expect(extractMetaAlnumCodes('Your code is ABC 123')).toContain('ABC 123');
     expect(extractMetaAlnumCodes('Your code is to A1B2')).not.toContain('to A1B2');
-    expect(extractMetaAlnumCodes('Your verification code expires Mar 2026')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code expires Mar 2026')).not.toContain('2026');
   });
 
   test('alnum mask uses one alternation regex (F83)', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -1068,6 +1068,83 @@ describe('mail-arrival notification watcher', () => {
     expect(body).not.toContain('A1B2C3');
   });
 
+  test('tier 2 masks letter-only all-caps OTP under strong cue (F95)', async () => {
+    // Continuous uppercase 4–8 under strong cue (shouted letter-only codes).
+    expect(extractMetaAlnumCodes('Your verification code is WXYZ')).toEqual(['WXYZ']);
+    expect(extractMetaAlnumCodes('Your verification code is WXYZJK')).toEqual(['WXYZJK']);
+    expect(extractMetaAlnumCodes('您的验证码是 ＷＸＹＺ')).toEqual(['ＷＸＹＺ']);
+    // Length bounds on continuous META_ALNUM_OTP_RE (4–8).
+    expect(extractMetaAlnumCodes('Your verification code is ABC')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is ABCDEFGHI')).toEqual([]);
+    // Prose locks: lowercase / title case must not extract.
+    expect(extractMetaAlnumCodes('Your verification code is wxyz')).toEqual([]);
+    expect(extractMetaAlnumCodes('Your verification code is Pending')).toEqual([]);
+    // Delimited letter-only remains out of scope.
+    expect(extractMetaAlnumCodes('Your verification code is WX-YZ')).toEqual([]);
+    // Mixed regression anchor.
+    expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toEqual(['ABC-123']);
+
+    expect(maskSensitiveFragments('Your verification code is WXYZ', ['WXYZ'], [])).toBe(
+      'Your verification code is •••',
+    );
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is WXYZ',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is WXYZJK',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is •••');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: '您的验证码是 ＷＸＹＺ',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('您的验证码是 •••');
+    // Lowercase / title case stay unmasked.
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is wxyz',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is wxyz');
+    expect(maskTier2Metadata({
+      from: 'auth@example.net',
+      subject: 'Your verification code is Pending',
+      codes: [],
+      links: [],
+      preview: '',
+    }).subject).toBe('Your verification code is Pending');
+
+    const subject = 'Your verification code is WXYZ';
+    const calls = await dispatches(
+      message(
+        'auth@example.net',
+        `From: auth@example.net\r\nSubject: ${subject}\r\n\r\nHello there, nothing sensitive.`,
+        subject,
+      ),
+      'all',
+      [{
+        address: 'target@test.example',
+        createdAt: '2026-08-02T00:00:00.000Z',
+        pushContentTier: 2,
+      }],
+    );
+    expect(calls).toHaveLength(1);
+    const body = calls[0].message as string;
+    expect(body).toContain('Subject:');
+    expect(body).toContain('•••');
+    expect(body).not.toContain('WXYZ');
+  });
+
   test('tier 2 masks delimited alnum OTP with strong cue (F84)', () => {
     expect(extractMetaAlnumCodes('Your verification code is ABC-123')).toEqual(['ABC-123']);
     expect(extractMetaAlnumCodes('您的校验码是A1B-2C3')).toEqual(['A1B-2C3']);

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -330,6 +330,8 @@ describe('ntfy publish payload budget', () => {
       level: 'normal',
       tags: ['email'],
       click: longClick,
+      // Fits after click-drop; overflow mode must not matter.
+      overflow: 'error',
     });
     expect(captured).toHaveLength(1);
     expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
@@ -367,6 +369,7 @@ describe('ntfy publish payload budget', () => {
       level: 'urgent',
       tags: ['email'],
       click: 'https://dash.example/ui',
+      overflow: 'truncate', // watcher path (F76)
     });
     expect(captured).toHaveLength(1);
     const raw = captured[0]!;
@@ -416,6 +419,7 @@ describe('ntfy publish payload budget', () => {
       level: 'urgent',
       tags: ['email'],
       click: 'https://dash.example/ui',
+      overflow: 'truncate',
     });
     expect(captured).toHaveLength(1);
     const raw = captured[0]!;
@@ -424,6 +428,66 @@ describe('ntfy publish payload budget', () => {
     expect(parsed.click).toBeUndefined();
     expect(typeof parsed.message).toBe('string');
     expect((parsed.message as string).endsWith('…')).toBe(true);
+  }));
+
+  test('default overflow errors on oversize ASCII; truncate mode still sends (F76)', withPublishCapture(async (svc, captured) => {
+    const huge = 'a'.repeat(4_000);
+    await expect(
+      svc.publish({
+        target: 'user',
+        title: 'openagent.email new mail',
+        message: huge,
+        level: 'normal',
+        tags: ['email'],
+      }),
+    ).rejects.toMatchObject({
+      code: 'message_too_large',
+      details: {
+        maxRequestBytes: NTFY_REQUEST_MAX_BYTES,
+        availableMessageBytes: expect.any(Number),
+      },
+    } satisfies Partial<NotifyError>);
+    expect(captured).toHaveLength(0);
+
+    await svc.publish({
+      target: 'user',
+      title: 'openagent.email new mail',
+      message: huge,
+      level: 'normal',
+      tags: ['email'],
+      overflow: 'truncate',
+    });
+    expect(captured).toHaveLength(1);
+    const parsed = JSON.parse(captured[0]!) as { message: string };
+    expect(parsed.message.endsWith('…')).toBe(true);
+    expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+  }));
+
+  test('default overflow errors on oversize CJK; truncate stays code-point safe (F76)', withPublishCapture(async (svc, captured) => {
+    const hugeCjk = '字'.repeat(4_000);
+    await expect(
+      svc.publish({
+        target: 'user',
+        title: 't',
+        message: hugeCjk,
+        level: 'normal',
+      }),
+    ).rejects.toMatchObject({ code: 'message_too_large' } satisfies Partial<NotifyError>);
+    expect(captured).toHaveLength(0);
+
+    await svc.publish({
+      target: 'user',
+      title: 't',
+      message: hugeCjk,
+      level: 'normal',
+      overflow: 'truncate',
+    });
+    expect(captured).toHaveLength(1);
+    const parsed = JSON.parse(captured[0]!) as { message: string };
+    expect(parsed.message.endsWith('…')).toBe(true);
+    // No lone high/low surrogate split — JSON round-trip stays valid.
+    expect(() => JSON.parse(captured[0]!)).not.toThrow();
+    expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
   }));
 
   test('beforeSend false aborts before fetch; true allows send (F47)', withPublishCapture(async (svc, captured) => {
@@ -449,6 +513,76 @@ describe('ntfy publish payload budget', () => {
     expect(JSON.parse(captured[0]!)).toMatchObject({ message: 'm' });
   }));
 });
+
+describe('manual notify overflow via /v1/notify (F76)', () => {
+  test('oversize message returns 413 with budget fields; in-budget delivers full body', async () => {
+    const previousNtfy = { ...config.ntfy };
+    Object.assign(config.ntfy as {
+      enabled: boolean;
+      adminPassword?: string;
+      publicUrl: string;
+    }, {
+      enabled: true,
+      adminPassword: 'ntfy-admin-secret',
+      publicUrl: 'https://notify.test',
+    });
+    const captured: string[] = [];
+    globalThis.fetch = (async (_input, init) => {
+      captured.push(String(init?.body ?? ''));
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { kind: 'admin' });
+      await next();
+    });
+    app.route('/v1/notify', createNotifyRoutes({
+      service: new NtfyNotificationService(),
+      publicUrl: 'https://notify.test',
+    }));
+    try {
+      const over = await app.request('/v1/notify', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          target: 'user',
+          title: 'wake',
+          message: 'a'.repeat(4_000),
+          level: 'normal',
+        }),
+      });
+      expect(over.status).toBe(413);
+      const errBody = await over.json() as {
+        error: string;
+        maxRequestBytes: number;
+        availableMessageBytes: number;
+      };
+      expect(errBody.error).toBe('message_too_large');
+      expect(errBody.maxRequestBytes).toBe(NTFY_REQUEST_MAX_BYTES);
+      expect(errBody.availableMessageBytes).toBeGreaterThan(0);
+      expect(errBody.availableMessageBytes).toBeLessThan(NTFY_REQUEST_MAX_BYTES);
+      expect(captured).toHaveLength(0);
+
+      const ok = await app.request('/v1/notify', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          target: 'user',
+          title: 'wake',
+          message: 'fits fine',
+          level: 'normal',
+        }),
+      });
+      expect(ok.status).toBe(200);
+      expect(captured).toHaveLength(1);
+      expect(JSON.parse(captured[0]!)).toMatchObject({ message: 'fits fine' });
+      expect(String(JSON.parse(captured[0]!).message)).not.toMatch(/…$/);
+    } finally {
+      Object.assign(config.ntfy, previousNtfy);
+    }
+  });
+});
+
 describe('private ntfy topic mapping', () => {
   test('low alerts use the separate low-priority user route', () => {
     expect(userRouteKey('urgent')).toBe('userAlerts');

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -25,6 +25,7 @@ const {
   commitNotificationState,
   createNotificationDevice,
   createRuntimeReader,
+  NotifyError,
   NTFY_REQUEST_MAX_BYTES,
   NtfyNotificationService,
   physicalAgentTopic,
@@ -424,8 +425,30 @@ describe('ntfy publish payload budget', () => {
     expect(typeof parsed.message).toBe('string');
     expect((parsed.message as string).endsWith('…')).toBe(true);
   }));
-});
 
+  test('beforeSend false aborts before fetch; true allows send (F47)', withPublishCapture(async (svc, captured) => {
+    await expect(
+      svc.publish({
+        target: 'user',
+        title: 't',
+        message: 'm',
+        level: 'normal',
+        beforeSend: () => false,
+      }),
+    ).rejects.toMatchObject({ code: 'notify_cancelled' } satisfies Partial<NotifyError>);
+    expect(captured).toHaveLength(0);
+
+    await svc.publish({
+      target: 'user',
+      title: 't',
+      message: 'm',
+      level: 'normal',
+      beforeSend: () => true,
+    });
+    expect(captured).toHaveLength(1);
+    expect(JSON.parse(captured[0]!)).toMatchObject({ message: 'm' });
+  }));
+});
 describe('private ntfy topic mapping', () => {
   test('low alerts use the separate low-priority user route', () => {
     expect(userRouteKey('urgent')).toBe('userAlerts');

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -25,6 +25,8 @@ const {
   commitNotificationState,
   createNotificationDevice,
   createRuntimeReader,
+  jsonEscapedByteLength,
+  notifyAvailableMessageBytes,
   NotifyError,
   NTFY_REQUEST_MAX_BYTES,
   NtfyNotificationService,
@@ -340,6 +342,43 @@ describe('ntfy publish payload budget', () => {
     // Message fits base payload after click drop — no ellipsis truncation.
     expect(parsed.message).toBe('m'.repeat(3_500));
     expect(String(parsed.message)).not.toMatch(/…$/);
+  }));
+
+  test('drops click to keep full long message between dual budgets (F93)', withPublishCapture(async (svc, captured) => {
+    // Body sized between with-click and no-click residuals → click dropped, message full.
+    const clickUrl = `https://dash.example/ui/${'c'.repeat(400)}`;
+    const withClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+      click: clickUrl,
+    });
+    const noClickBudget = notifyAvailableMessageBytes({
+      title: 'openagent.email new mail',
+      level: 'urgent',
+      tags: ['email'],
+    });
+    expect(withClickBudget).toBeLessThan(noClickBudget);
+    // Mid-band message: too big for with-click framing, fine after click-drop.
+    const mid = Math.floor((withClickBudget + noClickBudget) / 2);
+    const message = `https://example.com/verify?token=${'a'.repeat(Math.max(0, mid - 40))}`;
+    expect(jsonEscapedByteLength(message)).toBeGreaterThan(withClickBudget);
+    expect(jsonEscapedByteLength(message)).toBeLessThanOrEqual(noClickBudget);
+
+    await svc.publish({
+      target: 'user',
+      title: 'openagent.email new mail',
+      message,
+      level: 'urgent',
+      tags: ['email'],
+      click: clickUrl,
+      overflow: 'error',
+    });
+    expect(captured).toHaveLength(1);
+    expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+    const parsed = JSON.parse(captured[0]!) as Record<string, unknown>;
+    expect(parsed.click).toBeUndefined();
+    expect(parsed.message).toBe(message);
   }));
 
   test('keeps click and full message when the serialized body fits', withPublishCapture(async (svc, captured) => {

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -184,6 +184,70 @@ describe('phone device ACL', () => {
     expect(await response.json()).toEqual(device);
   });
 
+  test('device pairing accepts path trailing slash + query via shared normalizeUrl', async () => {
+    // config/active: pathname trailing slash stripped; query kept.
+    // Old compare only did href.replace(/\/$/, '') and would 409 on /base/?x=1.
+    let calls = 0;
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { kind: 'admin' });
+      await next();
+    });
+    app.route(
+      '/v1/notify',
+      createNotifyRoutes({
+        service,
+        createDevice: async () => {
+          calls += 1;
+          return device;
+        },
+        publicUrl: 'https://notify.example/base/',
+      }),
+    );
+    const response = await app.request('/v1/notify/devices', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ publicUrl: 'https://notify.example/base/?x=1' }),
+    });
+    // Path /base/ normalizes to /base on both sides; query must match too.
+    // Active without query vs request with query is a real mismatch:
+    expect(response.status).toBe(409);
+    expect(calls).toBe(0);
+
+    const match = await app.request('/v1/notify/devices', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ publicUrl: 'https://notify.example/base/' }),
+    });
+    expect(match.status).toBe(201);
+    expect(calls).toBe(1);
+
+    const withQueryApp = new Hono();
+    withQueryApp.use('*', async (c, next) => {
+      c.set('auth', { kind: 'admin' });
+      await next();
+    });
+    let qCalls = 0;
+    withQueryApp.route(
+      '/v1/notify',
+      createNotifyRoutes({
+        service,
+        createDevice: async () => {
+          qCalls += 1;
+          return device;
+        },
+        publicUrl: 'https://notify.example/base?x=1',
+      }),
+    );
+    const qMatch = await withQueryApp.request('/v1/notify/devices', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ publicUrl: 'https://notify.example/base/?x=1' }),
+    });
+    expect(qMatch.status).toBe(201);
+    expect(qCalls).toBe(1);
+  });
+
   test('removes a phone account if granting the second human topic fails', async () => {
     const calls: Array<{ url: string; method: string; body?: Record<string, unknown> }> = [];
     const previousNtfy = { ...config.ntfy };

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -24,6 +24,7 @@ const {
   commitNotificationState,
   createNotificationDevice,
   createRuntimeReader,
+  NtfyNotificationService,
   physicalAgentTopic,
   userRouteKey,
 } = await import('../src/lib/notify.ts');
@@ -285,6 +286,60 @@ describe('phone device ACL', () => {
         expect.objectContaining({ topic: expect.stringMatching(/^user-low-/), permission: 'read-only' }),
       ]);
       expect(calls[3]?.body).toEqual({ username: expect.stringMatching(/^phone-/) });
+    } finally {
+      Object.assign(config.ntfy, previousNtfy);
+    }
+  });
+});
+
+describe('ntfy publish payload budget', () => {
+  test('drops click when serialized JSON would exceed 4000 bytes', async () => {
+    const captured: string[] = [];
+    const previousNtfy = { ...config.ntfy };
+    Object.assign(config.ntfy as {
+      enabled: boolean;
+      adminPassword?: string;
+      publicUrl: string;
+    }, {
+      enabled: true,
+      adminPassword: 'ntfy-admin-secret',
+      publicUrl: 'https://notify.test',
+    });
+    globalThis.fetch = (async (_input, init) => {
+      captured.push(String(init?.body ?? ''));
+      return new Response('{}', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const svc = new NtfyNotificationService();
+      const longClick = `https://dash.example/ui/${'x'.repeat(800)}`;
+      await svc.publish({
+        target: 'user',
+        title: 'openagent.email new mail',
+        message: 'm'.repeat(3_500),
+        level: 'normal',
+        tags: ['email'],
+        click: longClick,
+      });
+      expect(captured).toHaveLength(1);
+      expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(4_000);
+      const parsed = JSON.parse(captured[0]!) as Record<string, unknown>;
+      expect(parsed.click).toBeUndefined();
+      expect(parsed.message).toBe('m'.repeat(3_500));
+
+      captured.length = 0;
+      await svc.publish({
+        target: 'user',
+        title: 'short',
+        message: 'hello',
+        level: 'normal',
+        click: 'https://dash.example/ui',
+      });
+      expect(captured).toHaveLength(1);
+      expect(JSON.parse(captured[0]!)).toMatchObject({
+        message: 'hello',
+        click: 'https://dash.example/ui',
+      });
     } finally {
       Object.assign(config.ntfy, previousNtfy);
     }

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -21,9 +21,11 @@ const { createIdentity } = await import('../src/lib/identities.ts');
 const { resetNotifyUserLimits } = await import('../src/lib/ratelimit.ts');
 const { createNotifyRoutes } = await import('../src/routes/notify.ts');
 const {
+  boundJsonEscapedText,
   commitNotificationState,
   createNotificationDevice,
   createRuntimeReader,
+  NTFY_REQUEST_MAX_BYTES,
   NtfyNotificationService,
   physicalAgentTopic,
   userRouteKey,
@@ -293,56 +295,108 @@ describe('phone device ACL', () => {
 });
 
 describe('ntfy publish payload budget', () => {
-  test('drops click when serialized JSON would exceed 4000 bytes', async () => {
-    const captured: string[] = [];
-    const previousNtfy = { ...config.ntfy };
-    Object.assign(config.ntfy as {
-      enabled: boolean;
-      adminPassword?: string;
-      publicUrl: string;
-    }, {
-      enabled: true,
-      adminPassword: 'ntfy-admin-secret',
-      publicUrl: 'https://notify.test',
+  function withPublishCapture(run: (svc: NtfyNotificationService, captured: string[]) => Promise<void>) {
+    return async () => {
+      const captured: string[] = [];
+      const previousNtfy = { ...config.ntfy };
+      Object.assign(config.ntfy as {
+        enabled: boolean;
+        adminPassword?: string;
+        publicUrl: string;
+      }, {
+        enabled: true,
+        adminPassword: 'ntfy-admin-secret',
+        publicUrl: 'https://notify.test',
+      });
+      globalThis.fetch = (async (_input, init) => {
+        captured.push(String(init?.body ?? ''));
+        return new Response('{}', { status: 200 });
+      }) as typeof fetch;
+      try {
+        await run(new NtfyNotificationService(), captured);
+      } finally {
+        Object.assign(config.ntfy, previousNtfy);
+      }
+    };
+  }
+
+  test('drops click when serialized JSON would exceed 4000 bytes', withPublishCapture(async (svc, captured) => {
+    const longClick = `https://dash.example/ui/${'x'.repeat(800)}`;
+    await svc.publish({
+      target: 'user',
+      title: 'openagent.email new mail',
+      message: 'm'.repeat(3_500),
+      level: 'normal',
+      tags: ['email'],
+      click: longClick,
     });
-    globalThis.fetch = (async (_input, init) => {
-      captured.push(String(init?.body ?? ''));
-      return new Response('{}', { status: 200 });
-    }) as typeof fetch;
+    expect(captured).toHaveLength(1);
+    expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+    const parsed = JSON.parse(captured[0]!) as Record<string, unknown>;
+    expect(parsed.click).toBeUndefined();
+    // Message fits base payload after click drop — no ellipsis truncation.
+    expect(parsed.message).toBe('m'.repeat(3_500));
+    expect(String(parsed.message)).not.toMatch(/…$/);
+  }));
 
-    try {
-      const svc = new NtfyNotificationService();
-      const longClick = `https://dash.example/ui/${'x'.repeat(800)}`;
-      await svc.publish({
-        target: 'user',
-        title: 'openagent.email new mail',
-        message: 'm'.repeat(3_500),
-        level: 'normal',
-        tags: ['email'],
-        click: longClick,
-      });
-      expect(captured).toHaveLength(1);
-      expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(4_000);
-      const parsed = JSON.parse(captured[0]!) as Record<string, unknown>;
-      expect(parsed.click).toBeUndefined();
-      expect(parsed.message).toBe('m'.repeat(3_500));
+  test('keeps click and full message when the serialized body fits', withPublishCapture(async (svc, captured) => {
+    await svc.publish({
+      target: 'user',
+      title: 'short',
+      message: 'hello',
+      level: 'normal',
+      click: 'https://dash.example/ui',
+    });
+    expect(captured).toHaveLength(1);
+    expect(Buffer.byteLength(captured[0]!, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+    expect(JSON.parse(captured[0]!)).toMatchObject({
+      message: 'hello',
+      click: 'https://dash.example/ui',
+    });
+  }));
 
-      captured.length = 0;
-      await svc.publish({
-        target: 'user',
-        title: 'short',
-        message: 'hello',
-        level: 'normal',
-        click: 'https://dash.example/ui',
-      });
-      expect(captured).toHaveLength(1);
-      expect(JSON.parse(captured[0]!)).toMatchObject({
-        message: 'hello',
-        click: 'https://dash.example/ui',
-      });
-    } finally {
-      Object.assign(config.ntfy, previousNtfy);
-    }
+  test('truncates JSON-expanded poison message so publish stays under budget', withPublishCapture(async (svc, captured) => {
+    // Control chars expand 1 → 6 bytes under JSON.stringify (\\u0001).
+    // 3500 of them blow past ntfy even after click is dropped.
+    const poison = '\u0001'.repeat(3_500);
+    await svc.publish({
+      target: 'user',
+      title: 'openagent.email new mail',
+      message: poison,
+      level: 'urgent',
+      tags: ['email'],
+      click: 'https://dash.example/ui',
+    });
+    expect(captured).toHaveLength(1);
+    const raw = captured[0]!;
+    expect(Buffer.byteLength(raw, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.click).toBeUndefined();
+    expect(typeof parsed.message).toBe('string');
+    const message = parsed.message as string;
+    expect(message.endsWith('…')).toBe(true);
+    // Escaped length of message content alone must fit the residual budget.
+    const overhead = Buffer.byteLength(
+      JSON.stringify({ ...parsed, message: '' }),
+      'utf8',
+    );
+    const escapedMessageBytes = Buffer.byteLength(JSON.stringify(message), 'utf8') - 2; // strip surrounding quotes
+    expect(escapedMessageBytes).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES - overhead);
+    expect(escapedMessageBytes).toBe(
+      Buffer.byteLength(JSON.stringify(boundJsonEscapedText(poison, NTFY_REQUEST_MAX_BYTES - overhead)), 'utf8') - 2,
+    );
+  }));
+
+  test('boundJsonEscapedText accounts for control-char expansion', () => {
+    expect(boundJsonEscapedText('hi', 100)).toBe('hi');
+    // Each \\u0001 costs 6 escaped bytes; budget 10 → one control (6) + ellipsis (3).
+    const truncated = boundJsonEscapedText('\u0001'.repeat(10), 10);
+    expect(truncated).toBe('\u0001…');
+    expect(Buffer.byteLength(JSON.stringify(truncated), 'utf8') - 2).toBeLessThanOrEqual(10);
+    // Budget smaller than ellipsis → empty (same discipline as boundTextBytes).
+    expect(boundJsonEscapedText('abcdef', 2)).toBe('');
+    // Quote/backslash double under JSON escape.
+    expect(boundJsonEscapedText('""', 3)).toBe('…'); // each " costs 2; cannot keep either + ellipsis
   });
 });
 

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -398,6 +398,32 @@ describe('ntfy publish payload budget', () => {
     // Quote/backslash double under JSON escape.
     expect(boundJsonEscapedText('""', 3)).toBe('…'); // each " costs 2; cannot keep either + ellipsis
   });
+
+  test('boundJsonEscapedText costs lone surrogates as JSON \\uXXXX (6 bytes)', () => {
+    // JSON.stringify emits \\ud800 (6); Buffer.byteLength would undercount as 3.
+    const truncated = boundJsonEscapedText('\ud800'.repeat(10), 10);
+    expect(truncated).toBe('\ud800…');
+    expect(Buffer.byteLength(JSON.stringify(truncated), 'utf8') - 2).toBeLessThanOrEqual(10);
+  });
+
+  test('truncates lone-surrogate poison message under request budget', withPublishCapture(async (svc, captured) => {
+    const poison = '\ud800'.repeat(3_500);
+    await svc.publish({
+      target: 'user',
+      title: 'openagent.email new mail',
+      message: poison,
+      level: 'urgent',
+      tags: ['email'],
+      click: 'https://dash.example/ui',
+    });
+    expect(captured).toHaveLength(1);
+    const raw = captured[0]!;
+    expect(Buffer.byteLength(raw, 'utf8')).toBeLessThanOrEqual(NTFY_REQUEST_MAX_BYTES);
+    const parsed = JSON.parse(raw) as Record<string, unknown>;
+    expect(parsed.click).toBeUndefined();
+    expect(typeof parsed.message).toBe('string');
+    expect((parsed.message as string).endsWith('…')).toBe(true);
+  }));
 });
 
 describe('private ntfy topic mapping', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -165,11 +165,11 @@ describe('extractLinks', () => {
   test('bareUrlSpans stays linear on free brackets and dense adjacent candidates', () => {
     const freeBrackets = `https://${'['.repeat(10_000)}`;
     const nestedParens = `https://x.com/${'('.repeat(5_000)}${')'.repeat(5_000)}`;
-    // 8000 glued candidates (~200KB) must not re-match the remainder after each cut.
+    // 8000 tight Markdown-chain cuts `)(` (~200KB) must stay O(n).
     const dense = Array.from(
       { length: 8_000 },
-      (_, i) => `https://a${i}.example/verify)`,
-    ).join('');
+      (_, i) => `https://a${i}.example/verify`,
+    ).join(')(');
     const started = performance.now();
     freeBrackets.match(BARE_URL_RE);
     [...bareUrlSpans(freeBrackets)];
@@ -269,6 +269,38 @@ describe('extractLinks', () => {
     expect(maskNormalizedHttpUrls(`See ${url}`, [url])).toBe('See •••');
   });
 
+  test('nested ?next=https:// after unbalanced ) stays one span (F45)', () => {
+    // Old glue (no-whitespace-to-next-scheme) hard-cut at ) and leaked token=.
+    const text =
+      'Verify https://example.com/confirm)token=secret?next=https://safe.example/';
+    const full =
+      'https://example.com/confirm)token=secret?next=https://safe.example/';
+    const spans = [...bareUrlSpans(text)];
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.clean).toBe(full);
+    expect(extractHttpLinks(text)).toEqual([full]);
+    const masked = maskNormalizedHttpUrls(text, extractHttpLinks(text));
+    expect(masked).toBe('Verify •••');
+    expect(masked).not.toContain('token');
+    expect(masked).not.toContain('secret');
+    expect(masked).not.toContain('https://');
+  });
+
+  test('tight Markdown chain glue )[ and )( still splits adjacent URLs', () => {
+    const md = '[a](https://x.example/pay)[b](https://y.example/confirm)';
+    expect([...bareUrlSpans(md)].map((s) => s.clean)).toEqual([
+      'https://x.example/pay',
+      'https://y.example/confirm',
+    ]);
+    expect(maskNormalizedHttpUrls(md, extractHttpLinks(md))).toBe('[a](•••)[b](•••)');
+
+    const tight = 'https://x.example/a)(https://y.example/b';
+    expect([...bareUrlSpans(tight)].map((s) => s.clean)).toEqual([
+      'https://x.example/a',
+      'https://y.example/b',
+    ]);
+  });
+
   test('space- or comma-separated adjacent URLs split without glue', () => {
     expect(extractHttpLinks('https://a.example/v https://b.example/c')).toEqual([
       'https://a.example/v',
@@ -281,7 +313,7 @@ describe('extractLinks', () => {
   });
 
   test('bareUrlSpans stays linear when many unbalanced closers precede whitespace', () => {
-    // Each closer used to re-scan to the distant whitespace (O(n²)); nextWs is O(1).
+    // Unbalanced ) with non-adjacent next scheme stays in-URL (O(n) depth walk + peel).
     const adversarial =
       `https://a.example/path${')'.repeat(40_000)} https://b.example/other`;
     const started = performance.now();

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -136,6 +136,18 @@ describe('extractCodes', () => {
     expect(extractCodes('call 555-1234')).toEqual([]);
   });
 
+  test('single-digit chains need strong cues (F132)', () => {
+    // Providers render codes spaced for readability: `1 2 3 4 5 6`.
+    expect(extractCodes('Your verification code is 1 2 3 4 5 6')).toEqual(['1 2 3 4 5 6']);
+    expect(extractCodes('Your OTP is 1-2-3-4')).toEqual(['1-2-3-4']);
+    expect(extractCodes('验证码 １ ２ ３ ４')).toEqual(['１ ２ ３ ４']);
+    expect(extractCodes('code 1 2 3 4 5 6 7 8')).toEqual(['1 2 3 4 5 6 7 8']);
+    // 9+ digit chains refuse whole (full-run integrity, same as other forms).
+    expect(extractCodes('code 1 2 3 4 5 6 7 8 9')).toEqual([]);
+    // No strong cue: stay out.
+    expect(extractCodes('meet at 1 2 3 4 main street')).toEqual([]);
+  });
+
   test('keyword window uses original offsets under expanding lowercasing (F99)', () => {
     // Turkish İ (U+0130) lowercases to two code units; whole-string lower shifts
     // later indices so a pre-lowercased window misses the cue (F99).
@@ -852,9 +864,14 @@ describe('extractLinks', () => {
     expect(extractHttpLinks('《https://example.com/verify》。')).toEqual(['https://example.com/verify']);
     // Smart-quoted span before CJK terminal punctuation also closes.
     expect(extractHttpLinks('“https://example.com/verify”。')).toEqual(['https://example.com/verify']);
+    // F133: compatibility-form (halfwidth/fullwidth) wrappers too.
+    expect(extractHttpLinks('（https://example.com/verify）')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('｢https://example.com/verify｣')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('＜https://example.com/verify＞')).toEqual(['https://example.com/verify']);
     // Closing mark without close-context stays (conservative, mirrors F122).
     expect(extractHttpLinks('«https://a.com/x»y')).toEqual(['https://a.com/x%C2%BBy']);
     expect(extractHttpLinks('《https://a.com/x》y')).toEqual(['https://a.com/x%E3%80%8By']);
+    expect(extractHttpLinks('（https://a.com/x）y')).toEqual(['https://a.com/x%EF%BC%89y']);
   });
 
   test('prose brackets cut before free closing ] (F67)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -202,6 +202,27 @@ describe('extractCodes', () => {
     expect(extractCodes('Your code is 123-456-7')).toEqual([]);
   });
 
+  test('Unicode decimal digits extract with original spelling (F75)', () => {
+    // Fullwidth continuous + CJK cue.
+    expect(extractCodes('您的验证码是 １２３４５６')).toEqual(['１２３４５６']);
+    // Fullwidth hyphen separator (U+FF0D).
+    expect(extractCodes('您的验证码是 １２３\uFF0D４５６')).toEqual(['１２３\uFF0D４５６']);
+    // Arabic-Indic (U+0660…) and Persian/Extended Arabic-Indic (U+06F0…).
+    expect(extractCodes('Your code is \u0661\u0662\u0663\u0664\u0665\u0666')).toEqual([
+      '\u0661\u0662\u0663\u0664\u0665\u0666',
+    ]);
+    expect(extractCodes('Your code is \u06F1\u06F2\u06F3\u06F4\u06F5\u06F6')).toEqual([
+      '\u06F1\u06F2\u06F3\u06F4\u06F5\u06F6',
+    ]);
+    // Fullwidth parens are non-alnum → bounds hold.
+    expect(extractCodes('验证码（１２３４５６）')).toEqual(['１２３４５６']);
+    // CJK glued to ASCII digits still works (must not regress: no \\p{L} in bounds).
+    expect(extractCodes('您的验证码是123456')).toEqual(['123456']);
+    // Latin letter glued → reject (same as old \\b).
+    expect(extractCodes('code abc１２３４５６')).toEqual([]);
+    expect(extractCodes('code １２３４５６x')).toEqual([]);
+  });
+
   test('Unicode-space delimited OTP extracts with original spelling (F70)', () => {
     const nbsp = '\u00A0';
     const nnbsp = '\u202F';

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -592,6 +592,18 @@ describe('extractLinks', () => {
       clean: 'https://a.com/x',
       trail: "'",
     });
+    // Even trailing '' without openQuoted: leave both (parity even).
+    expect(splitBareUrlCandidate("https://a.com/x''")).toEqual({
+      clean: "https://a.com/x''",
+      trail: '',
+    });
+  });
+
+  test('openQuoted peels only one closing quote (F63)', () => {
+    // URL legitimately ends with ' + outer prose quote → keep URL-terminal '.
+    const text = "Use 'https://example.com/verify/token'' now";
+    expect(extractHttpLinks(text)).toEqual(["https://example.com/verify/token'"]);
+    expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe("Use '•••' now");
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -362,6 +362,68 @@ describe('extractLinks', () => {
     expect(onlySecond).toContain('example.com/confirm');
   });
 
+  test('quote/angle hard-cut tails are redacted with the URL (F55)', () => {
+    // Codex original: " after confirm hard-cuts; tail must not leak.
+    const q = 'Verify https://example.com/confirm"token=secret';
+    expect(extractHttpLinks(q)).toEqual(['https://example.com/confirm']);
+    const qSpans = [...bareUrlSpans(q)];
+    expect(qSpans).toHaveLength(1);
+    expect(qSpans[0]!.tailAfter).toEqual({
+      start: q.indexOf('"token=secret'),
+      end: q.length,
+    });
+    const qMasked = maskNormalizedHttpUrls(q, extractHttpLinks(q));
+    expect(qMasked).toBe('Verify ••••••');
+    expect(qMasked).not.toContain('token');
+    expect(qMasked).not.toContain('secret');
+
+    // > glued tail
+    const gt = 'Verify https://example.com/confirm>token=secret';
+    expect(maskNormalizedHttpUrls(gt, extractHttpLinks(gt))).toBe('Verify ••••••');
+    expect(maskNormalizedHttpUrls(gt, extractHttpLinks(gt))).not.toContain('token');
+
+    // <url>token=secret — closer > glued to tail
+    const lt = 'See <https://example.com/confirm>token=secret';
+    const ltMasked = maskNormalizedHttpUrls(lt, extractHttpLinks(lt));
+    expect(ltMasked).toBe('See <••••••');
+    expect(ltMasked).not.toContain('token');
+    expect(ltMasked).not.toContain('secret');
+
+    // Balanced quote: whitespace after closer → no tail; delimiters stay.
+    const bal = 'Say "https://example.com/confirm" end';
+    expect(maskNormalizedHttpUrls(bal, extractHttpLinks(bal))).toBe('Say "•••" end');
+
+    // Autolink with space after >
+    const auto = 'See <https://example.com/confirm> end';
+    expect(maskNormalizedHttpUrls(auto, extractHttpLinks(auto))).toBe('See <•••> end');
+
+    // Apostrophe stays inside URL (whole span masked).
+    const ap = "See https://example.com/confirm'token=secret";
+    expect(extractHttpLinks(ap)).toEqual(["https://example.com/confirm'token=secret"]);
+    expect(maskNormalizedHttpUrls(ap, extractHttpLinks(ap))).toBe('See •••');
+
+    // Tail contains a scheme: stop tail at that scheme; second URL independent.
+    const nested = 'Verify https://a.example/x"https://b.example/y';
+    const nestedSpans = [...bareUrlSpans(nested)];
+    expect(nestedSpans.map((s) => s.clean)).toEqual([
+      'https://a.example/x',
+      'https://b.example/y',
+    ]);
+    expect(nestedSpans[0]!.tailAfter).toEqual({
+      start: nested.indexOf('"https://'),
+      end: nested.indexOf('https://b.example/y'),
+    });
+    const nestedMasked = maskNormalizedHttpUrls(nested, extractHttpLinks(nested));
+    expect(nestedMasked).toBe('Verify •••••••••');
+    expect(nestedMasked).not.toContain('a.example');
+    expect(nestedMasked).not.toContain('b.example');
+
+    // F54 glue still works alongside F55 (no cross-regression).
+    const glue =
+      'Verify https://example.com/confirm)[token=secret](https://safe.example/)';
+    expect(maskNormalizedHttpUrls(glue, extractHttpLinks(glue))).not.toContain('token');
+  });
+
   test('path segment )[token= is one WHATWG URL, not a Markdown cut (F48)', () => {
     const text = 'Verify https://example.com/confirm)[token=secret';
     const full = 'https://example.com/confirm)[token=secret';

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  BARE_URL_RE,
   extractCodes,
   extractHttpLinks,
   extractLinks,
@@ -156,6 +157,16 @@ describe('extractLinks', () => {
 
   test('returns empty for unrelated links only', () => {
     expect(extractLinks('Docs at https://example.com/docs and https://example.com/about')).toEqual([]);
+  });
+
+  test('BARE_URL_RE stays linear on a long run of free brackets', () => {
+    // Overlapping alternatives that re-scan free `[` are O(n²); keep a budget.
+    const poison = `https://${'['.repeat(10_000)}`;
+    const started = performance.now();
+    const matches = poison.match(BARE_URL_RE);
+    const elapsed = performance.now() - started;
+    expect(matches).toBeNull();
+    expect(elapsed).toBeLessThan(1_000);
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -794,7 +794,7 @@ describe('extractLinks', () => {
     expect(
       extractHttpLinks('(a: https://example.com/v)! and (b: https://example.com/w)!'),
     ).toEqual(['https://example.com/v', 'https://example.com/w']);
-    // No wrapper at all — still peel `)!`.
+    // No wrapper at all — still peel `)!` (closer-glued bang).
     expect(extractHttpLinks('open https://example.com/free)!')).toEqual([
       'https://example.com/free',
     ]);
@@ -809,7 +809,7 @@ describe('extractLinks', () => {
     expect(extractHttpLinks('see https://example.com/a_(b)! end')).toEqual([
       'https://example.com/a_(b)',
     ]);
-    // Trailing `?` (sentence interrogative, not query).
+    // Trailing `?` (sentence interrogative, not query) — unconditional.
     expect(extractHttpLinks('have you seen https://example.com/y?')).toEqual([
       'https://example.com/y',
     ]);
@@ -833,6 +833,26 @@ describe('extractLinks', () => {
       'https://example.com/verify',
     ]);
     expect(extractHttpLinks('See (secure: https://example.com/verify).')).toEqual([
+      'https://example.com/verify',
+    ]);
+  });
+
+  test('keeps bare terminal ! on valid URLs; peels only closer-glued ! (F92)', () => {
+    // Legal URL-final bangs (no closer context) must stay.
+    expect(extractHttpLinks('go https://example.com/verify/token! now')).toEqual([
+      'https://example.com/verify/token!',
+    ]);
+    expect(extractHttpLinks('go https://example.com/verify?token=abc! now')).toEqual([
+      'https://example.com/verify?token=abc!',
+    ]);
+    // Closer + punct run still peels (F90 preserved).
+    expect(extractHttpLinks('See (secure: https://example.com/verify)!?')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('See (secure: https://example.com/verify).!')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('See (secure: https://example.com/verify)!')).toEqual([
       'https://example.com/verify',
     ]);
   });

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -123,6 +123,23 @@ describe('extractCodes', () => {
     expect(extractCodes('call 555-1234')).toEqual([]);
   });
 
+  test('Unicode-space delimited OTP extracts with original spelling (F70)', () => {
+    const nbsp = '\u00A0';
+    const nnbsp = '\u202F';
+    const emsp = '\u2003';
+    expect(extractCodes(`Your verification code is 123${nbsp}456`)).toEqual([`123${nbsp}456`]);
+    expect(extractCodes(`Your PIN is 123${nnbsp}456`)).toEqual([`123${nnbsp}456`]);
+    expect(extractCodes(`Your OTP is 123${emsp}456`)).toEqual([`123${emsp}456`]);
+    // Half-suppression still applies with Unicode separators.
+    expect(extractCodes(`Your code is 1234${nbsp}5678`)).toEqual([`1234${nbsp}5678`]);
+    // No strong cue → skip.
+    expect(extractCodes(`call 555${nbsp}1234`)).toEqual([]);
+    // Newlines must not act as separators (meta/text joins use \n).
+    expect(extractCodes('Your verification code is 123\n456')).toEqual([]);
+    expect(extractCodes('Your verification code is 1234\n5678')).toEqual(['1234', '5678']);
+    expect(extractCodes('Your verification code is 123\r456')).toEqual([]);
+  });
+
   test('dedupes repeated codes', () => {
     expect(extractCodes('code 552211. Again: your code is 552211.')).toEqual(['552211']);
   });

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -192,6 +192,23 @@ describe('extractLinks', () => {
       clean: 'https://[2001:db8::1]/confirm?token=secret',
       trail: '',
     });
+    // Apostrophe is a legal URL char; only an odd trailing prose closer peels.
+    expect(splitBareUrlCandidate("https://example.com/confirm?'token=secret")).toEqual({
+      clean: "https://example.com/confirm?'token=secret",
+      trail: '',
+    });
+    expect(splitBareUrlCandidate("https://x.com/it's")).toEqual({
+      clean: "https://x.com/it's",
+      trail: '',
+    });
+    expect(splitBareUrlCandidate("https://example.com/verify?token=a'")).toEqual({
+      clean: 'https://example.com/verify?token=a',
+      trail: "'",
+    });
+    expect(splitBareUrlCandidate("https://example.com/verify?token=a'.")).toEqual({
+      clean: 'https://example.com/verify?token=a',
+      trail: "'.",
+    });
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -93,8 +93,16 @@ describe('extractCodes', () => {
     expect(extractCodes('Call us at 5551234 anytime.')).toEqual([]);
   });
 
-  test('ignores years without an explicit code keyword', () => {
-    expect(extractCodes('Our verification team, since 2024, sends regards.')).toEqual([]);
+  test('years next to OTP keywords are extracted as codes (F62)', () => {
+    // "verification" + "pin" are CODE_KEYWORDS; year guard no longer drops 2026.
+    expect(extractCodes('Your verification PIN is 2026')).toEqual(['2026']);
+    // "verification" alone also counts — update from prior "skip years" expectation.
+    expect(extractCodes('Our verification team, since 2024, sends regards.')).toEqual(['2024']);
+  });
+
+  test('years without any OTP keyword stay unextracted (F62)', () => {
+    expect(extractCodes('Born 1990, see link')).toEqual([]);
+    expect(extractCodes('This week in tech: 2024 trends.')).toEqual([]);
   });
 
   test('dedupes repeated codes', () => {
@@ -564,6 +572,26 @@ describe('extractLinks', () => {
     expect(extractHttpLinks(nbsp)[0]).not.toContain('%C2%A0');
     const em = `https://example.com/verify?token=abc\u2003NEXT`;
     expect(extractHttpLinks(em)).toEqual(['https://example.com/verify?token=abc']);
+  });
+
+  test('outer single quotes peel even with internal apostrophes (F61)', () => {
+    const text = "Use 'https://example.com/verify/o'brien' now";
+    expect(extractHttpLinks(text)).toEqual(["https://example.com/verify/o'brien"]);
+    expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe("Use '•••' now");
+
+    // Trailing prose punctuation after outer closer still peels the quote (even count).
+    expect(extractHttpLinks("See 'https://example.com/verify/o'brien'.")).toEqual([
+      "https://example.com/verify/o'brien",
+    ]);
+
+    // Balanced outer quotes without internal apostrophe — still peel closer.
+    expect(extractHttpLinks("'https://a.com/x'")).toEqual(['https://a.com/x']);
+
+    // Bare URL with trailing ' and even/odd count: no openQuoted (start===0 path via split).
+    expect(splitBareUrlCandidate("https://a.com/x'")).toEqual({
+      clean: 'https://a.com/x',
+      trail: "'",
+    });
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -93,11 +93,14 @@ describe('extractCodes', () => {
     expect(extractCodes('Call us at 5551234 anytime.')).toEqual([]);
   });
 
-  test('years next to OTP keywords are extracted as codes (F62)', () => {
-    // "verification" + "pin" are CODE_KEYWORDS; year guard no longer drops 2026.
+  test('years need strong OTP cues, not mere verification (F62/F65)', () => {
+    // Strong cue \bpin\b — still extract (F62 Codex / F65 keep).
     expect(extractCodes('Your verification PIN is 2026')).toEqual(['2026']);
-    // "verification" alone also counts — update from prior "skip years" expectation.
-    expect(extractCodes('Our verification team, since 2024, sends regards.')).toEqual(['2024']);
+    // "verification" alone is not strong enough (F65 restores year guard).
+    expect(extractCodes('Our verification team, since 2024, sends regards.')).toEqual([]);
+    expect(extractCodes('Read our identity verification roadmap for 2026')).toEqual([]);
+    // Substring "pin" inside "shopping" must not count (\bpin\b).
+    expect(extractCodes('shopping 2026 deals')).toEqual([]);
   });
 
   test('years without any OTP keyword stay unextracted (F62)', () => {
@@ -604,6 +607,23 @@ describe('extractLinks', () => {
     const text = "Use 'https://example.com/verify/token'' now";
     expect(extractHttpLinks(text)).toEqual(["https://example.com/verify/token'"]);
     expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe("Use '•••' now");
+  });
+
+  test('prose wrappers cut before closing punctuation (F64)', () => {
+    expect(extractHttpLinks('Visit (https://example.com/verify): now')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks("Use 'https://example.com/verify'!")).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(
+      [...bareUrlSpans('(https://a.com/f(1))')].map((s) => s.clean),
+    ).toEqual(['https://a.com/f(1)']);
+    expect(extractHttpLinks("'https://a.com/x',")).toEqual(['https://a.com/x']);
+    // URL-terminal ' kept; outer closer cut on whitespace (F63 + F64).
+    expect(extractHttpLinks("See 'https://example.com/verify/token'' now")).toEqual([
+      "https://example.com/verify/token'",
+    ]);
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -826,9 +826,9 @@ describe('extractLinks', () => {
     expect(extractHttpLinks('see https://example.com/a_(b)! end')).toEqual([
       'https://example.com/a_(b)',
     ]);
-    // Trailing `?` (sentence interrogative, not query) — unconditional.
+    // Trailing bare `?` kept as empty query (F100).
     expect(extractHttpLinks('have you seen https://example.com/y?')).toEqual([
-      'https://example.com/y',
+      'https://example.com/y?',
     ]);
     // Mid-URL `!` preserved.
     expect(extractHttpLinks('go https://example.com/a!b now')).toEqual([
@@ -886,6 +886,49 @@ describe('extractLinks', () => {
     // Stacked mixed terminal punct still peels (verdict cache must not diverge).
     expect(extractHttpLinks('See (secure: https://example.com/verify)!.:.?')).toEqual([
       'https://example.com/verify',
+    ]);
+    // F100: long trailing `?` run after a real query stays linear (peel extras).
+    const q = `go https://example.com/v?t=1${'?'.repeat(50_000)} end`;
+    const t0 = performance.now();
+    expect(extractHttpLinks(q)).toEqual(['https://example.com/v?t=1']);
+    expect(performance.now() - t0).toBeLessThan(1_000);
+  });
+
+  test('preserves structural terminal ? empty query; peels prose ? (F100)', () => {
+    // Bare empty query kept (WHATWG-significant).
+    expect(extractHttpLinks('go https://example.com/verify? end')).toEqual([
+      'https://example.com/verify?',
+    ]);
+    expect(extractHttpLinks('go https://example.com/verify?\nNEXT')).toEqual([
+      'https://example.com/verify?',
+    ]);
+    expect(extractHttpLinks('go https://example.com/verify?')).toEqual([
+      'https://example.com/verify?',
+    ]);
+    // Second bare `?` after a real query is prose — peel.
+    expect(extractHttpLinks('go https://example.com/v?t=1? end')).toEqual([
+      'https://example.com/v?t=1',
+    ]);
+    // `??` keeps one structural empty-query `?`.
+    expect(extractHttpLinks('go https://example.com/verify?? end')).toEqual([
+      'https://example.com/verify?',
+    ]);
+    // Closer / punct after `?` peels the `?` too (sentence context).
+    expect(extractHttpLinks('See (secure: https://example.com/verify?) now')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('See (secure: https://example.com/verify?). now')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('See [docs: https://example.com/verify?] next')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('go https://example.com/verify?. end')).toEqual([
+      'https://example.com/verify',
+    ]);
+    // Internal query regression.
+    expect(extractHttpLinks('Click https://example.com/verify?token=abc to continue')).toEqual([
+      'https://example.com/verify?token=abc',
     ]);
   });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from 'bun:test';
 import {
   BARE_URL_RE,
+  bareUrlSpans,
   extractCodes,
   extractHttpLinks,
   extractLinks,
   extractOtp,
   htmlToText,
+  maskNormalizedHttpUrls,
   splitBareUrlCandidate,
 } from '../src/lib/otp.ts';
 
@@ -209,6 +211,45 @@ describe('extractLinks', () => {
       clean: 'https://example.com/verify?token=a',
       trail: "'.",
     });
+    // Mid-string free closer between adjacent Markdown links.
+    expect(
+      splitBareUrlCandidate(
+        'https://a.example/verify)[Confirm](https://b.example/confirm',
+      ),
+    ).toEqual({
+      clean: 'https://a.example/verify',
+      trail: ')[Confirm](https://b.example/confirm',
+    });
+  });
+
+  test('HTML anchor hrefs keep a literal trailing ) that prose trim would peel', () => {
+    const html =
+      '<a href="https://example.com/confirm?token=abc)">Confirm your account</a>';
+    expect(extractLinks('Confirm your account', html)).toEqual([
+      'https://example.com/confirm?token=abc)',
+    ]);
+    // Prose path still peels free trailers.
+    expect(extractHttpLinks('(see https://x.com/a)')).toEqual(['https://x.com/a']);
+  });
+
+  test('adjacent Markdown links split into two bare spans and mask fully', () => {
+    const text = '[Verify](https://a.example/verify)[Confirm](https://b.example/confirm)';
+    const spans = [...bareUrlSpans(text)].map((s) => s.clean);
+    expect(spans).toEqual([
+      'https://a.example/verify',
+      'https://b.example/confirm',
+    ]);
+    expect(extractHttpLinks(text)).toEqual([
+      'https://a.example/verify',
+      'https://b.example/confirm',
+    ]);
+    // Monster merge must not appear as a single extracted URL.
+    expect(extractHttpLinks(text).join(' ')).not.toContain(')[Confirm](');
+    const masked = maskNormalizedHttpUrls(text, extractHttpLinks(text));
+    expect(masked).toBe('[Verify](•••)[Confirm](•••)');
+    expect(masked).not.toContain('a.example');
+    expect(masked).not.toContain('b.example');
+    expect(masked).not.toContain('https://');
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -108,6 +108,21 @@ describe('extractCodes', () => {
     expect(extractCodes('This week in tech: 2024 trends.')).toEqual([]);
   });
 
+  test('delimited OTP forms need strong cues (F68)', () => {
+    expect(extractCodes('Your verification code is 123-456')).toEqual(['123-456']);
+    // Full form only — continuous halves of a real 3–4|3–4 shape are suppressed.
+    expect(extractCodes('Your PIN is 1234-5678')).toEqual(['1234-5678']);
+    // Longer continuous runs are not delimited halves; keep continuous extract.
+    expect(extractCodes('Your code is 123456-7890')).toEqual(['123456', '7890']);
+    expect(extractCodes('code 1234-567890')).toEqual(['1234', '567890']);
+    // Other separators with strong cues.
+    expect(extractCodes('Your OTP is 123–456')).toEqual(['123–456']);
+    expect(extractCodes('验证码 123-456')).toEqual(['123-456']);
+    // No strong cue: roadmap ranges and phone-like numbers stay out.
+    expect(extractCodes('roadmap 2024-2025')).toEqual([]);
+    expect(extractCodes('call 555-1234')).toEqual([]);
+  });
+
   test('dedupes repeated codes', () => {
     expect(extractCodes('code 552211. Again: your code is 552211.')).toEqual(['552211']);
   });
@@ -624,6 +639,31 @@ describe('extractLinks', () => {
     expect(extractHttpLinks("See 'https://example.com/verify/token'' now")).toEqual([
       "https://example.com/verify/token'",
     ]);
+  });
+
+  test('prose brackets cut before free closing ] (F67)', () => {
+    expect(extractHttpLinks('Visit [https://example.com/verify]: now')).toEqual([
+      'https://example.com/verify',
+    ]);
+    // Free-`]` cut (not only peel): `!` / glued tail are not trailer peel chars.
+    expect(extractHttpLinks('Visit [https://example.com/verify]!')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(
+      [...bareUrlSpans('[https://example.com/verify]token=secret')].map((s) => s.clean),
+    ).toEqual(['https://example.com/verify']);
+    // Balanced paren inside still peels outer brackets.
+    expect(extractHttpLinks('[https://a.com/f(1)]')).toEqual(['https://a.com/f(1)']);
+    // Nested brackets: inner [1] is balanced; free outer ] cuts.
+    expect(
+      [...bareUrlSpans('[https://a.com/f[1]]')].map((s) => s.clean),
+    ).toEqual(['https://a.com/f[1]']);
+    // IPv6 host balanced; free outer ] cuts after path.
+    expect(extractHttpLinks('[http://[::1]:8080/v]')).toEqual(['http://[::1]:8080/v']);
+    // No prose `[` opener: free `]` mid-path stays (not a wrapper cut).
+    expect(
+      [...bareUrlSpans('https://a.com/x[1]')].map((s) => s.clean),
+    ).toEqual(['https://a.com/x[1]']);
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -142,6 +142,22 @@ describe('extractCodes', () => {
     expect(extractCodes(`${'ΐ'.repeat(50)}${labeled}`)).toEqual(['123456']);
   });
 
+  test('keyword window matches compatibility-form keywords (F104)', () => {
+    // Fullwidth keyword + fullwidth code: window NFKC lets `ｃｏｄｅ` hit `code`.
+    expect(extractCodes('ｃｏｄｅ １２３４５６')).toEqual(['１２３４５６']);
+    expect(extractCodes('Ｙｏｕｒ ｖｅｒｉｆｉｃａｔｉｏｎ ｃｏｄｅ ｉｓ １２３４５６')).toEqual(['１２３４５６']);
+    // Fullwidth keyword + ASCII code.
+    expect(extractCodes('ｃｏｄｅ 123456')).toEqual(['123456']);
+    // ASCII keyword + fullwidth code (regression).
+    expect(extractCodes('code １２３４５６')).toEqual(['１２３４５６']);
+    // Delimited form under fullwidth strong cue.
+    expect(extractCodes('ｃｏｄｅ １２３-４５６')).toEqual(['１２３-４５６']);
+    // Year guard sees fullwidth strong cue inside the window.
+    expect(extractCodes('ｃｏｄｅ ２０２６')).toEqual(['２０２６']);
+    // No keyword at all: still rejected.
+    expect(extractCodes('ｈｅｌｌｏ １２３４５６')).toEqual([]);
+  });
+
   test('strong cues cover CJK/JP code words for delimited and years (F71)', () => {
     expect(extractCodes('您的校验码是 123-456')).toEqual(['123-456']);
     expect(extractCodes('確認コードは 123-456')).toEqual(['123-456']);

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -120,6 +120,12 @@ describe('extractCodes', () => {
     // Other separators with strong cues.
     expect(extractCodes('Your OTP is 123–456')).toEqual(['123–456']);
     expect(extractCodes('验证码 123-456')).toEqual(['123-456']);
+    // F128: slash-delimited numeric OTPs (providers format codes as 123/456).
+    expect(extractCodes('Your verification code is 123/456')).toEqual(['123/456']);
+    expect(extractCodes('Your verification code is 1234/5678')).toEqual(['1234/5678']);
+    expect(extractCodes('验证码 １２３／４５６')).toEqual(['１２３／４５６']);
+    // No strong cue: dates stay out (same as hyphen/dot forms).
+    expect(extractCodes('due 08/07/2026')).toEqual([]);
     // No strong cue: roadmap ranges and phone-like numbers stay out.
     expect(extractCodes('roadmap 2024-2025')).toEqual([]);
     expect(extractCodes('call 555-1234')).toEqual([]);

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -125,6 +125,23 @@ describe('extractCodes', () => {
     expect(extractCodes('call 555-1234')).toEqual([]);
   });
 
+  test('keyword window uses original offsets under expanding lowercasing (F99)', () => {
+    // Turkish İ (U+0130) lowercases to two code units; whole-string lower shifts
+    // later indices so a pre-lowercased window misses the cue (F99).
+    const labeled = 'Your verification code is 123456';
+    const prefixLong = 'İ'.repeat(100);
+    const prefixShort = 'İ'.repeat(10);
+    const asciiPrefix = 'A'.repeat(100);
+    expect(extractCodes(`${prefixLong}${labeled}`)).toEqual(['123456']);
+    expect(extractCodes(`${prefixShort}${labeled}`)).toEqual(['123456']);
+    expect(extractCodes(`${asciiPrefix}${labeled}`)).toEqual(['123456']);
+    // Delimited form with expanding prefix.
+    expect(extractCodes(`${prefixLong}Your verification code is 123-456`)).toEqual(['123-456']);
+    // Other expanders (ligature / Greek dialytika-tonos).
+    expect(extractCodes(`${'ﬀ'.repeat(50)}${labeled}`)).toEqual(['123456']);
+    expect(extractCodes(`${'ΐ'.repeat(50)}${labeled}`)).toEqual(['123456']);
+  });
+
   test('strong cues cover CJK/JP code words for delimited and years (F71)', () => {
     expect(extractCodes('您的校验码是 123-456')).toEqual(['123-456']);
     expect(extractCodes('確認コードは 123-456')).toEqual(['123-456']);
@@ -853,6 +870,21 @@ describe('extractLinks', () => {
       'https://example.com/verify',
     ]);
     expect(extractHttpLinks('See (secure: https://example.com/verify)!')).toEqual([
+      'https://example.com/verify',
+    ]);
+  });
+
+  test('peel trailing punct stays linear on long colon runs (F98)', () => {
+    const base = 'go https://example.com/verify)';
+    const text = `${base}${':'.repeat(50_000)} end`;
+    const started = performance.now();
+    const links = extractHttpLinks(text);
+    const elapsed = performance.now() - started;
+    expect(links).toEqual(['https://example.com/verify']);
+    // Quadratic code took ~10s+ on 50k; linear must stay well under 1s.
+    expect(elapsed).toBeLessThan(1_000);
+    // Stacked mixed terminal punct still peels (verdict cache must not diverge).
+    expect(extractHttpLinks('See (secure: https://example.com/verify)!.:.?')).toEqual([
       'https://example.com/verify',
     ]);
   });

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -279,6 +279,25 @@ describe('extractLinks', () => {
       'https://b.example/c',
     ]);
   });
+
+  test('bareUrlSpans stays linear when many unbalanced closers precede whitespace', () => {
+    // Each closer used to re-scan to the distant whitespace (O(n²)); nextWs is O(1).
+    const adversarial =
+      `https://a.example/path${')'.repeat(40_000)} https://b.example/other`;
+    const started = performance.now();
+    const links = extractHttpLinks(adversarial);
+    expect(performance.now() - started).toBeLessThan(1_000);
+    // Free trailing ) peel leaves path; second URL still found after whitespace.
+    expect(links).toEqual(['https://a.example/path', 'https://b.example/other']);
+  });
+
+  test('JS whitespace (NBSP, em space) ends a bare URL candidate', () => {
+    const nbsp = `https://example.com/verify?token=abc\u00A0NEXT`;
+    expect(extractHttpLinks(nbsp)).toEqual(['https://example.com/verify?token=abc']);
+    expect(extractHttpLinks(nbsp)[0]).not.toContain('%C2%A0');
+    const em = `https://example.com/verify?token=abc\u2003NEXT`;
+    expect(extractHttpLinks(em)).toEqual(['https://example.com/verify?token=abc']);
+  });
 });
 
 describe('extractOtp (combined)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -376,14 +376,15 @@ describe('extractLinks', () => {
       clean: 'https://[2001:db8::1]/confirm?token=secret',
       trail: '',
     });
-    // Apostrophe is a legal URL char; only an odd trailing prose closer peels.
+    // Apostrophe is a legal URL char mid-URL; an odd trailing prose closer peels,
+    // and a trailing possessive/contraction `'s` peels as prose (F108).
     expect(splitBareUrlCandidate("https://example.com/confirm?'token=secret")).toEqual({
       clean: "https://example.com/confirm?'token=secret",
       trail: '',
     });
     expect(splitBareUrlCandidate("https://x.com/it's")).toEqual({
-      clean: "https://x.com/it's",
-      trail: '',
+      clean: 'https://x.com/it',
+      trail: "'s",
     });
     expect(splitBareUrlCandidate("https://example.com/verify?token=a'")).toEqual({
       clean: 'https://example.com/verify?token=a',
@@ -977,6 +978,32 @@ describe('extractLinks', () => {
     ]);
     expect(extractHttpLinks('go https://example.com/a:b now')).toEqual([
       'https://example.com/a:b',
+    ]);
+  });
+
+  test("peels English possessive 's from bare URL tails (F108)", () => {
+    // Possessive prose glued to the URL peels `'s`.
+    expect(extractHttpLinks("Check https://example.com/verify's status")).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks("Check https://example.com/verify's.")).toEqual([
+      'https://example.com/verify',
+    ]);
+    // Internal apostrophes are never trailing and stay put.
+    expect(extractHttpLinks("see https://example.com/don't/verify now")).toEqual([
+      "https://example.com/don't/verify",
+    ]);
+    // Quoted span regression: outer quotes still peel around the URL.
+    expect(extractHttpLinks("go 'https://example.com/verify' now")).toEqual([
+      'https://example.com/verify',
+    ]);
+    // Uppercase 'S is not peeled (conservative).
+    expect(extractHttpLinks("Check https://example.com/verify'S end")).toEqual([
+      "https://example.com/verify'S",
+    ]);
+    // Bare trailing apostrophe still peels via the odd-parity rule (F61 regression).
+    expect(extractHttpLinks("see https://example.com/verify' end")).toEqual([
+      'https://example.com/verify',
     ]);
   });
 });

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -424,6 +424,65 @@ describe('extractLinks', () => {
     expect(maskNormalizedHttpUrls(glue, extractHttpLinks(glue))).not.toContain('token');
   });
 
+  test('invalid nested scheme after tail/glue is swallowed into redaction (F57)', () => {
+    // Codex: tail stops at nested scheme; nested span is invalid and must not leak.
+    const text = 'Verify https://example.com/confirm"x=https://[token=secret';
+    const links = extractHttpLinks(text);
+    expect(links).toEqual(['https://example.com/confirm']);
+    const masked = maskNormalizedHttpUrls(text, links);
+    expect(masked).not.toContain('token');
+    expect(masked).not.toContain('secret');
+    expect(masked).not.toContain('https://[');
+    expect(masked.startsWith('Verify •••')).toBe(true);
+
+    // Chain of invalid nested schemes after quote tails.
+    const chain =
+      'See https://example.com/a"x=https://[bad"y=https://[worse';
+    const chainMasked = maskNormalizedHttpUrls(chain, extractHttpLinks(chain));
+    expect(chainMasked).not.toContain('bad');
+    expect(chainMasked).not.toContain('worse');
+    expect(chainMasked).not.toContain('https://[');
+    expect(chainMasked).not.toContain('token');
+
+    // Tail stops at a *valid* scheme that is not a mask target — leave it visible.
+    const keep =
+      'See https://a.example/x"https://b.example/visible';
+    const keepMasked = maskNormalizedHttpUrls(keep, ['https://a.example/x']);
+    expect(keepMasked).toContain('b.example/visible');
+    expect(keepMasked).not.toContain('a.example/x');
+
+    // Glue cut onto an invalid nested scheme — same swallow path.
+    const glueBad = 'See https://example.com/confirm)[x](https://[token=secret';
+    const glueMasked = maskNormalizedHttpUrls(glueBad, extractHttpLinks(glueBad));
+    expect(glueMasked).not.toContain('token');
+    expect(glueMasked).not.toContain('secret');
+    expect(glueMasked).not.toContain('https://[');
+  });
+
+  test('dense quote-tail fragments stay linear (F58)', () => {
+    // 4000 glued fragments: each "x= before the next https:// must not O(n²) scan.
+    const n = 4_000;
+    const dense = Array.from(
+      { length: n },
+      (_, i) => `https://a.example/${i}"x=`,
+    ).join('');
+    const started = performance.now();
+    const spans = [...bareUrlSpans(dense)];
+    const elapsed = performance.now() - started;
+    expect(spans).toHaveLength(n);
+    expect(spans[0]!.clean).toBe('https://a.example/0');
+    expect(spans[n - 1]!.clean).toBe(`https://a.example/${n - 1}`);
+    // Last fragment has no following scheme → tail may extend over "x=
+    expect(spans[0]!.tailAfter?.end).toBe(spans[1]!.start);
+    expect(elapsed).toBeLessThan(5_000);
+    // Masking must remain linear as well.
+    const maskStarted = performance.now();
+    const masked = maskNormalizedHttpUrls(dense, extractHttpLinks(dense));
+    expect(performance.now() - maskStarted).toBeLessThan(5_000);
+    expect(masked).not.toContain('https://');
+    expect(masked).not.toContain('a.example');
+  });
+
   test('path segment )[token= is one WHATWG URL, not a Markdown cut (F48)', () => {
     const text = 'Verify https://example.com/confirm)[token=secret';
     const full = 'https://example.com/confirm)[token=secret';

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -459,6 +459,38 @@ describe('extractLinks', () => {
     expect(glueMasked).not.toContain('https://[');
   });
 
+  test('Markdown link closer cuts free ) before glued prose (F59)', () => {
+    const text = '[Verify](https://example.com/confirm)now';
+    expect([...bareUrlSpans(text)].map((s) => s.clean)).toEqual([
+      'https://example.com/confirm',
+    ]);
+    expect(extractHttpLinks(text)).toEqual(['https://example.com/confirm']);
+    expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe(
+      '[Verify](•••)now',
+    );
+
+    expect(
+      [...bareUrlSpans('[x](https://a.com/f(1))tail')].map((s) => s.clean),
+    ).toEqual(['https://a.com/f(1)']);
+    expect(
+      [...bareUrlSpans('[x](https://a.com/p)foo)bar')].map((s) => s.clean),
+    ).toEqual(['https://a.com/p']);
+
+    // Space after MD closer — still clean URL (peel/cut both fine).
+    expect(
+      extractHttpLinks('[Verify](https://example.com/confirm) now'),
+    ).toEqual(['https://example.com/confirm']);
+    expect(extractHttpLinks('[Verify](https://example.com/confirm)')).toEqual([
+      'https://example.com/confirm',
+    ]);
+
+    // Bare URL free ) path must not use MD-link cutting (F48).
+    const bare = 'Verify https://example.com/confirm)[token=secret';
+    expect([...bareUrlSpans(bare)].map((s) => s.clean)).toEqual([
+      'https://example.com/confirm)[token=secret',
+    ]);
+  });
+
   test('dense quote-tail fragments stay linear (F58)', () => {
     // 4000 glued fragments: each "x= before the next https:// must not O(n²) scan.
     const n = 4_000;

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   BARE_URL_RE,
   bareUrlSpans,
+  CODE_KEYWORDS,
   extractCodes,
   extractHttpLinks,
   extractLinks,
@@ -9,6 +10,7 @@ import {
   htmlToText,
   maskNormalizedHttpUrls,
   splitBareUrlCandidate,
+  STRONG_OTP_CUES,
 } from '../src/lib/otp.ts';
 
 describe('htmlToText', () => {
@@ -121,6 +123,55 @@ describe('extractCodes', () => {
     // No strong cue: roadmap ranges and phone-like numbers stay out.
     expect(extractCodes('roadmap 2024-2025')).toEqual([]);
     expect(extractCodes('call 555-1234')).toEqual([]);
+  });
+
+  test('strong cues cover CJK/JP code words for delimited and years (F71)', () => {
+    expect(extractCodes('您的校验码是 123-456')).toEqual(['123-456']);
+    expect(extractCodes('確認コードは 123-456')).toEqual(['123-456']);
+    expect(extractCodes('認証コードは 123-456')).toEqual(['123-456']);
+    // Year path benefits from the same strong set.
+    expect(extractCodes('認証コード 2026')).toEqual(['2026']);
+    // Weak verification alone still does not unlock years.
+    expect(extractCodes('verification roadmap 2026')).toEqual([]);
+  });
+
+  test('STRONG_OTP_CUES stays aligned with CODE_KEYWORDS strong items (F71)', () => {
+    const strongSet = new Set<string>(STRONG_OTP_CUES);
+    const codeSet = new Set<string>(CODE_KEYWORDS);
+    const latinStrong = new Set(['code', 'otp', 'passcode', 'pin']);
+    for (const kw of CODE_KEYWORDS) {
+      const mustBeStrong = latinStrong.has(kw) || /码|コード/.test(kw);
+      if (mustBeStrong) {
+        expect(strongSet.has(kw)).toBe(true);
+      }
+    }
+    // No orphan strong cues outside the keyword list.
+    for (const cue of STRONG_OTP_CUES) {
+      expect(codeSet.has(cue)).toBe(true);
+    }
+    // Weak / action terms must remain outside the strong set.
+    for (const weak of [
+      'verification',
+      'verify',
+      'confirmation',
+      'one-time',
+      'one time',
+      'security code',
+    ] as const) {
+      expect(strongSet.has(weak)).toBe(false);
+      expect(codeSet.has(weak)).toBe(true);
+    }
+  });
+
+  test('multi-character separator runs extract delimited OTP (F72)', () => {
+    expect(extractCodes('Your code is 123 - 456')).toEqual(['123 - 456']);
+    expect(extractCodes('Your code is 123  456')).toEqual(['123  456']);
+    expect(extractCodes('Your code is 123 – 456')).toEqual(['123 – 456']);
+    expect(extractCodes('123 - 456')).toEqual([]);
+    // Half-suppression with multi-char seps.
+    expect(extractCodes('Your code is 1234 - 5678')).toEqual(['1234 - 5678']);
+    // Four+ seps intentionally miss (bounded false-positive surface).
+    expect(extractCodes('Your code is 123    456')).toEqual([]);
   });
 
   test('Unicode-space delimited OTP extracts with original spelling (F70)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -162,15 +162,21 @@ describe('extractLinks', () => {
     expect(extractLinks('Docs at https://example.com/docs and https://example.com/about')).toEqual([]);
   });
 
-  test('BARE_URL_RE and splitBareUrlCandidate stay linear on adversarial inputs', () => {
+  test('bareUrlSpans stays linear on free brackets and dense adjacent candidates', () => {
     const freeBrackets = `https://${'['.repeat(10_000)}`;
     const nestedParens = `https://x.com/${'('.repeat(5_000)}${')'.repeat(5_000)}`;
+    // 8000 glued candidates (~200KB) must not re-match the remainder after each cut.
+    const dense = Array.from(
+      { length: 8_000 },
+      (_, i) => `https://a${i}.example/verify)`,
+    ).join('');
     const started = performance.now();
     freeBrackets.match(BARE_URL_RE);
-    nestedParens.match(BARE_URL_RE);
-    splitBareUrlCandidate(freeBrackets);
-    splitBareUrlCandidate(nestedParens);
+    [...bareUrlSpans(freeBrackets)];
+    [...bareUrlSpans(nestedParens)];
+    const denseSpans = [...bareUrlSpans(dense)];
     expect(performance.now() - started).toBeLessThan(1_000);
+    expect(denseSpans).toHaveLength(8_000);
   });
 
   test('splitBareUrlCandidate keeps nested balanced parens and peels free trailers', () => {
@@ -211,7 +217,7 @@ describe('extractLinks', () => {
       clean: 'https://example.com/verify?token=a',
       trail: "'.",
     });
-    // Mid-string free closer between adjacent Markdown links.
+    // Mid-string free closer between adjacent Markdown links (glued next scheme).
     expect(
       splitBareUrlCandidate(
         'https://a.example/verify)[Confirm](https://b.example/confirm',
@@ -219,6 +225,11 @@ describe('extractLinks', () => {
     ).toEqual({
       clean: 'https://a.example/verify',
       trail: ')[Confirm](https://b.example/confirm',
+    });
+    // Unbalanced ) with no following scheme is URL content (WHATWG), not a cut.
+    expect(splitBareUrlCandidate('https://example.com/confirm)foo?token=secret')).toEqual({
+      clean: 'https://example.com/confirm)foo?token=secret',
+      trail: '',
     });
   });
 
@@ -250,6 +261,23 @@ describe('extractLinks', () => {
     expect(masked).not.toContain('a.example');
     expect(masked).not.toContain('b.example');
     expect(masked).not.toContain('https://');
+  });
+
+  test('unbalanced ) without a glued next scheme stays inside the URL', () => {
+    const url = 'https://example.com/confirm)foo?token=secret';
+    expect(extractHttpLinks(url)).toEqual([url]);
+    expect(maskNormalizedHttpUrls(`See ${url}`, [url])).toBe('See •••');
+  });
+
+  test('space- or comma-separated adjacent URLs split without glue', () => {
+    expect(extractHttpLinks('https://a.example/v https://b.example/c')).toEqual([
+      'https://a.example/v',
+      'https://b.example/c',
+    ]);
+    expect(extractHttpLinks('https://a.example/v, https://b.example/c')).toEqual([
+      'https://a.example/v',
+      'https://b.example/c',
+    ]);
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -792,6 +792,22 @@ describe('extractLinks', () => {
     ]);
   });
 
+  test('smart quotes do not extend verification URLs (F122)', () => {
+    // Typographic double/single quotes around a link: the closing smart quote
+    // is prose context, not URL content (WHATWG would percent-encode it).
+    expect(extractHttpLinks('“https://example.com/verify”')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('‘https://example.com/verify’,')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('see “https://example.com/verify?token=abc123” now')).toEqual([
+      'https://example.com/verify?token=abc123',
+    ]);
+    // Closing quote without close-context stays (conservative, mirrors F64).
+    expect(extractHttpLinks('“https://a.com/x”y')).toEqual(['https://a.com/x%E2%80%9Dy']);
+  });
+
   test('prose brackets cut before free closing ] (F67)', () => {
     expect(extractHttpLinks('Visit [https://example.com/verify]: now')).toEqual([
       'https://example.com/verify',

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -257,10 +257,12 @@ describe('extractLinks', () => {
     // Monster merge must not appear as a single extracted URL.
     expect(extractHttpLinks(text).join(' ')).not.toContain(')[Confirm](');
     const masked = maskNormalizedHttpUrls(text, extractHttpLinks(text));
-    expect(masked).toBe('[Verify](•••)[Confirm](•••)');
+    // Glue `)[Confirm](` is redacted with the URLs (F54) so labels cannot leak secrets.
+    expect(masked).toBe('[Verify](•••••••••)');
     expect(masked).not.toContain('a.example');
     expect(masked).not.toContain('b.example');
     expect(masked).not.toContain('https://');
+    expect(masked).not.toContain('Confirm');
   });
 
   test('unbalanced ) without a glued next scheme stays inside the URL', () => {
@@ -292,13 +294,15 @@ describe('extractLinks', () => {
       'https://x.example/pay',
       'https://y.example/confirm',
     ]);
-    expect(maskNormalizedHttpUrls(md, extractHttpLinks(md))).toBe('[a](•••)[b](•••)');
+    expect(maskNormalizedHttpUrls(md, extractHttpLinks(md))).toBe('[a](•••••••••)');
 
     const tight = 'https://x.example/a)(https://y.example/b';
     expect([...bareUrlSpans(tight)].map((s) => s.clean)).toEqual([
       'https://x.example/a',
       'https://y.example/b',
     ]);
+    // glue is `)(` → three placeholders concatenated
+    expect(maskNormalizedHttpUrls(tight, extractHttpLinks(tight))).toBe('•••••••••');
 
     const bracketChain = '[https://x.example/a][https://y.example/b]';
     expect([...bareUrlSpans(bracketChain)].map((s) => s.clean)).toEqual([
@@ -318,9 +322,44 @@ describe('extractLinks', () => {
       'https://a.example/verify?next=https://x.example/',
       'https://b.example/confirm',
     ]);
-    expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe(
-      '[Verify](•••)[Confirm](•••)',
-    );
+    expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe('[Verify](•••••••••)');
+  });
+
+  test('Markdown chain glue between URLs is redacted with the links (F54)', () => {
+    const text =
+      'Verify https://example.com/confirm)[token=secret](https://safe.example/)';
+    const links = extractHttpLinks(text);
+    expect(links).toEqual([
+      'https://example.com/confirm',
+      'https://safe.example/',
+    ]);
+    const spans = [...bareUrlSpans(text)];
+    expect(spans).toHaveLength(2);
+    expect(spans[0]!.glueAfter).toEqual({
+      start: text.indexOf(')[token=secret]('),
+      end: text.indexOf('https://safe.example/'),
+    });
+    const masked = maskNormalizedHttpUrls(text, links);
+    // Trailing Markdown `)` after the second URL stays; glue+URLs are placeholders.
+    expect(masked).toBe('Verify •••••••••)');
+    expect(masked).not.toContain('token');
+    expect(masked).not.toContain('secret');
+    expect(masked).not.toContain('https://');
+    expect(masked).not.toContain('example.com');
+  });
+
+  test('glue redacts when only one adjacent URL is a target (F54)', () => {
+    const text =
+      'Verify https://example.com/confirm)[token=secret](https://safe.example/)';
+    const onlyFirst = maskNormalizedHttpUrls(text, ['https://example.com/confirm']);
+    expect(onlyFirst).not.toContain('token');
+    expect(onlyFirst).not.toContain('secret');
+    expect(onlyFirst).toContain('safe.example');
+
+    const onlySecond = maskNormalizedHttpUrls(text, ['https://safe.example/']);
+    expect(onlySecond).not.toContain('token');
+    expect(onlySecond).not.toContain('secret');
+    expect(onlySecond).toContain('example.com/confirm');
   });
 
   test('path segment )[token= is one WHATWG URL, not a Markdown cut (F48)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -299,6 +299,33 @@ describe('extractLinks', () => {
       'https://x.example/a',
       'https://y.example/b',
     ]);
+
+    const bracketChain = '[https://x.example/a][https://y.example/b]';
+    expect([...bareUrlSpans(bracketChain)].map((s) => s.clean)).toEqual([
+      'https://x.example/a',
+      'https://y.example/b',
+    ]);
+  });
+
+  test('path segment )[token= is one WHATWG URL, not a Markdown cut (F48)', () => {
+    const text = 'Verify https://example.com/confirm)[token=secret';
+    const full = 'https://example.com/confirm)[token=secret';
+    const spans = [...bareUrlSpans(text)];
+    expect(spans).toHaveLength(1);
+    expect(spans[0]!.clean).toBe(full);
+    expect(extractHttpLinks(text)).toEqual([full]);
+    const masked = maskNormalizedHttpUrls(text, extractHttpLinks(text));
+    expect(masked).toBe('Verify •••');
+    expect(masked).not.toContain('token');
+    expect(masked).not.toContain('secret');
+
+    // Mixed: nested scheme after path junk still one span (scheme not after ]().
+    const mixed =
+      'See https://example.com/confirm)[token=secret?next=https://safe.example/';
+    const mixedFull =
+      'https://example.com/confirm)[token=secret?next=https://safe.example/';
+    expect([...bareUrlSpans(mixed)].map((s) => s.clean)).toEqual([mixedFull]);
+    expect(maskNormalizedHttpUrls(mixed, extractHttpLinks(mixed))).toBe('See •••');
   });
 
   test('space- or comma-separated adjacent URLs split without glue', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -6,6 +6,7 @@ import {
   extractLinks,
   extractOtp,
   htmlToText,
+  splitBareUrlCandidate,
 } from '../src/lib/otp.ts';
 
 describe('htmlToText', () => {
@@ -159,14 +160,38 @@ describe('extractLinks', () => {
     expect(extractLinks('Docs at https://example.com/docs and https://example.com/about')).toEqual([]);
   });
 
-  test('BARE_URL_RE stays linear on a long run of free brackets', () => {
-    // Overlapping alternatives that re-scan free `[` are O(n²); keep a budget.
-    const poison = `https://${'['.repeat(10_000)}`;
+  test('BARE_URL_RE and splitBareUrlCandidate stay linear on adversarial inputs', () => {
+    const freeBrackets = `https://${'['.repeat(10_000)}`;
+    const nestedParens = `https://x.com/${'('.repeat(5_000)}${')'.repeat(5_000)}`;
     const started = performance.now();
-    const matches = poison.match(BARE_URL_RE);
-    const elapsed = performance.now() - started;
-    expect(matches).toBeNull();
-    expect(elapsed).toBeLessThan(1_000);
+    freeBrackets.match(BARE_URL_RE);
+    nestedParens.match(BARE_URL_RE);
+    splitBareUrlCandidate(freeBrackets);
+    splitBareUrlCandidate(nestedParens);
+    expect(performance.now() - started).toBeLessThan(1_000);
+  });
+
+  test('splitBareUrlCandidate keeps nested balanced parens and peels free trailers', () => {
+    expect(splitBareUrlCandidate('https://example.com/confirm(foo(bar))?token=secret')).toEqual({
+      clean: 'https://example.com/confirm(foo(bar))?token=secret',
+      trail: '',
+    });
+    expect(splitBareUrlCandidate('https://example.com/verify?token=a)')).toEqual({
+      clean: 'https://example.com/verify?token=a',
+      trail: ')',
+    });
+    expect(splitBareUrlCandidate('https://example.com/verify?token=a).')).toEqual({
+      clean: 'https://example.com/verify?token=a',
+      trail: ').',
+    });
+    expect(splitBareUrlCandidate('https://example.com/verify?token=a.)')).toEqual({
+      clean: 'https://example.com/verify?token=a',
+      trail: '.)',
+    });
+    expect(splitBareUrlCandidate('https://[2001:db8::1]/confirm?token=secret')).toEqual({
+      clean: 'https://[2001:db8::1]/confirm?token=secret',
+      trail: '',
+    });
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -124,8 +124,13 @@ describe('extractCodes', () => {
     expect(extractCodes('Your verification code is 123/456')).toEqual(['123/456']);
     expect(extractCodes('Your verification code is 1234/5678')).toEqual(['1234/5678']);
     expect(extractCodes('验证码 １２３／４５６')).toEqual(['１２３／４５６']);
+    // F129: colon-delimited numeric OTPs (providers format codes as 123:456).
+    expect(extractCodes('Your verification code is 123:456')).toEqual(['123:456']);
+    expect(extractCodes('验证码 １２３：４５６')).toEqual(['１２３：４５６']);
     // No strong cue: dates stay out (same as hyphen/dot forms).
     expect(extractCodes('due 08/07/2026')).toEqual([]);
+    // No strong cue: times stay out (same as other delimited forms).
+    expect(extractCodes('meeting 12:30')).toEqual([]);
     // No strong cue: roadmap ranges and phone-like numbers stay out.
     expect(extractCodes('roadmap 2024-2025')).toEqual([]);
     expect(extractCodes('call 555-1234')).toEqual([]);
@@ -812,6 +817,20 @@ describe('extractLinks', () => {
     ]);
     // Closing quote without close-context stays (conservative, mirrors F64).
     expect(extractHttpLinks('“https://a.com/x”y')).toEqual(['https://a.com/x%E2%80%9Dy']);
+  });
+
+  test('Markdown wrappers do not extend verification URLs (F130)', () => {
+    // Backtick/code-span and emphasis markers around a link: the closing
+    // marker in prose context is not URL content.
+    expect(extractHttpLinks('`https://example.com/verify`')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('**https://example.com/verify**')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('*https://example.com/verify*.')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('see `https://example.com/verify?token=abc` now')).toEqual([
+      'https://example.com/verify?token=abc',
+    ]);
+    // Closing marker without close-context stays (conservative, mirrors F64/F122).
+    expect(extractHttpLinks('`https://a.com/x`y')).toEqual(['https://a.com/x%60y']);
+    expect(extractHttpLinks('*https://a.com/x*y')).toEqual(['https://a.com/x*y']);
   });
 
   test('prose brackets cut before free closing ] (F67)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -833,6 +833,30 @@ describe('extractLinks', () => {
     expect(extractHttpLinks('*https://a.com/x*y')).toEqual(['https://a.com/x*y']);
   });
 
+  test('paired Unicode quotes do not extend verification URLs (F131)', () => {
+    // Guillemets / German quotes / CJK brackets around a link: the closing
+    // mark in prose context is not URL content (same percent-encoding
+    // argument as F122). CJK terminal punctuation is prose close context.
+    expect(extractHttpLinks('«https://example.com/verify»')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('‹https://example.com/verify›')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('„https://example.com/verify“')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('‚https://example.com/verify‘.')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('「https://example.com/verify」')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('『https://example.com/verify』,')).toEqual(['https://example.com/verify']);
+    expect(extractHttpLinks('【https://example.com/verify?token=abc】')).toEqual([
+      'https://example.com/verify?token=abc',
+    ]);
+    expect(extractHttpLinks('请看《https://example.com/verify?t=1》！')).toEqual([
+      'https://example.com/verify?t=1',
+    ]);
+    expect(extractHttpLinks('《https://example.com/verify》。')).toEqual(['https://example.com/verify']);
+    // Smart-quoted span before CJK terminal punctuation also closes.
+    expect(extractHttpLinks('“https://example.com/verify”。')).toEqual(['https://example.com/verify']);
+    // Closing mark without close-context stays (conservative, mirrors F122).
+    expect(extractHttpLinks('«https://a.com/x»y')).toEqual(['https://a.com/x%C2%BBy']);
+    expect(extractHttpLinks('《https://a.com/x》y')).toEqual(['https://a.com/x%E3%80%8By']);
+  });
+
   test('prose brackets cut before free closing ] (F67)', () => {
     expect(extractHttpLinks('Visit [https://example.com/verify]: now')).toEqual([
       'https://example.com/verify',

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -762,7 +762,7 @@ describe('extractLinks', () => {
     expect(extractHttpLinks('Visit [https://example.com/verify]: now')).toEqual([
       'https://example.com/verify',
     ]);
-    // Free-`]` cut (not only peel): `!` / glued tail are not trailer peel chars.
+    // Free-`]` cut (adjacent prose wrapper); trailing `!` also peels (F90).
     expect(extractHttpLinks('Visit [https://example.com/verify]!')).toEqual([
       'https://example.com/verify',
     ]);
@@ -781,6 +781,60 @@ describe('extractLinks', () => {
     expect(
       [...bareUrlSpans('https://a.com/x[1]')].map((s) => s.clean),
     ).toEqual(['https://a.com/x[1]']);
+  });
+
+  test('peels trailing !/? so non-adjacent prose closers clean up (F90)', () => {
+    // Non-adjacent paren wrapper: `(` not next to scheme → peel `!` then free `)`.
+    expect(extractHttpLinks('See this link (secure: https://example.com/verify)!')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('try (step 2: open https://example.com/s)! ok')).toEqual([
+      'https://example.com/s',
+    ]);
+    expect(
+      extractHttpLinks('(a: https://example.com/v)! and (b: https://example.com/w)!'),
+    ).toEqual(['https://example.com/v', 'https://example.com/w']);
+    // No wrapper at all — still peel `)!`.
+    expect(extractHttpLinks('open https://example.com/free)!')).toEqual([
+      'https://example.com/free',
+    ]);
+    // Bracket / quote twins.
+    expect(extractHttpLinks('docs [see: https://example.com/d]!')).toEqual([
+      'https://example.com/d',
+    ]);
+    expect(extractHttpLinks("note 'see https://example.com/v'!")).toEqual([
+      'https://example.com/v',
+    ]);
+    // Balanced path parens kept; only glued `!` peels.
+    expect(extractHttpLinks('see https://example.com/a_(b)! end')).toEqual([
+      'https://example.com/a_(b)',
+    ]);
+    // Trailing `?` (sentence interrogative, not query).
+    expect(extractHttpLinks('have you seen https://example.com/y?')).toEqual([
+      'https://example.com/y',
+    ]);
+    // Mid-URL `!` preserved.
+    expect(extractHttpLinks('go https://example.com/a!b now')).toEqual([
+      'https://example.com/a!b',
+    ]);
+    // Port + query intact (no trailing `:` peel).
+    expect(extractHttpLinks('see https://example.com:8080/x?q=1 ok')).toEqual([
+      'https://example.com:8080/x?q=1',
+    ]);
+    // F48 LOCK: glued path after `)!` / `)[` is not pure trailing peel.
+    expect(extractHttpLinks('visit https://example.com/confirm)[token=abc now')).toEqual([
+      'https://example.com/confirm)[token=abc',
+    ]);
+    expect(extractHttpLinks('https://example.com/confirm)!token=abc')).toEqual([
+      'https://example.com/confirm)!token=abc',
+    ]);
+    // Adjacent wrappers (F64) still clean.
+    expect(extractHttpLinks('See this link (https://example.com/verify)!')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('See (secure: https://example.com/verify).')).toEqual([
+      'https://example.com/verify',
+    ]);
   });
 });
 

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -189,6 +189,19 @@ describe('extractCodes', () => {
     expect(extractCodes('call 555-12')).toEqual([]);
   });
 
+  test('four digit-group form extracts whole; five+ groups rejected (F74)', () => {
+    expect(extractCodes('Your verification code is 12 34 56 78')).toEqual(['12 34 56 78']);
+    expect(extractCodes('Your PIN is 12-34-56-78')).toEqual(['12-34-56-78']);
+    // 5+ groups: no prefix/suffix partial matches.
+    expect(extractCodes('Your code is 12 34 56 78 90')).toEqual([]);
+    // F73/F68 regressions.
+    expect(extractCodes('Your code is 12 34 56')).toEqual(['12 34 56']);
+    expect(extractCodes('Your code is 123-456')).toEqual(['123-456']);
+    // Trailing incomplete group: full-run integrity rejects partial prefix.
+    // (Previously F73 could yield ['123-456'] from '123-456-7'.)
+    expect(extractCodes('Your code is 123-456-7')).toEqual([]);
+  });
+
   test('Unicode-space delimited OTP extracts with original spelling (F70)', () => {
     const nbsp = '\u00A0';
     const nnbsp = '\u202F';

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -856,6 +856,38 @@ describe('extractLinks', () => {
       'https://example.com/verify',
     ]);
   });
+
+  test('peels colon after prose closers; keeps bare trailing colon (F96)', () => {
+    // Non-adjacent wrappers with closer-glued colon.
+    expect(extractHttpLinks('See this link (secure: https://example.com/verify): now')).toEqual([
+      'https://example.com/verify',
+    ]);
+    expect(extractHttpLinks('docs [see: https://example.com/d]: next')).toEqual([
+      'https://example.com/d',
+    ]);
+    expect(extractHttpLinks("note 'see https://example.com/v': end")).toEqual([
+      'https://example.com/v',
+    ]);
+    // Stacked punct after closer-colon.
+    expect(extractHttpLinks('See (secure: https://example.com/verify):.')).toEqual([
+      'https://example.com/verify',
+    ]);
+    // Balanced path parens kept; colon peels.
+    expect(extractHttpLinks('see https://example.com/a_(b): end')).toEqual([
+      'https://example.com/a_(b)',
+    ]);
+    // Bare trailing colon kept (conservative; not closer-preceded).
+    expect(extractHttpLinks('see https://example.com/v: done')).toEqual([
+      'https://example.com/v:',
+    ]);
+    // Port and mid-URL colon unchanged.
+    expect(extractHttpLinks('see https://example.com:8080/x?q=1 ok')).toEqual([
+      'https://example.com:8080/x?q=1',
+    ]);
+    expect(extractHttpLinks('go https://example.com/a:b now')).toEqual([
+      'https://example.com/a:b',
+    ]);
+  });
 });
 
 describe('extractOtp (combined)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -112,7 +112,7 @@ describe('extractCodes', () => {
 
   test('delimited OTP forms need strong cues (F68)', () => {
     expect(extractCodes('Your verification code is 123-456')).toEqual(['123-456']);
-    // Full form only — continuous halves of a real 3–4|3–4 shape are suppressed.
+    // Full form only — continuous 4-digit halves of a delimited shape are suppressed.
     expect(extractCodes('Your PIN is 1234-5678')).toEqual(['1234-5678']);
     // Longer continuous runs are not delimited halves; keep continuous extract.
     expect(extractCodes('Your code is 123456-7890')).toEqual(['123456', '7890']);
@@ -172,6 +172,21 @@ describe('extractCodes', () => {
     expect(extractCodes('Your code is 1234 - 5678')).toEqual(['1234 - 5678']);
     // Four+ seps intentionally miss (bounded false-positive surface).
     expect(extractCodes('Your code is 123    456')).toEqual([]);
+  });
+
+  test('three digit-group delimited OTP extracts with original spelling (F73)', () => {
+    expect(extractCodes('Your code is 12 34 56')).toEqual(['12 34 56']);
+    expect(extractCodes('Your PIN is 12-34-56')).toEqual(['12-34-56']);
+    // Two-group short halves still work (2+2).
+    expect(extractCodes('Your code is 12 34')).toEqual(['12 34']);
+    // Continuous left half suppressed when right group is only 2 digits.
+    expect(extractCodes('Your code is 1234 - 56')).toEqual(['1234 - 56']);
+    // F68 long continuous regression: not one delimited form.
+    expect(extractCodes('Your code is 123456-7890')).toEqual(['123456', '7890']);
+    // No strong cue / roadmap range.
+    expect(extractCodes('12 34 56')).toEqual([]);
+    expect(extractCodes('roadmap 2024-2025')).toEqual([]);
+    expect(extractCodes('call 555-12')).toEqual([]);
   });
 
   test('Unicode-space delimited OTP extracts with original spelling (F70)', () => {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -307,6 +307,22 @@ describe('extractLinks', () => {
     ]);
   });
 
+  test('nested ?next= scheme does not hide following Markdown chain (F52)', () => {
+    const text =
+      '[Verify](https://a.example/verify?next=https://x.example/)[Confirm](https://b.example/confirm)';
+    expect([...bareUrlSpans(text)].map((s) => s.clean)).toEqual([
+      'https://a.example/verify?next=https://x.example/',
+      'https://b.example/confirm',
+    ]);
+    expect(extractHttpLinks(text)).toEqual([
+      'https://a.example/verify?next=https://x.example/',
+      'https://b.example/confirm',
+    ]);
+    expect(maskNormalizedHttpUrls(text, extractHttpLinks(text))).toBe(
+      '[Verify](•••)[Confirm](•••)',
+    );
+  });
+
   test('path segment )[token= is one WHATWG URL, not a Markdown cut (F48)', () => {
     const text = 'Verify https://example.com/confirm)[token=secret';
     const full = 'https://example.com/confirm)[token=secret';

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -543,6 +543,27 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain("querySelector('.overview-row-nav')");
   });
 
+  // F126: an overview rerender during the tier-3 dialog must not allow a
+  // competing tier PUT on a replacement select.
+  test('handlePushTierChange locks a pending address and renders pending immediately (F126)', () => {
+    const handleTier = UI_JS.slice(
+      UI_JS.indexOf('function handlePushTierChange('),
+      UI_JS.indexOf('function formatDate('),
+    );
+    // Entry lock: after the isAdmin gate, before reading the previous tier.
+    expect(handleTier.indexOf('if (!isAdmin()) return;')).toBeLessThan(
+      handleTier.indexOf('if (state.tierPending[address]) return;'),
+    );
+    expect(handleTier.indexOf('if (state.tierPending[address]) return;')).toBeLessThan(
+      handleTier.indexOf('var previous ='),
+    );
+    // Pending renders immediately (disabled replacement select) before the PUT.
+    const pendingSet = handleTier.indexOf('state.tierPending[address] = true;');
+    const putStart = handleTier.indexOf('await savePushContentTier(', pendingSet);
+    const prologue = handleTier.slice(pendingSet, putStart);
+    expect(prologue).toContain('renderOverviewRows()');
+  });
+
   // F51: fuzzy push-tier PUT failure must re-fetch authoritative tier; known rejects restore.
   test('handlePushTierChange fuzzy failure re-fetches tier; known failures restore (F51)', () => {
     const handleTier = UI_JS.slice(

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -474,9 +474,13 @@ describe('UI static asset contract', () => {
     expect(cycle).not.toContain('await ');
     expect(cycle).not.toContain('Promise.all');
     expect(cycle).toContain('var generation = ++state.overviewGen;');
+    expect(cycle).toContain('state.overviewCycleGen = generation;');
     expect(cycle.indexOf('identitiesPromise.then')).toBeLessThan(cycle.indexOf('overviewPromise.then'));
     expect(cycle.split('generation !== state.overviewGen').length - 1).toBe(4);
     expect(cycle).toContain('renderOverview();');
+    // Stale overview responses clear stuck pending without writing data.
+    expect(cycle).toContain('state.overviewCycleGen !== state.overviewGen');
+    expect(cycle).toContain('state.overviewPending = false;');
     // Tier save / delete must bump the epoch so a late /identities cannot clobber them.
     expect(UI_JS).toContain('function bumpIdentityEpoch()');
     const saveTier = UI_JS.slice(
@@ -484,6 +488,15 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function handlePushTierChange('),
     );
     expect(saveTier).toContain('bumpIdentityEpoch()');
+    // Tier save restarts the overview cycle so Refresh cannot stick on "Refreshing…".
+    const handleTier = UI_JS.slice(
+      UI_JS.indexOf('function handlePushTierChange('),
+      UI_JS.indexOf('function formatDate('),
+    );
+    expect(handleTier).toContain("loadOverviewCycle({ refresh: false })");
+    // Tier-3 confirm disables Cancel while the PUT is in flight.
+    expect(handleTier).toContain('confirmModalCancel.disabled = true;');
+    expect(handleTier).toContain('confirmModalCancel.disabled = false;');
   });
 
   // §7.6：复制成功态只是附加信号，失败降级路径逐字不动

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -339,7 +339,7 @@ describe('UI static asset contract', () => {
   // A22：断点值不动，其内规则按嵌套栅格适配
   test('both breakpoints survive and the nested inbox grid collapses on mobile', () => {
     const flat = UI_CSS.replace(/\s+/g, ' ');
-    expect(UI_CSS).toContain('@media (max-width: 900px)');
+    expect(UI_CSS).toContain('@media (max-width: 1100px)');
     expect(UI_CSS).toContain('@media (max-width: 719px)');
     expect(UI_CSS).toContain('[data-scope="overview"]');
     expect(UI_CSS).toContain('[data-mobile-view="overview"]');

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -589,6 +589,34 @@ describe('UI static asset contract', () => {
     expect(sessionBranch).not.toContain("apiJson('/ui/api/identities')");
   });
 
+  // F107: an indirect close (background action) must still restore the tier
+  // select; the confirmed success path must not restore.
+  test('tier-3 dialog restores on indirect close but not after confirm (F107)', () => {
+    const closeAll = UI_JS.slice(
+      UI_JS.indexOf('function closeAllModals()'),
+      UI_JS.indexOf('function showTokenModal('),
+    );
+    // Pending cancel side-effect is consumed exactly once on any close.
+    expect(closeAll).toContain('var onCancel = confirmModalOnCancel;');
+    expect(closeAll.indexOf('var onCancel = confirmModalOnCancel;')).toBeLessThan(
+      closeAll.indexOf('confirmModalOnCancel = null;'),
+    );
+    expect(closeAll.indexOf('confirmModalOnCancel = null;')).toBeLessThan(
+      closeAll.indexOf('if (onCancel) onCancel();'),
+    );
+    const handleTier = UI_JS.slice(
+      UI_JS.indexOf('function handlePushTierChange('),
+      UI_JS.indexOf('function formatDate('),
+    );
+    // Success path clears the restore hook before closing so a confirmed tier 3 sticks.
+    const applyIdx = handleTier.indexOf('await apply(3, true);');
+    const clearIdx = handleTier.indexOf('confirmModalOnCancel = null;');
+    const closeIdx = handleTier.indexOf('closeAllModals();', applyIdx);
+    expect(applyIdx).toBeGreaterThanOrEqual(0);
+    expect(clearIdx).toBeGreaterThan(applyIdx);
+    expect(closeIdx).toBeGreaterThan(clearIdx);
+  });
+
   // §7.6：复制成功态只是附加信号，失败降级路径逐字不动
   test('a successful copy adds a transient class without replacing the announcement', () => {
     expect(UI_JS).toContain("announce('Copied to clipboard');");

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -517,6 +517,19 @@ describe('UI static asset contract', () => {
     );
     expect(renderRows).toContain('state.tierPending[model.identity.address]');
     expect(renderRows).toContain('tierSelect.disabled = true;');
+    // F66: tier <select> is not nested under the row nav role=button.
+    expect(renderRows).toContain("navNode.className = 'overview-row-nav'");
+    expect(renderRows).toContain("navNode.setAttribute('role', 'button')");
+    expect(renderRows).toContain("tierSelect.className = 'push-tier-select'");
+    expect(renderRows.indexOf("rowNode.append(navNode)")).toBeLessThan(
+      renderRows.indexOf('rowNode.append(tierCell)'),
+    );
+    expect(renderRows).toContain("'push tier ' + currentTier");
+    // Row container is neutral (no role=button on overview-row itself).
+    expect(renderRows).not.toContain("rowNode.setAttribute('role', 'button')");
+    expect(renderRows).not.toContain('rowNode.tabIndex = 0');
+    // Return-to-overview focus must land on the focusable nav, not the outer row.
+    expect(UI_JS).toContain("querySelector('.overview-row-nav')");
   });
 
   // F51: fuzzy push-tier PUT failure must re-fetch authoritative tier; known rejects restore.

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -536,6 +536,16 @@ describe('UI static asset contract', () => {
     expect(catchBody).toContain('selectEl.value = String(authoritative)');
     expect(catchBody).toContain('selectEl.dataset.currentTier = String(authoritative)');
     expect(catchBody).toContain("(refreshed).");
+    // F53: bump epoch before recovery re-fetch so stale overview identities cannot clobber.
+    const fuzzyStart = catchBody.indexOf('// Fuzzy failure');
+    expect(fuzzyStart).toBeGreaterThanOrEqual(0);
+    const fuzzyBranch = catchBody.slice(fuzzyStart);
+    expect(fuzzyBranch.indexOf('bumpIdentityEpoch()')).toBeGreaterThanOrEqual(0);
+    expect(fuzzyBranch.indexOf('bumpIdentityEpoch()')).toBeLessThan(
+      fuzzyBranch.indexOf("apiJson('/ui/api/identities')"),
+    );
+    expect(fuzzyBranch).toContain('var recoveryGen = state.overviewGen;');
+    expect(fuzzyBranch).toContain('if (recoveryGen !== state.overviewGen) return;');
 
     // confirm_risk_required: restore before announce (server clearly rejected).
     const confirmIdx = catchBody.indexOf("error.body.error === 'confirm_risk_required'");

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -340,7 +340,7 @@ describe('UI static asset contract', () => {
   test('both breakpoints survive and the nested inbox grid collapses on mobile', () => {
     const flat = UI_CSS.replace(/\s+/g, ' ');
     expect(UI_CSS).toContain('@media (max-width: 1100px)');
-    expect(UI_CSS).toContain('@media (max-width: 719px)');
+    expect(UI_CSS).toContain('@media (max-width: 820px)');
     expect(UI_CSS).toContain('[data-scope="overview"]');
     expect(UI_CSS).toContain('[data-mobile-view="overview"]');
     expect(flat).toContain('.inbox-layout { min-height: calc(100vh - 74px); display: grid; grid-template-columns: 240px minmax(0, 1fr); }');
@@ -477,6 +477,13 @@ describe('UI static asset contract', () => {
     expect(cycle.indexOf('identitiesPromise.then')).toBeLessThan(cycle.indexOf('overviewPromise.then'));
     expect(cycle.split('generation !== state.overviewGen').length - 1).toBe(4);
     expect(cycle).toContain('renderOverview();');
+    // Tier save / delete must bump the epoch so a late /identities cannot clobber them.
+    expect(UI_JS).toContain('function bumpIdentityEpoch()');
+    const saveTier = UI_JS.slice(
+      UI_JS.indexOf('async function savePushContentTier('),
+      UI_JS.indexOf('function handlePushTierChange('),
+    );
+    expect(saveTier).toContain('bumpIdentityEpoch()');
   });
 
   // §7.6：复制成功态只是附加信号，失败降级路径逐字不动

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -282,6 +282,14 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain('      reconcileActiveAddress();');
     expect(UI_JS).toContain('if (isAdmin()) refreshInboxIdentities();');
     expect(UI_JS.split('reconcileActiveAddress();').length - 1).toBe(2);
+    // Inbox identity refresh shares overviewGen so a late response cannot
+    // clobber a push-tier save that bumped the epoch mid-flight.
+    const inboxRefresh = UI_JS.slice(
+      UI_JS.indexOf('function refreshInboxIdentities() {'),
+      UI_JS.indexOf('function loadOverviewCycle('),
+    );
+    expect(inboxRefresh).toContain('var generation = state.overviewGen;');
+    expect(inboxRefresh).toContain('if (generation !== state.overviewGen) return;');
   });
 
   // A18 / A19 / A20 / A21

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -157,6 +157,17 @@ describe('UI static asset contract', () => {
     }
   });
 
+  test('confirm modal exposes dialog semantics for tier-3 risk (F89)', () => {
+    expect(UI_HTML).toMatch(
+      /id="confirm-modal"[\s\S]*?role="dialog"[\s\S]*?aria-modal="true"/,
+    );
+    expect(UI_HTML).toContain('aria-labelledby="confirm-modal-title"');
+    expect(UI_HTML).toContain('aria-describedby="confirm-modal-text confirm-modal-risk"');
+    expect(UI_HTML).toContain('id="confirm-modal-title"');
+    expect(UI_HTML).toContain('id="confirm-modal-text"');
+    expect(UI_HTML).toContain('id="confirm-modal-risk"');
+  });
+
   // A15：landmark 挂在包住两个面板的 inbox 容器上，移动 list 态才有可见 <main>
   test('exactly three mains exist and #main-content wraps the message and detail panels', () => {
     expect(UI_HTML).toContain('<main id="overview-panel" class="overview-panel" tabindex="-1"');

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -511,6 +511,12 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain('tierPending: {}');
     expect(handleTier).toContain('state.tierPending[address] = true;');
     expect(handleTier).toContain('delete state.tierPending[address];');
+    // F51: fuzzy PUT failure re-fetches authoritative tier; known failures restore.
+    expect(handleTier).toContain("apiJson('/ui/api/identities')");
+    expect(handleTier).toContain('selectEl.dataset.currentTier = String(authoritative)');
+    expect(handleTier).toContain("(refreshed).");
+    expect(handleTier).toContain("error.body.error === 'confirm_risk_required'");
+    expect(handleTier).toContain("error.message === 'session_expired'");
     const renderRows = UI_JS.slice(
       UI_JS.indexOf('function renderOverviewRows('),
       UI_JS.indexOf('function updateOverviewRefreshButton('),

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -494,6 +494,8 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function formatDate('),
     );
     expect(handleTier).toContain("loadOverviewCycle({ refresh: false })");
+    // Only restart while still on Overview (do not revive polling after openAddress).
+    expect(handleTier).toContain("state.scope === 'overview'");
     // Tier-3 confirm disables Cancel while the PUT is in flight.
     expect(handleTier).toContain('confirmModalCancel.disabled = true;');
     expect(handleTier).toContain('confirmModalCancel.disabled = false;');

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -511,18 +511,48 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain('tierPending: {}');
     expect(handleTier).toContain('state.tierPending[address] = true;');
     expect(handleTier).toContain('delete state.tierPending[address];');
-    // F51: fuzzy PUT failure re-fetches authoritative tier; known failures restore.
-    expect(handleTier).toContain("apiJson('/ui/api/identities')");
-    expect(handleTier).toContain('selectEl.dataset.currentTier = String(authoritative)');
-    expect(handleTier).toContain("(refreshed).");
-    expect(handleTier).toContain("error.body.error === 'confirm_risk_required'");
-    expect(handleTier).toContain("error.message === 'session_expired'");
     const renderRows = UI_JS.slice(
       UI_JS.indexOf('function renderOverviewRows('),
       UI_JS.indexOf('function updateOverviewRefreshButton('),
     );
     expect(renderRows).toContain('state.tierPending[model.identity.address]');
     expect(renderRows).toContain('tierSelect.disabled = true;');
+  });
+
+  // F51: fuzzy push-tier PUT failure must re-fetch authoritative tier; known rejects restore.
+  test('handlePushTierChange fuzzy failure re-fetches tier; known failures restore (F51)', () => {
+    const handleTier = UI_JS.slice(
+      UI_JS.indexOf('function handlePushTierChange('),
+      UI_JS.indexOf('function formatDate('),
+    );
+    const catchStart = handleTier.indexOf('} catch (error) {');
+    const finallyStart = handleTier.indexOf('} finally {', catchStart);
+    expect(catchStart).toBeGreaterThanOrEqual(0);
+    expect(finallyStart).toBeGreaterThan(catchStart);
+    const catchBody = handleTier.slice(catchStart, finallyStart);
+
+    // Fuzzy path: re-fetch list, write select + dataset from server tier, announce refresh.
+    expect(catchBody).toContain("apiJson('/ui/api/identities')");
+    expect(catchBody).toContain('selectEl.value = String(authoritative)');
+    expect(catchBody).toContain('selectEl.dataset.currentTier = String(authoritative)');
+    expect(catchBody).toContain("(refreshed).");
+
+    // confirm_risk_required: restore before announce (server clearly rejected).
+    const confirmIdx = catchBody.indexOf("error.body.error === 'confirm_risk_required'");
+    expect(confirmIdx).toBeGreaterThanOrEqual(0);
+    const afterConfirm = catchBody.slice(confirmIdx);
+    expect(afterConfirm.indexOf('restore()')).toBeGreaterThanOrEqual(0);
+    expect(afterConfirm.indexOf('restore()')).toBeLessThan(
+      afterConfirm.indexOf("announce('Tier 3 requires explicit risk confirmation.')"),
+    );
+
+    // session_expired: restore only (session flow takes over).
+    const sessionIdx = catchBody.indexOf("error.message === 'session_expired'");
+    expect(sessionIdx).toBeGreaterThan(confirmIdx);
+    const sessionBranch = catchBody.slice(sessionIdx, catchBody.indexOf('} else {', sessionIdx));
+    expect(sessionBranch).toContain('restore()');
+    // Fuzzy re-fetch must not live inside the session_expired branch.
+    expect(sessionBranch).not.toContain("apiJson('/ui/api/identities')");
   });
 
   // §7.6：复制成功态只是附加信号，失败降级路径逐字不动

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -497,6 +497,16 @@ describe('UI static asset contract', () => {
     // Tier-3 confirm disables Cancel while the PUT is in flight.
     expect(handleTier).toContain('confirmModalCancel.disabled = true;');
     expect(handleTier).toContain('confirmModalCancel.disabled = false;');
+    // Per-address pending lock survives re-render so a second select cannot race.
+    expect(UI_JS).toContain('tierPending: {}');
+    expect(handleTier).toContain('state.tierPending[address] = true;');
+    expect(handleTier).toContain('delete state.tierPending[address];');
+    const renderRows = UI_JS.slice(
+      UI_JS.indexOf('function renderOverviewRows('),
+      UI_JS.indexOf('function updateOverviewRefreshButton('),
+    );
+    expect(renderRows).toContain('state.tierPending[model.identity.address]');
+    expect(renderRows).toContain('tierSelect.disabled = true;');
   });
 
   // §7.6：复制成功态只是附加信号，失败降级路径逐字不动

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -562,6 +562,15 @@ describe('UI static asset contract', () => {
     const putStart = handleTier.indexOf('await savePushContentTier(', pendingSet);
     const prologue = handleTier.slice(pendingSet, putStart);
     expect(prologue).toContain('renderOverviewRows()');
+    // F127: apply() rechecks the lock — a stale tier-3 dialog confirm bypasses
+    // the entry guard and must drop instead of starting a competing PUT.
+    const applyStart = handleTier.indexOf('async function apply(');
+    expect(handleTier.indexOf('if (state.tierPending[address]) {', applyStart)).toBeGreaterThan(
+      applyStart,
+    );
+    expect(handleTier.indexOf('if (state.tierPending[address]) {', applyStart)).toBeLessThan(
+      pendingSet,
+    );
   });
 
   // F51: fuzzy push-tier PUT failure must re-fetch authoritative tier; known rejects restore.

--- a/packages/api/test/ui-authz.test.ts
+++ b/packages/api/test/ui-authz.test.ts
@@ -42,6 +42,7 @@ function dependencies(): UiApiDependencies {
       revalidating: false,
       refreshError: false,
     })),
+    setPushContentTier: mock(() => null),
   };
 }
 

--- a/packages/api/test/ui-authz.test.ts
+++ b/packages/api/test/ui-authz.test.ts
@@ -72,11 +72,13 @@ describe('UI authorization boundaries', () => {
           name: 'Fox',
           createdAt: '2026-07-27T00:00:00.000Z',
           hasToken: true,
+          pushContentTier: 1,
         },
         {
           address: 'owl@test.example',
           createdAt: '2026-07-27T00:01:00.000Z',
           hasToken: false,
+          pushContentTier: 1,
         },
       ],
     });
@@ -103,6 +105,7 @@ describe('UI authorization boundaries', () => {
         name: 'Fox',
         createdAt: '2026-07-27T00:00:00.000Z',
         hasToken: true,
+        pushContentTier: 1,
       },
     ]);
 

--- a/packages/api/test/ui-messages.test.ts
+++ b/packages/api/test/ui-messages.test.ts
@@ -58,6 +58,7 @@ function makeApp(overrides: Partial<UiApiDependencies> = {}) {
       otp: { codes: ['123456'], links: ['https://example.net/verify'] },
       links: ['https://example.net/news', 'https://example.net/verify'],
     })),
+    setPushContentTier: mock(() => null),
     ...overrides,
   };
   const store = new UiSessionStore({

--- a/packages/api/test/ui-overview.test.ts
+++ b/packages/api/test/ui-overview.test.ts
@@ -185,6 +185,7 @@ function makeApp(overrides: Partial<UiApiDependencies> = {}) {
     getMessage: mock(async () => null),
     setMessageSeen: mock(async () => true),
     getMailboxScan: mock(async () => zeroSnapshotOutcome()),
+    setPushContentTier: mock(() => null),
     ...overrides,
   };
   const store = new UiSessionStore({

--- a/packages/api/test/ui-overview.test.ts
+++ b/packages/api/test/ui-overview.test.ts
@@ -391,6 +391,7 @@ describe('Overview 端点契约', () => {
       'hasToken',
       'lastReceivedAt',
       'name',
+      'pushContentTier',
       'unseen',
     ]);
     expect(body.scan.scanBack).toBe(500);


### PR DESCRIPTION
Closes #19.

## Summary
- Per-identity push content tiers for mail-arrival ntfy alerts: tier 1 (default, interrupt only), tier 2 (+ sender/subject), tier 3 (+ bounded body preview and extracted OTP codes/links).
- Tier persists in identities.json as pushContentTier; absent or invalid values resolve to 1, so existing identities keep current behavior.
- REST: GET/PUT /v1/identities/:address/push-tier. PUT is admin-only; tier 3 requires confirm_risk: true or it fails with 400 confirm_risk_required. Identity tokens may read only their own tier.
- UI API mirrors the same rules; dashboard overview gains a per-identity Push column with a tier selector and an explicit risk-confirmation dialog for tier 3.
- Optional DASHBOARD_PUBLIC_URL: when set, mail-arrival pushes include a click action that opens the dashboard.
- Docs updated: README, packages/api README, .env.example.

## Test plan
- packages/api: bun test = 306 pass / 0 fail (baseline 287, +19 new).
- packages/mcp: 10 pass / 0 fail.
- New coverage: default tier resolution, persistence and list surfacing, authz boundaries (identity token 403 on PUT, own-tier read allowed, cross-identity read denied), tier-3 confirm_risk enforcement with state unchanged on denial, preview length bound, click field present only with clickUrl, DASHBOARD_PUBLIC_URL normalization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable push-content tiers for mail-arrival notifications:
    - Tier 1: interruption-only alerts.
    - Tier 2: masked sender and subject details.
    - Tier 3: limited previews, OTPs, and links with explicit risk confirmation.
  - Added dashboard controls and API support for viewing and updating notification tiers.
  - Notifications can link directly to the public dashboard when configured.
  - Added safeguards, warnings, and size limits for sensitive notification content.

- **Documentation**
  - Updated feature and API documentation with tier, permission, privacy, and confirmation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->