### PR TITLE
feat(ui): add Dashboard Tasks ticket board

### DIFF
--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -33,6 +33,13 @@ import {
 } from '../lib/imap.ts';
 import { createOverviewCache, type ScanOutcome } from '../lib/overview-cache.ts';
 import {
+  TASK_STATES,
+  type Task,
+  type TaskService,
+  taskParticipants,
+  taskService,
+} from '../lib/tasks.ts';
+import {
   UiSessionStore,
   uiPrivateHeaders,
   uiSessionAuth,
@@ -83,6 +90,11 @@ export type UiApiDependencies = {
     identityAddress?: string,
     since?: string,
   ) => Promise<NotifyMessage[]>;
+  /**
+   * 任务工单：语义等同 GET /v1/tasks（ACL 在本路由强制）。
+   * 测试可注入；生产默认走 taskService。
+   */
+  taskService?: Pick<TaskService, 'list' | 'get'>;
 };
 
 /** 进程内单例：快照与会话一样活在进程里，重启后第一次 Overview 是冷启动。 */
@@ -100,7 +112,17 @@ const defaultDependencies: UiApiDependencies = {
   setPushContentTier: setIdentityPushContentTier,
   notifyMessages: (topic, identityAddress, since) =>
     notificationService().messages(topic, identityAddress, since),
+  taskService,
 };
+
+const taskListQuerySchema = z.object({ state: z.enum(TASK_STATES).optional() });
+const taskIdParamSchema = z.string().uuid();
+
+/** 与 routes/tasks.ts#canReadTask 保持同一口径（Dashboard cookie 入口的镜像）。 */
+function canReadUiTask(c: Context, task: Task): boolean {
+  const auth = getAuth(c);
+  return auth.kind === 'admin' || taskParticipants(task).has(auth.address);
+}
 
 /** 将 NotifyError 折成与 /v1/notify 一致的 JSON 状态码（历史只读路径）。 */
 function notifyHistoryError(c: Context, err: unknown) {
@@ -462,6 +484,38 @@ export function createUiApiRoutes(
     const marked = await dependencies.setMessageSeen(address, id, parsed.data.seen);
     if (!marked) return c.json({ error: 'not_found' }, 404);
     return c.json({ id, seen: parsed.data.seen });
+  });
+
+  /**
+   * Dashboard 任务工单：cookie 会话入口，ACL 与 GET /v1/tasks 对齐
+   *（admin 全量；identity 仅参与者可见）。
+   */
+  routes.get('/tasks', async (c) => {
+    const parsed = taskListQuerySchema.safeParse(c.req.query());
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+    const service = dependencies.taskService ?? taskService;
+    const tasks = await service.list(parsed.data.state);
+    const auth = getAuth(c);
+    return c.json({
+      tasks:
+        auth.kind === 'admin'
+          ? tasks
+          : tasks.filter((task) => taskParticipants(task).has(auth.address)),
+    });
+  });
+
+  routes.get('/tasks/:id', async (c) => {
+    const parsed = taskIdParamSchema.safeParse(c.req.param('id'));
+    if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
+    const service = dependencies.taskService ?? taskService;
+    const task = await service.get(parsed.data);
+    if (!task) return c.json({ error: 'not_found' }, 404);
+    if (!canReadUiTask(c, task)) {
+      return c.json({ error: 'forbidden: task participant required' }, 403);
+    }
+    return c.json(task);
   });
 
   /**

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -121,7 +121,8 @@ const taskIdParamSchema = z.string().uuid();
 /** 与 routes/tasks.ts#canReadTask 保持同一口径（Dashboard cookie 入口的镜像）。 */
 function canReadUiTask(c: Context, task: Task): boolean {
   const auth = getAuth(c);
-  return auth.kind === 'admin' || taskParticipants(task).has(auth.address);
+  // 参与者集合按小写存；identity 会话地址比较前归一化，避免大小写漂移。
+  return auth.kind === 'admin' || taskParticipants(task).has(auth.address.toLowerCase());
 }
 
 /** 将 NotifyError 折成与 /v1/notify 一致的 JSON 状态码（历史只读路径）。 */
@@ -502,7 +503,9 @@ export function createUiApiRoutes(
       tasks:
         auth.kind === 'admin'
           ? tasks
-          : tasks.filter((task) => taskParticipants(task).has(auth.address)),
+          : tasks.filter((task) =>
+              taskParticipants(task).has(auth.address.toLowerCase()),
+            ),
     });
   });
 

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -148,8 +148,7 @@ export const UI_HTML = `<!doctype html>
         <div id="notify-rows" class="notify-rows"></div>
       </main>
 
-      <!-- Tasks 面板：暂用 section 以兼容范围外 ui-assets 的四主区计数契约；后续可升为 landmark。 -->
-      <section id="tasks-panel" class="tasks-panel" tabindex="-1" aria-labelledby="tasks-title" hidden>
+      <main id="tasks-panel" class="tasks-panel" tabindex="-1" aria-labelledby="tasks-title" hidden>
         <div class="panel-heading overview-heading">
           <div>
             <h2 id="tasks-title">Tasks</h2>
@@ -196,7 +195,7 @@ export const UI_HTML = `<!doctype html>
             </div>
           </div>
         </div>
-      </section>
+      </main>
 
       <main id="main-content" class="inbox-main" tabindex="-1">
         <section id="message-panel" class="message-panel" aria-labelledby="messages-title">
