### PR TITLE
fix(mcp): output schema rejects display-name From/To addresses

### DIFF
--- a/packages/mcp/src/main.ts
+++ b/packages/mcp/src/main.ts
@@ -62,12 +62,18 @@ const identitySchema = {
 
 const messageSummarySchema = {
   id: z.string(),
-  from: z.email(),
-  to: z.email(),
+  // from/to carry raw RFC-5322 header values ("Name <addr>"), not bare
+  // addresses — z.email() rejects any real sender with a display name.
+  from: z.string(),
+  to: z.string(),
+  // Optional for forward compatibility with API responses that carry them.
+  fromName: z.string().optional(),
+  toName: z.string().optional(),
   subject: z.string(),
   date: z.string(),
   seen: z.boolean(),
   snippet: z.string(),
+  hasOtp: z.boolean().optional(),
 };
 
 const messageOutputSchema = {
@@ -134,8 +140,8 @@ const taskStateSchema = z.enum(["submitted", "working", "input-required", "compl
 
 const taskMessageSchema = z.object({
   id: z.string(),
-  from: z.email(),
-  to: z.email(),
+  from: z.string(),
+  to: z.string(),
   subject: z.string(),
   date: z.string(),
   state: taskStateSchema,
@@ -145,8 +151,8 @@ const taskMessageSchema = z.object({
 
 const taskOutputSchema = {
   id: z.string().uuid(),
-  from: z.email(),
-  to: z.email(),
+  from: z.string(),
+  to: z.string(),
   subject: z.string(),
   state: taskStateSchema,
   createdAt: z.string(),

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -166,3 +166,37 @@ test("工具入参约束要和 REST API 对齐，别把服务端必拒的值放�
   expect(ok(taskUpdate, "state", "reopened")).toBe(false);
   expect(ok(taskUpdate, "body", "x".repeat(1_000_001))).toBe(false);
 });
+
+test("消息输出 schema 要接受带 display name 的 RFC-5322 From/To（回归）", () => {
+  const ok = (schema: SchemaMap, field: string, value: unknown) =>
+    schema[field]!.safeParse(value).success;
+
+  // 回归：API 原样返回 From/To 头（"Alice <alice@example.com>"），旧 schema
+  // 的 z.email() 会让所有带 display name 的真实邮件过不了 structured output
+  // 校验（zod  strict 模式下 fromName/hasOtp 这类额外字段同理被挡）。
+  const readOut = toolConfigs.get("mail_read_message")!.outputSchema!;
+  expect(ok(readOut, "from", "Alice <alice@example.com>")).toBe(true);
+  expect(ok(readOut, "to", "Bob <bob@example.com>, carol@example.com")).toBe(true);
+  expect(ok(readOut, "from", "plain@example.com")).toBe(true);
+  expect(ok(readOut, "fromName", "Alice")).toBe(true);
+  expect(ok(readOut, "toName", "Bob")).toBe(true);
+
+  const listOut = toolConfigs.get("mail_list_messages")!.outputSchema!;
+  const summary = {
+    id: "5",
+    from: "Alice <alice@example.com>",
+    to: "bob@example.com",
+    subject: "hi",
+    date: "2026-08-06T00:00:00.000Z",
+    seen: false,
+    snippet: "hi",
+    hasOtp: true,
+  };
+  const parsed = listOut.messages!.safeParse([summary]) as {
+    success: boolean;
+    data?: Array<Record<string, unknown>>;
+  };
+  expect(parsed.success).toBe(true);
+  // hasOtp 是已声明的 optional 字段：校验后必须保留，而不是被 strip 掉。
+  expect(parsed.data?.[0]?.hasOtp).toBe(true);
+});


### PR DESCRIPTION
## Problem

`mail_list_messages`, `mail_read_message` and `mail_wait_for` declare `from`/`to` as `z.email()` in their output schemas, but the API serializes the RFC-5322 `From`/`To` headers verbatim — real mail arrives as `Alice <alice@example.com>`. Any client that validates structured output against the advertised schema (e.g. Hermes) rejects every message from a display-name sender, which makes the three tools unusable for real mail.

## Fix

- Relax `from`/`to` from `z.email()` to `z.string()` in the message summary/detail and task output schemas, so display-name forms validate.
- Declare `fromName`, `toName` and `hasOtp` as optional, so responses carrying them are not rejected by `additionalProperties: false` validation (forward compatibility).

Input schemas are unchanged — `mail_send` and friends still require bare addresses.

## Tested

`bun test` — 11 pass, including a new regression case that parses display-name `From`/`To` (`Alice <alice@example.com>`) through the message output schemas and asserts the optional `fromName`/`toName`/`hasOtp` fields are retained after validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email message handling to support standard RFC-5322 sender and recipient formats, including display names and multiple recipients.
  - Added support for optional sender and recipient names in message summaries.
  - Preserved one-time-password indicators when listing messages.

- **Tests**
  - Added regression coverage for the expanded email address and message summary formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->