### PR TITLE
feat(ui): add Notifications history panel on the dashboard

### DIFF
--- a/packages/api/dev/preview.ts
+++ b/packages/api/dev/preview.ts
@@ -197,6 +197,66 @@ async function getMailboxScan(_opts: { refresh: boolean; identityAddresses: stri
   };
 }
 
+/** 通知记录假数据：覆盖 urgent/normal/low/unknown 四档 + user / agent 两路 topic。 */
+const previewNotifyByTopic: Record<
+  string,
+  Array<{
+    id: string;
+    time: number;
+    title: string;
+    message: string;
+    priority: number;
+    tags: string[];
+  }>
+> = {
+  'user-alerts': [
+    {
+      id: 'preview-n1',
+      time: 1_753_430_000,
+      title: 'Urgent: mailbox full',
+      message: 'fox@preview.test is near the retention ceiling.',
+      priority: 5,
+      tags: ['warning'],
+    },
+    {
+      id: 'preview-n2',
+      time: 1_753_429_700,
+      title: 'Normal: new signup',
+      message: 'An agent requested can_notify_user.',
+      priority: 3,
+      tags: [],
+    },
+  ],
+  'user-low': [
+    {
+      id: 'preview-n3',
+      time: 1_753_429_400,
+      title: 'Low: weekly digest',
+      message: '12 pushes delivered in the last 7 days.',
+      priority: 1,
+      tags: ['memo'],
+    },
+    {
+      id: 'preview-n4',
+      time: 1_753_429_100,
+      title: 'Odd priority sample',
+      message: 'priority=2 should render as unknown tier in the panel.',
+      priority: 2,
+      tags: [],
+    },
+  ],
+  'agent:fox': [
+    {
+      id: 'preview-n5',
+      time: 1_753_428_800,
+      title: 'openagent.email new mail',
+      message: 'fox@preview.test received new email',
+      priority: 3,
+      tags: ['email'],
+    },
+  ],
+};
+
 const dependencies = {
   listIdentities: () => identities,
   listMessages: async (address: string, limit: number) =>
@@ -210,6 +270,8 @@ const dependencies = {
     (identity as { pushContentTier?: 1 | 2 | 3 }).pushContentTier = tier;
     return identity as typeof identity & { pushContentTier: 1 | 2 | 3 };
   },
+  // 确定性假数据：预览不连 ntfy，避免 Notifications 面板永远 502/503。
+  notifyMessages: async (topic: string) => previewNotifyByTopic[topic] ?? [],
 };
 
 const app = new Hono();

--- a/packages/api/dev/preview.ts
+++ b/packages/api/dev/preview.ts
@@ -197,65 +197,104 @@ async function getMailboxScan(_opts: { refresh: boolean; identityAddresses: stri
   };
 }
 
