### PR TITLE
docs: note exact API paths (trailing slash 404s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ curl -X POST http://localhost:3100/v1/identities \
 The API binds to `127.0.0.1` by default — reach it from other hosts over an
 SSH tunnel or a TLS proxy: [docs/security.md](https://openagent.email/docs/guides/security/).
 
+Paths are exact: call `/v1/notify`, not `/v1/notify/` — a trailing slash
+returns a plain 404 rather than the API error format.
+
 ## Using your own mail server
 
 Already have a mail provider for your domain? Run the API by itself with


### PR DESCRIPTION
Tiny docs addition: API paths are exact — `/v1/notify` works, `/v1/notify/` returns a plain 404. Surfaced while building fleet tooling against the notify endpoint; worth one line so API consumers don't have to rediscover it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that API paths must match exactly.
  * Documented the different responses for `/v1/notify/` and `/v1/notify`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->