@@ -1613,7 +1612,7 @@ export const UI_JS = `(function () {
     detailContent.append(placeholder);
   }
 
-  /* ---- scope 迁移：任一时刻恰好一个可见主面板（overview / notifications / tasks / inbox） ---- */
+  /* ---- scope 迁移：任一时刻恰好一个可见 <main>（overview / notifications / tasks / inbox） ---- */
   function applyScope(next, options) {
     var opts = options || {};
     var overviewActive = next === 'overview';
@@ -1668,7 +1667,6 @@ export const UI_JS = `(function () {
      scope 下必须走 openAddress（切 scope、播报、聚焦），否则会在不可见的 inbox
      里取消息、画面却停在当前面板。 */
   function activateAddress(address) {
-    /* 子串须保留 overview||notifications，以兼容 ui-assets 静态契约；tasks 同批并入。 */
     if (state.scope === 'overview' || state.scope === 'notifications' || state.scope === 'tasks') {
       openAddress(address);
       return;

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -148,6 +148,56 @@ export const UI_HTML = `<!doctype html>
         <div id="notify-rows" class="notify-rows"></div>
       </main>
 
+      <!-- Tasks 面板：暂用 section 以兼容范围外 ui-assets 的四主区计数契约；后续可升为 landmark。 -->
+      <section id="tasks-panel" class="tasks-panel" tabindex="-1" aria-labelledby="tasks-title" hidden>
+        <div class="panel-heading overview-heading">
+          <div>
+            <h2 id="tasks-title">Tasks</h2>
+            <p id="tasks-subtitle" class="overview-subtitle">Task tickets rebuilt from X-OA-Task mail threads</p>
+            <p id="tasks-updated" class="overview-updated"></p>
+          </div>
+          <div class="overview-heading-actions">
+            <button id="tasks-refresh" class="quiet" type="button">Refresh</button>
+          </div>
+        </div>
+        <p id="tasks-notice" class="notice warning" hidden></p>
+        <div class="tasks-layout">
+          <div id="tasks-list-section" class="tasks-list-section" aria-label="Task list">
+            <div class="overview-controls notify-controls">
+              <label class="search-label" for="tasks-state-filter">Filter state</label>
+              <select id="tasks-state-filter" class="search-input notify-topic-filter">
+                <option value="">All states</option>
+                <option value="submitted">submitted</option>
+                <option value="working">working</option>
+                <option value="input-required">input-required</option>
+                <option value="completed">completed</option>
+                <option value="failed">failed</option>
+              </select>
+              <span id="tasks-shown" class="count"></span>
+            </div>
+            <p id="tasks-state" class="empty-state"></p>
+            <div class="tasks-header" aria-hidden="true">
+              <span>State</span>
+              <span>Participants</span>
+              <span>Subject</span>
+              <span>Updated</span>
+              <span>Msgs</span>
+            </div>
+            <div id="tasks-rows" class="tasks-rows"></div>
+          </div>
+          <div id="tasks-detail-section" class="tasks-detail-section" tabindex="-1" aria-label="Task detail">
+            <button id="tasks-mobile-back" class="quiet mobile-back" type="button">Back to tasks</button>
+            <div id="tasks-detail-content" class="tasks-detail-content">
+              <div class="detail-placeholder">
+                <p class="eyebrow">Task ticket</p>
+                <h2>Select a task</h2>
+                <p class="muted">Choose a ticket to inspect its state timeline and result.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <main id="main-content" class="inbox-main" tabindex="-1">
         <section id="message-panel" class="message-panel" aria-labelledby="messages-title">
           <div class="panel-heading message-heading">
@@ -432,15 +482,137 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   display: grid;
   grid-template-columns: 360px minmax(0, 1fr);
 }
-.identity-panel, .message-panel, .detail-panel, .overview-panel, .notify-panel { min-width: 0; }
+.identity-panel, .message-panel, .detail-panel, .overview-panel, .notify-panel, .tasks-panel { min-width: 0; }
 .identity-panel, .message-panel { border-right: 1px solid var(--line-strong); }
 .identity-panel { padding: 20px 14px; background: var(--bg); }
 .inbox-view[data-scope="overview"] .identity-panel,
-.inbox-view[data-scope="notifications"] .identity-panel { border-right-color: var(--line-strong); }
+.inbox-view[data-scope="notifications"] .identity-panel,
+.inbox-view[data-scope="tasks"] .identity-panel { border-right-color: var(--line-strong); }
 .message-panel { background: var(--bg-raise); }
 .detail-panel { background: var(--bg); }
-.overview-panel, .notify-panel { background: var(--bg); padding: 20px clamp(16px, 3vw, 30px) 48px; overflow-x: hidden; }
+.overview-panel, .notify-panel, .tasks-panel { background: var(--bg); padding: 20px clamp(16px, 3vw, 30px) 48px; overflow-x: hidden; }
 .notify-topic-filter { max-width: 280px; }
+.tasks-layout {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(280px, 1.1fr) minmax(0, 1.4fr);
+  gap: 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  overflow: hidden;
+  background: var(--bg-raise);
+}
+.tasks-list-section { min-width: 0; border-right: 1px solid var(--line-strong); background: var(--bg-raise); padding: 14px 12px 24px; }
+.tasks-detail-section { min-width: 0; background: var(--bg); padding: 0; }
+.tasks-detail-content { padding: 22px 20px 40px; }
+.tasks-header {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 110px minmax(120px, 1.2fr) minmax(0, 1.6fr) 96px 48px;
+  padding: 8px 10px;
+  color: var(--ink-dim);
+  font-size: 11px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--line);
+}
+.tasks-rows { border-top: 1px solid var(--line); }
+.task-row {
+  width: 100%;
+  display: grid;
+  gap: 10px;
+  grid-template-columns: 110px minmax(120px, 1.2fr) minmax(0, 1.6fr) 96px 48px;
+  align-items: start;
+  padding: 12px 10px;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  border-radius: 0;
+  background: transparent;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  min-height: 44px;
+}
+.task-row:hover, .task-row[aria-current="true"] { background: var(--gold-dim); }
+.task-row .cell-label { display: none; color: var(--ink-dim); font-size: 12px; }
+.task-participants { min-width: 0; font-size: 12px; color: var(--ink-dim); }
+.task-participants > span:last-child {
+  display: block;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.task-subject { margin: 0; font-size: 14px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.task-updated { color: var(--ink-dim); font-size: 13px; font-variant-numeric: tabular-nums; }
+.task-msgs { color: var(--ink-dim); font-size: 13px; font-variant-numeric: tabular-nums; }
+.task-badge {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  color: var(--ink-dim);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+.task-badge[data-state="submitted"] { border-color: rgba(96, 165, 250, 0.45); color: #93c5fd; }
+.task-badge[data-state="working"] { border-color: rgba(251, 191, 36, 0.45); color: var(--gold); }
+.task-badge[data-state="input-required"] { border-color: rgba(251, 146, 60, 0.5); color: #fdba74; }
+.task-badge[data-state="completed"] { border-color: rgba(52, 211, 153, 0.45); color: var(--green); }
+.task-badge[data-state="failed"] { border-color: rgba(248, 113, 113, 0.45); color: var(--red); }
+.task-detail-head { display: grid; gap: 8px; margin-bottom: 18px; }
+.task-detail-head h3 { margin: 0; font-size: 20px; letter-spacing: -0.01em; }
+.task-detail-meta { margin: 0; color: var(--ink-dim); font-size: 13px; }
+.task-timeline { list-style: none; margin: 0; padding: 0; border-top: 1px solid var(--line); }
+.task-timeline-item {
+  padding: 14px 0;
+  border-bottom: 1px solid var(--line);
+}
+.task-timeline-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  margin-bottom: 8px;
+}
+.task-timeline-from { font-size: 13px; font-weight: 700; }
+.task-timeline-time { color: var(--ink-dim); font-size: 12px; font-variant-numeric: tabular-nums; }
+.task-timeline-body {
+  margin: 0;
+  color: var(--ink);
+  font-size: 14px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.task-result {
+  margin-top: 18px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+  padding: 10px 12px;
+}
+.task-result summary {
+  cursor: pointer;
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--ink-dim);
+}
+.task-result pre {
+  margin: 10px 0 0;
+  overflow: auto;
+  max-height: 320px;
+  font: 12px/1.45 var(--mono);
+  color: var(--gold-soft);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
 .notify-header {
   display: grid;
   gap: 10px;
@@ -796,7 +968,7 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   .inbox-layout { min-height: calc(100vh - 66px); display: block; }
   .inbox-main { display: block; }
   .identity-panel { display: none; }
-  .message-panel, .detail-panel, .overview-panel, .notify-panel { min-height: calc(100vh - 66px); border: 0; }
+  .message-panel, .detail-panel, .overview-panel, .notify-panel, .tasks-panel { min-height: calc(100vh - 66px); border: 0; }
   .mobile-identity { display: grid; gap: 5px; padding: 12px 16px; border-bottom: 1px solid var(--line); }
   .mobile-back { display: inline-block; margin: 14px 16px 0; }
   .inbox-view[data-mobile-view="list"] .detail-panel { display: none; }
@@ -806,6 +978,17 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   .notify-row .cell { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; min-height: 24px; margin-bottom: 4px; }
   .notify-row .cell-label { display: inline; }
   .notify-row .notify-content { display: block; }
+  .tasks-layout { display: block; border: 0; border-radius: 0; background: transparent; }
+  .tasks-list-section { border: 0; padding: 0; background: transparent; }
+  .tasks-detail-section { padding: 0; }
+  .tasks-detail-content { padding: 22px 16px 40px; }
+  .inbox-view[data-mobile-view="tasks-list"] .tasks-detail-section { display: none; }
+  .inbox-view[data-mobile-view="tasks-detail"] .tasks-list-section { display: none; }
+  .tasks-header { display: none; }
+  .task-row { display: block; }
+  .task-row .cell { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; min-height: 24px; margin-bottom: 4px; }
+  .task-row .cell-label { display: inline; }
+  .task-row .task-subject { white-space: normal; }
   .inbox-view[data-mobile-view="overview"] .overview-stats { grid-template-columns: minmax(0, 1fr); gap: 0; }
   .inbox-view[data-mobile-view="overview"] .stat-card {
     display: flex;
@@ -886,7 +1069,18 @@ export const UI_JS = `(function () {
     notifyUpdatedAt: 0,
     notifyPending: false,
     /* 上次成功拉取对应的 topic 集合指纹，避免 All 误用单路缓存。 */
-    notifyFetchKey: ''
+    notifyFetchKey: '',
+    /* 任务工单：列表 + 详情缓存 */
+    tasks: [],
+    tasksStatus: 'idle',
+    tasksMessage: '',
+    tasksFilter: '',
+    tasksUpdatedAt: 0,
+    tasksPending: false,
+    activeTaskId: '',
+    taskDetail: null,
+    taskDetailStatus: 'idle',
+    taskDetailMessage: ''
   };
   var refreshTask = null;
   var refreshController = null;
@@ -894,6 +1088,8 @@ export const UI_JS = `(function () {
   var overviewController = null;
   var overviewTimer = null;
   var notifyController = null;
+  var tasksController = null;
+  var taskDetailController = null;
 
   function byId(id) {
     return document.getElementById(id);
@@ -943,6 +1139,17 @@ export const UI_JS = `(function () {
   var notifyShown = byId('notify-shown');
   var notifyRefresh = byId('notify-refresh');
   var notifyTopicFilter = byId('notify-topic-filter');
+  var tasksPanel = byId('tasks-panel');
+  var tasksRows = byId('tasks-rows');
+  var tasksStateNode = byId('tasks-state');
+  var tasksNotice = byId('tasks-notice');
+  var tasksUpdated = byId('tasks-updated');
+  var tasksShown = byId('tasks-shown');
+  var tasksRefresh = byId('tasks-refresh');
+  var tasksStateFilter = byId('tasks-state-filter');
+  var tasksDetailSection = byId('tasks-detail-section');
+  var tasksDetailContent = byId('tasks-detail-content');
+  var tasksMobileBack = byId('tasks-mobile-back');
   var tokenModal = byId('token-modal');
   var tokenModalTitle = byId('token-modal-title');
   var tokenValue = byId('token-value');
@@ -995,10 +1202,26 @@ export const UI_JS = `(function () {
     state.notifyPending = false;
   }
 
+  /* 401 / 登出共用：清掉工单缓存，避免换主体后渲染上一会话任务。 */
+  function clearTasksState() {
+    state.tasks = [];
+    state.tasksStatus = 'idle';
+    state.tasksMessage = '';
+    state.tasksFilter = '';
+    state.tasksUpdatedAt = 0;
+    state.tasksPending = false;
+    state.activeTaskId = '';
+    state.taskDetail = null;
+    state.taskDetailStatus = 'idle';
+    state.taskDetailMessage = '';
+  }
+
   function showLogin(message) {
     cancelOverview();
     cancelNotifyLoad();
+    cancelTasksLoad();
     clearNotifyState();
+    clearTasksState();
     closeAllModals();
     inboxView.hidden = true;
     loginView.hidden = false;
@@ -1390,43 +1613,63 @@ export const UI_JS = `(function () {
     detailContent.append(placeholder);
   }
 
-  /* ---- scope 迁移：任一时刻恰好一个可见 <main>（overview / notifications / inbox） ---- */
+  /* ---- scope 迁移：任一时刻恰好一个可见主面板（overview / notifications / tasks / inbox） ---- */
   function applyScope(next, options) {
     var opts = options || {};
     var overviewActive = next === 'overview';
     var notifyActive = next === 'notifications';
+    var tasksActive = next === 'tasks';
     var inboxActive = next === 'inbox';
     state.scope = next;
     inboxView.dataset.scope = next;
     overviewPanel.hidden = !overviewActive;
     notifyPanel.hidden = !notifyActive;
+    tasksPanel.hidden = !tasksActive;
     mainContent.hidden = !inboxActive;
-    viewTitle.textContent = overviewActive ? 'Overview' : notifyActive ? 'Notifications' : 'Inbox';
+    viewTitle.textContent = overviewActive
+      ? 'Overview'
+      : notifyActive
+        ? 'Notifications'
+        : tasksActive
+          ? 'Tasks'
+          : 'Inbox';
     document.title = overviewActive
       ? 'OpenAgent Overview'
       : notifyActive
         ? 'OpenAgent Notifications'
-        : 'OpenAgent Inbox';
+        : tasksActive
+          ? 'OpenAgent Tasks'
+          : 'OpenAgent Inbox';
     skipLink.textContent = overviewActive
       ? 'Skip to overview'
       : notifyActive
         ? 'Skip to notifications'
-        : 'Skip to inbox';
+        : tasksActive
+          ? 'Skip to tasks'
+          : 'Skip to inbox';
     skipLink.setAttribute(
       'href',
-      overviewActive ? '#overview-panel' : notifyActive ? '#notify-panel' : '#main-content'
+      overviewActive
+        ? '#overview-panel'
+        : notifyActive
+          ? '#notify-panel'
+          : tasksActive
+            ? '#tasks-panel'
+            : '#main-content'
     );
     if (overviewActive) inboxView.dataset.mobileView = 'overview';
     else if (notifyActive) inboxView.dataset.mobileView = 'notifications';
+    else if (tasksActive) inboxView.dataset.mobileView = 'tasks-list';
     renderIdentities();
     if (opts.announce) announce(opts.announce);
   }
 
-  /* 侧栏地址项与移动 <select> 是 Overview / Notifications 之外的入口：在非 inbox
+  /* 侧栏地址项与移动 <select> 是 Overview / Notifications / Tasks 之外的入口：在非 inbox
      scope 下必须走 openAddress（切 scope、播报、聚焦），否则会在不可见的 inbox
      里取消息、画面却停在当前面板。 */
   function activateAddress(address) {
-    if (state.scope === 'overview' || state.scope === 'notifications') {
+    /* 子串须保留 overview||notifications，以兼容 ui-assets 静态契约；tasks 同批并入。 */
+    if (state.scope === 'overview' || state.scope === 'notifications' || state.scope === 'tasks') {
       openAddress(address);
       return;
     }
@@ -1456,12 +1699,18 @@ export const UI_JS = `(function () {
       mobileIdentity.append(overviewOption);
     }
 
-    /* 通知面板哨兵：合法地址不会以双下划线开头。 */
+    /* 通知/工单面板哨兵：合法地址不会以双下划线开头。 */
     var notifyOption = document.createElement('option');
     notifyOption.value = '__notifications__';
     notifyOption.textContent = 'Notifications — push history';
     notifyOption.selected = state.scope === 'notifications';
     mobileIdentity.append(notifyOption);
+
+    var tasksOption = document.createElement('option');
+    tasksOption.value = '__tasks__';
+    tasksOption.textContent = 'Tasks — ticket board';
+    tasksOption.selected = state.scope === 'tasks';
+    mobileIdentity.append(tasksOption);
 
     state.identities.forEach(function (identity) {
       var option = document.createElement('option');
@@ -1504,6 +1753,22 @@ export const UI_JS = `(function () {
     });
     notifyItem.append(notifyButton);
     identityList.append(notifyItem);
+
+    var tasksItem = document.createElement('li');
+    var tasksButton = document.createElement('button');
+    tasksButton.type = 'button';
+    tasksButton.className = 'identity-button overview-nav';
+    tasksButton.setAttribute('aria-current', state.scope === 'tasks' ? 'true' : 'false');
+    var tasksName = document.createElement('strong');
+    tasksName.textContent = 'Tasks';
+    var tasksHint = document.createElement('span');
+    tasksHint.textContent = 'Ticket board';
+    tasksButton.append(tasksName, tasksHint);
+    tasksButton.addEventListener('click', function () {
+      enterTasks({ announce: 'Opened tasks' });
+    });
+    tasksItem.append(tasksButton);
+    identityList.append(tasksItem);
 
     filteredIdentities().forEach(function (identity) {
       var item = document.createElement('li');
@@ -2213,6 +2478,7 @@ export const UI_JS = `(function () {
     var opts = options || {};
     cancelOverviewPoll();
     cancelNotifyLoad();
+    cancelTasksLoad();
     applyScope('overview', { announce: opts.announce });
     renderOverview();
     /* 两条聚焦路径分开处理：从 inbox 返回时焦点回到原来那一行，那一行可能在长表格深处，
@@ -2232,6 +2498,7 @@ export const UI_JS = `(function () {
     state.returnAddress = address;
     cancelOverview();
     cancelNotifyLoad();
+    cancelTasksLoad();
     applyScope('inbox');
     inboxView.dataset.mobileView = 'list';
     announce('Opened ' + address);
@@ -2639,6 +2906,7 @@ export const UI_JS = `(function () {
   function enterNotifications(options) {
     var opts = options || {};
     cancelOverview();
+    cancelTasksLoad();
     applyScope('notifications', { announce: opts.announce });
     renderNotify();
     focusNotifyPanel();
@@ -2650,6 +2918,370 @@ export const UI_JS = `(function () {
       state.notifyFetchKey === notifyFetchKey()
     ) return;
     loadNotifyHistory();
+  }
+
+  /* ---- 任务工单面板（与 Notifications 并列；列表走 /ui/api/tasks，详情走 /:id） ---- */
+  function focusTasksPanel() {
+    tasksPanel.focus({ preventScroll: true });
+  }
+
+  function cancelTasksListLoad() {
+    if (tasksController) {
+      tasksController.abort();
+      tasksController = null;
+    }
+    state.tasksPending = false;
+  }
+
+  function cancelTaskDetailLoad() {
+    if (taskDetailController) {
+      taskDetailController.abort();
+      taskDetailController = null;
+    }
+    /* 离开 scope / 换单时 abort：勿把 loading 粘住，否则 FRESH_MS 内重进会假刷新。 */
+    if (state.taskDetailStatus === 'loading') {
+      state.taskDetailStatus = state.taskDetail ? 'ready' : 'idle';
+    }
+  }
+
+  function cancelTasksLoad() {
+    cancelTasksListLoad();
+    cancelTaskDetailLoad();
+  }
+
+  function clearTaskDetail() {
+    cancelTaskDetailLoad();
+    state.activeTaskId = '';
+    state.taskDetail = null;
+    state.taskDetailStatus = 'idle';
+    state.taskDetailMessage = '';
+    tasksDetailContent.replaceChildren();
+    var placeholder = document.createElement('div');
+    placeholder.className = 'detail-placeholder';
+    var label = document.createElement('p');
+    label.className = 'eyebrow';
+    label.textContent = 'Task ticket';
+    var title = document.createElement('h2');
+    title.textContent = 'Select a task';
+    var copy = document.createElement('p');
+    copy.className = 'muted';
+    copy.textContent = 'Choose a ticket to inspect its state timeline and result.';
+    placeholder.append(label, title, copy);
+    tasksDetailContent.append(placeholder);
+  }
+
+  function renderTasksMeta() {
+    if (state.tasksUpdatedAt) {
+      tasksUpdated.textContent = 'Updated ' + formatClock(new Date(state.tasksUpdatedAt).toISOString(), true);
+    } else {
+      tasksUpdated.textContent = '';
+    }
+    /* 详情错误优先；列表刷新失败且仍有缓存时也用 notice（空列表错误走 empty-state）。 */
+    if (state.taskDetailStatus === 'error' && state.taskDetailMessage) {
+      tasksNotice.hidden = false;
+      tasksNotice.textContent = state.taskDetailMessage;
+    } else if (state.tasksStatus === 'error' && state.tasksMessage && state.tasks.length > 0) {
+      tasksNotice.hidden = false;
+      tasksNotice.textContent = state.tasksMessage;
+    } else {
+      tasksNotice.hidden = true;
+      tasksNotice.textContent = '';
+    }
+    tasksRefresh.disabled = state.tasksPending;
+    tasksRefresh.textContent = state.tasksPending ? 'Refreshing…' : 'Refresh';
+    tasksStateFilter.value = state.tasksFilter;
+  }
+
+  function renderTaskRows() {
+    tasksRows.replaceChildren();
+    var awaiting = state.tasksStatus === 'loading';
+    tasksShown.textContent = awaiting ? '' : String(state.tasks.length);
+    if (awaiting) {
+      tasksStateNode.textContent = 'Loading…';
+      return;
+    }
+    if (state.tasksStatus === 'error' && state.tasks.length === 0) {
+      tasksStateNode.textContent = state.tasksMessage || 'Tasks could not be loaded. Try Refresh.';
+      return;
+    }
+    if (state.tasks.length === 0) {
+      tasksStateNode.textContent = state.tasksFilter
+        ? 'No tasks in state "' + state.tasksFilter + '".'
+        : 'No tasks yet. Refresh after a task mail arrives.';
+      return;
+    }
+    tasksStateNode.textContent = '';
+    state.tasks.forEach(function (task) {
+      var button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'task-row';
+      button.setAttribute('aria-current', task.id === state.activeTaskId ? 'true' : 'false');
+
+      var stateCell = document.createElement('div');
+      stateCell.className = 'cell';
+      var stateLabel = document.createElement('span');
+      stateLabel.className = 'cell-label';
+      stateLabel.textContent = 'State';
+      var badge = document.createElement('span');
+      badge.className = 'task-badge';
+      badge.setAttribute('data-state', task.state || '');
+      badge.textContent = task.state || '—';
+      stateCell.append(stateLabel, badge);
+
+      var peopleCell = document.createElement('div');
+      peopleCell.className = 'cell task-participants';
+      var peopleLabel = document.createElement('span');
+      peopleLabel.className = 'cell-label';
+      peopleLabel.textContent = 'Participants';
+      var peopleValue = document.createElement('span');
+      peopleValue.textContent = (task.from || '—') + ' → ' + (task.to || '—');
+      peopleCell.append(peopleLabel, peopleValue);
+
+      var subjectCell = document.createElement('div');
+      subjectCell.className = 'cell';
+      var subjectLabel = document.createElement('span');
+      subjectLabel.className = 'cell-label';
+      subjectLabel.textContent = 'Subject';
+      var subjectValue = document.createElement('p');
+      subjectValue.className = 'task-subject';
+      subjectValue.textContent = task.subject || '(no subject)';
+      subjectCell.append(subjectLabel, subjectValue);
+
+      var updatedCell = document.createElement('div');
+      updatedCell.className = 'cell task-updated';
+      var updatedLabel = document.createElement('span');
+      updatedLabel.className = 'cell-label';
+      updatedLabel.textContent = 'Updated';
+      var updatedValue = document.createElement('time');
+      updatedValue.dateTime = task.updatedAt || '';
+      updatedValue.textContent = formatAgo(task.updatedAt);
+      updatedCell.append(updatedLabel, updatedValue);
+
+      var msgsCell = document.createElement('div');
+      msgsCell.className = 'cell task-msgs';
+      var msgsLabel = document.createElement('span');
+      msgsLabel.className = 'cell-label';
+      msgsLabel.textContent = 'Msgs';
+      var msgsValue = document.createElement('span');
+      msgsValue.textContent = String(Array.isArray(task.messages) ? task.messages.length : 0);
+      msgsCell.append(msgsLabel, msgsValue);
+
+      button.append(stateCell, peopleCell, subjectCell, updatedCell, msgsCell);
+      button.addEventListener('click', function () {
+        selectTask(task.id);
+      });
+      tasksRows.append(button);
+    });
+  }
+
+  function renderTaskDetail() {
+    if (!state.activeTaskId) {
+      clearTaskDetail();
+      return;
+    }
+    /* 错误态绝不回落成「成功详情」：列表缓存也不能冒充 GET /:id 成功。 */
+    if (state.taskDetailStatus === 'error') {
+      tasksDetailContent.replaceChildren();
+      var err = document.createElement('p');
+      err.className = 'empty-state';
+      err.textContent = state.taskDetailMessage || 'Task could not be loaded.';
+      tasksDetailContent.append(err);
+      return;
+    }
+    if (state.taskDetailStatus === 'loading' && !state.taskDetail) {
+      tasksDetailContent.replaceChildren();
+      var loading = document.createElement('p');
+      loading.className = 'empty-state';
+      loading.textContent = 'Loading task…';
+      tasksDetailContent.append(loading);
+      return;
+    }
+    var task = state.taskDetail;
+    if (!task) {
+      clearTaskDetail();
+      return;
+    }
+    tasksDetailContent.replaceChildren();
+
+    var head = document.createElement('div');
+    head.className = 'task-detail-head';
+    var badge = document.createElement('span');
+    badge.className = 'task-badge';
+    badge.setAttribute('data-state', task.state || '');
+    badge.textContent = task.state || '—';
+    var title = document.createElement('h3');
+    title.textContent = task.subject || '(no subject)';
+    var meta = document.createElement('p');
+    meta.className = 'task-detail-meta';
+    meta.textContent =
+      (task.from || '—') +
+      ' → ' +
+      (task.to || '—') +
+      ' · updated ' +
+      formatAgo(task.updatedAt) +
+      ' · ' +
+      (Array.isArray(task.messages) ? task.messages.length : 0) +
+      ' messages';
+    head.append(badge, title, meta);
+    if (state.taskDetailStatus === 'loading') {
+      var pending = document.createElement('p');
+      pending.className = 'task-detail-meta';
+      pending.textContent = 'Refreshing ticket detail…';
+      head.append(pending);
+    }
+    tasksDetailContent.append(head);
+
+    var timeline = document.createElement('ol');
+    timeline.className = 'task-timeline';
+    (Array.isArray(task.messages) ? task.messages : []).forEach(function (message) {
+      var item = document.createElement('li');
+      item.className = 'task-timeline-item';
+      var metaRow = document.createElement('div');
+      metaRow.className = 'task-timeline-meta';
+      var msgBadge = document.createElement('span');
+      msgBadge.className = 'task-badge';
+      msgBadge.setAttribute('data-state', message.state || '');
+      msgBadge.textContent = message.state || '—';
+      var from = document.createElement('span');
+      from.className = 'task-timeline-from';
+      from.textContent = message.from || '—';
+      var when = document.createElement('time');
+      when.className = 'task-timeline-time';
+      when.dateTime = message.date || '';
+      when.textContent = message.date ? formatDate(message.date) : '—';
+      metaRow.append(msgBadge, from, when);
+      var body = document.createElement('p');
+      body.className = 'task-timeline-body';
+      body.textContent = message.body || '';
+      item.append(metaRow, body);
+      timeline.append(item);
+    });
+    tasksDetailContent.append(timeline);
+
+    if (task.result !== undefined) {
+      var resultBlock = document.createElement('details');
+      resultBlock.className = 'task-result';
+      resultBlock.open = true;
+      var summary = document.createElement('summary');
+      summary.textContent = 'Result';
+      var pre = document.createElement('pre');
+      try {
+        pre.textContent = JSON.stringify(task.result, null, 2);
+      } catch (_error) {
+        pre.textContent = String(task.result);
+      }
+      resultBlock.append(summary, pre);
+      tasksDetailContent.append(resultBlock);
+    }
+  }
+
+  function renderTasks() {
+    renderTasksMeta();
+    renderTaskRows();
+    renderTaskDetail();
+  }
+
+  async function loadTasks() {
+    /* 刷新列表不打断详情请求，避免 activeTask 卡在 loading。 */
+    cancelTasksListLoad();
+    var controller = new AbortController();
+    tasksController = controller;
+    state.tasksPending = true;
+    state.tasksMessage = '';
+    if (state.tasks.length === 0) state.tasksStatus = 'loading';
+    renderTasks();
+    try {
+      var path = '/ui/api/tasks';
+      if (state.tasksFilter) {
+        path += '?state=' + encodeURIComponent(state.tasksFilter);
+      }
+      var payload = await apiJson(path, { signal: controller.signal });
+      if (tasksController !== controller) return;
+      state.tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
+      state.tasksUpdatedAt = Date.now();
+      state.tasksStatus = 'ready';
+      state.tasksMessage = '';
+      renderTasks();
+      announce(state.tasks.length + ' tasks loaded');
+      if (state.activeTaskId) {
+        var stillThere = state.tasks.some(function (task) {
+          return task.id === state.activeTaskId;
+        });
+        if (!stillThere) clearTaskDetail();
+      }
+    } catch (error) {
+      if (error.name === 'AbortError' || error.message === 'session_expired') return;
+      if (state.tasks.length === 0) {
+        state.tasksStatus = 'error';
+        state.tasksMessage = 'Tasks could not be loaded. Try Refresh.';
+      } else {
+        state.tasksStatus = 'error';
+        state.tasksMessage = 'Refresh failed. Showing previous tasks.';
+      }
+      renderTasks();
+    } finally {
+      if (tasksController === controller) {
+        tasksController = null;
+        state.tasksPending = false;
+        renderTasksMeta();
+      }
+    }
+  }
+
+  async function selectTask(id) {
+    if (!id) return;
+    cancelTaskDetailLoad();
+    state.activeTaskId = id;
+    state.taskDetailStatus = 'loading';
+    state.taskDetailMessage = '';
+    /* 列表摘要可先展示，但失败时必须清空，不能冒充详情成功。 */
+    var cached = state.tasks.find(function (task) {
+      return task.id === id;
+    });
+    state.taskDetail = cached || null;
+    inboxView.dataset.mobileView = 'tasks-detail';
+    renderTasks();
+    tasksDetailSection.focus({ preventScroll: true });
+    var controller = new AbortController();
+    taskDetailController = controller;
+    try {
+      var detail = await apiJson('/ui/api/tasks/' + encodeURIComponent(id), {
+        signal: controller.signal
+      });
+      if (taskDetailController !== controller || state.activeTaskId !== id) return;
+      state.taskDetail = detail;
+      state.taskDetailStatus = 'ready';
+      state.taskDetailMessage = '';
+      renderTasks();
+      announce('Opened task ' + (detail.subject || id));
+    } catch (error) {
+      if (error.name === 'AbortError' || error.message === 'session_expired') return;
+      if (state.activeTaskId !== id) return;
+      state.taskDetail = null;
+      state.taskDetailStatus = 'error';
+      state.taskDetailMessage =
+        error.status === 403
+          ? 'You are not a participant on this task.'
+          : error.status === 404
+            ? 'Task not found.'
+            : 'Task could not be loaded.';
+      renderTasks();
+      announce(state.taskDetailMessage);
+    } finally {
+      if (taskDetailController === controller) taskDetailController = null;
+    }
+  }
+
+  function enterTasks(options) {
+    var opts = options || {};
+    cancelOverview();
+    cancelNotifyLoad();
+    applyScope('tasks', { announce: opts.announce });
+    renderTasks();
+    focusTasksPanel();
+    var age = state.tasksUpdatedAt ? Math.max(0, Date.now() - state.tasksUpdatedAt) : Infinity;
+    if (state.tasksStatus === 'ready' && age < FRESH_MS) return;
+    loadTasks();
   }
 
   async function waitForPreviousRefresh() {
@@ -3094,6 +3726,10 @@ export const UI_JS = `(function () {
       enterNotifications({ announce: 'Opened notifications' });
       return;
     }
+    if (mobileIdentity.value === '__tasks__') {
+      enterTasks({ announce: 'Opened tasks' });
+      return;
+    }
     activateAddress(mobileIdentity.value);
   });
   refreshButton.addEventListener('click', function () {
@@ -3113,6 +3749,20 @@ export const UI_JS = `(function () {
     state.notifyFilter = notifyTopicFilter.value;
     /* 过滤切换会改变要请求的 topic 集合（All 扇出 vs 单路），重新拉取。 */
     loadNotifyHistory();
+  });
+  tasksRefresh.addEventListener('click', function () {
+    loadTasks();
+  });
+  tasksStateFilter.addEventListener('change', function () {
+    state.tasksFilter = tasksStateFilter.value;
+    clearTaskDetail();
+    loadTasks();
+  });
+  tasksMobileBack.addEventListener('click', function () {
+    inboxView.dataset.mobileView = 'tasks-list';
+    var active = tasksRows.querySelector('[aria-current="true"]');
+    if (active) active.focus();
+    else focusTasksPanel();
   });
   createIdentityButton.addEventListener('click', showCreateModal);
   createModalSubmit.addEventListener('click', handleCreateSubmit);

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -515,20 +515,6 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   text-transform: uppercase;
   border-bottom: 1px solid var(--line);
 }
-/*
- * 窄桌面藏 Updated/Msgs：sidebar 240 + panel 左右 pad≤30×2 + list 轨 1.1/2.5。
- * 五列头≈458px → 列表轨需 ≥458 → 视口 ≥1341；取 1360 留余量（1280 时轨≈431 仍裁）。
- */
-@media (max-width: 1360px) and (min-width: 821px) {
-  .tasks-header,
-  .task-row {
-    grid-template-columns: 100px minmax(0, 1.1fr) minmax(0, 1.4fr);
-  }
-  .tasks-header > :nth-child(4),
-  .tasks-header > :nth-child(5),
-  .task-row .task-updated,
-  .task-row .task-msgs { display: none; }
-}
 .tasks-rows { border-top: 1px solid var(--line); }
 .task-row {
   width: 100%;
@@ -556,6 +542,20 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+/*
+ * 窄桌面藏 Updated/Msgs：须写在基础 .task-row/.tasks-header 之后，否则同特异性后者覆盖三列模板。
+ * 算术：sidebar 240 + pad≤60 + list×1.1/2.5；五列头≈458 → 视口≥~1341；取 1360。
+ */
+@media (max-width: 1360px) and (min-width: 821px) {
+  .tasks-header,
+  .task-row {
+    grid-template-columns: 100px minmax(0, 1.1fr) minmax(0, 1.4fr);
+  }
+  .tasks-header > :nth-child(4),
+  .tasks-header > :nth-child(5),
+  .task-row .task-updated,
+  .task-row .task-msgs { display: none; }
 }
 .task-subject { margin: 0; font-size: 14px; font-weight: 700; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .task-updated { color: var(--ink-dim); font-size: 13px; font-variant-numeric: tabular-nums; }
@@ -1043,6 +1043,8 @@ export const UI_JS = `(function () {
   var NOTIFY_RENDER_LIMIT = 500;
   /* 任务工单行数上限：与 notify 同口径，避免大邮箱卡死页面。 */
   var TASKS_RENDER_LIMIT = 500;
+  /* 单工单时间线条目上限：长历史不全量建节点。 */
+  var TASK_TIMELINE_RENDER_LIMIT = 200;
   /* 与 lib/tasks.ts RESULT_MARKER 逐字一致；时间线正文剥离用。 */
   var TASK_RESULT_MARKER = '<!-- openagent.email task result -->';
   var SORT_COLUMNS = [
@@ -3017,7 +3019,7 @@ export const UI_JS = `(function () {
 
   /*
    * 展示层剥离 result 块：口径对齐 lib/tasks.ts readResult——
-   * lastIndexOf 找最后一处 marker，且其后须是尾部 fenced json 块直到结尾才剥（中途字面量不剥）。
+   * lastIndexOf + 尾部 fenced json + JSON.parse 成功才剥（malformed 当普通正文；中途字面量不剥）。
    * UI_JS 外层是模板字符串：fence 用 RegExp + fromCharCode(96) 拼反引号，避免打断 backtick。
    */
   function taskTimelineBody(body) {
@@ -3027,7 +3029,13 @@ export const UI_JS = `(function () {
     var after = text.slice(markerAt + TASK_RESULT_MARKER.length);
     var ticks = String.fromCharCode(96, 96, 96);
     var fence = new RegExp('^\\\\s*' + ticks + 'json\\\\s*\\\\n([\\\\s\\\\S]*?)\\\\n' + ticks + '\\\\s*$');
-    if (!fence.test(after)) return text;
+    var match = after.match(fence);
+    if (!match) return text;
+    try {
+      JSON.parse(match[1]);
+    } catch (_err) {
+      return text;
+    }
     return text.slice(0, markerAt).replace(/\\s+$/, '');
   }
 
@@ -3183,9 +3191,22 @@ export const UI_JS = `(function () {
     }
     tasksDetailContent.append(head);
 
+    var messages = Array.isArray(task.messages) ? task.messages : [];
+    var timelineTotal = messages.length;
+    var timelineTruncated = timelineTotal > TASK_TIMELINE_RENDER_LIMIT;
+    var visibleMessages = timelineTruncated
+      ? messages.slice(timelineTotal - TASK_TIMELINE_RENDER_LIMIT)
+      : messages;
+    if (timelineTruncated) {
+      var timelineNote = document.createElement('p');
+      timelineNote.className = 'task-detail-meta';
+      timelineNote.textContent =
+        'Showing latest ' + TASK_TIMELINE_RENDER_LIMIT + ' of ' + timelineTotal + ' timeline events.';
+      tasksDetailContent.append(timelineNote);
+    }
     var timeline = document.createElement('ol');
     timeline.className = 'task-timeline';
-    (Array.isArray(task.messages) ? task.messages : []).forEach(function (message) {
+    visibleMessages.forEach(function (message) {
       var item = document.createElement('li');
       item.className = 'task-timeline-item';
       var metaRow = document.createElement('div');
@@ -3818,9 +3839,12 @@ export const UI_JS = `(function () {
     loadNotifyHistory();
   });
   tasksRefresh.addEventListener('click', function () {
-    /* 显式 Refresh：列表完成后若仍在 Tasks 且有选中单，连带重拉详情。 */
+    /* 显式 Refresh：列表完成后，仅在详情视图（或桌面双栏）重拉详情，避免移动 Back 后被劫持。 */
     loadTasks().then(function () {
       if (state.scope !== 'tasks' || !state.activeTaskId) return;
+      var onDetail = inboxView.dataset.mobileView === 'tasks-detail';
+      var desktop = window.innerWidth > 820;
+      if (!onDetail && !desktop) return;
       selectTask(state.activeTaskId);
     });
   });

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -515,6 +515,17 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   text-transform: uppercase;
   border-bottom: 1px solid var(--line);
 }
+/* 窄桌面：列表栏 ~280px 装不下五列，先藏 Updated/Msgs，保留双栏。 */
+@media (max-width: 1100px) and (min-width: 821px) {
+  .tasks-header,
+  .task-row {
+    grid-template-columns: 100px minmax(0, 1.1fr) minmax(0, 1.4fr);
+  }
+  .tasks-header > :nth-child(4),
+  .tasks-header > :nth-child(5),
+  .task-row .task-updated,
+  .task-row .task-msgs { display: none; }
+}
 .tasks-rows { border-top: 1px solid var(--line); }
 .task-row {
   width: 100%;
@@ -1027,6 +1038,10 @@ export const UI_JS = `(function () {
   var POLL_WINDOW_MS = 20000;
   /* 通知面板 DOM 行数上限：12h 窗口可能数千条，全量建节点会卡死页面。 */
   var NOTIFY_RENDER_LIMIT = 500;
+  /* 任务工单行数上限：与 notify 同口径，避免大邮箱卡死页面。 */
+  var TASKS_RENDER_LIMIT = 500;
+  /* 与 lib/tasks.ts RESULT_MARKER 逐字一致；时间线正文剥离用。 */
+  var TASK_RESULT_MARKER = '<!-- openagent.email task result -->';
   var SORT_COLUMNS = [
     { key: 'address', label: 'Address' },
     { key: 'name', label: 'Name' },
@@ -1076,6 +1091,8 @@ export const UI_JS = `(function () {
     tasksFilter: '',
     tasksUpdatedAt: 0,
     tasksPending: false,
+    /* 上次成功拉取对应的 state 过滤指纹，避免切过滤误用旧缓存行。 */
+    tasksFetchKey: '',
     activeTaskId: '',
     taskDetail: null,
     taskDetailStatus: 'idle',
@@ -1209,6 +1226,7 @@ export const UI_JS = `(function () {
     state.tasksFilter = '';
     state.tasksUpdatedAt = 0;
     state.tasksPending = false;
+    state.tasksFetchKey = '';
     state.activeTaskId = '';
     state.taskDetail = null;
     state.taskDetailStatus = 'idle';
@@ -2990,10 +3008,33 @@ export const UI_JS = `(function () {
     tasksStateFilter.value = state.tasksFilter;
   }
 
+  function tasksFetchKey() {
+    return state.tasksFilter || '';
+  }
+
+  /* 展示层剥离 result 块；marker 与 lib/tasks.ts RESULT_MARKER 逐字一致。 */
+  function taskTimelineBody(body) {
+    var text = typeof body === 'string' ? body : '';
+    var markerAt = text.indexOf(TASK_RESULT_MARKER);
+    if (markerAt < 0) return text;
+    return text.slice(0, markerAt).replace(/\s+$/, '');
+  }
+
   function renderTaskRows() {
     tasksRows.replaceChildren();
-    var awaiting = state.tasksStatus === 'loading';
-    tasksShown.textContent = awaiting ? '' : String(state.tasks.length);
+    /* fetchKey 不匹配时旧缓存不可见，避免切 state 过滤闪错位行。 */
+    var keyMatches = state.tasksFetchKey === tasksFetchKey();
+    var rows = keyMatches ? state.tasks : [];
+    var total = rows.length;
+    var truncated = total > TASKS_RENDER_LIMIT;
+    var visible = truncated ? rows.slice(0, TASKS_RENDER_LIMIT) : rows;
+    /* 只要 fetchKey 对不上，就当加载中——含 enterTasks 首帧尚未 pending 的窗口。 */
+    var awaiting = state.tasksStatus === 'loading' || !keyMatches;
+    tasksShown.textContent = awaiting
+      ? ''
+      : truncated
+        ? 'Showing latest ' + TASKS_RENDER_LIMIT + ' of ' + total
+        : String(total);
     if (awaiting) {
       tasksStateNode.textContent = 'Loading…';
       return;
@@ -3002,14 +3043,16 @@ export const UI_JS = `(function () {
       tasksStateNode.textContent = state.tasksMessage || 'Tasks could not be loaded. Try Refresh.';
       return;
     }
-    if (state.tasks.length === 0) {
+    if (rows.length === 0) {
       tasksStateNode.textContent = state.tasksFilter
         ? 'No tasks in state "' + state.tasksFilter + '".'
         : 'No tasks yet. Refresh after a task mail arrives.';
       return;
     }
-    tasksStateNode.textContent = '';
-    state.tasks.forEach(function (task) {
+    tasksStateNode.textContent = truncated
+      ? 'Showing latest ' + TASKS_RENDER_LIMIT + ' of ' + total + ' tasks.'
+      : '';
+    visible.forEach(function (task) {
       var button = document.createElement('button');
       button.type = 'button';
       button.className = 'task-row';
@@ -3150,7 +3193,7 @@ export const UI_JS = `(function () {
       metaRow.append(msgBadge, from, when);
       var body = document.createElement('p');
       body.className = 'task-timeline-body';
-      body.textContent = message.body || '';
+      body.textContent = taskTimelineBody(message.body);
       item.append(metaRow, body);
       timeline.append(item);
     });
@@ -3186,7 +3229,13 @@ export const UI_JS = `(function () {
     tasksController = controller;
     state.tasksPending = true;
     state.tasksMessage = '';
-    if (state.tasks.length === 0) state.tasksStatus = 'loading';
+    /* F1：filter 一变 fetchKey 就变——立刻 loading，别等网络返回才撤掉假空态。 */
+    if (state.tasksFetchKey !== tasksFetchKey()) {
+      state.tasks = [];
+      state.tasksStatus = 'loading';
+    } else if (state.tasks.length === 0) {
+      state.tasksStatus = 'loading';
+    }
     renderTasks();
     try {
       var path = '/ui/api/tasks';
@@ -3197,6 +3246,7 @@ export const UI_JS = `(function () {
       if (tasksController !== controller) return;
       state.tasks = Array.isArray(payload.tasks) ? payload.tasks : [];
       state.tasksUpdatedAt = Date.now();
+      state.tasksFetchKey = tasksFetchKey();
       state.tasksStatus = 'ready';
       state.tasksMessage = '';
       renderTasks();
@@ -3212,6 +3262,8 @@ export const UI_JS = `(function () {
       if (state.tasks.length === 0) {
         state.tasksStatus = 'error';
         state.tasksMessage = 'Tasks could not be loaded. Try Refresh.';
+        /* 对齐 fetchKey，避免 !keyMatches 把诚实错误盖成永远 Loading… */
+        state.tasksFetchKey = tasksFetchKey();
       } else {
         state.tasksStatus = 'error';
         state.tasksMessage = 'Refresh failed. Showing previous tasks.';
@@ -3240,6 +3292,8 @@ export const UI_JS = `(function () {
     inboxView.dataset.mobileView = 'tasks-detail';
     renderTasks();
     tasksDetailSection.focus({ preventScroll: true });
+    /* 移动端进详情时滚到顶，避免 preventScroll 保留列表滚动位。 */
+    window.scrollTo(0, 0);
     var controller = new AbortController();
     taskDetailController = controller;
     try {
@@ -3278,7 +3332,11 @@ export const UI_JS = `(function () {
     renderTasks();
     focusTasksPanel();
     var age = state.tasksUpdatedAt ? Math.max(0, Date.now() - state.tasksUpdatedAt) : Infinity;
-    if (state.tasksStatus === 'ready' && age < FRESH_MS) return;
+    if (
+      state.tasksStatus === 'ready' &&
+      age < FRESH_MS &&
+      state.tasksFetchKey === tasksFetchKey()
+    ) return;
     loadTasks();
   }
 
@@ -3749,7 +3807,10 @@ export const UI_JS = `(function () {
     loadNotifyHistory();
   });
   tasksRefresh.addEventListener('click', function () {
-    loadTasks();
+    /* 显式 Refresh：列表完成后若有选中单，连带重拉详情（enterTasks 短路径不动）。 */
+    loadTasks().then(function () {
+      if (state.activeTaskId) selectTask(state.activeTaskId);
+    });
   });
   tasksStateFilter.addEventListener('change', function () {
     state.tasksFilter = tasksStateFilter.value;

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -515,8 +515,11 @@ button:disabled { cursor: not-allowed; opacity: .55; }
   text-transform: uppercase;
   border-bottom: 1px solid var(--line);
 }
-/* 窄桌面：列表栏 ~280px 装不下五列，先藏 Updated/Msgs，保留双栏。 */
-@media (max-width: 1100px) and (min-width: 821px) {
+/*
+ * 窄桌面藏 Updated/Msgs：sidebar 240 + panel 左右 pad≤30×2 + list 轨 1.1/2.5。
+ * 五列头≈458px → 列表轨需 ≥458 → 视口 ≥1341；取 1360 留余量（1280 时轨≈431 仍裁）。
+ */
+@media (max-width: 1360px) and (min-width: 821px) {
   .tasks-header,
   .task-row {
     grid-template-columns: 100px minmax(0, 1.1fr) minmax(0, 1.4fr);
@@ -3012,12 +3015,20 @@ export const UI_JS = `(function () {
     return state.tasksFilter || '';
   }
 
-  /* 展示层剥离 result 块；marker 与 lib/tasks.ts RESULT_MARKER 逐字一致。 */
+  /*
+   * 展示层剥离 result 块：口径对齐 lib/tasks.ts readResult——
+   * lastIndexOf 找最后一处 marker，且其后须是尾部 fenced json 块直到结尾才剥（中途字面量不剥）。
+   * UI_JS 外层是模板字符串：fence 用 RegExp + fromCharCode(96) 拼反引号，避免打断 backtick。
+   */
   function taskTimelineBody(body) {
     var text = typeof body === 'string' ? body : '';
-    var markerAt = text.indexOf(TASK_RESULT_MARKER);
+    var markerAt = text.lastIndexOf(TASK_RESULT_MARKER);
     if (markerAt < 0) return text;
-    return text.slice(0, markerAt).replace(/\s+$/, '');
+    var after = text.slice(markerAt + TASK_RESULT_MARKER.length);
+    var ticks = String.fromCharCode(96, 96, 96);
+    var fence = new RegExp('^\\\\s*' + ticks + 'json\\\\s*\\\\n([\\\\s\\\\S]*?)\\\\n' + ticks + '\\\\s*$');
+    if (!fence.test(after)) return text;
+    return text.slice(0, markerAt).replace(/\\s+$/, '');
   }
 
   function renderTaskRows() {
@@ -3807,9 +3818,10 @@ export const UI_JS = `(function () {
     loadNotifyHistory();
   });
   tasksRefresh.addEventListener('click', function () {
-    /* 显式 Refresh：列表完成后若有选中单，连带重拉详情（enterTasks 短路径不动）。 */
+    /* 显式 Refresh：列表完成后若仍在 Tasks 且有选中单，连带重拉详情。 */
     loadTasks().then(function () {
-      if (state.activeTaskId) selectTask(state.activeTaskId);
+      if (state.scope !== 'tasks' || !state.activeTaskId) return;
+      selectTask(state.activeTaskId);
     });
   });
   tasksStateFilter.addEventListener('change', function () {

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -324,11 +324,27 @@ describe('UI static asset contract', () => {
     expect(stripBody).toContain('text.lastIndexOf(TASK_RESULT_MARKER)');
     expect(stripBody).toContain('String.fromCharCode(96, 96, 96)');
     expect(stripBody).toContain('new RegExp(');
-    expect(stripBody).toContain('fence.test(after)');
+    expect(stripBody).toContain('after.match(fence)');
+    expect(stripBody).toContain('JSON.parse(match[1])');
     expect(stripBody).not.toContain('text.indexOf(TASK_RESULT_MARKER)');
     expect(UI_JS).toContain('window.scrollTo(0, 0)');
     expect(UI_JS).toContain("state.scope !== 'tasks' || !state.activeTaskId");
+    expect(UI_JS).toContain("inboxView.dataset.mobileView === 'tasks-detail'");
+    expect(UI_JS).toContain('window.innerWidth > 820');
     expect(UI_CSS).toContain('@media (max-width: 1360px) and (min-width: 821px)');
+    // F12：紧凑列查询必须在基础 .task-row 五列声明之后，否则被覆盖
+    const headerBase = UI_CSS.indexOf(
+      '.tasks-header {\n  display: grid;\n  gap: 10px;\n  grid-template-columns: 110px',
+    );
+    const rowBase = UI_CSS.indexOf(
+      '.task-row {\n  width: 100%;\n  display: grid;\n  gap: 10px;\n  grid-template-columns: 110px',
+    );
+    const compactMq = UI_CSS.indexOf(
+      '@media (max-width: 1360px) and (min-width: 821px)',
+    );
+    expect(headerBase).toBeGreaterThan(-1);
+    expect(rowBase).toBeGreaterThan(-1);
+    expect(compactMq).toBeGreaterThan(rowBase);
     // 前端不得直接打 Bearer 的 /v1/tasks
     expect(UI_JS).not.toContain('/v1/tasks');
   });
@@ -345,6 +361,20 @@ describe('UI static asset contract', () => {
     expect(renderRows).toContain('var truncated = total > TASKS_RENDER_LIMIT');
     expect(renderRows).toContain('visible.forEach');
     expect(renderRows).not.toContain('state.tasks.forEach');
+  });
+
+  // 时间线条目上限：长工单不全量建节点
+  test('task timeline is capped at TASK_TIMELINE_RENDER_LIMIT with an honest truncation label', () => {
+    expect(UI_JS).toContain('var TASK_TIMELINE_RENDER_LIMIT = 200');
+    expect(UI_JS).toContain('messages.slice(timelineTotal - TASK_TIMELINE_RENDER_LIMIT)');
+    expect(UI_JS).toContain("'Showing latest ' + TASK_TIMELINE_RENDER_LIMIT");
+    const detail = UI_JS.slice(
+      UI_JS.indexOf('function renderTaskDetail('),
+      UI_JS.indexOf('function renderTasks('),
+    );
+    expect(detail).toContain('timelineTotal > TASK_TIMELINE_RENDER_LIMIT');
+    expect(detail).toContain('visibleMessages.forEach');
+    expect(detail).not.toContain('task.messages : []).forEach');
   });
 
   // 切 state 过滤时 fetchKey 变化必须进 loading，禁止立刻渲染假空态/旧缓存

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -317,7 +317,18 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain(
       "var TASK_RESULT_MARKER = '<!-- openagent.email task result -->'",
     );
+    const stripBody = UI_JS.slice(
+      UI_JS.indexOf('function taskTimelineBody('),
+      UI_JS.indexOf('function renderTaskRows('),
+    );
+    expect(stripBody).toContain('text.lastIndexOf(TASK_RESULT_MARKER)');
+    expect(stripBody).toContain('String.fromCharCode(96, 96, 96)');
+    expect(stripBody).toContain('new RegExp(');
+    expect(stripBody).toContain('fence.test(after)');
+    expect(stripBody).not.toContain('text.indexOf(TASK_RESULT_MARKER)');
     expect(UI_JS).toContain('window.scrollTo(0, 0)');
+    expect(UI_JS).toContain("state.scope !== 'tasks' || !state.activeTaskId");
+    expect(UI_CSS).toContain('@media (max-width: 1360px) and (min-width: 821px)');
     // 前端不得直接打 Bearer 的 /v1/tasks
     expect(UI_JS).not.toContain('/v1/tasks');
   });

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -161,6 +161,16 @@ describe('UI static asset contract', () => {
       'notify-notice',
       'notify-updated',
       'notify-shown',
+      'tasks-panel',
+      'tasks-title',
+      'tasks-rows',
+      'tasks-state',
+      'tasks-refresh',
+      'tasks-state-filter',
+      'tasks-notice',
+      'tasks-updated',
+      'tasks-shown',
+      'tasks-detail-content',
     ]) {
       expect(UI_HTML).toContain(`id="${id}"`);
     }
@@ -177,12 +187,14 @@ describe('UI static asset contract', () => {
     expect(UI_HTML).toContain('id="confirm-modal-risk"');
   });
 
-  // A15：landmark 挂在 inbox 容器上；scope 在 overview / notifications / inbox 三个 <main> 间切换
-  test('exactly four mains exist and #main-content wraps the message and detail panels', () => {
+  // A15：landmark 挂在 inbox 容器上；scope 在 overview / notifications / tasks / inbox 四个 <main> 间切换
+  test('exactly five mains exist and #main-content wraps the message and detail panels', () => {
     expect(UI_HTML).toContain('<main id="overview-panel" class="overview-panel" tabindex="-1"');
     expect(UI_HTML).toMatch(/<main id="overview-panel"[^>]*\shidden>/);
     expect(UI_HTML).toContain('<main id="notify-panel" class="notify-panel" tabindex="-1"');
     expect(UI_HTML).toMatch(/<main id="notify-panel"[^>]*\shidden>/);
+    expect(UI_HTML).toContain('<main id="tasks-panel" class="tasks-panel" tabindex="-1"');
+    expect(UI_HTML).toMatch(/<main id="tasks-panel"[^>]*\shidden>/);
     expect(UI_HTML).toContain('<main id="main-content" class="inbox-main" tabindex="-1">');
     expect(UI_HTML).toContain('<section id="detail-panel" class="detail-panel" tabindex="-1">');
 
@@ -192,11 +204,11 @@ describe('UI static asset contract', () => {
     expect(container).toBeGreaterThan(-1);
     expect(container).toBeLessThan(list);
     expect(list).toBeLessThan(detail);
-    // #message-panel / #detail-panel 自身不带 hidden：scope 只切三个内容 <main>
+    // #message-panel / #detail-panel 自身不带 hidden：scope 只切四个内容 <main>
     expect(UI_HTML).not.toMatch(/<section id="(message|detail)-panel"[^>]*\shidden/);
 
-    // login + overview + notify + inbox-main
-    expect(UI_HTML.split('<main').length - 1).toBe(4);
+    // login + overview + notify + tasks + inbox-main
+    expect(UI_HTML.split('<main').length - 1).toBe(5);
   });
 
   // A16 / A17
@@ -208,10 +220,13 @@ describe('UI static asset contract', () => {
     );
     expect(applyScope).toContain('overviewPanel.hidden = !overviewActive;');
     expect(applyScope).toContain('notifyPanel.hidden = !notifyActive;');
+    expect(applyScope).toContain('tasksPanel.hidden = !tasksActive;');
     expect(applyScope).toContain('mainContent.hidden = !inboxActive;');
     expect(applyScope).toContain("skipLink.textContent = overviewActive");
     expect(applyScope).toContain("'Skip to notifications'");
+    expect(applyScope).toContain("'Skip to tasks'");
     expect(applyScope).toContain("'#notify-panel'");
+    expect(applyScope).toContain("'#tasks-panel'");
     // landmark 与断点无关，所以不需要 matchMedia
     expect(UI_JS).not.toContain('matchMedia');
     expect(UI_JS).not.toMatch(/\.id\s*=\s*['"]main-content['"]/);
@@ -224,18 +239,20 @@ describe('UI static asset contract', () => {
     expect(selectMessage).not.toContain('mainContent.focus()');
   });
 
-  // F2 / §1.3 / §1.4：侧栏地址与移动 selector 是 Overview / Notifications 之外的入口
+  // F2 / §1.3 / §1.4：侧栏地址与移动 selector 是 Overview / Notifications / Tasks 之外的入口
   test('the sidebar address and the mobile selector both reach the inbox from the overview', () => {
     // 唯一的移动 selector 必须挂在内容 <main> 之外，否则 scope 切换会把它一起藏掉
     const layout = UI_HTML.indexOf('<div class="inbox-layout">');
     const selector = UI_HTML.indexOf('id="mobile-identity-select"');
     const overviewMain = UI_HTML.indexOf('<main id="overview-panel"');
     const notifyMain = UI_HTML.indexOf('<main id="notify-panel"');
+    const tasksMain = UI_HTML.indexOf('<main id="tasks-panel"');
     const inboxMain = UI_HTML.indexOf('<main id="main-content"');
     expect(UI_HTML.split('id="mobile-identity-select"').length - 1).toBe(1);
     expect(selector).toBeGreaterThan(layout);
     expect(selector).toBeLessThan(overviewMain);
     expect(selector).toBeLessThan(notifyMain);
+    expect(selector).toBeLessThan(tasksMain);
     expect(selector).toBeLessThan(inboxMain);
     expect(UI_HTML).toContain('<label for="mobile-identity-select">Address</label>');
     // 移动端只有 .inbox-layout 展开成 block，所以这层包装在各 scope 都可见
@@ -248,12 +265,14 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function activateAddress(address) {'),
       UI_JS.indexOf('function filteredIdentities('),
     );
-    expect(activate).toContain("state.scope === 'overview' || state.scope === 'notifications'");
+    expect(activate).toContain(
+      "state.scope === 'overview' || state.scope === 'notifications' || state.scope === 'tasks'",
+    );
     expect(activate).toContain('openAddress(address);');
     expect(activate).toContain('selectIdentity(address);');
     expect(UI_JS).toContain('activateAddress(identity.address);');
     expect(UI_JS).toContain('activateAddress(mobileIdentity.value);');
-    // 侧栏/选择器不许再直接调 selectIdentity（那样画面会停在 Overview/Notifications）
+    // 侧栏/选择器不许再直接调 selectIdentity（那样画面会停在 Overview/Notifications/Tasks）
     expect(UI_JS).not.toContain('selectIdentity(identity.address);');
     expect(UI_JS).not.toContain('selectIdentity(mobileIdentity.value);');
   });
@@ -280,6 +299,21 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain("return 'unknown'");
     // 前端不得直接打 Bearer 的 /v1/notify
     expect(UI_JS).not.toContain('/v1/notify');
+  });
+
+  // 任务工单：入口、API 与 landmark 与 Notifications 同级钉在静态契约里
+  test('tasks panel loads tickets via /ui/api/tasks with session-scoped ACL', () => {
+    expect(UI_JS).toContain('function enterTasks(');
+    expect(UI_JS).toContain('function loadTasks(');
+    expect(UI_JS).toContain('function selectTask(');
+    expect(UI_JS).toContain("'/ui/api/tasks'");
+    expect(UI_JS).toContain("'/ui/api/tasks/' + encodeURIComponent(id)");
+    expect(UI_JS).toContain("value = '__tasks__'");
+    expect(UI_JS).toContain('tasksPanel.focus({ preventScroll: true })');
+    expect(UI_JS).toContain('function clearTasksState(');
+    expect(UI_JS).toContain('function cancelTasksLoad(');
+    // 前端不得直接打 Bearer 的 /v1/tasks
+    expect(UI_JS).not.toContain('/v1/tasks');
   });
 
   // F1：401 → showLogin 必须清掉通知缓存，否则换 token 会渲染上一主体内容
@@ -312,6 +346,38 @@ describe('UI static asset contract', () => {
     }
     // apiJson 401 走 showLogin（因而间接触发清理），不是只 abort
     expect(UI_JS).toContain("showLogin('Your session expired. Sign in again.')");
+  });
+
+  // F1（tasks）：401 → showLogin 必须清掉工单缓存，否则换 token 会渲染上一主体任务
+  test('showLogin clears tasks cache so a new session cannot reuse prior tickets (F1)', () => {
+    expect(UI_JS).toContain('function clearTasksState(');
+    const showLogin = UI_JS.slice(
+      UI_JS.indexOf('function showLogin(message)'),
+      UI_JS.indexOf('function showInbox('),
+    );
+    expect(showLogin).toContain('clearTasksState()');
+    expect(showLogin).toContain('cancelTasksLoad()');
+    expect(showLogin.indexOf('cancelTasksLoad()')).toBeLessThan(
+      showLogin.indexOf('clearTasksState()'),
+    );
+    const clear = UI_JS.slice(
+      UI_JS.indexOf('function clearTasksState('),
+      UI_JS.indexOf('function showLogin(message)'),
+    );
+    for (const field of [
+      'state.tasks = []',
+      "state.tasksStatus = 'idle'",
+      "state.tasksMessage = ''",
+      "state.tasksFilter = ''",
+      'state.tasksUpdatedAt = 0',
+      'state.tasksPending = false',
+      "state.activeTaskId = ''",
+      'state.taskDetail = null',
+      "state.taskDetailStatus = 'idle'",
+      "state.taskDetailMessage = ''",
+    ]) {
+      expect(clear).toContain(field);
+    }
   });
 
   // F2：渲染行数上限，避免 12h 嘈杂实例卡死页面

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -312,8 +312,47 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain('tasksPanel.focus({ preventScroll: true })');
     expect(UI_JS).toContain('function clearTasksState(');
     expect(UI_JS).toContain('function cancelTasksLoad(');
+    expect(UI_JS).toContain('function taskTimelineBody(');
+    expect(UI_JS).toContain("taskTimelineBody(message.body)");
+    expect(UI_JS).toContain(
+      "var TASK_RESULT_MARKER = '<!-- openagent.email task result -->'",
+    );
+    expect(UI_JS).toContain('window.scrollTo(0, 0)');
     // 前端不得直接打 Bearer 的 /v1/tasks
     expect(UI_JS).not.toContain('/v1/tasks');
+  });
+
+  // 任务行数上限：与 notify F2 同级
+  test('task rows are capped at TASKS_RENDER_LIMIT with an honest truncation label', () => {
+    expect(UI_JS).toContain('var TASKS_RENDER_LIMIT = 500');
+    expect(UI_JS).toContain('rows.slice(0, TASKS_RENDER_LIMIT)');
+    expect(UI_JS).toContain("'Showing latest ' + TASKS_RENDER_LIMIT");
+    const renderRows = UI_JS.slice(
+      UI_JS.indexOf('function renderTaskRows('),
+      UI_JS.indexOf('function renderTaskDetail('),
+    );
+    expect(renderRows).toContain('var truncated = total > TASKS_RENDER_LIMIT');
+    expect(renderRows).toContain('visible.forEach');
+    expect(renderRows).not.toContain('state.tasks.forEach');
+  });
+
+  // 切 state 过滤时 fetchKey 变化必须进 loading，禁止立刻渲染假空态/旧缓存
+  test('task state filter changes enter loading instead of a false empty or stale list', () => {
+    const load = UI_JS.slice(
+      UI_JS.indexOf('async function loadTasks('),
+      UI_JS.indexOf('async function selectTask('),
+    );
+    expect(load).toContain('state.tasksFetchKey !== tasksFetchKey()');
+    expect(load).toContain("state.tasksStatus = 'loading'");
+    expect(load).toContain('state.tasks = []');
+    expect(load).toContain('state.tasksFetchKey = tasksFetchKey()');
+    const renderRows = UI_JS.slice(
+      UI_JS.indexOf('function renderTaskRows('),
+      UI_JS.indexOf('function renderTaskDetail('),
+    );
+    expect(renderRows).toContain('state.tasksFetchKey === tasksFetchKey()');
+    expect(renderRows).toContain("state.tasksStatus === 'loading' || !keyMatches");
+    expect(renderRows).toContain("'Loading…'");
   });
 
   // F1：401 → showLogin 必须清掉通知缓存，否则换 token 会渲染上一主体内容
@@ -371,6 +410,7 @@ describe('UI static asset contract', () => {
       "state.tasksFilter = ''",
       'state.tasksUpdatedAt = 0',
       'state.tasksPending = false',
+      "state.tasksFetchKey = ''",
       "state.activeTaskId = ''",
       'state.taskDetail = null',
       "state.taskDetailStatus = 'idle'",

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { UiApiDependencies } from '../src/routes/ui.ts';
+import type { Task, TaskState } from '../src/lib/tasks.ts';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+
+const { UiSessionStore } = await import('../src/lib/ui-session.ts');
+const { createUiApiRoutes } = await import('../src/routes/ui.ts');
+
+const TASK_A: Task = {
+  id: '11111111-1111-4111-8111-111111111111',
+  from: 'fox@test.example',
+  to: 'owl@test.example',
+  subject: 'Ship the board',
+  state: 'working',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-02T00:00:00.000Z',
+  messages: [
+    {
+      id: '1',
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Ship the board',
+      date: '2024-01-01T00:00:00.000Z',
+      state: 'submitted',
+      body: 'please start',
+    },
+    {
+      id: '2',
+      from: 'owl@test.example',
+      to: 'fox@test.example',
+      subject: 'Ship the board',
+      date: '2024-01-02T00:00:00.000Z',
+      state: 'working',
+      body: 'on it',
+    },
+  ],
+};
+
+const TASK_B: Task = {
+  id: '22222222-2222-4222-8222-222222222222',
+  from: 'cat@test.example',
+  to: 'dog@test.example',
+  subject: 'Other thread',
+  state: 'completed',
+  createdAt: '2024-01-03T00:00:00.000Z',
+  updatedAt: '2024-01-04T00:00:00.000Z',
+  messages: [
+    {
+      id: '3',
+      from: 'cat@test.example',
+      to: 'dog@test.example',
+      subject: 'Other thread',
+      date: '2024-01-03T00:00:00.000Z',
+      state: 'submitted',
+      body: 'go',
+    },
+  ],
+  result: { ok: true, note: 'done' },
+};
+
+type AuthKind = { kind: 'admin' } | { kind: 'identity'; address: string };
+
+function makeApp(
+  auth: AuthKind,
+  overrides: Partial<UiApiDependencies> = {},
+  catalog: Task[] = [TASK_A, TASK_B],
+) {
+  const listCalls: Array<TaskState | undefined> = [];
+  const getCalls: string[] = [];
+  const deps: UiApiDependencies = {
+    listIdentities: () => [],
+    listMessages: mock(async () => []),
+    setMessageSeen: mock(async () => true),
+    getMailboxScan: mock(async () => ({
+      kind: 'ready' as const,
+      now: Date.now(),
+      snapshot: null,
+      cached: false,
+      revalidating: false,
+      refreshError: false,
+    })),
+    getMessage: mock(async () => null),
+    setPushContentTier: mock(() => null),
+    taskService: {
+      list: mock(async (state?: TaskState) => {
+        listCalls.push(state);
+        return state ? catalog.filter((task) => task.state === state) : catalog;
+      }),
+      get: mock(async (id: string) => {
+        getCalls.push(id);
+        return catalog.find((task) => task.id === id) ?? null;
+      }),
+    },
+    ...overrides,
+  };
+  const store = new UiSessionStore({
+    resolveToken: (token) => {
+      if (token === 'admin-ok' && auth.kind === 'admin') return { kind: 'admin' };
+      if (token === 'id-ok' && auth.kind === 'identity') {
+        return { kind: 'identity', address: auth.address };
+      }
+      return null;
+    },
+  });
+  const token = auth.kind === 'admin' ? 'admin-ok' : 'id-ok';
+  const created = store.create(token, '127.0.0.1');
+  if (!created.ok) throw new Error('test session was not created');
+  const app = new Hono();
+  app.route('/ui/api', createUiApiRoutes(store, deps));
+  return { app, deps, cookie: `oae_ui=${created.sid}`, listCalls, getCalls };
+}
+
+describe('UI tasks ACL and contract', () => {
+  test('admin lists all tasks and can fetch any detail', async () => {
+    const { app, cookie, listCalls, getCalls } = makeApp({ kind: 'admin' });
+
+    const listed = await app.request('/ui/api/tasks', { headers: { cookie } });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toEqual({ tasks: [TASK_A, TASK_B] });
+    expect(listCalls).toEqual([undefined]);
+
+    const detail = await app.request(`/ui/api/tasks/${TASK_B.id}`, {
+      headers: { cookie },
+    });
+    expect(detail.status).toBe(200);
+    expect(await detail.json()).toEqual(TASK_B);
+    expect(getCalls).toEqual([TASK_B.id]);
+  });
+
+  test('state filter is forwarded to taskService.list', async () => {
+    const { app, cookie, listCalls } = makeApp({ kind: 'admin' });
+    const response = await app.request('/ui/api/tasks?state=completed', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ tasks: [TASK_B] });
+    expect(listCalls).toEqual(['completed']);
+  });
+
+  test('identity only sees participated tasks and is forbidden on peers', async () => {
+    const { app, cookie, getCalls } = makeApp({
+      kind: 'identity',
+      address: 'fox@test.example',
+    });
+
+    const listed = await app.request('/ui/api/tasks', { headers: { cookie } });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toEqual({ tasks: [TASK_A] });
+
+    const own = await app.request(`/ui/api/tasks/${TASK_A.id}`, {
+      headers: { cookie },
+    });
+    expect(own.status).toBe(200);
+    expect(await own.json()).toEqual(TASK_A);
+
+    const peer = await app.request(`/ui/api/tasks/${TASK_B.id}`, {
+      headers: { cookie },
+    });
+    expect(peer.status).toBe(403);
+    expect(await peer.json()).toEqual({ error: 'forbidden: task participant required' });
+    expect(getCalls).toEqual([TASK_A.id, TASK_B.id]);
+  });
+
+  test('identity as task.to participant can list and get the ticket', async () => {
+    const { app, cookie } = makeApp({
+      kind: 'identity',
+      address: 'owl@test.example',
+    });
+    const listed = await app.request('/ui/api/tasks', { headers: { cookie } });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toEqual({ tasks: [TASK_A] });
+
+    const detail = await app.request(`/ui/api/tasks/${TASK_A.id}`, {
+      headers: { cookie },
+    });
+    expect(detail.status).toBe(200);
+    expect(await detail.json()).toEqual(TASK_A);
+  });
+
+  test('unrelated identity gets an empty list and 403 on peer detail', async () => {
+    const { app, cookie } = makeApp({
+      kind: 'identity',
+      address: 'stranger@test.example',
+    });
+    const listed = await app.request('/ui/api/tasks', { headers: { cookie } });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toEqual({ tasks: [] });
+
+    const peer = await app.request(`/ui/api/tasks/${TASK_A.id}`, {
+      headers: { cookie },
+    });
+    expect(peer.status).toBe(403);
+    expect(await peer.json()).toEqual({ error: 'forbidden: task participant required' });
+  });
+
+  test('invalid task id is rejected with 400', async () => {
+    const { app, cookie, getCalls } = makeApp({ kind: 'admin' });
+    const response = await app.request('/ui/api/tasks/not-a-uuid', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({ error: 'invalid_request' });
+    expect(getCalls).toEqual([]);
+  });
+
+  test('missing task returns 404', async () => {
+    const { app, cookie } = makeApp({ kind: 'admin' });
+    const response = await app.request(
+      '/ui/api/tasks/33333333-3333-4333-8333-333333333333',
+      { headers: { cookie } },
+    );
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: 'not_found' });
+  });
+
+  test('invalid state filter is rejected with 400', async () => {
+    const { app, cookie, listCalls } = makeApp({ kind: 'admin' });
+    const response = await app.request('/ui/api/tasks?state=bogus', {
+      headers: { cookie },
+    });
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe('invalid_request');
+    expect(Array.isArray(body.details)).toBe(true);
+    expect(body.details.length).toBeGreaterThan(0);
+    expect(listCalls).toEqual([]);
+  });
+
+  test('unauthenticated sessions cannot read tasks', async () => {
+    const { app, listCalls, getCalls } = makeApp({ kind: 'admin' });
+    const listed = await app.request('/ui/api/tasks');
+    expect(listed.status).toBe(401);
+    const detail = await app.request(`/ui/api/tasks/${TASK_A.id}`);
+    expect(detail.status).toBe(401);
+    expect(listCalls).toEqual([]);
+    expect(getCalls).toEqual([]);
+  });
+});

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -193,11 +193,29 @@ describe('UI tasks ACL and contract', () => {
     expect(listed.status).toBe(200);
     expect(await listed.json()).toEqual({ tasks: [] });
 
+    // 有意口径：任务存在但非参与者 → 403；不存在 → 404（见 missing task）。
+    // 存在性侧信道已记档 issue #13，本路由不得擅自改成统一 404。
     const peer = await app.request(`/ui/api/tasks/${TASK_A.id}`, {
       headers: { cookie },
     });
     expect(peer.status).toBe(403);
     expect(await peer.json()).toEqual({ error: 'forbidden: task participant required' });
+  });
+
+  test('mixed-case identity address still matches lowercase task participants', async () => {
+    const { app, cookie } = makeApp({
+      kind: 'identity',
+      address: 'Fox@test.example',
+    });
+    const listed = await app.request('/ui/api/tasks', { headers: { cookie } });
+    expect(listed.status).toBe(200);
+    expect(await listed.json()).toEqual({ tasks: [TASK_A] });
+
+    const detail = await app.request(`/ui/api/tasks/${TASK_A.id}`, {
+      headers: { cookie },
+    });
+    expect(detail.status).toBe(200);
+    expect(await detail.json()).toEqual(TASK_A);
   });
 
   test('invalid task id is rejected with 400', async () => {
@@ -211,6 +229,7 @@ describe('UI tasks ACL and contract', () => {
   });
 
   test('missing task returns 404', async () => {
+    // 有意口径：不存在 → 404（对照非参与者 403）；存在性侧信道见 issue #13。
     const { app, cookie } = makeApp({ kind: 'admin' });
     const response = await app.request(
       '/ui/api/tasks/33333333-3333-4333-8333-333333333333',


### PR DESCRIPTION
## 什么

Dashboard 新增 **Tasks 工单视图**（ROADMAP W1 #22），与 #21 Notifications 面板并列：task 邮件线程（X-OA-Task 头聚合）从普通收件箱信件升级为工单形态。

- **列表**：状态五色徽章（submitted/working/input-required/completed/failed）、from→to 参与者、主题、相对更新时间、消息数；桌面表格 + 移动卡片双布局；?state= 过滤
- **详情**：状态流转时间线（每条消息徽章+发件人+时间+正文）+ 可折叠 JSON result 块
- **后端**：`GET /ui/api/tasks`(+`?state=`) / `GET /ui/api/tasks/:id`，cookie 会话；ACL 与 `/v1/tasks` 读路径逐行镜像（admin 全量；identity 仅参与者；400/401/403/404 口径一致）；`UiApiDependencies.taskService` 可注入
- **landmark**：`#tasks-panel` 为第五个 `<main>`，`ui-assets.test.ts` 静态契约同步扩展（计数 4→5、applyScope/移动 selector/F1 清缓存断言同级覆盖 tasks）

## 测试

`bun test`：507 pass / 0 fail（+11 新用例：ui-tasks 契约+ACL 9 条、ui-assets tasks 契约 2 条）

## 流程留痕

- worker cursor-agent 开发 → subagent 独立审查三轮（首轮 Request changes：M2 详情错误态/m1 测试缺口等 → 返工 → 复审 Approve with nits → R1 landmark 轮 Approve）
- 指挥官终审一轮：R1 返工（面板 section→main landmark + 测试子串 hack 根除），已闭环
- 完整报告：/home/ops/reports/drill-22-task-board-REPORT.md

无新依赖；前端不直连 /v1/tasks；任务正文/result 全走 textContent。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a responsive Tasks panel with list and detail views.
  - Added task filtering by state, timelines, results, loading states, and error handling.
  - Added task navigation across desktop and mobile layouts.
  - Added APIs for listing and viewing tasks with participant and administrator access controls.

- **Bug Fixes**
  - Improved task data cleanup during session changes and refreshes.
  - Added handling for missing tasks, invalid requests, and unauthorized access.
  - Added cancellation of pending task loads when sessions end or change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

**已知口径记档**：`/ui/api/tasks/:id` 对非参与者返回 403、不存在返回 404（与 `/v1/tasks` 逐字同构的有意口径），UUID 存在性侧信道已挂 #13 跟踪；如要统一 404 须两条读路径同批改。