-/** 通知记录假数据：覆盖 urgent/normal/low/unknown 四档 + user / agent 两路 topic。 */
-const previewNotifyByTopic: Record<
-  string,
-  Array<{
-    id: string;
-    time: number;
-    title: string;
-    message: string;
-    priority: number;
-    tags: string[];
-  }>
-> = {
-  'user-alerts': [
-    {
-      id: 'preview-n1',
-      time: 1_753_430_000,
-      title: 'Urgent: mailbox full',
-      message: 'fox@preview.test is near the retention ceiling.',
-      priority: 5,
-      tags: ['warning'],
-    },
-    {
-      id: 'preview-n2',
-      time: 1_753_429_700,
-      title: 'Normal: new signup',
-      message: 'An agent requested can_notify_user.',
-      priority: 3,
-      tags: [],
-    },
-  ],
-  'user-low': [
-    {
-      id: 'preview-n3',
-      time: 1_753_429_400,
-      title: 'Low: weekly digest',
-      message: '12 pushes delivered in the last 7 days.',
-      priority: 1,
-      tags: ['memo'],
-    },
-    {
-      id: 'preview-n4',
-      time: 1_753_429_100,
-      title: 'Odd priority sample',
-      message: 'priority=2 should render as unknown tier in the panel.',
-      priority: 2,
-      tags: [],
-    },
-  ],
-  'agent:fox': [
-    {
-      id: 'preview-n5',
-      time: 1_753_428_800,
-      title: 'openagent.email new mail',
-      message: 'fox@preview.test received new email',
-      priority: 3,
-      tags: ['email'],
-    },
-  ],
+type PreviewNotifyMessage = {
+  id: string;
+  time: number;
+  title: string;
+  message: string;
+  priority: number;
+  tags: string[];
 };
+
+/** 把 ntfy since（如 12h / 10m / unix 秒）折成 unix 截止秒；无法解析则不过滤。 */
+function previewSinceCutoff(since?: string): number | null {
+  if (!since) return null;
+  const relative = /^(\d+)([smhd])$/i.exec(since.trim());
+  if (relative) {
+    const amount = Number(relative[1]);
+    const unit = relative[2]!.toLowerCase();
+    const ms =
+      unit === 's'
+        ? amount * 1000
+        : unit === 'm'
+          ? amount * 60_000
+          : unit === 'h'
+            ? amount * 3_600_000
+            : amount * 86_400_000;
+    return Math.floor((Date.now() - ms) / 1000);
+  }
+  const asUnix = Number(since);
+  if (Number.isFinite(asUnix) && asUnix > 0) return Math.floor(asUnix);
+  return null;
+}
+
+/**
+ * 通知记录假数据：覆盖 urgent/normal/low/unknown 四档 + user / agent 两路 topic。
+ * 时间相对 Date.now()；附带一条 >12h 的旧消息，供 since=12h 过滤验收。
+ */
+function buildPreviewNotifyMessages(topic: string, since?: string): PreviewNotifyMessage[] {
+  const now = Math.floor(Date.now() / 1000);
+  const catalog: Record<string, PreviewNotifyMessage[]> = {
+    'user-alerts': [
+      {
+        id: 'preview-n1',
+        time: now - 60,
+        title: 'Urgent: mailbox full',
+        message: 'fox@preview.test is near the retention ceiling.',
+        priority: 5,
+        tags: ['warning'],
+      },
+      {
+        id: 'preview-n2',
+        time: now - 300,
+        title: 'Normal: new signup',
+        message: 'An agent requested can_notify_user.',
+        priority: 3,
+        tags: [],
+      },
+      {
+        id: 'preview-n-old-alerts',
+        time: now - 48 * 3600,
+        title: 'Stale alert outside 12h',
+        message: 'Should be filtered out when since=12h.',
+        priority: 3,
+        tags: [],
+      },
+    ],
+    'user-low': [
+      {
+        id: 'preview-n3',
+        time: now - 600,
+        title: 'Low: weekly digest',
+        message: '12 pushes delivered in the last 7 days.',
+        priority: 1,
+        tags: ['memo'],
+      },
+      {
+        id: 'preview-n4',
+        time: now - 900,
+        title: 'Odd priority sample',
+        message: 'priority=2 should render as unknown tier in the panel.',
+        priority: 2,
+        tags: [],
+      },
+    ],
+    'agent:fox': [
+      {
+        id: 'preview-n5',
+        time: now - 120,
+        title: 'openagent.email new mail',
+        message: 'fox@preview.test received new email',
+        priority: 3,
+        tags: ['email'],
+      },
+    ],
+  };
+  const list = catalog[topic] ?? [];
+  const cutoff = previewSinceCutoff(since);
+  if (cutoff == null) return list;
+  return list.filter((entry) => entry.time >= cutoff);
+}
 
 const dependencies = {
   listIdentities: () => identities,
@@ -270,8 +309,9 @@ const dependencies = {
     (identity as { pushContentTier?: 1 | 2 | 3 }).pushContentTier = tier;
     return identity as typeof identity & { pushContentTier: 1 | 2 | 3 };
   },
-  // 确定性假数据：预览不连 ntfy，避免 Notifications 面板永远 502/503。
-  notifyMessages: async (topic: string) => previewNotifyByTopic[topic] ?? [],
+  // 确定性假数据：预览不连 ntfy；相对时间 + since 过滤，面板演示不会像「坏了」。
+  notifyMessages: async (topic: string, _identityAddress?: string, since?: string) =>
+    buildPreviewNotifyMessages(topic, since),
 };
 
 const app = new Hono();

--- a/packages/api/src/routes/notify.ts
+++ b/packages/api/src/routes/notify.ts
@@ -41,6 +41,7 @@ const deviceSchema = z.object({
   publicUrl: z.string().url(),
 }).strict();
 
+/** 与 routes/ui.ts#toNotifyTopic 必须保持同一口径（Bearer 入口）；改则两边同步。 */
 function toTopic(value: string): NotifyTopic | null {
   if (value === 'self' || value === 'user-alerts' || value === 'user-low') return value;
   if (!value.startsWith('agent:')) return null;

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -15,7 +15,13 @@ import {
   type Identity,
   type PushContentTier,
 } from '../lib/identities.ts';
-import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
+import {
+  NotifyError,
+  notificationService,
+  provisionIdentityNotifications,
+  type NotifyMessage,
+  type NotifyTopic,
+} from '../lib/notify.ts';
 import {
   SCAN_BACK,
   getMessage,
@@ -32,6 +38,24 @@ import {
   uiSessionAuth,
 } from '../lib/ui-session.ts';
 import { MAX_EMAIL_HTML_LENGTH } from '../lib/sanitize-email-html.ts';
+
+/**
+ * 与 routes/notify.ts#toTopic 必须保持同一口径（Dashboard cookie 入口的镜像校验）。
+ * 若改一侧，另一侧同步；抽出共享 helper 前先靠注释钉死。
+ */
+const AGENT_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,62}$/;
+
+const notifyHistoryQuerySchema = z.object({
+  topic: z.string().min(1).max(80),
+  since: z.string().min(1).max(64).optional(),
+});
+
+function toNotifyTopic(value: string): NotifyTopic | null {
+  if (value === 'self' || value === 'user-alerts' || value === 'user-low') return value;
+  if (!value.startsWith('agent:')) return null;
+  const agent = value.slice('agent:'.length);
+  return AGENT_NAME_RE.test(agent) ? `agent:${agent}` : null;
+}
 
 export type UiApiDependencies = {
   listIdentities: () => Identity[];
@@ -50,6 +74,15 @@ export type UiApiDependencies = {
   }) => Promise<ScanOutcome>;
   /** Persist an identity's mail-arrival push content tier (admin UI). */
   setPushContentTier: (address: string, tier: PushContentTier) => Identity | null;
+  /**
+   * 通知历史：语义等同 GET /v1/notify/messages（ACL 在本路由强制，不信任客户端 topic）。
+   * 测试可注入；生产默认走 notificationService().messages。
+   */
+  notifyMessages?: (
+    topic: NotifyTopic,
+    identityAddress?: string,
+    since?: string,
+  ) => Promise<NotifyMessage[]>;
 };
 
 /** 进程内单例：快照与会话一样活在进程里，重启后第一次 Overview 是冷启动。 */
@@ -65,7 +98,19 @@ const defaultDependencies: UiApiDependencies = {
   setMessageSeen,
   getMailboxScan: (opts) => overviewCache.getOverview(opts),
   setPushContentTier: setIdentityPushContentTier,
+  notifyMessages: (topic, identityAddress, since) =>
+    notificationService().messages(topic, identityAddress, since),
 };
+
+/** 将 NotifyError 折成与 /v1/notify 一致的 JSON 状态码（历史只读路径）。 */
+function notifyHistoryError(c: Context, err: unknown) {
+  if (!(err instanceof NotifyError)) throw err;
+  if (err.code === 'notifications_disabled' || err.code === 'notifications_unconfigured') {
+    return c.json({ error: err.code }, 503);
+  }
+  if (err.code === 'unknown_agent') return c.json({ error: err.code }, 404);
+  return c.json({ error: err.code }, 502);
+}
 
 /** 「最近活跃」的窗口长度（小时）。 */
 const RECENT_HOURS = 24;
@@ -417,6 +462,44 @@ export function createUiApiRoutes(
     const marked = await dependencies.setMessageSeen(address, id, parsed.data.seen);
     if (!marked) return c.json({ error: 'not_found' }, 404);
     return c.json({ id, seen: parsed.data.seen });
+  });
+
+  /**
+   * Dashboard 通知记录：cookie 会话入口，ACL 与 GET /v1/notify/messages 对齐
+   *（identity 只能读自己的 agent topic；admin 必须显式选 topic，禁止 self）。
+   */
+  routes.get('/notify/messages', async (c) => {
+    const parsed = notifyHistoryQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+    let topic = toNotifyTopic(parsed.data.topic);
+    if (!topic) return c.json({ error: 'invalid_request' }, 400);
+
+    const auth = getAuth(c);
+    let identityAddress: string | undefined;
+    if (auth.kind === 'identity') {
+      const localpart = auth.address.split('@')[0];
+      const own = localpart ? (`agent:${localpart}` as NotifyTopic) : null;
+      if (!own) return c.json({ error: 'forbidden' }, 403);
+      // 授权边界：identity 不可用历史窥探 user 频道或其他 agent。
+      if (topic === 'self') topic = own;
+      if (topic !== own) {
+        return c.json({ error: 'forbidden: token is scoped to another notification topic' }, 403);
+      }
+      identityAddress = auth.address;
+    } else if (topic === 'self') {
+      return c.json({ error: 'invalid_request: admin must choose a topic' }, 400);
+    }
+
+    const read =
+      dependencies.notifyMessages ??
+      ((t, addr, since) => notificationService().messages(t, addr, since));
+    try {
+      return c.json({ messages: await read(topic, identityAddress, parsed.data.since) });
+    } catch (err) {
+      return notifyHistoryError(c, err);
+    }
   });
 
   return routes;

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -2329,14 +2329,20 @@ export const UI_JS = `(function () {
 
   function renderNotifyRows() {
     notifyRows.replaceChildren();
-    var rows = filteredNotifyMessages();
+    /* fetchKey 不匹配时旧缓存不可见，避免切频道闪「该频道无通知」。 */
+    var keyMatches = state.notifyFetchKey === notifyFetchKey();
+    var rows = keyMatches ? filteredNotifyMessages() : [];
     var total = rows.length;
     var truncated = total > NOTIFY_RENDER_LIMIT;
     var visible = truncated ? rows.slice(0, NOTIFY_RENDER_LIMIT) : rows;
-    notifyShown.textContent = truncated
-      ? 'Showing latest ' + NOTIFY_RENDER_LIMIT + ' of ' + total
-      : String(total);
-    if (state.notifyStatus === 'loading' && state.notifyMessages.length === 0) {
+    /* 只要 fetchKey 对不上，就当加载中——含 enterNotifications 首帧尚未 pending 的窗口。 */
+    var awaiting = state.notifyStatus === 'loading' || !keyMatches;
+    notifyShown.textContent = awaiting
+      ? ''
+      : truncated
+        ? 'Showing latest ' + NOTIFY_RENDER_LIMIT + ' of ' + total
+        : String(total);
+    if (awaiting) {
       notifyStateNode.textContent = 'Loading…';
       return;
     }
@@ -2445,6 +2451,9 @@ export const UI_JS = `(function () {
   }
 
   async function fetchNotifyTopic(topic, signal) {
+    if (signal.aborted) {
+      return { ok: true, skipped: true, topic: topic, messages: [] };
+    }
     try {
       var payload = await apiJson(
         '/ui/api/notify/messages?topic=' + encodeURIComponent(topic) + '&since=12h',
@@ -2456,10 +2465,25 @@ export const UI_JS = `(function () {
         messages: Array.isArray(payload.messages) ? payload.messages : []
       };
     } catch (error) {
-      if (error.name === 'AbortError' || error.message === 'session_expired') throw error;
+      if (error.message === 'session_expired') throw error;
+      /* 扇出短路 abort：当作跳过，不计入失败。 */
+      if (error.name === 'AbortError') {
+        return { ok: true, skipped: true, topic: topic, messages: [] };
+      }
       /* unknown_agent / 未开通频道 → 空列表，不报「加载失败」（诚实空态）。 */
       if (error.status === 404) {
         return { ok: true, topic: topic, messages: [] };
+      }
+      /* ntfy 未启用/未配置：标记 disabled，由上层短路剩余 topic。 */
+      if (error.status === 503) {
+        var code = error.body && error.body.error;
+        return {
+          ok: false,
+          disabled: true,
+          disabledCode: typeof code === 'string' ? code : '',
+          topic: topic,
+          messages: []
+        };
       }
       return { ok: false, topic: topic, messages: [] };
     }
@@ -2470,12 +2494,20 @@ export const UI_JS = `(function () {
     var controller = new AbortController();
     notifyController = controller;
     state.notifyPending = true;
-    state.notifyStatus = state.notifyMessages.length ? state.notifyStatus : 'loading';
     state.notifyMessage = '';
+    /* F4：filter 一变 fetchKey 就变——立刻 loading，别等网络返回才撤掉假空态。 */
+    if (state.notifyFetchKey !== notifyFetchKey()) {
+      state.notifyMessages = [];
+      state.notifyStatus = 'loading';
+    } else if (state.notifyMessages.length === 0) {
+      state.notifyStatus = 'loading';
+    }
     renderNotify();
 
     var merged = [];
     var failures = 0;
+    /* 503 全局短路文案；一旦置位则不再发起新的 topic 请求。 */
+    var disabledMessage = '';
     try {
       /* admin 若尚未跑过 Overview，先补 identities，才能派生 agent:* topic。 */
       if (isAdmin() && state.identities.length === 0) {
@@ -2485,16 +2517,53 @@ export const UI_JS = `(function () {
           ? identityPayload.identities
           : [];
         renderIdentities();
+        /* identities 到位后 topic 集合可能变宽，再次对齐 loading。 */
+        if (state.notifyFetchKey !== notifyFetchKey()) {
+          state.notifyMessages = [];
+          state.notifyStatus = 'loading';
+          renderNotify();
+        }
       }
       /* 选了具体频道时只拉一路；All 才扇出，并用有限并发。 */
       var topics = notifyTopicsToFetch();
       var fetchKey = topics.join('|');
+
       var batches = await mapPool(topics, 6, function (topic) {
-        return fetchNotifyTopic(topic, controller.signal);
+        if (disabledMessage) {
+          return Promise.resolve({
+            ok: true,
+            skipped: true,
+            topic: topic,
+            messages: []
+          });
+        }
+        return fetchNotifyTopic(topic, controller.signal).then(function (result) {
+          if (result && result.disabled && !disabledMessage) {
+            disabledMessage = result.disabledCode === 'notifications_disabled'
+              ? 'Notifications are disabled on this server.'
+              : 'Notifications are not configured on this server.';
+            try {
+              controller.abort();
+            } catch (_abortError) {
+              /* ignore */
+            }
+          }
+          return result;
+        });
       });
-      if (controller.signal.aborted || notifyController !== controller) return;
+      if (notifyController !== controller) return;
+      if (disabledMessage) {
+        state.notifyMessages = [];
+        state.notifyUpdatedAt = Date.now();
+        state.notifyFetchKey = fetchKey;
+        state.notifyStatus = 'error';
+        state.notifyMessage = disabledMessage;
+        renderNotify();
+        announce(disabledMessage);
+        return;
+      }
       batches.forEach(function (batch) {
-        if (!batch) return;
+        if (!batch || batch.skipped) return;
         if (!batch.ok) {
           failures += 1;
           return;
@@ -2538,6 +2607,8 @@ export const UI_JS = `(function () {
       if (state.notifyMessages.length === 0) {
         state.notifyStatus = 'error';
         state.notifyMessage = 'Notifications could not be loaded. Try Refresh.';
+        /* 对齐 fetchKey，避免 !keyMatches 把诚实错误盖成永远 Loading… */
+        state.notifyFetchKey = notifyFetchKey();
       } else {
         state.notifyStatus = 'error';
         state.notifyMessage = 'Refresh failed. Showing previous notifications.';

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -843,6 +843,8 @@ export const UI_JS = `(function () {
   var FRESH_MS = 15000;
   var POLL_LIMIT = 15;
   var POLL_WINDOW_MS = 20000;
+  /* 通知面板 DOM 行数上限：12h 窗口可能数千条，全量建节点会卡死页面。 */
+  var NOTIFY_RENDER_LIMIT = 500;
   var SORT_COLUMNS = [
     { key: 'address', label: 'Address' },
     { key: 'name', label: 'Name' },
@@ -982,9 +984,21 @@ export const UI_JS = `(function () {
     return safe;
   }
 
+  /* 401 / 登出共用：清掉通知缓存，避免换 token 后 15s 命中渲染上一主体内容。 */
+  function clearNotifyState() {
+    state.notifyMessages = [];
+    state.notifyStatus = 'idle';
+    state.notifyMessage = '';
+    state.notifyFilter = '';
+    state.notifyUpdatedAt = 0;
+    state.notifyFetchKey = '';
+    state.notifyPending = false;
+  }
+
   function showLogin(message) {
     cancelOverview();
     cancelNotifyLoad();
+    clearNotifyState();
     closeAllModals();
     inboxView.hidden = true;
     loginView.hidden = false;
@@ -2316,7 +2330,12 @@ export const UI_JS = `(function () {
   function renderNotifyRows() {
     notifyRows.replaceChildren();
     var rows = filteredNotifyMessages();
-    notifyShown.textContent = String(rows.length);
+    var total = rows.length;
+    var truncated = total > NOTIFY_RENDER_LIMIT;
+    var visible = truncated ? rows.slice(0, NOTIFY_RENDER_LIMIT) : rows;
+    notifyShown.textContent = truncated
+      ? 'Showing latest ' + NOTIFY_RENDER_LIMIT + ' of ' + total
+      : String(total);
     if (state.notifyStatus === 'loading' && state.notifyMessages.length === 0) {
       notifyStateNode.textContent = 'Loading…';
       return;
@@ -2331,8 +2350,10 @@ export const UI_JS = `(function () {
         : 'No notifications in the last 12 hours. Refresh after a push is sent.';
       return;
     }
-    notifyStateNode.textContent = '';
-    rows.forEach(function (row) {
+    notifyStateNode.textContent = truncated
+      ? 'Showing latest ' + NOTIFY_RENDER_LIMIT + ' of ' + total + ' notifications.'
+      : '';
+    visible.forEach(function (row) {
       var tier = tierFromPriority(row.priority);
       var item = document.createElement('article');
       item.className = 'notify-row';
@@ -2961,18 +2982,12 @@ export const UI_JS = `(function () {
         credentials: 'same-origin'
       });
     } finally {
-      cancelNotifyLoad();
       state.me = null;
       state.identities = [];
       state.messages = [];
       state.overview = null;
       state.overviewStatus = 'idle';
-      state.notifyMessages = [];
-      state.notifyStatus = 'idle';
-      state.notifyMessage = '';
-      state.notifyFilter = '';
-      state.notifyUpdatedAt = 0;
-      state.notifyFetchKey = '';
+      /* showLogin → clearNotifyState：与 401 过期路径同一套清理。 */
       showLogin('');
     }
   });

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -119,6 +119,35 @@ export const UI_HTML = `<!doctype html>
         <div id="overview-rows" class="overview-rows"></div>
       </main>
 
+      <main id="notify-panel" class="notify-panel" tabindex="-1" aria-labelledby="notify-title" hidden>
+        <div class="panel-heading overview-heading">
+          <div>
+            <h2 id="notify-title">Notifications</h2>
+            <p id="notify-subtitle" class="overview-subtitle">Push history from ntfy cache (last 12 hours)</p>
+            <p id="notify-updated" class="overview-updated"></p>
+          </div>
+          <div class="overview-heading-actions">
+            <button id="notify-refresh" class="quiet" type="button">Refresh</button>
+          </div>
+        </div>
+        <p id="notify-notice" class="notice warning" hidden></p>
+        <div class="overview-controls notify-controls">
+          <label class="search-label" for="notify-topic-filter">Filter channel</label>
+          <select id="notify-topic-filter" class="search-input notify-topic-filter" hidden>
+            <option value="">All channels</option>
+          </select>
+          <span id="notify-shown" class="count"></span>
+        </div>
+        <p id="notify-state" class="empty-state"></p>
+        <div class="notify-header" aria-hidden="true">
+          <span>When</span>
+          <span>Channel</span>
+          <span>Tier</span>
+          <span>Content</span>
+        </div>
+        <div id="notify-rows" class="notify-rows"></div>
+      </main>
+
       <main id="main-content" class="inbox-main" tabindex="-1">
         <section id="message-panel" class="message-panel" aria-labelledby="messages-title">
           <div class="panel-heading message-heading">
@@ -403,13 +432,57 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   display: grid;
   grid-template-columns: 360px minmax(0, 1fr);
 }
-.identity-panel, .message-panel, .detail-panel, .overview-panel { min-width: 0; }
+.identity-panel, .message-panel, .detail-panel, .overview-panel, .notify-panel { min-width: 0; }
 .identity-panel, .message-panel { border-right: 1px solid var(--line-strong); }
 .identity-panel { padding: 20px 14px; background: var(--bg); }
-.inbox-view[data-scope="overview"] .identity-panel { border-right-color: var(--line-strong); }
+.inbox-view[data-scope="overview"] .identity-panel,
+.inbox-view[data-scope="notifications"] .identity-panel { border-right-color: var(--line-strong); }
 .message-panel { background: var(--bg-raise); }
 .detail-panel { background: var(--bg); }
-.overview-panel { background: var(--bg); padding: 20px clamp(16px, 3vw, 30px) 48px; overflow-x: hidden; }
+.overview-panel, .notify-panel { background: var(--bg); padding: 20px clamp(16px, 3vw, 30px) 48px; overflow-x: hidden; }
+.notify-topic-filter { max-width: 280px; }
+.notify-header {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 160px 140px 88px minmax(0, 1fr);
+  padding: 8px 10px;
+  color: var(--ink-dim);
+  font-size: 11px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--line);
+}
+.notify-rows { border-top: 1px solid var(--line); }
+.notify-row {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 160px 140px 88px minmax(0, 1fr);
+  align-items: start;
+  padding: 12px 10px;
+  border-bottom: 1px solid var(--line);
+  min-height: 44px;
+}
+.notify-row:hover { background: var(--gold-dim); }
+.notify-row .cell-label { display: none; color: var(--ink-dim); font-size: 12px; }
+.notify-when { color: var(--ink-dim); font-size: 13px; font-variant-numeric: tabular-nums; }
+.notify-channel { font-size: 13px; overflow: hidden; text-overflow: ellipsis; }
+.notify-tier {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--ink-dim);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.notify-tier[data-tier="urgent"] { border-color: rgba(248, 113, 113, 0.45); color: var(--red); }
+.notify-tier[data-tier="normal"] { border-color: rgba(251, 191, 36, 0.4); color: var(--gold); }
+.notify-tier[data-tier="low"], .notify-tier[data-tier="unknown"] { color: var(--ink-dim); }
+.notify-title-text { margin: 0; font-size: 14px; font-weight: 700; }
+.notify-body-text { margin: 4px 0 0; color: var(--ink-dim); font-size: 13px; white-space: pre-wrap; word-break: break-word; }
 .panel-heading {
   display: flex;
   align-items: center;
@@ -723,11 +796,16 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   .inbox-layout { min-height: calc(100vh - 66px); display: block; }
   .inbox-main { display: block; }
   .identity-panel { display: none; }
-  .message-panel, .detail-panel, .overview-panel { min-height: calc(100vh - 66px); border: 0; }
+  .message-panel, .detail-panel, .overview-panel, .notify-panel { min-height: calc(100vh - 66px); border: 0; }
   .mobile-identity { display: grid; gap: 5px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
   .mobile-back { display: inline-block; margin: 14px 16px 0; }
   .inbox-view[data-mobile-view="list"] .detail-panel { display: none; }
   .inbox-view[data-mobile-view="detail"] .message-panel { display: none; }
+  .notify-header { display: none; }
+  .notify-row { display: block; }
+  .notify-row .cell { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; min-height: 24px; margin-bottom: 4px; }
+  .notify-row .cell-label { display: inline; }
+  .notify-row .notify-content { display: block; }
   .inbox-view[data-mobile-view="overview"] .overview-stats { grid-template-columns: minmax(0, 1fr); gap: 0; }
   .inbox-view[data-mobile-view="overview"] .stat-card {
     display: flex;
@@ -797,13 +875,23 @@ export const UI_JS = `(function () {
     overviewLoadingSince: 0,
     returnAddress: '',
     /* address -> true while a push-tier PUT is in flight (survives re-render). */
-    tierPending: {}
+    tierPending: {},
+    /* 通知记录：合并后的行（含逻辑 topic），以及加载态 */
+    notifyMessages: [],
+    notifyStatus: 'idle',
+    notifyMessage: '',
+    notifyFilter: '',
+    notifyUpdatedAt: 0,
+    notifyPending: false,
+    /* 上次成功拉取对应的 topic 集合指纹，避免 All 误用单路缓存。 */
+    notifyFetchKey: ''
   };
   var refreshTask = null;
   var refreshController = null;
   var detailController = null;
   var overviewController = null;
   var overviewTimer = null;
+  var notifyController = null;
 
   function byId(id) {
     return document.getElementById(id);
@@ -845,6 +933,14 @@ export const UI_JS = `(function () {
   var skipLink = byId('skip-link');
   var viewTitle = byId('view-title');
   var statusRegion = byId('status');
+  var notifyPanel = byId('notify-panel');
+  var notifyRows = byId('notify-rows');
+  var notifyStateNode = byId('notify-state');
+  var notifyNotice = byId('notify-notice');
+  var notifyUpdated = byId('notify-updated');
+  var notifyShown = byId('notify-shown');
+  var notifyRefresh = byId('notify-refresh');
+  var notifyTopicFilter = byId('notify-topic-filter');
   var tokenModal = byId('token-modal');
   var tokenModalTitle = byId('token-modal-title');
   var tokenValue = byId('token-value');
@@ -888,6 +984,7 @@ export const UI_JS = `(function () {
 
   function showLogin(message) {
     cancelOverview();
+    cancelNotifyLoad();
     closeAllModals();
     inboxView.hidden = true;
     loginView.hidden = false;
@@ -1279,28 +1376,43 @@ export const UI_JS = `(function () {
     detailContent.append(placeholder);
   }
 
-  /* ---- scope 迁移：任一时刻恰好一个可见 <main> ---- */
+  /* ---- scope 迁移：任一时刻恰好一个可见 <main>（overview / notifications / inbox） ---- */
   function applyScope(next, options) {
     var opts = options || {};
     var overviewActive = next === 'overview';
+    var notifyActive = next === 'notifications';
+    var inboxActive = next === 'inbox';
     state.scope = next;
     inboxView.dataset.scope = next;
     overviewPanel.hidden = !overviewActive;
-    mainContent.hidden = overviewActive;
-    viewTitle.textContent = overviewActive ? 'Overview' : 'Inbox';
-    document.title = overviewActive ? 'OpenAgent Overview' : 'OpenAgent Inbox';
-    skipLink.textContent = overviewActive ? 'Skip to overview' : 'Skip to inbox';
-    skipLink.setAttribute('href', overviewActive ? '#overview-panel' : '#main-content');
+    notifyPanel.hidden = !notifyActive;
+    mainContent.hidden = !inboxActive;
+    viewTitle.textContent = overviewActive ? 'Overview' : notifyActive ? 'Notifications' : 'Inbox';
+    document.title = overviewActive
+      ? 'OpenAgent Overview'
+      : notifyActive
+        ? 'OpenAgent Notifications'
+        : 'OpenAgent Inbox';
+    skipLink.textContent = overviewActive
+      ? 'Skip to overview'
+      : notifyActive
+        ? 'Skip to notifications'
+        : 'Skip to inbox';
+    skipLink.setAttribute(
+      'href',
+      overviewActive ? '#overview-panel' : notifyActive ? '#notify-panel' : '#main-content'
+    );
     if (overviewActive) inboxView.dataset.mobileView = 'overview';
+    else if (notifyActive) inboxView.dataset.mobileView = 'notifications';
     renderIdentities();
     if (opts.announce) announce(opts.announce);
   }
 
-  /* 侧栏地址项与移动 <select> 是 Overview 之外的两条入口：在 overview scope 下
-     它们必须和表格行走同一条路（openAddress 会切 scope、播报、聚焦），否则会在
-     不可见的 inbox 里取消息、画面却停在 Overview。 */
+  /* 侧栏地址项与移动 <select> 是 Overview / Notifications 之外的入口：在非 inbox
+     scope 下必须走 openAddress（切 scope、播报、聚焦），否则会在不可见的 inbox
+     里取消息、画面却停在当前面板。 */
   function activateAddress(address) {
-    if (state.scope === 'overview') {
+    if (state.scope === 'overview' || state.scope === 'notifications') {
       openAddress(address);
       return;
     }
@@ -1330,6 +1442,13 @@ export const UI_JS = `(function () {
       mobileIdentity.append(overviewOption);
     }
 
+    /* 通知面板哨兵：合法地址不会以双下划线开头。 */
+    var notifyOption = document.createElement('option');
+    notifyOption.value = '__notifications__';
+    notifyOption.textContent = 'Notifications — push history';
+    notifyOption.selected = state.scope === 'notifications';
+    mobileIdentity.append(notifyOption);
+
     state.identities.forEach(function (identity) {
       var option = document.createElement('option');
       option.value = identity.address;
@@ -1355,6 +1474,22 @@ export const UI_JS = `(function () {
       item.append(button);
       identityList.append(item);
     }
+
+    var notifyItem = document.createElement('li');
+    var notifyButton = document.createElement('button');
+    notifyButton.type = 'button';
+    notifyButton.className = 'identity-button overview-nav';
+    notifyButton.setAttribute('aria-current', state.scope === 'notifications' ? 'true' : 'false');
+    var notifyName = document.createElement('strong');
+    notifyName.textContent = 'Notifications';
+    var notifyHint = document.createElement('span');
+    notifyHint.textContent = 'Push history';
+    notifyButton.append(notifyName, notifyHint);
+    notifyButton.addEventListener('click', function () {
+      enterNotifications({ announce: 'Opened notifications' });
+    });
+    notifyItem.append(notifyButton);
+    identityList.append(notifyItem);
 
     filteredIdentities().forEach(function (identity) {
       var item = document.createElement('li');
@@ -2063,6 +2198,7 @@ export const UI_JS = `(function () {
   function enterOverview(options) {
     var opts = options || {};
     cancelOverviewPoll();
+    cancelNotifyLoad();
     applyScope('overview', { announce: opts.announce });
     renderOverview();
     /* 两条聚焦路径分开处理：从 inbox 返回时焦点回到原来那一行，那一行可能在长表格深处，
@@ -2081,11 +2217,334 @@ export const UI_JS = `(function () {
   function openAddress(address) {
     state.returnAddress = address;
     cancelOverview();
+    cancelNotifyLoad();
     applyScope('inbox');
     inboxView.dataset.mobileView = 'list';
     announce('Opened ' + address);
     messagesTitle.focus();
     selectIdentity(address);
+  }
+
+  /* ---- 通知记录面板（放在 overview cycle 切片之后，避免污染其 await 断言） ---- */
+  function focusNotifyPanel() {
+    notifyPanel.focus({ preventScroll: true });
+  }
+
+  /* priority → 档位文案（与 lib/notify.ts priority() 互逆；未知值不强行标 normal）。 */
+  function tierFromPriority(priority) {
+    if (priority === 5) return 'urgent';
+    if (priority === 1) return 'low';
+    if (priority === 3) return 'normal';
+    return 'unknown';
+  }
+
+  function formatNotifyChannel(topic) {
+    if (topic === 'user-alerts') return 'User alerts';
+    if (topic === 'user-low') return 'User low';
+    return topic;
+  }
+
+  /* 本会话允许查询的逻辑 topic：identity 只打 self；admin 用 identities 派生，不另开列表 API。 */
+  function notifyTopicsForSession() {
+    if (!isAdmin()) return ['self'];
+    var topics = ['user-alerts', 'user-low'];
+    state.identities.forEach(function (identity) {
+      var localpart = identity.address.split('@')[0];
+      if (localpart) topics.push('agent:' + localpart);
+    });
+    return topics;
+  }
+
+  function notifyTopicsToFetch() {
+    return state.notifyFilter ? [state.notifyFilter] : notifyTopicsForSession();
+  }
+
+  function notifyFetchKey() {
+    return notifyTopicsToFetch().join('|');
+  }
+
+  function cancelNotifyLoad() {
+    if (notifyController) {
+      notifyController.abort();
+      notifyController = null;
+    }
+    state.notifyPending = false;
+  }
+
+  function filteredNotifyMessages() {
+    if (!state.notifyFilter) return state.notifyMessages;
+    return state.notifyMessages.filter(function (row) {
+      return row.topic === state.notifyFilter;
+    });
+  }
+
+  function populateNotifyTopicFilter() {
+    var previous = state.notifyFilter;
+    notifyTopicFilter.replaceChildren();
+    var all = document.createElement('option');
+    all.value = '';
+    all.textContent = 'All channels';
+    notifyTopicFilter.append(all);
+    if (!isAdmin()) {
+      notifyTopicFilter.hidden = true;
+      state.notifyFilter = '';
+      return;
+    }
+    notifyTopicFilter.hidden = false;
+    ['user-alerts', 'user-low'].forEach(function (topic) {
+      var option = document.createElement('option');
+      option.value = topic;
+      option.textContent = formatNotifyChannel(topic);
+      notifyTopicFilter.append(option);
+    });
+    state.identities.forEach(function (identity) {
+      var localpart = identity.address.split('@')[0];
+      if (!localpart) return;
+      var topic = 'agent:' + localpart;
+      var option = document.createElement('option');
+      option.value = topic;
+      option.textContent = topic;
+      notifyTopicFilter.append(option);
+    });
+    var stillValid = previous === '' || Array.prototype.some.call(notifyTopicFilter.options, function (opt) {
+      return opt.value === previous;
+    });
+    state.notifyFilter = stillValid ? previous : '';
+    notifyTopicFilter.value = state.notifyFilter;
+  }
+
+  function renderNotifyRows() {
+    notifyRows.replaceChildren();
+    var rows = filteredNotifyMessages();
+    notifyShown.textContent = String(rows.length);
+    if (state.notifyStatus === 'loading' && state.notifyMessages.length === 0) {
+      notifyStateNode.textContent = 'Loading…';
+      return;
+    }
+    if (state.notifyStatus === 'error' && state.notifyMessages.length === 0) {
+      notifyStateNode.textContent = state.notifyMessage || 'Notifications could not be loaded. Try Refresh.';
+      return;
+    }
+    if (rows.length === 0) {
+      notifyStateNode.textContent = state.notifyFilter
+        ? 'No notifications on this channel in the last 12 hours.'
+        : 'No notifications in the last 12 hours. Refresh after a push is sent.';
+      return;
+    }
+    notifyStateNode.textContent = '';
+    rows.forEach(function (row) {
+      var tier = tierFromPriority(row.priority);
+      var item = document.createElement('article');
+      item.className = 'notify-row';
+
+      var whenCell = document.createElement('div');
+      whenCell.className = 'cell notify-when';
+      var whenLabel = document.createElement('span');
+      whenLabel.className = 'cell-label';
+      whenLabel.textContent = 'When';
+      var whenValue = document.createElement('time');
+      whenValue.dateTime = row.time ? new Date(row.time * 1000).toISOString() : '';
+      whenValue.textContent = row.time
+        ? formatDate(new Date(row.time * 1000).toISOString())
+        : '—';
+      whenCell.append(whenLabel, whenValue);
+
+      var channelCell = document.createElement('div');
+      channelCell.className = 'cell notify-channel';
+      var channelLabel = document.createElement('span');
+      channelLabel.className = 'cell-label';
+      channelLabel.textContent = 'Channel';
+      var channelValue = document.createElement('span');
+      channelValue.textContent = formatNotifyChannel(row.topic);
+      channelCell.append(channelLabel, channelValue);
+
+      var tierCell = document.createElement('div');
+      tierCell.className = 'cell';
+      var tierLabel = document.createElement('span');
+      tierLabel.className = 'cell-label';
+      tierLabel.textContent = 'Tier';
+      var tierValue = document.createElement('span');
+      tierValue.className = 'notify-tier';
+      tierValue.setAttribute('data-tier', tier);
+      tierValue.textContent = tier;
+      tierCell.append(tierLabel, tierValue);
+
+      var contentCell = document.createElement('div');
+      contentCell.className = 'cell notify-content';
+      var contentLabel = document.createElement('span');
+      contentLabel.className = 'cell-label';
+      contentLabel.textContent = 'Content';
+      var title = document.createElement('p');
+      title.className = 'notify-title-text';
+      title.textContent = row.title || '(no title)';
+      var body = document.createElement('p');
+      body.className = 'notify-body-text';
+      body.textContent = row.message || '';
+      contentCell.append(contentLabel, title, body);
+
+      item.append(whenCell, channelCell, tierCell, contentCell);
+      notifyRows.append(item);
+    });
+  }
+
+  function renderNotifyMeta() {
+    if (state.notifyUpdatedAt) {
+      notifyUpdated.textContent = 'Updated ' + formatClock(new Date(state.notifyUpdatedAt).toISOString(), true);
+    } else {
+      notifyUpdated.textContent = '';
+    }
+    notifyNotice.hidden = !state.notifyMessage || state.notifyStatus !== 'error' || state.notifyMessages.length === 0;
+    notifyNotice.textContent = notifyNotice.hidden ? '' : state.notifyMessage;
+    notifyRefresh.disabled = state.notifyPending;
+    notifyRefresh.textContent = state.notifyPending ? 'Refreshing…' : 'Refresh';
+  }
+
+  function renderNotify() {
+    populateNotifyTopicFilter();
+    renderNotifyMeta();
+    renderNotifyRows();
+  }
+
+  /* 有限并发拉取各 topic，避免 admin 身份很多时 Refresh 串行卡死。 */
+  async function mapPool(items, concurrency, worker) {
+    var results = new Array(items.length);
+    var cursor = 0;
+    async function run() {
+      while (cursor < items.length) {
+        var index = cursor;
+        cursor += 1;
+        results[index] = await worker(items[index], index);
+      }
+    }
+    var runners = [];
+    var width = Math.max(1, Math.min(concurrency, items.length || 1));
+    for (var i = 0; i < width; i++) runners.push(run());
+    await Promise.all(runners);
+    return results;
+  }
+
+  async function fetchNotifyTopic(topic, signal) {
+    try {
+      var payload = await apiJson(
+        '/ui/api/notify/messages?topic=' + encodeURIComponent(topic) + '&since=12h',
+        { signal: signal }
+      );
+      return {
+        ok: true,
+        topic: topic,
+        messages: Array.isArray(payload.messages) ? payload.messages : []
+      };
+    } catch (error) {
+      if (error.name === 'AbortError' || error.message === 'session_expired') throw error;
+      /* unknown_agent / 未开通频道 → 空列表，不报「加载失败」（诚实空态）。 */
+      if (error.status === 404) {
+        return { ok: true, topic: topic, messages: [] };
+      }
+      return { ok: false, topic: topic, messages: [] };
+    }
+  }
+
+  async function loadNotifyHistory() {
+    cancelNotifyLoad();
+    var controller = new AbortController();
+    notifyController = controller;
+    state.notifyPending = true;
+    state.notifyStatus = state.notifyMessages.length ? state.notifyStatus : 'loading';
+    state.notifyMessage = '';
+    renderNotify();
+
+    var merged = [];
+    var failures = 0;
+    try {
+      /* admin 若尚未跑过 Overview，先补 identities，才能派生 agent:* topic。 */
+      if (isAdmin() && state.identities.length === 0) {
+        var identityPayload = await apiJson('/ui/api/identities', { signal: controller.signal });
+        if (controller.signal.aborted || notifyController !== controller) return;
+        state.identities = Array.isArray(identityPayload.identities)
+          ? identityPayload.identities
+          : [];
+        renderIdentities();
+      }
+      /* 选了具体频道时只拉一路；All 才扇出，并用有限并发。 */
+      var topics = notifyTopicsToFetch();
+      var fetchKey = topics.join('|');
+      var batches = await mapPool(topics, 6, function (topic) {
+        return fetchNotifyTopic(topic, controller.signal);
+      });
+      if (controller.signal.aborted || notifyController !== controller) return;
+      batches.forEach(function (batch) {
+        if (!batch) return;
+        if (!batch.ok) {
+          failures += 1;
+          return;
+        }
+        /* identity 的 self 在 UI 上标成 agent:<localpart>，不暴露 self 别名。 */
+        var displayTopic = batch.topic === 'self' && state.me && state.me.address
+          ? 'agent:' + state.me.address.split('@')[0]
+          : batch.topic;
+        batch.messages.forEach(function (message) {
+          merged.push({
+            id: message.id,
+            time: typeof message.time === 'number' ? message.time : 0,
+            title: message.title || '',
+            message: message.message || '',
+            priority: typeof message.priority === 'number' ? message.priority : 0,
+            tags: Array.isArray(message.tags) ? message.tags : [],
+            topic: displayTopic
+          });
+        });
+      });
+      merged.sort(function (left, right) {
+        return (right.time || 0) - (left.time || 0);
+      });
+      state.notifyMessages = merged;
+      state.notifyUpdatedAt = Date.now();
+      state.notifyFetchKey = fetchKey;
+      if (failures && merged.length === 0) {
+        state.notifyStatus = 'error';
+        state.notifyMessage = 'Notifications could not be loaded. Try Refresh.';
+      } else if (failures) {
+        state.notifyStatus = 'error';
+        state.notifyMessage = 'Some channels could not be loaded. Showing what succeeded.';
+      } else {
+        state.notifyStatus = 'ready';
+        state.notifyMessage = '';
+      }
+      renderNotify();
+      announce(merged.length + ' notifications loaded');
+    } catch (error) {
+      if (error.name === 'AbortError' || error.message === 'session_expired') return;
+      if (state.notifyMessages.length === 0) {
+        state.notifyStatus = 'error';
+        state.notifyMessage = 'Notifications could not be loaded. Try Refresh.';
+      } else {
+        state.notifyStatus = 'error';
+        state.notifyMessage = 'Refresh failed. Showing previous notifications.';
+      }
+      renderNotify();
+    } finally {
+      if (notifyController === controller) {
+        notifyController = null;
+        state.notifyPending = false;
+        renderNotifyMeta();
+      }
+    }
+  }
+
+  function enterNotifications(options) {
+    var opts = options || {};
+    cancelOverview();
+    applyScope('notifications', { announce: opts.announce });
+    renderNotify();
+    focusNotifyPanel();
+    /* 15s 内有成功缓存且 topic 集合未变则只重绘，避免 All 误用单路缓存。 */
+    var age = state.notifyUpdatedAt ? Math.max(0, Date.now() - state.notifyUpdatedAt) : Infinity;
+    if (
+      state.notifyStatus === 'ready' &&
+      age < FRESH_MS &&
+      state.notifyFetchKey === notifyFetchKey()
+    ) return;
+    loadNotifyHistory();
   }
 
   async function waitForPreviousRefresh() {
@@ -2502,11 +2961,18 @@ export const UI_JS = `(function () {
         credentials: 'same-origin'
       });
     } finally {
+      cancelNotifyLoad();
       state.me = null;
       state.identities = [];
       state.messages = [];
       state.overview = null;
       state.overviewStatus = 'idle';
+      state.notifyMessages = [];
+      state.notifyStatus = 'idle';
+      state.notifyMessage = '';
+      state.notifyFilter = '';
+      state.notifyUpdatedAt = 0;
+      state.notifyFetchKey = '';
       showLogin('');
     }
   });
@@ -2525,6 +2991,10 @@ export const UI_JS = `(function () {
       enterOverview({ announce: 'Back to overview' });
       return;
     }
+    if (mobileIdentity.value === '__notifications__') {
+      enterNotifications({ announce: 'Opened notifications' });
+      return;
+    }
     activateAddress(mobileIdentity.value);
   });
   refreshButton.addEventListener('click', function () {
@@ -2536,6 +3006,14 @@ export const UI_JS = `(function () {
     state.overviewPolls = 0;
     state.overviewLoadingSince = 0;
     loadOverviewCycle({ refresh: true });
+  });
+  notifyRefresh.addEventListener('click', function () {
+    loadNotifyHistory();
+  });
+  notifyTopicFilter.addEventListener('change', function () {
+    state.notifyFilter = notifyTopicFilter.value;
+    /* 过滤切换会改变要请求的 topic 集合（All 扇出 vs 单路），重新拉取。 */
+    loadNotifyHistory();
   });
   createIdentityButton.addEventListener('click', showCreateModal);
   createModalSubmit.addEventListener('click', handleCreateSubmit);

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -2587,21 +2587,34 @@ export const UI_JS = `(function () {
       merged.sort(function (left, right) {
         return (right.time || 0) - (left.time || 0);
       });
-      state.notifyMessages = merged;
-      state.notifyUpdatedAt = Date.now();
-      state.notifyFetchKey = fetchKey;
-      if (failures && merged.length === 0) {
+      /* F8：同频道全败刷新保留旧缓存；外层 catch 走不到这条路（每路已折成 ok:false）。 */
+      if (
+        failures &&
+        merged.length === 0 &&
+        state.notifyMessages.length > 0 &&
+        state.notifyFetchKey === fetchKey
+      ) {
         state.notifyStatus = 'error';
-        state.notifyMessage = 'Notifications could not be loaded. Try Refresh.';
-      } else if (failures) {
-        state.notifyStatus = 'error';
-        state.notifyMessage = 'Some channels could not be loaded. Showing what succeeded.';
+        state.notifyMessage = 'Refresh failed. Showing previous notifications.';
+        renderNotify();
+        announce(state.notifyMessage);
       } else {
-        state.notifyStatus = 'ready';
-        state.notifyMessage = '';
+        state.notifyMessages = merged;
+        state.notifyUpdatedAt = Date.now();
+        state.notifyFetchKey = fetchKey;
+        if (failures && merged.length === 0) {
+          state.notifyStatus = 'error';
+          state.notifyMessage = 'Notifications could not be loaded. Try Refresh.';
+        } else if (failures) {
+          state.notifyStatus = 'error';
+          state.notifyMessage = 'Some channels could not be loaded. Showing what succeeded.';
+        } else {
+          state.notifyStatus = 'ready';
+          state.notifyMessage = '';
+        }
+        renderNotify();
+        announce(merged.length + ' notifications loaded');
       }
-      renderNotify();
-      announce(merged.length + ' notifications loaded');
     } catch (error) {
       if (error.name === 'AbortError' || error.message === 'session_expired') return;
       if (state.notifyMessages.length === 0) {

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -282,6 +282,50 @@ describe('UI static asset contract', () => {
     expect(UI_JS).not.toContain('/v1/notify');
   });
 
+  // F1：401 → showLogin 必须清掉通知缓存，否则换 token 会渲染上一主体内容
+  test('showLogin clears notify cache so a new session cannot reuse prior history (F1)', () => {
+    expect(UI_JS).toContain('function clearNotifyState(');
+    const showLogin = UI_JS.slice(
+      UI_JS.indexOf('function showLogin(message)'),
+      UI_JS.indexOf('function showInbox('),
+    );
+    expect(showLogin).toContain('clearNotifyState()');
+    expect(showLogin.indexOf('cancelNotifyLoad()')).toBeLessThan(
+      showLogin.indexOf('clearNotifyState()'),
+    );
+    const clear = UI_JS.slice(
+      UI_JS.indexOf('function clearNotifyState('),
+      UI_JS.indexOf('function showLogin(message)'),
+    );
+    for (const field of [
+      'state.notifyMessages = []',
+      "state.notifyStatus = 'idle'",
+      "state.notifyMessage = ''",
+      "state.notifyFilter = ''",
+      'state.notifyUpdatedAt = 0',
+      "state.notifyFetchKey = ''",
+      'state.notifyPending = false',
+    ]) {
+      expect(clear).toContain(field);
+    }
+    // apiJson 401 走 showLogin（因而间接触发清理），不是只 abort
+    expect(UI_JS).toContain("showLogin('Your session expired. Sign in again.')");
+  });
+
+  // F2：渲染行数上限，避免 12h 嘈杂实例卡死页面
+  test('notify rows are capped at NOTIFY_RENDER_LIMIT with an honest truncation label (F2)', () => {
+    expect(UI_JS).toContain('var NOTIFY_RENDER_LIMIT = 500');
+    expect(UI_JS).toContain('rows.slice(0, NOTIFY_RENDER_LIMIT)');
+    expect(UI_JS).toContain("'Showing latest ' + NOTIFY_RENDER_LIMIT");
+    const renderRows = UI_JS.slice(
+      UI_JS.indexOf('function renderNotifyRows('),
+      UI_JS.indexOf('function renderNotifyMeta('),
+    );
+    expect(renderRows).toContain('var truncated = total > NOTIFY_RENDER_LIMIT');
+    expect(renderRows).toContain('visible.forEach');
+    expect(renderRows).not.toContain('rows.forEach');
+  });
+
   // N1 / §1.4：落焦 Overview 面板不许滚动首屏，聚焦返回行的那条路径照旧滚动
   test('landing on the overview keeps the first screen while a return row still scrolls', () => {
     expect(UI_JS).toContain('overviewPanel.focus({ preventScroll: true });');

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -290,6 +290,8 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function showInbox('),
     );
     expect(showLogin).toContain('clearNotifyState()');
+    // F5：先钉存在性，避免 indexOf 得到 -1 让顺序断言空转
+    expect(showLogin).toContain('cancelNotifyLoad()');
     expect(showLogin.indexOf('cancelNotifyLoad()')).toBeLessThan(
       showLogin.indexOf('clearNotifyState()'),
     );
@@ -324,6 +326,38 @@ describe('UI static asset contract', () => {
     expect(renderRows).toContain('var truncated = total > NOTIFY_RENDER_LIMIT');
     expect(renderRows).toContain('visible.forEach');
     expect(renderRows).not.toContain('rows.forEach');
+  });
+
+  // F4：切频道时 fetchKey 变化必须进 loading，禁止立刻渲染假空态
+  test('channel filter changes enter loading instead of a false empty state (F4)', () => {
+    const load = UI_JS.slice(
+      UI_JS.indexOf('async function loadNotifyHistory('),
+      UI_JS.indexOf('function enterNotifications('),
+    );
+    expect(load).toContain('state.notifyFetchKey !== notifyFetchKey()');
+    expect(load).toContain("state.notifyStatus = 'loading'");
+    expect(load).toContain('state.notifyMessages = []');
+    const renderRows = UI_JS.slice(
+      UI_JS.indexOf('function renderNotifyRows('),
+      UI_JS.indexOf('function renderNotifyMeta('),
+    );
+    expect(renderRows).toContain('state.notifyFetchKey === notifyFetchKey()');
+    expect(renderRows).toContain("state.notifyStatus === 'loading' || !keyMatches");
+    expect(renderRows).toContain("'Loading…'");
+  });
+
+  // F7：任一路 503 短路扇出，不再打剩余 topic
+  test('a 503 from notify history short-circuits the remaining topic fan-out (F7)', () => {
+    expect(UI_JS).toContain('error.status === 503');
+    expect(UI_JS).toContain('disabled: true');
+    expect(UI_JS).toContain("'Notifications are not configured on this server.'");
+    expect(UI_JS).toContain("'Notifications are disabled on this server.'");
+    const load = UI_JS.slice(
+      UI_JS.indexOf('async function loadNotifyHistory('),
+      UI_JS.indexOf('function enterNotifications('),
+    );
+    expect(load).toContain('if (disabledMessage)');
+    expect(load).toContain('controller.abort()');
   });
 
   // N1 / §1.4：落焦 Overview 面板不许滚动首屏，聚焦返回行的那条路径照旧滚动

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -152,6 +152,15 @@ describe('UI static asset contract', () => {
       'overview-refresh',
       'back-to-overview',
       'skip-link',
+      'notify-panel',
+      'notify-title',
+      'notify-rows',
+      'notify-state',
+      'notify-refresh',
+      'notify-topic-filter',
+      'notify-notice',
+      'notify-updated',
+      'notify-shown',
     ]) {
       expect(UI_HTML).toContain(`id="${id}"`);
     }
@@ -168,10 +177,12 @@ describe('UI static asset contract', () => {
     expect(UI_HTML).toContain('id="confirm-modal-risk"');
   });
 
-  // A15：landmark 挂在包住两个面板的 inbox 容器上，移动 list 态才有可见 <main>
-  test('exactly three mains exist and #main-content wraps the message and detail panels', () => {
+  // A15：landmark 挂在 inbox 容器上；scope 在 overview / notifications / inbox 三个 <main> 间切换
+  test('exactly four mains exist and #main-content wraps the message and detail panels', () => {
     expect(UI_HTML).toContain('<main id="overview-panel" class="overview-panel" tabindex="-1"');
     expect(UI_HTML).toMatch(/<main id="overview-panel"[^>]*\shidden>/);
+    expect(UI_HTML).toContain('<main id="notify-panel" class="notify-panel" tabindex="-1"');
+    expect(UI_HTML).toMatch(/<main id="notify-panel"[^>]*\shidden>/);
     expect(UI_HTML).toContain('<main id="main-content" class="inbox-main" tabindex="-1">');
     expect(UI_HTML).toContain('<section id="detail-panel" class="detail-panel" tabindex="-1">');
 
@@ -181,10 +192,11 @@ describe('UI static asset contract', () => {
     expect(container).toBeGreaterThan(-1);
     expect(container).toBeLessThan(list);
     expect(list).toBeLessThan(detail);
-    // #message-panel / #detail-panel 自身不带 hidden：scope 只切两个 <main>
+    // #message-panel / #detail-panel 自身不带 hidden：scope 只切三个内容 <main>
     expect(UI_HTML).not.toMatch(/<section id="(message|detail)-panel"[^>]*\shidden/);
 
-    expect(UI_HTML.split('<main').length - 1).toBe(3);
+    // login + overview + notify + inbox-main
+    expect(UI_HTML.split('<main').length - 1).toBe(4);
   });
 
   // A16 / A17
@@ -195,9 +207,11 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function filteredIdentities('),
     );
     expect(applyScope).toContain('overviewPanel.hidden = !overviewActive;');
-    expect(applyScope).toContain('mainContent.hidden = overviewActive;');
-    expect(applyScope).toContain("skipLink.textContent = overviewActive ? 'Skip to overview' : 'Skip to inbox';");
-    expect(applyScope).toContain("skipLink.setAttribute('href', overviewActive ? '#overview-panel' : '#main-content');");
+    expect(applyScope).toContain('notifyPanel.hidden = !notifyActive;');
+    expect(applyScope).toContain('mainContent.hidden = !inboxActive;');
+    expect(applyScope).toContain("skipLink.textContent = overviewActive");
+    expect(applyScope).toContain("'Skip to notifications'");
+    expect(applyScope).toContain("'#notify-panel'");
     // landmark 与断点无关，所以不需要 matchMedia
     expect(UI_JS).not.toContain('matchMedia');
     expect(UI_JS).not.toMatch(/\.id\s*=\s*['"]main-content['"]/);
@@ -210,36 +224,62 @@ describe('UI static asset contract', () => {
     expect(selectMessage).not.toContain('mainContent.focus()');
   });
 
-  // F2 / §1.3 / §1.4：侧栏地址与移动 selector 是 Overview 之外的两条入口
+  // F2 / §1.3 / §1.4：侧栏地址与移动 selector 是 Overview / Notifications 之外的入口
   test('the sidebar address and the mobile selector both reach the inbox from the overview', () => {
-    // 唯一的移动 selector 必须挂在两个 <main> 之外，否则 scope=overview 会把它一起藏掉
+    // 唯一的移动 selector 必须挂在内容 <main> 之外，否则 scope 切换会把它一起藏掉
     const layout = UI_HTML.indexOf('<div class="inbox-layout">');
     const selector = UI_HTML.indexOf('id="mobile-identity-select"');
     const overviewMain = UI_HTML.indexOf('<main id="overview-panel"');
+    const notifyMain = UI_HTML.indexOf('<main id="notify-panel"');
     const inboxMain = UI_HTML.indexOf('<main id="main-content"');
     expect(UI_HTML.split('id="mobile-identity-select"').length - 1).toBe(1);
     expect(selector).toBeGreaterThan(layout);
     expect(selector).toBeLessThan(overviewMain);
+    expect(selector).toBeLessThan(notifyMain);
     expect(selector).toBeLessThan(inboxMain);
     expect(UI_HTML).toContain('<label for="mobile-identity-select">Address</label>');
-    // 移动端只有 .inbox-layout 展开成 block，所以这层包装在两个 scope 都可见
+    // 移动端只有 .inbox-layout 展开成 block，所以这层包装在各 scope 都可见
     expect(UI_CSS).toContain('.mobile-back, .mobile-identity { display: none; }');
     expect(UI_CSS).toContain('.mobile-identity { display: grid;');
 
-    // 两条入口在 overview scope 下都走 openAddress（它才会切 scope、播报、聚焦）
+    // 非 inbox scope 下都走 openAddress（它才会切 scope、播报、聚焦）
     expect(UI_JS).toContain('function activateAddress(address) {');
     const activate = UI_JS.slice(
       UI_JS.indexOf('function activateAddress(address) {'),
       UI_JS.indexOf('function filteredIdentities('),
     );
-    expect(activate).toContain("if (state.scope === 'overview') {");
+    expect(activate).toContain("state.scope === 'overview' || state.scope === 'notifications'");
     expect(activate).toContain('openAddress(address);');
     expect(activate).toContain('selectIdentity(address);');
     expect(UI_JS).toContain('activateAddress(identity.address);');
     expect(UI_JS).toContain('activateAddress(mobileIdentity.value);');
-    // 侧栏/选择器不许再直接调 selectIdentity（那样画面会停在 Overview）
+    // 侧栏/选择器不许再直接调 selectIdentity（那样画面会停在 Overview/Notifications）
     expect(UI_JS).not.toContain('selectIdentity(identity.address);');
     expect(UI_JS).not.toContain('selectIdentity(mobileIdentity.value);');
+  });
+
+  // 通知记录：入口、API、字段渲染与权限口径钉在静态契约里
+  test('notifications panel loads history via /ui/api/notify/messages with session-scoped topics', () => {
+    expect(UI_JS).toContain('function enterNotifications(');
+    expect(UI_JS).toContain('function loadNotifyHistory(');
+    expect(UI_JS).toContain('function mapPool(');
+    expect(UI_JS).toContain('function fetchNotifyTopic(');
+    expect(UI_JS).toContain("'/ui/api/notify/messages?topic='");
+    expect(UI_JS).toContain('&since=12h');
+    expect(UI_JS).toContain('mapPool(topics, 6,');
+    expect(UI_JS).toContain('error.status === 404');
+    expect(UI_JS).toContain("return ['self']");
+    expect(UI_JS).toContain("'user-alerts'");
+    expect(UI_JS).toContain("'user-low'");
+    expect(UI_JS).toContain("'agent:' + localpart");
+    expect(UI_JS).toContain("value = '__notifications__'");
+    expect(UI_JS).toContain('notifyPanel.focus({ preventScroll: true })');
+    expect(UI_JS).toContain('tierFromPriority');
+    expect(UI_JS).toContain("priority === 5");
+    expect(UI_JS).toContain("priority === 1");
+    expect(UI_JS).toContain("return 'unknown'");
+    // 前端不得直接打 Bearer 的 /v1/notify
+    expect(UI_JS).not.toContain('/v1/notify');
   });
 
   // N1 / §1.4：落焦 Overview 面板不许滚动首屏，聚焦返回行的那条路径照旧滚动

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -360,6 +360,29 @@ describe('UI static asset contract', () => {
     expect(load).toContain('controller.abort()');
   });
 
+  // F8：同频道全败刷新不清缓存，诚实保留上一版数据
+  test('a total refresh failure keeps previous notify cache for the same fetchKey (F8)', () => {
+    const load = UI_JS.slice(
+      UI_JS.indexOf('async function loadNotifyHistory('),
+      UI_JS.indexOf('function enterNotifications('),
+    );
+    expect(load).toContain('failures &&');
+    expect(load).toContain('merged.length === 0');
+    expect(load).toContain('state.notifyMessages.length > 0');
+    expect(load).toContain('state.notifyFetchKey === fetchKey');
+    expect(load).toContain("'Refresh failed. Showing previous notifications.'");
+    // 保留文案必须出现在「写回 merged」之前；else 侧才允许赋值
+    const keepMsgIdx = load.indexOf("'Refresh failed. Showing previous notifications.'");
+    const assignIdx = load.indexOf('state.notifyMessages = merged;');
+    expect(keepMsgIdx).toBeGreaterThan(-1);
+    expect(assignIdx).toBeGreaterThan(keepMsgIdx);
+    const beforeAssign = load.slice(0, assignIdx);
+    expect(beforeAssign).toContain("'Refresh failed. Showing previous notifications.'");
+    expect(beforeAssign).toContain('state.notifyMessages.length > 0');
+    // else 侧仍写 merged（部分失败 / 首载全败 / 成功）
+    expect(load.slice(assignIdx)).toContain('Some channels could not be loaded');
+  });
+
   // N1 / §1.4：落焦 Overview 面板不许滚动首屏，聚焦返回行的那条路径照旧滚动
   test('landing on the overview keeps the first screen while a return row still scrolls', () => {
     expect(UI_JS).toContain('overviewPanel.focus({ preventScroll: true });');

--- a/packages/api/test/ui-dev-acceptance.test.ts
+++ b/packages/api/test/ui-dev-acceptance.test.ts
@@ -172,7 +172,7 @@ describe('development browser acceptance harness', () => {
   // F3：Notifications 预览必须注入 notifyMessages stub，否则面板永远打真实 ntfy
   test('the preview fixture stubs notifyMessages across tiers and topics (F3)', () => {
     expect(previewSource).toContain('notifyMessages:');
-    expect(previewSource).toContain('previewNotifyByTopic');
+    expect(previewSource).toContain('buildPreviewNotifyMessages');
     expect(previewSource).toContain("'user-alerts'");
     expect(previewSource).toContain("'user-low'");
     expect(previewSource).toContain("'agent:fox'");
@@ -181,5 +181,17 @@ describe('development browser acceptance harness', () => {
     expect(previewSource).toContain('priority: 3');
     expect(previewSource).toContain('priority: 1');
     expect(previewSource).toContain('priority: 2');
+  });
+
+  // F6：preview stub 用相对时间，并按 since 过滤；12h 查询不含窗口外旧消息
+  test('preview notify stubs use relative timestamps and honor since=12h (F6)', () => {
+    expect(previewSource).toContain('function previewSinceCutoff(');
+    expect(previewSource).toContain('Math.floor(Date.now() / 1000)');
+    expect(previewSource).toContain('now - 60');
+    expect(previewSource).toContain('now - 48 * 3600');
+    expect(previewSource).toContain('entry.time >= cutoff');
+    expect(previewSource).toContain('buildPreviewNotifyMessages(topic, since)');
+    // 契约：当前 12h 查询只返回窗口内消息（旧消息时间戳在窗口外）
+    expect(previewSource).toContain("Should be filtered out when since=12h.");
   });
 });

--- a/packages/api/test/ui-dev-acceptance.test.ts
+++ b/packages/api/test/ui-dev-acceptance.test.ts
@@ -168,4 +168,18 @@ describe('development browser acceptance harness', () => {
     }
     expect(previewSource).toContain('getMailboxScan');
   });
+
+  // F3：Notifications 预览必须注入 notifyMessages stub，否则面板永远打真实 ntfy
+  test('the preview fixture stubs notifyMessages across tiers and topics (F3)', () => {
+    expect(previewSource).toContain('notifyMessages:');
+    expect(previewSource).toContain('previewNotifyByTopic');
+    expect(previewSource).toContain("'user-alerts'");
+    expect(previewSource).toContain("'user-low'");
+    expect(previewSource).toContain("'agent:fox'");
+    // urgent / normal / low / unknown（priority 2）
+    expect(previewSource).toContain('priority: 5');
+    expect(previewSource).toContain('priority: 3');
+    expect(previewSource).toContain('priority: 1');
+    expect(previewSource).toContain('priority: 2');
+  });
 });

--- a/packages/api/test/ui-notify.test.ts
+++ b/packages/api/test/ui-notify.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { UiApiDependencies } from '../src/routes/ui.ts';
+import type { NotifyMessage, NotifyTopic } from '../src/lib/notify.ts';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+
+const { UiSessionStore } = await import('../src/lib/ui-session.ts');
+const { createUiApiRoutes } = await import('../src/routes/ui.ts');
+
+const sample: NotifyMessage = {
+  id: 'evt-1',
+  time: 1_700_000_000,
+  title: 'wake',
+  message: 'please look',
+  priority: 5,
+  tags: ['warning'],
+};
+
+type AuthKind = { kind: 'admin' } | { kind: 'identity'; address: string };
+
+function makeApp(
+  auth: AuthKind,
+  overrides: Partial<UiApiDependencies> = {},
+) {
+  const readCalls: Array<{ topic: NotifyTopic; identityAddress?: string; since?: string }> = [];
+  const deps: UiApiDependencies = {
+    listIdentities: () => [],
+    listMessages: mock(async () => []),
+    setMessageSeen: mock(async () => true),
+    getMailboxScan: mock(async () => ({
+      kind: 'ready' as const,
+      now: Date.now(),
+      snapshot: null,
+      cached: false,
+      revalidating: false,
+      refreshError: false,
+    })),
+    getMessage: mock(async () => null),
+    setPushContentTier: mock(() => null),
+    notifyMessages: mock(async (topic, identityAddress, since) => {
+      readCalls.push({ topic, identityAddress, since });
+      return [sample];
+    }),
+    ...overrides,
+  };
+  const store = new UiSessionStore({
+    resolveToken: (token) => {
+      if (token === 'admin-ok' && auth.kind === 'admin') return { kind: 'admin' };
+      if (token === 'id-ok' && auth.kind === 'identity') {
+        return { kind: 'identity', address: auth.address };
+      }
+      return null;
+    },
+  });
+  const token = auth.kind === 'admin' ? 'admin-ok' : 'id-ok';
+  const created = store.create(token, '127.0.0.1');
+  if (!created.ok) throw new Error('test session was not created');
+  const app = new Hono();
+  app.route('/ui/api', createUiApiRoutes(store, deps));
+  return { app, deps, cookie: `oae_ui=${created.sid}`, readCalls };
+}
+
+describe('UI notify history ACL', () => {
+  test('identity can read self (mapped to own agent topic) and cannot read user or peer topics', async () => {
+    const { app, cookie, readCalls } = makeApp({
+      kind: 'identity',
+      address: 'fox@test.example',
+    });
+
+    const own = await app.request('/ui/api/notify/messages?topic=self&since=12h', {
+      headers: { cookie },
+    });
+    expect(own.status).toBe(200);
+    expect(await own.json()).toEqual({ messages: [sample] });
+    expect(readCalls).toEqual([
+      { topic: 'agent:fox', identityAddress: 'fox@test.example', since: '12h' },
+    ]);
+
+    const peer = await app.request('/ui/api/notify/messages?topic=agent:other', {
+      headers: { cookie },
+    });
+    expect(peer.status).toBe(403);
+
+    const human = await app.request('/ui/api/notify/messages?topic=user-alerts', {
+      headers: { cookie },
+    });
+    expect(human.status).toBe(403);
+    expect(readCalls).toHaveLength(1);
+  });
+
+  test('admin can read user and agent topics but must not use self', async () => {
+    const { app, cookie, readCalls } = makeApp({ kind: 'admin' });
+
+    const self = await app.request('/ui/api/notify/messages?topic=self', {
+      headers: { cookie },
+    });
+    expect(self.status).toBe(400);
+    expect(readCalls).toEqual([]);
+
+    const alerts = await app.request('/ui/api/notify/messages?topic=user-alerts&since=12h', {
+      headers: { cookie },
+    });
+    expect(alerts.status).toBe(200);
+    expect(await alerts.json()).toEqual({ messages: [sample] });
+
+    const agent = await app.request('/ui/api/notify/messages?topic=agent:fox', {
+      headers: { cookie },
+    });
+    expect(agent.status).toBe(200);
+    expect(readCalls).toEqual([
+      { topic: 'user-alerts', identityAddress: undefined, since: '12h' },
+      { topic: 'agent:fox', identityAddress: undefined, since: undefined },
+    ]);
+  });
+
+  test('disabled notifications surface as 503 without leaking stack details', async () => {
+    const { NotifyError } = await import('../src/lib/notify.ts');
+    const { app, cookie } = makeApp(
+      { kind: 'admin' },
+      {
+        notifyMessages: mock(async () => {
+          throw new NotifyError('notifications_disabled');
+        }),
+      },
+    );
+    const response = await app.request('/ui/api/notify/messages?topic=user-low', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: 'notifications_disabled' });
+  });
+
+  test('unauthenticated sessions cannot read notify history', async () => {
+    const { app } = makeApp({ kind: 'admin' });
+    const response = await app.request('/ui/api/notify/messages?topic=user-alerts');
+    expect(response.status).toBe(401);
+  });
+
+  test('identity may name its own agent topic explicitly', async () => {
+    const { app, cookie, readCalls } = makeApp({
+      kind: 'identity',
+      address: 'fox@test.example',
+    });
+    const response = await app.request('/ui/api/notify/messages?topic=agent:fox', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(200);
+    expect(readCalls).toEqual([
+      { topic: 'agent:fox', identityAddress: 'fox@test.example', since: undefined },
+    ]);
+  });
+
+  test('invalid agent topic grammar is rejected', async () => {
+    const { app, cookie, readCalls } = makeApp({ kind: 'admin' });
+    const response = await app.request('/ui/api/notify/messages?topic=agent:Bad', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(400);
+    expect(readCalls).toEqual([]);
+  });
+
+  test('unknown_agent surfaces as 404 so the UI can treat it as an empty channel', async () => {
+    const { NotifyError } = await import('../src/lib/notify.ts');
+    const { app, cookie } = makeApp(
+      { kind: 'admin' },
+      {
+        notifyMessages: mock(async () => {
+          throw new NotifyError('unknown_agent');
+        }),
+      },
+    );
+    const response = await app.request('/ui/api/notify/messages?topic=agent:ghost', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'unknown_agent' });
+  });
+});


### PR DESCRIPTION
## What

Adds a **Notifications history panel** to the Dashboard (`/ui`) — roadmap item #21. Push notifications were fire-and-forget with no UI trace; the panel lists recent notifications (last 12h, aligned with ntfy `cache-duration`) with **time / channel / tier / content**.

## How

- New `GET /ui/api/notify/messages?topic=&since=` — cookie-session sibling of `GET /v1/notify/messages`, mirroring its ACL exactly: identity sessions read only their own agent topic (`self` or explicit `agent:<localpart>`), admin reads `user-alerts` / `user-low` / any `agent:*` but not `self`. Unknown agents → 404; notify disabled → 503.
- Frontend (vanilla JS in `packages/api/src/ui/assets.ts`, no deps, CSP unchanged): new `notifications` scope with sidebar + mobile-select entries, admin channel filter, bounded-parallel fan-out (`mapPool`, 6), 404-treated-as-empty-channel, honest empty/partial-failure states, abort-safe refresh, logout state cleanup. All rendering via `textContent` (no HTML injection surface). Tier is derived from ntfy priority (5→urgent / 3→normal / 1→low, unknown values shown as `unknown` rather than mislabeled).

## Tests

- `bun test`: **489 pass / 0 fail** (24 files) — includes 7 new ACL/error-code cases (`ui-notify.test.ts`) and updated static contracts (`ui-assets.test.ts`: 4 `<main>` scopes, panel hooks, no `/v1/notify` browser calls).
- Independently verified by the coordinator (fresh `bun test` run: same 489/0).

## Review trail

Built by cursor-agent (worker) per dispatch rules: two rounds of independent subagent code review (round 1 flagged admin serial fan-out + 404 false-failure — both fixed; round 2 passed), then coordinator final review (diff read in full, no redundancy, scope confined to `packages/api`).

## Follow-ups (deliberately not in this PR)

- `DESIGN.md` §3 page list should gain the Notifications page (docs change, out of scope here).
- `toTopic` (notify.ts) / `toNotifyTopic` (ui.ts) share one grammar via sync comments; extract to `lib/` helper later.
- No browser-level e2e for the panel yet (static contracts + API ACL tests only).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Notifications panel with channel filtering, push-history loading, priority display, responsive layouts, and mobile navigation.
  * Added notification history access with topic validation, timestamp filtering, and identity-based permissions.
  * Added navigation between notification history, overview, and inbox views.

* **Bug Fixes**
  * Improved handling of unavailable notifications, invalid topics, unknown agents, and access errors.
  * Added resilient loading with caching, cancellation, and partial-failure handling.

* **Tests**
  * Expanded coverage for notification history, access control, navigation, rendering, and error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->