### PR TITLE
feat(api): minimal OAuth 2.1 Authorization Server for MCP (ROADMAP #28, P3)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,5 +16,6 @@ The website docs are canonical — edit them in the [website repo](https://githu
 | POST | `/oauth/revoke` | RFC 7009 |
 | GET | `/ui/oauth/grants` | 已授权客户端管理页 |
 | GET/DELETE | `/ui/api/oauth/grants[/:id]` | 列表 / 吊销 |
+| POST | `/ui/api/oauth/grants/:id/revoke` | 管理页表单吊销（同 origin + session；成功 302 回列表） |
 
 不做：DCR（`/oauth/register`）、OIDC discovery、admin 级 OAuth 票、公网暴露（P4）。

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,3 +3,18 @@
 **Moved:** this document now lives at https://openagent.email/docs/reference/api/
 
 The website docs are canonical — edit them in the [website repo](https://github.com/openagentemail/website) (`src/content/docs/docs/`).
+
+## OAuth Authorization Server（P3，本仓增量）
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| GET | `/.well-known/oauth-authorization-server` | RFC 8414 AS 元数据（公开） |
+| GET | `/.well-known/oauth-protected-resource` | RFC 9728 PRM；`authorization_servers` = AS issuer |
+| GET | `/authorize` | 302 → `/ui/oauth/authorize`（cookie path=/ui） |
+| GET/POST | `/ui/oauth/authorize` | 同意页（需 Dashboard 会话）；回跳一律带 `iss`（RFC 9207） |
+| POST | `/oauth/token` | `authorization_code` + PKCE S256；`refresh_token` 轮换 |
+| POST | `/oauth/revoke` | RFC 7009 |
+| GET | `/ui/oauth/grants` | 已授权客户端管理页 |
+| GET/DELETE | `/ui/api/oauth/grants[/:id]` | 列表 / 吊销 |
+
+不做：DCR（`/oauth/register`）、OIDC discovery、admin 级 OAuth 票、公网暴露（P4）。

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -12,8 +12,12 @@ API 进程暴露无状态 MCP 端点 `POST /mcp`（MCP 2026-07-28 / SDK v2）。
 | 项 | 值 |
 | --- | --- |
 | URL | `https://<your-api-host>/mcp`（或 tailnet / 内网 `http://…:3100/mcp`） |
-| Auth | `Authorization: Bearer <oa_… 或 admin API_KEYS>` |
-| 发现 | `GET /.well-known/oauth-protected-resource`（RFC 9728；完整 OAuth AS 为后续工作） |
+| Auth | `Authorization: Bearer <oa_… / admin API_KEYS / OAuth access>` |
+| 发现 | `GET /.well-known/oauth-protected-resource`（RFC 9728）→ `authorization_servers` 指向本机 AS issuer |
+| AS | `GET /.well-known/oauth-authorization-server`（RFC 8414；CIMD，无 DCR） |
+| 授权 | 浏览器打开 `/authorize`（同意页在 Dashboard 会话内）；业主选已有身份或当场新建 |
+
+网页 Agent（ChatGPT / Claude 等）走标准 OAuth 授权码 + PKCE（仅 S256）+ CIMD。OAuth access token 仅为 **identity** 级（永非 admin），绑定 MCP resource（`…/mcp`）。管理已授权客户端：Dashboard `/ui/oauth/grants`。
 
 ### Cursor / 通用 MCP `type: http` 示例
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,6 +20,14 @@ retention window before reusing one.
 <!-- Canonical copy lives in the website repo (src/content/docs/docs/); mirror
      this note there when publishing. -->
 
+## OAuth access tokens（P3 AS）
+
+- OAuth 票**永远是 identity 级**，不能经授权流获得 admin。
+- access / refresh / code 只存 SHA-256 哈希（`DATA_DIR/oauth.json`，0600）；access 默认 1h，refresh 30d 且轮换即作废旧票。
+- 令牌绑定 RFC 8707 `resource`（本机 `{base}/mcp`）；aud 不符 → 403。
+- CIMD SSRF：当前部署在 loopback/tailnet，放行 RFC1918/CGNAT/loopback；**永拒** `169.254.0.0/16` 与 `0.0.0.0/8`（P4 公网须收紧）。
+- 授权响应（含错误）一律带 `iss`（RFC 9207）。Dashboard `/ui/oauth/grants` 可整串吊销。
+
 ## Prompt-injection 防护
 
 Agent 通过 REST / MCP 读外部来信时，正文会进入 LLM 上下文。本项目的主防线是

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,7 +25,7 @@ retention window before reusing one.
 - OAuth 票**永远是 identity 级**，不能经授权流获得 admin。
 - access / refresh / code 只存 SHA-256 哈希（`DATA_DIR/oauth.json`，0600）；access 默认 1h，refresh 30d 且轮换即作废旧票。
 - 令牌绑定 RFC 8707 `resource`（本机 `{base}/mcp`）；aud 不符 → 403。
-- CIMD SSRF：当前部署在 loopback/tailnet，放行 RFC1918/CGNAT/loopback；**永拒** `169.254.0.0/16` 与 `0.0.0.0/8`（P4 公网须收紧）。
+- CIMD SSRF：当前部署在 loopback/tailnet，放行 RFC1918/CGNAT/loopback；**永拒** `169.254.0.0/16`、`0.0.0.0/8`、`fe80::/10`（与 IPv4 链路本地对齐）、`fd00:ec2::/16`（AWS IMDS IPv6，如 `fd00:ec2::254`）。含 IPv4-mapped（含 URL 规范化后的 `::ffff:a9fe:a9fe` 形）。连接时 lookup 钉死解析结果，消除校验/fetch 间 DNS-rebinding TOCTOU（P4 公网须进一步收紧私网放行）。
 - 授权响应（含错误）一律带 `iss`（RFC 9207）。Dashboard `/ui/oauth/grants` 可整串吊销。
 
 ## Prompt-injection 防护

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -22,6 +22,7 @@ bun run typecheck
 | `PORT` | `3100` | HTTP listen port |
 | `DOMAIN` | — | identity domain (`localpart@DOMAIN`) |
 | `API_KEYS` | — | comma-separated **admin** Bearer keys (full access; agents should use per-identity tokens instead) |
+| `MCP_PUBLIC_URL` | — | optional public origin for PRM / AS issuer / MCP loopback aud（`http(s)://…`，去尾斜杠）；反代后与浏览器所见 origin 不一致时必填 |
 | `IMAP_HOST/PORT/USER/PASS` | `127.0.0.1:993` | catch-all mailbox login |
 | `IMAP_TLS` | `true` | `false` for plaintext/STARTTLS (143) |
 | `SMTP_HOST/PORT/USER/PASS` | `127.0.0.1:587` | catch-all account; From is rewritten to the identity |

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -32,8 +32,11 @@ bun run typecheck
 
 All `/v1/*` require `Authorization: Bearer <key>`.
 
-- `POST /mcp` — 无状态 MCP（SDK v2 / 2026-07-28）；**需** `Authorization: Bearer`（admin 或 `oa_`）；无/坏 token → 401 + `WWW-Authenticate`
-- `GET /.well-known/oauth-protected-resource`（及 `/mcp` path-aware 变体）— RFC 9728 PRM；**公开、无鉴权**。可选 env `MCP_PUBLIC_URL` 覆盖元数据里的对外 origin
+- `POST /mcp` — 无状态 MCP（SDK v2 / 2026-07-28）；**需** `Authorization: Bearer`（admin / `oa_` / OAuth access）；无/坏 token → 401 + `WWW-Authenticate`；OAuth aud 不符 → 403
+- `GET /.well-known/oauth-protected-resource`（及 `/mcp` path-aware 变体）— RFC 9728 PRM；**公开**；`authorization_servers` = AS issuer。可选 env `MCP_PUBLIC_URL` 覆盖对外 origin
+- `GET /.well-known/oauth-authorization-server` — RFC 8414（PKCE S256、CIMD、iss 响应）；**公开**
+- `GET /authorize` → `/ui/oauth/authorize` — OAuth 同意页（Dashboard 会话）；`POST /oauth/token` / `POST /oauth/revoke`；管理页 `/ui/oauth/grants`
+- OAuth 存储：`DATA_DIR/oauth.json`（只存哈希；与 identities.json 同模式）
 - `POST /v1/identities` `{name?, localpart?}` → `201 {address, name?, pushContentTier, token}` (409 if taken)
 - `GET /v1/identities` → `{identities:[{address,name?,createdAt,pushContentTier,...}]}`
 - `GET /v1/identities/:address/push-tier` → `{address, pushContentTier, warning?}` (admin any; identity own only)

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { bearerAuth, resolveToken, type Auth } from './lib/auth.ts';
+import { bearerAuth, resolveUiSessionToken, type Auth } from './lib/auth.ts';
 import { config } from './lib/config.ts';
 import { JSON_BODY_LIMIT_BYTES } from './lib/limits.ts';
 import {
@@ -16,20 +16,27 @@ import { sendRoute } from './routes/send.ts';
 import { notifyRoute } from './routes/notify.ts';
 import { tasksRoute } from './routes/tasks.ts';
 import { agentCardRoute } from './routes/agent-card.ts';
+import { registerOAuthRoutes, type OAuthRouteOptions } from './routes/oauth.ts';
 import { createUiApiRoutes } from './routes/ui.ts';
 import { registerUiAssets } from './routes/ui-assets.ts';
 import { createUiFrameRoutes } from './routes/ui-frame.ts';
+import {
+  createUiOAuthApiRoutes,
+  createUiOAuthPageRoutes,
+} from './routes/ui-oauth.ts';
 
 type AppOptions = {
   uiEnabled?: boolean;
   tokenResolver?: (token: string) => Auth | null;
+  /** 测试可注入 CIMD fetcher。 */
+  oauth?: OAuthRouteOptions;
 };
 
 export function createApp(options: AppOptions = {}): Hono {
   const app = new Hono();
 
   app.get('/healthz', (c) => c.json({ ok: true }));
-  // PRM 必须在 agentCard 子应用之前注册，避免 /.well-known 前缀吞掉该路径。
+  // PRM / 8414 必须在 agentCard 子应用之前注册，避免 /.well-known 前缀吞掉路径。
   registerMcpHttpRoutes(app, {
     // OpenAgentEmailClient 固定 base `http://mcp.internal`；此处只取 pathname+search
     // 回环进本进程。host 必须是 mcp.internal，否则视为契约破坏（显式断言）。
@@ -54,6 +61,7 @@ export function createApp(options: AppOptions = {}): Hono {
       return app.request(url.pathname + url.search, init);
     },
   });
+  registerOAuthRoutes(app, options.oauth ?? {});
   app.route('/.well-known', agentCardRoute);
 
   // Bound allocation before auth or JSON parsing.
@@ -73,7 +81,8 @@ export function createApp(options: AppOptions = {}): Hono {
 
   if (options.uiEnabled ?? config.uiEnabled) {
     const uiSessions = new UiSessionStore({
-      resolveToken: options.tokenResolver ?? resolveToken,
+      // UI 会话默认拒 OAuth access；测试可经 tokenResolver 注入覆盖。
+      resolveToken: options.tokenResolver ?? resolveUiSessionToken,
     });
     registerUiAssets(app);
     app.use('/ui/api/session', uiSessionBodyLimit);
@@ -83,7 +92,9 @@ export function createApp(options: AppOptions = {}): Hono {
     // passes GET/HEAD/OPTIONS through, so this only guards the writes.
     app.use('/ui/api/*', uiSessionBodyLimit);
     app.use('/ui/api/*', requireUiOrigin);
+    app.route('/ui/api/oauth', createUiOAuthApiRoutes(uiSessions));
     app.route('/ui/api', createUiApiRoutes(uiSessions));
+    app.route('/ui/oauth', createUiOAuthPageRoutes(uiSessions, options.oauth ?? {}));
     app.route('/ui/frame', createUiFrameRoutes(uiSessions));
   }
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -9,6 +9,7 @@ import {
   requireUiOrigin,
   uiSessionBodyLimit,
 } from './lib/ui-session.ts';
+import { getMcpLoopbackBase } from './lib/mcp-loopback.ts';
 import { registerMcpHttpRoutes } from './mcp/http.ts';
 import { identitiesRoute } from './routes/identities.ts';
 import { messagesRoute } from './routes/messages.ts';
@@ -38,27 +39,36 @@ export function createApp(options: AppOptions = {}): Hono {
   app.get('/healthz', (c) => c.json({ ok: true }));
   // PRM / 8414 必须在 agentCard 子应用之前注册，避免 /.well-known 前缀吞掉路径。
   registerMcpHttpRoutes(app, {
-    // OpenAgentEmailClient 固定 base `http://mcp.internal`；此处只取 pathname+search
-    // 回环进本进程。host 必须是 mcp.internal，否则视为契约破坏（显式断言）。
+    // 工具回环：base 为外部 origin / MCP_PUBLIC_URL（见 mcp-loopback ALS）。
+    // 必须用完整绝对 URL 的 Request 走 app.fetch，使 /v1 的 c.req.url.origin
+    // 与 OAuth aud 同源——禁止额外 header 传信任（/v1 对外可达）。
     apiFetch: (input, init) => {
+      const expectedBase = getMcpLoopbackBase();
+      if (!expectedBase) {
+        throw new Error('mcp apiFetch: missing loopback public base context');
+      }
+      const expectedOrigin = new URL(expectedBase).origin;
+
+      let request: Request;
       if (typeof input !== 'string' && !(input instanceof URL) && init === undefined) {
-        const host = new URL(input.url).hostname;
-        if (host !== 'mcp.internal') {
-          throw new Error(`mcp apiFetch: unexpected host ${host}; expected mcp.internal`);
-        }
-        return app.fetch(input);
+        request = input;
+      } else {
+        const href =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url;
+        request = new Request(href, init);
       }
-      const href =
-        typeof input === 'string'
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input.url;
-      const url = new URL(href);
-      if (url.hostname !== 'mcp.internal') {
-        throw new Error(`mcp apiFetch: unexpected host ${url.hostname}; expected mcp.internal`);
+      const url = new URL(request.url);
+      if (url.origin !== expectedOrigin) {
+        throw new Error(
+          `mcp apiFetch: unexpected origin ${url.origin}; expected ${expectedOrigin}`,
+        );
       }
-      return app.request(url.pathname + url.search, init);
+      // 保留绝对 URL，供 bearerAuth 用同一 origin 推导 resource
+      return app.fetch(request);
     },
   });
   registerOAuthRoutes(app, options.oauth ?? {});

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -16,7 +16,7 @@
 import { createMiddleware } from 'hono/factory';
 import type { Context } from 'hono';
 import { config } from './config.ts';
-import { findIdentityByToken } from './identities.ts';
+import { findIdentity, findIdentityByToken } from './identities.ts';
 import { lookupAccessToken } from './oauth-store.ts';
 import { resolveResourceUri } from './oauth-url.ts';
 
@@ -83,6 +83,11 @@ export function resolveAccessToken(
   }
   if (oauth.aud !== expectedResource) {
     return { status: 'forbidden_audience' };
+  }
+
+  // 身份已删：票作废（与级联吊销互补；防竞态/旧库残留）
+  if (!findIdentity(oauth.address)) {
+    return { status: 'unauthorized' };
   }
 
   return {

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -1,11 +1,14 @@
 /**
- * Bearer-token auth middleware. Two kinds of tokens:
+ * Bearer-token auth middleware. Three kinds of tokens:
  *
  *   admin    — keys from the API_KEYS env. Full access: manage identities,
  *              read/send as any address.
  *   identity — per-identity scoped tokens issued by POST /v1/identities
  *              (hashed in the identity store). May only touch its own
  *              address; routes enforce the scope via `getAuth(c)`.
+ *   oauth    — opaque access tokens from the P3 Authorization Server.
+ *              Always map to identity scope (never admin). Require unexpired
+ *              + audience match against our MCP resource URI.
  *
  * All /v1/* routes sit behind this.
  */
@@ -14,6 +17,8 @@ import { createMiddleware } from 'hono/factory';
 import type { Context } from 'hono';
 import { config } from './config.ts';
 import { findIdentityByToken } from './identities.ts';
+import { lookupAccessToken } from './oauth-store.ts';
+import { resolveResourceUri } from './oauth-url.ts';
 
 export type Auth =
   | { kind: 'admin' }
@@ -25,13 +30,88 @@ declare module 'hono' {
   }
 }
 
+export type ResolveTokenOptions = {
+  /**
+   * 期望的 RFC 8707 resource / aud（通常为 `{base}/mcp`）。
+   * OAuth access 必须匹配；未提供时回落 MCP_PUBLIC_URL 推导值（若可解析）。
+   */
+  resource?: string;
+  /** 测试可注入时钟。 */
+  now?: number;
+};
+
+export type ResolveAccessResult =
+  | { status: 'ok'; auth: Auth }
+  | { status: 'unauthorized' }
+  | { status: 'forbidden_audience' };
+
+/**
+ * 解析凭证到授权范围（含 OAuth aud/过期细分）。
+ * /v1 与 /mcp 应走此入口，避免分叉。
+ */
+export function resolveAccessToken(
+  token: string,
+  options: ResolveTokenOptions = {},
+): ResolveAccessResult {
+  if (config.apiKeys.has(token)) {
+    return { status: 'ok', auth: { kind: 'admin' } };
+  }
+
+  const identity = findIdentityByToken(token);
+  if (identity) {
+    return { status: 'ok', auth: { kind: 'identity', address: identity.address } };
+  }
+
+  const oauth = lookupAccessToken(token, options.now);
+  if (oauth.status === 'missing') {
+    return { status: 'unauthorized' };
+  }
+  if (oauth.status === 'expired') {
+    return { status: 'unauthorized' };
+  }
+
+  // 安全红线：OAuth 票永远是 identity，永不升格 admin。
+  // aud 必须有外部期望值（请求 resource 或 MCP_PUBLIC_URL）；禁止用令牌自带 aud 自洽，
+  // 否则 UI session 等无 resource 入口会被 OAuth 票绕过观众校验。
+  let expectedResource = options.resource;
+  if (!expectedResource) {
+    try {
+      expectedResource = resolveResourceUri();
+    } catch {
+      return { status: 'unauthorized' };
+    }
+  }
+  if (oauth.aud !== expectedResource) {
+    return { status: 'forbidden_audience' };
+  }
+
+  return {
+    status: 'ok',
+    auth: { kind: 'identity', address: oauth.address },
+  };
+}
+
 /**
  * Resolve either supported credential to its authorization scope.
  *
  * Both Bearer auth and the UI session exchange call this function so token
  * rotation/deletion and admin-key semantics cannot drift between entrances.
+ * OAuth aud 不匹配时返回 null（与过期/无效同形）；需 403 的调用方请用 resolveAccessToken。
  */
-export function resolveToken(token: string): Auth | null {
+export function resolveToken(
+  token: string,
+  options: ResolveTokenOptions = {},
+): Auth | null {
+  const result = resolveAccessToken(token, options);
+  return result.status === 'ok' ? result.auth : null;
+}
+
+/**
+ * Dashboard UI 会话交换专用：只认 admin API_KEYS 与 oa_ identity 票。
+ * **永不**查 OAuth access 表——即使 MCP_PUBLIC_URL 已配置、aud 可解析，
+ * OAuth 票也不能换浏览器会话（防注入邮件诱导的持久化 UI 入口）。
+ */
+export function resolveUiSessionToken(token: string): Auth | null {
   if (config.apiKeys.has(token)) return { kind: 'admin' };
   const identity = findIdentityByToken(token);
   return identity ? { kind: 'identity', address: identity.address } : null;
@@ -43,11 +123,21 @@ export const bearerAuth = createMiddleware(async (c, next) => {
   if (!token) {
     return c.json({ error: 'unauthorized' }, 401);
   }
-  const auth = resolveToken(token);
-  if (auth) {
-    c.set('auth', auth);
+  const origin = new URL(c.req.url).origin;
+  let resource: string | undefined;
+  try {
+    resource = resolveResourceUri(origin);
+  } catch {
+    resource = undefined;
+  }
+  const result = resolveAccessToken(token, { resource });
+  if (result.status === 'ok') {
+    c.set('auth', result.auth);
     await next();
     return;
+  }
+  if (result.status === 'forbidden_audience') {
+    return c.json({ error: 'invalid_audience' }, 403);
   }
   return c.json({ error: 'unauthorized' }, 401);
 });

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -24,6 +24,7 @@ import {
 import { join } from 'node:path';
 import { createHash, randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
 import { config } from './config.ts';
+import { revokeGrantsForAddress } from './oauth-store.ts';
 
 /** Mail-arrival push content detail. 1 = interrupt only (default), 2 = +subject/from, 3 = +body preview/OTP. */
 export type PushContentTier = 1 | 2 | 3;
@@ -302,6 +303,11 @@ export function createIdentity(input: {
   name?: string;
   localpart?: string;
   canNotifyUser?: boolean;
+  /**
+   * 默认 true。同意页新建身份传 false：不发 oa_ 票，避免幽灵 token 落库。
+   * 此时返回的 token 为空串。
+   */
+  issueToken?: boolean;
 }): { identity: Identity; token: string } | null {
   const identities = load();
   let localpart = input.localpart?.toLowerCase();
@@ -324,13 +330,20 @@ export function createIdentity(input: {
   const address = `${localpart}@${config.domain}`;
   if (identities.some((i) => i.address === address)) return null;
 
-  const { token, tokenHash } = generateToken();
+  const issueToken = input.issueToken !== false;
+  let token = '';
+  let tokenHash: string | undefined;
+  if (issueToken) {
+    const generated = generateToken();
+    token = generated.token;
+    tokenHash = generated.tokenHash;
+  }
   const identity: Identity = {
     address,
     ...(input.name ? { name: input.name } : {}),
     ...(input.canNotifyUser ? { canNotifyUser: true } : {}),
     createdAt: new Date().toISOString(),
-    tokenHash,
+    ...(tokenHash ? { tokenHash } : {}),
   };
   identities.push(identity);
   save(identities);
@@ -355,6 +368,7 @@ export function rotateIdentityToken(address: string): string | null {
 /**
  * Remove an identity (its mail stays in the catch-all until retention
  * sweeps it). Returns false if the address didn't exist.
+ * 同步级联吊销该身份下全部 OAuth grant + access/refresh。
  */
 export function deleteIdentity(address: string): boolean {
   const identities = load();
@@ -362,6 +376,7 @@ export function deleteIdentity(address: string): boolean {
   const kept = identities.filter((i) => i.address !== needle);
   if (kept.length === identities.length) return false;
   save(kept);
+  revokeGrantsForAddress(needle);
   return true;
 }
 

--- a/packages/api/src/lib/mcp-loopback.ts
+++ b/packages/api/src/lib/mcp-loopback.ts
@@ -1,0 +1,19 @@
+/**
+ * /mcp → /v1 进程内回环的公共 base 上下文。
+ * 用 AsyncLocalStorage 传递「外部请求 origin / MCP_PUBLIC_URL」，
+ * 让 /v1 bearerAuth 的 c.req.url.origin 与 OAuth aud 同一条规则推导。
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const store = new AsyncLocalStorage<string>();
+
+/** 当前 MCP 工具回环应使用的绝对 base（无尾斜杠）。 */
+export function getMcpLoopbackBase(): string | undefined {
+  return store.getStore();
+}
+
+/** 在 publicBase 上下文中执行（POST /mcp 包裹工具调度）。 */
+export function runWithMcpLoopbackBase<T>(publicBase: string, fn: () => T): T {
+  return store.run(publicBase.replace(/\/+$/, ''), fn);
+}

--- a/packages/api/src/lib/net.ts
+++ b/packages/api/src/lib/net.ts
@@ -1,0 +1,118 @@
+/**
+ * 主机名 / IP 私网与 SSRF 判定的唯一共享实现。
+ * CIMD SSRF 与 MCP insecure-issuer 门闩都走这里，禁止再抄一份。
+ *
+ * 部署例外：本服务跑在 loopback/tailnet 时放行 RFC1918 / CGNAT / loopback / ULA；
+ * **169.254.0.0/16（云 metadata）与 0.0.0.0/8 永远拒绝**（含 IPv4-mapped）。P4 公网须收紧。
+ */
+
+import { isIP } from 'node:net';
+
+function normalizeHost(hostname: string): string {
+  return hostname.replace(/^\[(.+)\]$/, '$1').toLowerCase();
+}
+
+function isLoopbackIpv4(ip: string): boolean {
+  const [a] = ip.split('.').map(Number);
+  return a === 127;
+}
+
+/**
+ * 永拒：169.254.0.0/16（链路本地 / 云 metadata）、0.0.0.0/8。
+ * 与「私网放行清单」分离，便于单测对照。
+ */
+export function isBlockedSsrfIp(ip: string): boolean {
+  const host = normalizeHost(ip);
+  const v = isIP(host);
+  if (v === 4) {
+    const parts = host.split('.').map(Number);
+    if (parts.length !== 4 || parts.some((n) => n < 0 || n > 255)) return true;
+    const [a, b] = parts;
+    if (a === 0) return true; // 0.0.0.0/8
+    if (a === 169 && b === 254) return true; // 169.254.0.0/16
+    return false;
+  }
+  if (v === 6) {
+    // IPv4-mapped :ffff:169.254.x.x / :ffff:0.x.x.x
+    const mapped = ipv4MappedFromV6(host);
+    if (mapped) return isBlockedSsrfIp(mapped);
+    return false;
+  }
+  return true; // 非 IP 字面量交由 DNS 后再判
+}
+
+/** 部署例外下允许的私网 IPv4（含 loopback / CGNAT）。不含 169.254 / 0.0.0.0。 */
+export function isAllowedPrivateIpv4(ip: string): boolean {
+  const parts = ip.split('.').map(Number);
+  if (parts.length !== 4 || parts.some((n) => n < 0 || n > 255)) return false;
+  const [a, b] = parts;
+  if (a === 10) return true;
+  if (a === 192 && b === 168) return true;
+  if (a === 172 && b >= 16 && b <= 31) return true;
+  if (a === 100 && b >= 64 && b <= 127) return true; // CGNAT
+  if (a === 127) return true;
+  return false;
+}
+
+function isLoopbackOrUlaIpv6(host: string): boolean {
+  if (host === '::1') return true;
+  const first = host.split(':').find((p) => p.length > 0) ?? '';
+  // fd00::/8 ULA；fe80::/10 链路本地（与旧 http.ts 仅认 fd 不同——以本完整版为准）
+  return first.toLowerCase().startsWith('fd') || first.toLowerCase().startsWith('fe80');
+}
+
+function ipv4MappedFromV6(host: string): string | null {
+  const lower = host.toLowerCase();
+  const idx = lower.lastIndexOf(':ffff:');
+  if (idx === -1) return null;
+  const tail = lower.slice(idx + 6);
+  if (isIP(tail) === 4) return tail;
+  return null;
+}
+
+/**
+ * 判断 hostname 字面量是否为可放行的私网/loopback（未解析 DNS）。
+ * 169.254 / 0.0.0.0 **不算**私网（永拒段）。
+ */
+export function isPrivateOrLoopbackHostname(hostname: string): boolean {
+  const host = normalizeHost(hostname);
+  if (host === 'localhost' || host === '::1') return true;
+  // 永拒段即使是「特殊用途」也不得当作私网放行（含 v4-mapped）
+  if (isIP(host) !== 0 && isBlockedSsrfIp(host)) return false;
+  const ipVersion = isIP(host);
+  if (ipVersion === 4) return isAllowedPrivateIpv4(host) || isLoopbackIpv4(host);
+  if (ipVersion === 6) return isLoopbackOrUlaIpv6(host);
+  return false;
+}
+
+/** @deprecated 别名：旧 mcp/http 导出名，指向同一实现。 */
+export const isPrivateOrLoopbackHost = isPrivateOrLoopbackHostname;
+
+/**
+ * 解析后的每个 A/AAAA 必须通过 SSRF 策略。
+ * 永拒 169.254/0.0.0.0；私网/loopback 因 AS 同部署例外放行。
+ */
+export function isSsrfBlockedResolvedIp(ip: string): boolean {
+  if (isBlockedSsrfIp(ip)) return true;
+  const host = normalizeHost(ip);
+  const v = isIP(host);
+  if (v === 0) return true;
+  if (v === 4) {
+    if (isAllowedPrivateIpv4(host)) return false;
+    if (isSpecialUseIpv4BeyondAllowlist(host)) return true;
+    return false;
+  }
+  if (host === '::1' || isLoopbackOrUlaIpv6(host)) return false;
+  if (host === '::' || host.startsWith('ff')) return true;
+  return false;
+}
+
+function isSpecialUseIpv4BeyondAllowlist(ip: string): boolean {
+  const [a, b] = ip.split('.').map(Number);
+  if (a === 0) return true;
+  if (a === 169 && b === 254) return true;
+  if (a === 127) return false;
+  if (a >= 224) return true; // multicast / reserved
+  if (a === 100 && b >= 64 && b <= 127) return false;
+  return false;
+}

--- a/packages/api/src/lib/net.ts
+++ b/packages/api/src/lib/net.ts
@@ -2,8 +2,9 @@
  * 主机名 / IP 私网与 SSRF 判定的唯一共享实现。
  * CIMD SSRF 与 MCP insecure-issuer 门闩都走这里，禁止再抄一份。
  *
- * 部署例外：本服务跑在 loopback/tailnet 时放行 RFC1918 / CGNAT / loopback / ULA；
- * **169.254.0.0/16（云 metadata）与 0.0.0.0/8 永远拒绝**（含 IPv4-mapped）。P4 公网须收紧。
+ * 部署例外：本服务跑在 loopback/tailnet 时放行 RFC1918 / CGNAT / loopback / ULA(fd)；
+ * **永拒**：169.254.0.0/16、0.0.0.0/8、fe80::/10（与 IPv4 链路本地对齐）、
+ * fd00:ec2::/16（AWS IMDS IPv6）。含 IPv4-mapped。P4 公网须收紧。
  */
 
 import { isIP } from 'node:net';
@@ -17,9 +18,94 @@ function isLoopbackIpv4(ip: string): boolean {
   return a === 127;
 }
 
+/** fe80::/10：前 10 位为 1111111010（即首 hextet 的高 10 位）。 */
+export function isFe80LinkLocalIpv6(host: string): boolean {
+  const h = normalizeHost(host);
+  if (isIP(h) !== 6) return false;
+  // 展开压缩以便读首 hextet
+  const parts = expandIpv6Hextets(h);
+  if (!parts) return false;
+  const first = Number.parseInt(parts[0]!, 16);
+  // 0xfe80 >> 6 == 0x3fa；等价于 (first & 0xffc0) === 0xfe80
+  return (first & 0xffc0) === 0xfe80;
+}
+
+/** AWS IMDS IPv6：fd00:ec2::/16 */
+export function isAwsImdsIpv6(host: string): boolean {
+  const h = normalizeHost(host);
+  if (isIP(h) !== 6) return false;
+  const parts = expandIpv6Hextets(h);
+  if (!parts) return false;
+  return parts[0] === 'fd00' && parts[1] === '0ec2';
+}
+
+function expandIpv6Hextets(host: string): string[] | null {
+  const raw = host.toLowerCase();
+  if (raw.includes('.')) {
+    // IPv4-mapped 内嵌点分：先抽 v4 再展开前缀
+    const mapped = ipv4MappedFromV6(raw);
+    if (!mapped) return null;
+  }
+  let [head, tail] = raw.split('::');
+  if (tail === undefined) {
+    const parts = raw.split(':');
+    if (parts.length !== 8) return null;
+    return parts.map((p) => p.padStart(4, '0'));
+  }
+  const left = head ? head.split(':') : [];
+  const right = tail ? tail.split(':') : [];
+  // 内嵌 IPv4 时右侧最后一段可能是 a.b.c.d
+  if (right.length && right[right.length - 1]!.includes('.')) {
+    const v4 = right.pop()!;
+    const nums = v4.split('.').map(Number);
+    if (nums.length !== 4 || nums.some((n) => n < 0 || n > 255)) return null;
+    right.push(
+      ((nums[0]! << 8) | nums[1]!).toString(16).padStart(4, '0'),
+      ((nums[2]! << 8) | nums[3]!).toString(16).padStart(4, '0'),
+    );
+  }
+  const missing = 8 - left.length - right.length;
+  if (missing < 0) return null;
+  const mid = Array.from({ length: missing }, () => '0000');
+  return [...left, ...mid, ...right].map((p) => p.padStart(4, '0'));
+}
+
 /**
- * 永拒：169.254.0.0/16（链路本地 / 云 metadata）、0.0.0.0/8。
- * 与「私网放行清单」分离，便于单测对照。
+ * 从 IPv6 抽出 IPv4-mapped 的点分 v4。
+ * 支持：
+ * - ::ffff:169.254.1.1
+ * - ::ffff:a9fe:a9fe（URL 规范化后的十六进制形）
+ * - ::ffff:0:a.b.c.d
+ */
+export function ipv4MappedFromV6(host: string): string | null {
+  const lower = normalizeHost(host);
+  if (isIP(lower) !== 6 && !lower.includes(':ffff:')) {
+    // 仍尝试：部分形式 isIP 可识别
+  }
+  const idx = lower.lastIndexOf(':ffff:');
+  if (idx === -1) return null;
+  const tail = lower.slice(idx + ':ffff:'.length);
+  if (isIP(tail) === 4) return tail;
+
+  // ::ffff:0:a.b.c.d → 丢掉中间的 0:
+  const maybeSkip = /^0:(.+)$/.exec(tail);
+  if (maybeSkip && isIP(maybeSkip[1]!) === 4) return maybeSkip[1]!;
+
+  // ::ffff:HHHH:LLLL 十六进制两 hextet → 4 字节
+  const hexParts = tail.split(':');
+  if (hexParts.length === 2) {
+    const hi = Number.parseInt(hexParts[0]!, 16);
+    const lo = Number.parseInt(hexParts[1]!, 16);
+    if (Number.isFinite(hi) && Number.isFinite(lo) && hi <= 0xffff && lo <= 0xffff) {
+      return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+    }
+  }
+  return null;
+}
+
+/**
+ * 永拒：169.254/16、0.0.0.0/8、fe80::/10、fd00:ec2::/16。
+ * 与「私网放行清单」分离。
  */
 export function isBlockedSsrfIp(ip: string): boolean {
   const host = normalizeHost(ip);
@@ -33,9 +119,10 @@ export function isBlockedSsrfIp(ip: string): boolean {
     return false;
   }
   if (v === 6) {
-    // IPv4-mapped :ffff:169.254.x.x / :ffff:0.x.x.x
     const mapped = ipv4MappedFromV6(host);
     if (mapped) return isBlockedSsrfIp(mapped);
+    if (isFe80LinkLocalIpv6(host)) return true;
+    if (isAwsImdsIpv6(host)) return true;
     return false;
   }
   return true; // 非 IP 字面量交由 DNS 后再判
@@ -54,34 +141,30 @@ export function isAllowedPrivateIpv4(ip: string): boolean {
   return false;
 }
 
-function isLoopbackOrUlaIpv6(host: string): boolean {
+function isUlaIpv6(host: string): boolean {
   if (host === '::1') return true;
-  const first = host.split(':').find((p) => p.length > 0) ?? '';
-  // fd00::/8 ULA；fe80::/10 链路本地（与旧 http.ts 仅认 fd 不同——以本完整版为准）
-  return first.toLowerCase().startsWith('fd') || first.toLowerCase().startsWith('fe80');
-}
-
-function ipv4MappedFromV6(host: string): string | null {
-  const lower = host.toLowerCase();
-  const idx = lower.lastIndexOf(':ffff:');
-  if (idx === -1) return null;
-  const tail = lower.slice(idx + 6);
-  if (isIP(tail) === 4) return tail;
-  return null;
+  const parts = expandIpv6Hextets(host);
+  if (!parts) {
+    const first = host.split(':').find((p) => p.length > 0) ?? '';
+    return first.toLowerCase().startsWith('fd');
+  }
+  // fd00::/8 ULA；排除 fd00:ec2::/16（已永拒）
+  if (!parts[0]!.startsWith('fd')) return false;
+  if (isAwsImdsIpv6(host)) return false;
+  return true;
 }
 
 /**
  * 判断 hostname 字面量是否为可放行的私网/loopback（未解析 DNS）。
- * 169.254 / 0.0.0.0 **不算**私网（永拒段）。
+ * 永拒段（含 fe80 / 169.254 / fd00:ec2）**不算**私网。
  */
 export function isPrivateOrLoopbackHostname(hostname: string): boolean {
   const host = normalizeHost(hostname);
   if (host === 'localhost' || host === '::1') return true;
-  // 永拒段即使是「特殊用途」也不得当作私网放行（含 v4-mapped）
   if (isIP(host) !== 0 && isBlockedSsrfIp(host)) return false;
   const ipVersion = isIP(host);
   if (ipVersion === 4) return isAllowedPrivateIpv4(host) || isLoopbackIpv4(host);
-  if (ipVersion === 6) return isLoopbackOrUlaIpv6(host);
+  if (ipVersion === 6) return isUlaIpv6(host);
   return false;
 }
 
@@ -90,7 +173,7 @@ export const isPrivateOrLoopbackHost = isPrivateOrLoopbackHostname;
 
 /**
  * 解析后的每个 A/AAAA 必须通过 SSRF 策略。
- * 永拒 169.254/0.0.0.0；私网/loopback 因 AS 同部署例外放行。
+ * 永拒名单见 isBlockedSsrfIp；RFC1918/CGNAT/loopback/ULA(fd) 因部署例外放行。
  */
 export function isSsrfBlockedResolvedIp(ip: string): boolean {
   if (isBlockedSsrfIp(ip)) return true;
@@ -102,7 +185,7 @@ export function isSsrfBlockedResolvedIp(ip: string): boolean {
     if (isSpecialUseIpv4BeyondAllowlist(host)) return true;
     return false;
   }
-  if (host === '::1' || isLoopbackOrUlaIpv6(host)) return false;
+  if (host === '::1' || isUlaIpv6(host)) return false;
   if (host === '::' || host.startsWith('ff')) return true;
   return false;
 }
@@ -112,7 +195,7 @@ function isSpecialUseIpv4BeyondAllowlist(ip: string): boolean {
   if (a === 0) return true;
   if (a === 169 && b === 254) return true;
   if (a === 127) return false;
-  if (a >= 224) return true; // multicast / reserved
+  if (a >= 224) return true;
   if (a === 100 && b >= 64 && b <= 127) return false;
   return false;
 }

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -1,0 +1,344 @@
+/**
+ * CIMD（Client ID Metadata Documents）校验器。
+ * 规范锚点 draft-ietf-oauth-client-id-metadata-document-00；SSRF/200 按 -01 MUST。
+ *
+ * SSRF 部署例外（写进注释与 PR）：本 AS 跑在 loopback/tailnet 私网，验收模拟
+ * 客户端 CIMD 也开在私网 → 放行 RFC1918 / CGNAT / loopback；
+ * **169.254.0.0/16（云 metadata）与 0.0.0.0/8 永远拒绝**。P4 公网部署须收紧。
+ */
+
+import { lookup } from 'node:dns/promises';
+import { isIP } from 'node:net';
+import {
+  isPrivateOrLoopbackHostname,
+  isSsrfBlockedResolvedIp,
+} from './net.ts';
+
+// 再导出：既有测试从本模块导入 SSRF 助手；实现唯一在 lib/net.ts。
+export {
+  isBlockedSsrfIp,
+  isPrivateOrLoopbackHostname,
+  isSsrfBlockedResolvedIp,
+} from './net.ts';
+
+export const CIMD_FETCH_TIMEOUT_MS = 10_000;
+export const CIMD_MAX_BYTES = 5 * 1024;
+/** 缓存下限 60s、上限 7 天（对齐 Cloudflare 封顶惯例）。 */
+export const CIMD_CACHE_MIN_S = 60;
+export const CIMD_CACHE_MAX_S = 7 * 24 * 60 * 60;
+
+export type CimdDocument = {
+  client_id: string;
+  client_name: string;
+  redirect_uris: string[];
+  token_endpoint_auth_method?: string;
+};
+
+export type CimdFetchResult =
+  | { ok: true; doc: CimdDocument }
+  | { ok: false; reason: string };
+
+export type Fetcher = (
+  url: string,
+  init: RequestInit,
+) => Promise<Response>;
+
+/** 测试可注入的窄 DNS 查找（避免绑死 node:dns/promises lookup 全重载）。 */
+export type DnsLookup = (
+  hostname: string,
+) => Promise<Array<{ address: string; family: number }>>;
+
+type CacheEntry = {
+  doc: CimdDocument;
+  expiresAt: number;
+};
+
+const cache = new Map<string, CacheEntry>();
+
+/** 测试用清空 CIMD 缓存。 */
+export function clearCimdCacheForTests(): void {
+  cache.clear();
+}
+
+/**
+ * client_id URL 合法性（CIMD MUST）。
+ * https + 含 path；禁 `.`/`..` 段、fragment、userinfo；本实现拒 query（规范 SHOULD NOT）。
+ */
+export function validateClientIdUrl(clientId: string): { ok: true; url: URL } | { ok: false; reason: string } {
+  // 点段 / fragment / query 检查兼顾原始串：`new URL` 会规范化 `/./a` → `/a`。
+  let url: URL;
+  try {
+    url = new URL(clientId);
+  } catch {
+    return { ok: false, reason: 'client_id_not_url' };
+  }
+  if (url.protocol !== 'https:') {
+    // 私网 dogfood：允许 http 仅当 host 为 loopback/私网（与 AS 同部署例外一致）
+    if (url.protocol !== 'http:' || !isPrivateOrLoopbackHostname(url.hostname)) {
+      return { ok: false, reason: 'client_id_not_https' };
+    }
+  }
+  if (!url.pathname || url.pathname === '/') {
+    return { ok: false, reason: 'client_id_missing_path' };
+  }
+  if (url.username || url.password) {
+    return { ok: false, reason: 'client_id_has_userinfo' };
+  }
+  // 原始串含 # 即视为 fragment（规范化后 hash 可能仍在）
+  if (url.hash || clientId.includes('#')) {
+    return { ok: false, reason: 'client_id_has_fragment' };
+  }
+  if (url.search || clientId.includes('?')) {
+    return { ok: false, reason: 'client_id_has_query' };
+  }
+  // 从原始 path 取段（authority 之后、?/# 之前），避免规范化吞掉 `.`/`..`
+  const rawPath = rawUrlPath(clientId);
+  const segments = rawPath.split('/').filter((s) => s.length > 0);
+  if (segments.some((s) => s === '.' || s === '..')) {
+    return { ok: false, reason: 'client_id_dot_segment' };
+  }
+  return { ok: true, url };
+}
+
+/** 提取 URL 原始 path（未百分号解码、未去点段）。 */
+function rawUrlPath(clientId: string): string {
+  const withoutFrag = clientId.split('#')[0] ?? clientId;
+  const withoutQuery = withoutFrag.split('?')[0] ?? withoutFrag;
+  const schemeIdx = withoutQuery.indexOf('://');
+  if (schemeIdx < 0) return withoutQuery;
+  const afterScheme = withoutQuery.slice(schemeIdx + 3);
+  const pathIdx = afterScheme.indexOf('/');
+  if (pathIdx < 0) return '/';
+  return afterScheme.slice(pathIdx);
+}
+
+async function defaultDnsLookup(
+  hostname: string,
+): Promise<Array<{ address: string; family: number }>> {
+  const results = await lookup(hostname, { all: true, verbatim: true });
+  const list = Array.isArray(results) ? results : [results];
+  return list.map((r) =>
+    typeof r === 'string'
+      ? { address: r, family: 0 }
+      : { address: r.address, family: r.family },
+  );
+}
+
+/** DNS 解析并对每个地址做 SSRF 检查。 */
+export async function assertClientIdHostSafe(
+  hostname: string,
+  dnsLookup: DnsLookup = defaultDnsLookup,
+): Promise<{ ok: true } | { ok: false; reason: string }> {
+  const host = hostname.replace(/^\[(.+)\]$/, '$1');
+  if (isIP(host)) {
+    if (isSsrfBlockedResolvedIp(host)) {
+      return { ok: false, reason: 'ssrf_blocked_ip' };
+    }
+    return { ok: true };
+  }
+  try {
+    const list = await dnsLookup(host);
+    if (list.length === 0) return { ok: false, reason: 'dns_empty' };
+    for (const r of list) {
+      if (isSsrfBlockedResolvedIp(r.address)) {
+        return { ok: false, reason: 'ssrf_blocked_ip' };
+      }
+    }
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: 'dns_failed' };
+  }
+}
+
+/** RFC 8252：loopback redirect 比较时忽略端口。 */
+export function redirectUrisMatch(requested: string, registered: string): boolean {
+  let a: URL;
+  let b: URL;
+  try {
+    a = new URL(requested);
+    b = new URL(registered);
+  } catch {
+    return false;
+  }
+  if (a.protocol !== b.protocol) return false;
+  if (a.username || b.username || a.password || b.password) return false;
+  if (a.hash || b.hash) return false;
+  // 路径 + query 精确
+  if (a.pathname !== b.pathname || a.search !== b.search) return false;
+
+  const aHost = a.hostname.replace(/^\[(.+)\]$/, '$1').toLowerCase();
+  const bHost = b.hostname.replace(/^\[(.+)\]$/, '$1').toLowerCase();
+  if (aHost !== bHost) return false;
+
+  if (isLoopbackHostname(aHost)) {
+    // 忽略端口
+    return true;
+  }
+  return a.port === b.port;
+}
+
+function isLoopbackHostname(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === 'localhost' || h === '::1') return true;
+  if (isIP(h) === 4) {
+    const [a] = h.split('.').map(Number);
+    return a === 127;
+  }
+  return false;
+}
+
+export function redirectUriIsLoopback(redirectUri: string): boolean {
+  try {
+    const u = new URL(redirectUri);
+    return isLoopbackHostname(u.hostname.replace(/^\[(.+)\]$/, '$1'));
+  } catch {
+    return false;
+  }
+}
+
+function parseCacheMaxAge(header: string | null): number | null {
+  if (!header) return null;
+  const m = /(?:^|,)\s*max-age\s*=\s*(\d+)/i.exec(header);
+  if (!m) return null;
+  return Number(m[1]);
+}
+
+function cacheTtlSeconds(res: Response): number {
+  const cc = res.headers.get('cache-control');
+  if (cc && /no-store|no-cache/i.test(cc)) return 0;
+  const maxAge = parseCacheMaxAge(cc);
+  if (maxAge === null) return CIMD_CACHE_MIN_S;
+  if (maxAge <= 0) return 0;
+  return Math.min(CIMD_CACHE_MAX_S, Math.max(CIMD_CACHE_MIN_S, maxAge));
+}
+
+function validateDocument(
+  clientId: string,
+  json: unknown,
+): CimdFetchResult {
+  if (!json || typeof json !== 'object' || Array.isArray(json)) {
+    return { ok: false, reason: 'cimd_not_object' };
+  }
+  const doc = json as Record<string, unknown>;
+  if (typeof doc.client_id !== 'string' || doc.client_id !== clientId) {
+    // 逐字符一致（RFC 3986 simple string comparison）
+    return { ok: false, reason: 'client_id_mismatch' };
+  }
+  if (typeof doc.client_name !== 'string' || !doc.client_name.trim()) {
+    return { ok: false, reason: 'missing_client_name' };
+  }
+  if (!Array.isArray(doc.redirect_uris) || doc.redirect_uris.length === 0) {
+    return { ok: false, reason: 'missing_redirect_uris' };
+  }
+  if (!doc.redirect_uris.every((u) => typeof u === 'string' && u.length > 0)) {
+    return { ok: false, reason: 'invalid_redirect_uris' };
+  }
+
+  // 禁一切 client_secret*
+  for (const key of Object.keys(doc)) {
+    if (key.startsWith('client_secret')) {
+      return { ok: false, reason: 'client_secret_forbidden' };
+    }
+  }
+
+  const method =
+    typeof doc.token_endpoint_auth_method === 'string'
+      ? doc.token_endpoint_auth_method
+      : 'none';
+  if (method !== 'none') {
+    // 声明 private_key_jwt 等一律拒（本 AS 只接受 none）
+    return { ok: false, reason: 'auth_method_unsupported' };
+  }
+
+  return {
+    ok: true,
+    doc: {
+      client_id: doc.client_id,
+      client_name: doc.client_name.trim(),
+      redirect_uris: doc.redirect_uris as string[],
+      token_endpoint_auth_method: 'none',
+    },
+  };
+}
+
+/**
+ * 拉取并校验 CIMD。可注入 fetcher（测试不启真 HTTP）。
+ * MUST NOT 跟随重定向；MUST 200；响应限 5KB。
+ */
+export async function fetchClientMetadata(
+  clientId: string,
+  options: {
+    fetcher?: Fetcher;
+    dnsLookup?: DnsLookup;
+    now?: number;
+  } = {},
+): Promise<CimdFetchResult> {
+  const now = options.now ?? Date.now();
+  const cached = cache.get(clientId);
+  if (cached && cached.expiresAt > now) {
+    return { ok: true, doc: cached.doc };
+  }
+
+  const urlCheck = validateClientIdUrl(clientId);
+  if (!urlCheck.ok) return urlCheck;
+
+  const hostSafe = await assertClientIdHostSafe(
+    urlCheck.url.hostname,
+    options.dnsLookup,
+  );
+  if (!hostSafe.ok) return hostSafe;
+
+  const fetcher = options.fetcher ?? defaultFetcher;
+  let res: Response;
+  try {
+    res = await fetcher(clientId, {
+      method: 'GET',
+      redirect: 'manual',
+      headers: { accept: 'application/json' },
+      signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),
+    });
+  } catch {
+    return { ok: false, reason: 'fetch_failed' };
+  }
+
+  // 3xx：MUST NOT 跟随
+  if (res.status >= 300 && res.status < 400) {
+    return { ok: false, reason: 'redirect_forbidden' };
+  }
+  if (res.status !== 200) {
+    return { ok: false, reason: 'http_not_200' };
+  }
+
+  const buf = Buffer.from(await res.arrayBuffer());
+  if (buf.byteLength > CIMD_MAX_BYTES) {
+    return { ok: false, reason: 'response_too_large' };
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(buf.toString('utf8'));
+  } catch {
+    return { ok: false, reason: 'invalid_json' };
+  }
+
+  const validated = validateDocument(clientId, json);
+  if (!validated.ok) return validated;
+
+  const ttl = cacheTtlSeconds(res);
+  if (ttl > 0) {
+    cache.set(clientId, { doc: validated.doc, expiresAt: now + ttl * 1000 });
+  }
+  return validated;
+}
+
+async function defaultFetcher(url: string, init: RequestInit): Promise<Response> {
+  return fetch(url, init);
+}
+
+/** 授权请求的 redirect_uri 是否在文档列表中（含 loopback 端口放宽）。 */
+export function matchRedirectUri(
+  requested: string,
+  registered: string[],
+): boolean {
+  return registered.some((r) => redirectUrisMatch(requested, r));
+}

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -156,10 +156,35 @@ export async function assertClientIdHostSafe(
 }
 
 /**
+ * redirect_uri scheme 白名单（CIMD 文档与匹配共用）。
+ * - https：一律放行
+ * - http：仅 loopback（IP 字面量 127/::1 或 localhost 主机名）
+ * - 其余（javascript:/data:/file:/自定义私有 scheme）一律拒
+ */
+export function isAllowedRedirectUri(uri: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (url.protocol === 'https:') return true;
+  if (url.protocol === 'http:') {
+    const host = url.hostname.replace(/^\[(.+)\]$/, '$1');
+    return isLoopbackHostname(host);
+  }
+  return false;
+}
+
+/**
  * RFC 8252 §7.3：仅 http + IP 字面量（127.0.0.1 / [::1]）比较时忽略端口。
  * localhost 主机名与 https 仍精确匹配端口。
  */
 export function redirectUrisMatch(requested: string, registered: string): boolean {
+  // 两侧都必须过 scheme 白名单（防存量脏数据 / 精确匹配绕过）
+  if (!isAllowedRedirectUri(requested) || !isAllowedRedirectUri(registered)) {
+    return false;
+  }
   let a: URL;
   let b: URL;
   try {
@@ -251,6 +276,10 @@ function validateDocument(
   }
   if (!doc.redirect_uris.every((u) => typeof u === 'string' && u.length > 0)) {
     return { ok: false, reason: 'invalid_redirect_uris' };
+  }
+  // scheme 白名单：禁 javascript:/data: 等（过渡页可点链接/meta refresh 的 XSS 面）
+  if (!doc.redirect_uris.every((u) => typeof u === 'string' && isAllowedRedirectUri(u))) {
+    return { ok: false, reason: 'redirect_uri_scheme_forbidden' };
   }
 
   // 禁一切 client_secret*
@@ -346,8 +375,8 @@ export async function pinnedCimdFetcher(
         path: `${url.pathname}${url.search}`,
         method: (init.method as string) || 'GET',
         headers,
-        // https：显式 SNI = 原始 hostname（即使 dial 到解析 IP）
-        servername: isHttps ? literal : undefined,
+        // https：非 IP 字面量时显式 SNI；直连 IP 不设 servername（交系统默认）
+        servername: isHttps && !isIP(literal) ? literal : undefined,
         // 连接时解析并对每个结果跑 SSRF（钉死，消灭校验/fetch 间 TOCTOU）
         lookup: ((hostname, options, callback) => {
           const fail = (err: NodeJS.ErrnoException) => {

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -127,8 +127,10 @@ async function defaultDnsLookup(
 }
 
 /**
- * DNS 解析并对每个地址做 SSRF 检查（测试/字面量预检用）。
- * 生产 CIMD 默认传输在连接 lookup 内再钉一次，避免 TOCTOU。
+ * DNS 解析并对每个地址做 SSRF 检查。
+ *
+ * **警示：仅供预检/测试。** 生产必须走 `pinnedCimdFetcher` 的连接期钉死 lookup，
+ * 禁止「校验后直接 fetch」——二者之间存在 DNS-rebinding TOCTOU 窗口。
  */
 export async function assertClientIdHostSafe(
   hostname: string,
@@ -473,13 +475,14 @@ export async function fetchClientMetadata(
   } = {},
 ): Promise<CimdFetchResult> {
   const now = options.now ?? Date.now();
-  const cached = cache.get(clientId);
+  const urlCheck = validateClientIdUrl(clientId);
+  if (!urlCheck.ok) return urlCheck;
+  // 缓存键用规范化后的 href（避免大小写/尾斜杠等变体分裂缓存）
+  const cacheKey = urlCheck.url.href;
+  const cached = cache.get(cacheKey);
   if (cached && cached.expiresAt > now) {
     return { ok: true, doc: cached.doc };
   }
-
-  const urlCheck = validateClientIdUrl(clientId);
-  if (!urlCheck.ok) return urlCheck;
 
   // 字面量 IP：连接前预检。主机名 SSRF 留给连接 lookup（钉死，无二次解析窗口）。
   const host = urlCheck.url.hostname.replace(/^\[(.+)\]$/, '$1');
@@ -552,7 +555,7 @@ export async function fetchClientMetadata(
 
   const ttl = cacheTtlSeconds(res);
   if (ttl > 0) {
-    cache.set(clientId, { doc: validated.doc, expiresAt: now + ttl * 1000 });
+    cache.set(cacheKey, { doc: validated.doc, expiresAt: now + ttl * 1000 });
   }
   return validated;
 }

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -4,15 +4,17 @@
  *
  * SSRF 部署例外（写进注释与 PR）：本 AS 跑在 loopback/tailnet 私网，验收模拟
  * 客户端 CIMD 也开在私网 → 放行 RFC1918 / CGNAT / loopback；
- * **169.254.0.0/16（云 metadata）与 0.0.0.0/8 永远拒绝**。P4 公网部署须收紧。
+ * **永拒**：169.254.0.0/16、0.0.0.0/8、fe80::/10、fd00:ec2::/16。P4 公网部署须收紧。
+ *
+ * DNS-rebinding：不在校验后再另开一次 DNS；连接时用自定义 lookup 钉死，
+ * 对连接实际使用的每个解析结果跑 SSRF；https 保留 SNI/Host。
  */
 
-import { lookup } from 'node:dns/promises';
-import { isIP } from 'node:net';
-import {
-  isPrivateOrLoopbackHostname,
-  isSsrfBlockedResolvedIp,
-} from './net.ts';
+import { lookup as dnsLookupAll } from 'node:dns/promises';
+import http from 'node:http';
+import https from 'node:https';
+import { isIP, type LookupFunction } from 'node:net';
+import { isPrivateOrLoopbackHostname, isSsrfBlockedResolvedIp } from './net.ts';
 
 // 再导出：既有测试从本模块导入 SSRF 助手；实现唯一在 lib/net.ts。
 export {
@@ -115,7 +117,7 @@ function rawUrlPath(clientId: string): string {
 async function defaultDnsLookup(
   hostname: string,
 ): Promise<Array<{ address: string; family: number }>> {
-  const results = await lookup(hostname, { all: true, verbatim: true });
+  const results = await dnsLookupAll(hostname, { all: true, verbatim: true });
   const list = Array.isArray(results) ? results : [results];
   return list.map((r) =>
     typeof r === 'string'
@@ -124,7 +126,10 @@ async function defaultDnsLookup(
   );
 }
 
-/** DNS 解析并对每个地址做 SSRF 检查。 */
+/**
+ * DNS 解析并对每个地址做 SSRF 检查（测试/字面量预检用）。
+ * 生产 CIMD 默认传输在连接 lookup 内再钉一次，避免 TOCTOU。
+ */
 export async function assertClientIdHostSafe(
   hostname: string,
   dnsLookup: DnsLookup = defaultDnsLookup,
@@ -150,7 +155,10 @@ export async function assertClientIdHostSafe(
   }
 }
 
-/** RFC 8252：loopback redirect 比较时忽略端口。 */
+/**
+ * RFC 8252 §7.3：仅 http + IP 字面量（127.0.0.1 / [::1]）比较时忽略端口。
+ * localhost 主机名与 https 仍精确匹配端口。
+ */
 export function redirectUrisMatch(requested: string, registered: string): boolean {
   let a: URL;
   let b: URL;
@@ -170,11 +178,22 @@ export function redirectUrisMatch(requested: string, registered: string): boolea
   const bHost = b.hostname.replace(/^\[(.+)\]$/, '$1').toLowerCase();
   if (aHost !== bHost) return false;
 
-  if (isLoopbackHostname(aHost)) {
-    // 忽略端口
+  // 仅 http + IP 字面量忽端口（RFC 8252 精确口径）
+  if (a.protocol === 'http:' && isIpLiteralLoopback(aHost)) {
     return true;
   }
   return a.port === b.port;
+}
+
+/** 127.0.0.0/8 或 ::1 字面量（不含 localhost 主机名）。 */
+function isIpLiteralLoopback(host: string): boolean {
+  const h = host.toLowerCase();
+  if (h === '::1') return true;
+  if (isIP(h) === 4) {
+    const [a] = h.split('.').map(Number);
+    return a === 127;
+  }
+  return false;
 }
 
 function isLoopbackHostname(host: string): boolean {
@@ -261,9 +280,160 @@ function validateDocument(
   };
 }
 
+/** 流式读取响应体，超过 CIMD_MAX_BYTES 截断失败（不整缓冲 arrayBuffer）。 */
+async function readBodyCapped(
+  stream: NodeJS.ReadableStream,
+  maxBytes: number,
+): Promise<{ ok: true; buf: Buffer } | { ok: false; reason: 'response_too_large' }> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.byteLength;
+    if (total > maxBytes) {
+      // 尽早停读，避免大响应占内存
+      const maybeDestroy = (stream as unknown as { destroy?: () => void }).destroy;
+      if (typeof maybeDestroy === 'function') maybeDestroy.call(stream);
+      return { ok: false, reason: 'response_too_large' };
+    }
+    chunks.push(buf);
+  }
+  return { ok: true, buf: Buffer.concat(chunks) };
+}
+
+/**
+ * 默认 CIMD 传输：node:http(s) + 连接时 lookup 钉死 SSRF。
+ * Host / SNI 仍用原始 hostname；实际 TCP 目标由 lookup 结果决定。
+ */
+export async function pinnedCimdFetcher(
+  urlStr: string,
+  init: RequestInit = {},
+  dnsLookup: DnsLookup = defaultDnsLookup,
+): Promise<Response> {
+  const url = new URL(urlStr);
+  const isHttps = url.protocol === 'https:';
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('unsupported_protocol');
+  }
+
+  // IP 字面量：连接前即判黑名单（无 DNS TOCTOU）
+  const literal = url.hostname.replace(/^\[(.+)\]$/, '$1');
+  if (isIP(literal) && isSsrfBlockedResolvedIp(literal)) {
+    throw new Error('ssrf_blocked_ip');
+  }
+
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    host: url.host,
+  };
+  if (init.headers) {
+    const h = new Headers(init.headers);
+    h.forEach((v, k) => {
+      if (k.toLowerCase() === 'host') return;
+      headers[k] = v;
+    });
+  }
+
+  const lib = isHttps ? https : http;
+  const timeoutMs = CIMD_FETCH_TIMEOUT_MS;
+
+  return new Promise<Response>((resolve, reject) => {
+    const req = lib.request(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port || (isHttps ? 443 : 80),
+        path: `${url.pathname}${url.search}`,
+        method: (init.method as string) || 'GET',
+        headers,
+        // https：显式 SNI = 原始 hostname（即使 dial 到解析 IP）
+        servername: isHttps ? literal : undefined,
+        // 连接时解析并对每个结果跑 SSRF（钉死，消灭校验/fetch 间 TOCTOU）
+        lookup: ((hostname, options, callback) => {
+          const fail = (err: NodeJS.ErrnoException) => {
+            // LookupFunction 要求 (err, address, family) 三参
+            callback(err, '', 4);
+          };
+          void (async () => {
+            try {
+              const list = await dnsLookup(hostname.replace(/^\[(.+)\]$/, '$1'));
+              if (list.length === 0) {
+                fail(Object.assign(new Error('dns_empty'), { code: 'ENOTFOUND' }));
+                return;
+              }
+              for (const r of list) {
+                if (isSsrfBlockedResolvedIp(r.address)) {
+                  fail(Object.assign(new Error('ssrf_blocked_ip'), { code: 'EACCES' }));
+                  return;
+                }
+              }
+              const mapped = list.map((r) => ({
+                address: r.address,
+                family: (r.family === 6 ? 6 : 4) as 4 | 6,
+              }));
+              const opts = options as { all?: boolean } | number | undefined;
+              const wantAll =
+                typeof opts === 'object' && opts !== null && Boolean(opts.all);
+              if (wantAll) {
+                (callback as (err: Error | null, addresses: typeof mapped) => void)(
+                  null,
+                  mapped,
+                );
+              } else {
+                const first = mapped[0]!;
+                callback(null, first.address, first.family);
+              }
+            } catch (err) {
+              fail(err as NodeJS.ErrnoException);
+            }
+          })();
+        }) as LookupFunction,
+      },
+      (res) => {
+        void (async () => {
+          try {
+            const capped = await readBodyCapped(res, CIMD_MAX_BYTES);
+            if (!capped.ok) {
+              res.resume();
+              reject(new Error(capped.reason));
+              return;
+            }
+            const headerInit: Record<string, string> = {};
+            for (const [k, v] of Object.entries(res.headers)) {
+              if (typeof v === 'string') headerInit[k] = v;
+              else if (Array.isArray(v)) headerInit[k] = v.join(', ');
+            }
+            resolve(
+              new Response(capped.buf, {
+                status: res.statusCode ?? 0,
+                headers: headerInit,
+              }),
+            );
+          } catch (err) {
+            reject(err);
+          }
+        })();
+      },
+    );
+
+    req.setTimeout(timeoutMs, () => {
+      req.destroy(new Error('timeout'));
+    });
+    req.on('error', reject);
+
+    // MUST NOT 跟随重定向：node http 默认不跟随；3xx 原样交上层
+    if (init.signal) {
+      const onAbort = () => req.destroy(new Error('aborted'));
+      if (init.signal.aborted) onAbort();
+      else init.signal.addEventListener('abort', onAbort, { once: true });
+    }
+    req.end();
+  });
+}
+
 /**
  * 拉取并校验 CIMD。可注入 fetcher（测试不启真 HTTP）。
- * MUST NOT 跟随重定向；MUST 200；响应限 5KB。
+ * MUST NOT 跟随重定向；MUST 200；响应边读边限 5KB。
  */
 export async function fetchClientMetadata(
   clientId: string,
@@ -282,13 +452,17 @@ export async function fetchClientMetadata(
   const urlCheck = validateClientIdUrl(clientId);
   if (!urlCheck.ok) return urlCheck;
 
-  const hostSafe = await assertClientIdHostSafe(
-    urlCheck.url.hostname,
-    options.dnsLookup,
-  );
-  if (!hostSafe.ok) return hostSafe;
+  // 字面量 IP：连接前预检。主机名 SSRF 留给连接 lookup（钉死，无二次解析窗口）。
+  const host = urlCheck.url.hostname.replace(/^\[(.+)\]$/, '$1');
+  if (isIP(host)) {
+    const hostSafe = await assertClientIdHostSafe(host, options.dnsLookup);
+    if (!hostSafe.ok) return hostSafe;
+  }
 
-  const fetcher = options.fetcher ?? defaultFetcher;
+  const fetcher =
+    options.fetcher ??
+    ((url, init) => pinnedCimdFetcher(url, init, options.dnsLookup));
+
   let res: Response;
   try {
     res = await fetcher(clientId, {
@@ -297,7 +471,14 @@ export async function fetchClientMetadata(
       headers: { accept: 'application/json' },
       signal: AbortSignal.timeout(CIMD_FETCH_TIMEOUT_MS),
     });
-  } catch {
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : '';
+    if (msg === 'ssrf_blocked_ip' || msg.includes('ssrf_blocked')) {
+      return { ok: false, reason: 'ssrf_blocked_ip' };
+    }
+    if (msg === 'response_too_large') {
+      return { ok: false, reason: 'response_too_large' };
+    }
     return { ok: false, reason: 'fetch_failed' };
   }
 
@@ -309,9 +490,25 @@ export async function fetchClientMetadata(
     return { ok: false, reason: 'http_not_200' };
   }
 
-  const buf = Buffer.from(await res.arrayBuffer());
-  if (buf.byteLength > CIMD_MAX_BYTES) {
-    return { ok: false, reason: 'response_too_large' };
+  // 注入 fetcher 可能仍整包返回；统一再限一次体积
+  let buf: Buffer;
+  try {
+    if (res.body) {
+      const capped = await readBodyCapped(
+        res.body as unknown as NodeJS.ReadableStream,
+        CIMD_MAX_BYTES,
+      );
+      if (!capped.ok) return capped;
+      buf = capped.buf;
+    } else {
+      const ab = Buffer.from(await res.arrayBuffer());
+      if (ab.byteLength > CIMD_MAX_BYTES) {
+        return { ok: false, reason: 'response_too_large' };
+      }
+      buf = ab;
+    }
+  } catch {
+    return { ok: false, reason: 'fetch_failed' };
   }
 
   let json: unknown;
@@ -331,11 +528,7 @@ export async function fetchClientMetadata(
   return validated;
 }
 
-async function defaultFetcher(url: string, init: RequestInit): Promise<Response> {
-  return fetch(url, init);
-}
-
-/** 授权请求的 redirect_uri 是否在文档列表中（含 loopback 端口放宽）。 */
+/** 授权请求的 redirect_uri 是否在文档列表中（含 RFC8252 端口放宽）。 */
 export function matchRedirectUri(
   requested: string,
   registered: string[],

--- a/packages/api/src/lib/oauth-pkce.ts
+++ b/packages/api/src/lib/oauth-pkce.ts
@@ -1,0 +1,24 @@
+/**
+ * OAuth PKCE：本 AS 只实现 S256（OAuth 2.1 / MCP 强制面）。
+ */
+
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+/** 校验 code_verifier 是否匹配授权时存下的 S256 challenge。 */
+export function verifyS256CodeChallenge(
+  codeVerifier: string,
+  codeChallenge: string,
+): boolean {
+  if (!codeVerifier || !codeChallenge) return false;
+  // RFC 7636：verifier 长度 43–128
+  if (codeVerifier.length < 43 || codeVerifier.length > 128) return false;
+  const computed = createHash('sha256').update(codeVerifier).digest('base64url');
+  const a = Buffer.from(computed, 'utf8');
+  const b = Buffer.from(codeChallenge, 'utf8');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/** 生成测试用 S256 challenge。 */
+export function s256Challenge(codeVerifier: string): string {
+  return createHash('sha256').update(codeVerifier).digest('base64url');
+}

--- a/packages/api/src/lib/oauth-return.ts
+++ b/packages/api/src/lib/oauth-return.ts
@@ -1,0 +1,52 @@
+/**
+ * OAuth 同意页登录回跳：用 Path=/ui 的短时 cookie 携带 returnTo，
+ * 避免前端读 location.search（UI 资产契约禁止 URLSearchParams）。
+ */
+
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
+import type { Context } from 'hono';
+
+const COOKIE_NAME = 'oae_oauth_return';
+const MAX_AGE_S = 10 * 60;
+
+function cookieSecure(url: string): boolean {
+  const parsed = new URL(url);
+  const localHost =
+    parsed.hostname === 'localhost' ||
+    parsed.hostname === '127.0.0.1' ||
+    parsed.hostname === '[::1]';
+  return !(parsed.protocol === 'http:' && localHost);
+}
+
+/** 仅允许同站 /ui/... 相对路径，防开放重定向。 */
+export function sanitizeUiReturnTo(raw: string): string | null {
+  if (!raw || raw.charAt(0) !== '/' || raw.startsWith('//')) return null;
+  if (raw !== '/ui' && !raw.startsWith('/ui/')) return null;
+  if (raw.includes('\\') || raw.includes('\n') || raw.includes('\r')) return null;
+  return raw;
+}
+
+export function setOAuthReturnCookie(c: Context, returnPath: string): void {
+  const safe = sanitizeUiReturnTo(returnPath);
+  if (!safe) return;
+  setCookie(c, COOKIE_NAME, safe, {
+    httpOnly: true,
+    sameSite: 'Strict',
+    path: '/ui',
+    secure: cookieSecure(c.req.url),
+    maxAge: MAX_AGE_S,
+  });
+}
+
+/** 读取并清除 return cookie；非法则丢弃。无 cookie 时不写 Set-Cookie，避免干扰会话测试。 */
+export function consumeOAuthReturnCookie(c: Context): string | undefined {
+  const raw = getCookie(c, COOKIE_NAME);
+  if (!raw) return undefined;
+  deleteCookie(c, COOKIE_NAME, {
+    httpOnly: true,
+    sameSite: 'Strict',
+    path: '/ui',
+    secure: cookieSecure(c.req.url),
+  });
+  return sanitizeUiReturnTo(raw) ?? undefined;
+}

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -1,0 +1,524 @@
+/**
+ * OAuth 令牌/授权存储（oauth.json）。
+ * 模式照抄 identities.json：单写者、tmp+rename、0600、只存哈希、损坏 fail-closed。
+ */
+
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { config } from './config.ts';
+
+export const CODE_TTL_MS = 10 * 60 * 1000;
+export const ACCESS_TTL_MS = 60 * 60 * 1000;
+export const REFRESH_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export type OAuthGrant = {
+  id: string;
+  clientId: string;
+  clientName: string;
+  address: string;
+  createdAt: string;
+  lastUsedAt: string;
+};
+
+export type OAuthCode = {
+  grantId: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  resource: string;
+  address: string;
+  expiresAt: number;
+};
+
+export type OAuthAccess = {
+  grantId: string;
+  address: string;
+  aud: string;
+  expiresAt: number;
+};
+
+export type OAuthRefresh = {
+  grantId: string;
+  address: string;
+  aud: string;
+  expiresAt: number;
+};
+
+type OAuthStoreFile = {
+  grants: Record<string, OAuthGrant>;
+  codes: Record<string, OAuthCode>;
+  access: Record<string, OAuthAccess>;
+  refresh: Record<string, OAuthRefresh>;
+};
+
+type StoreFileVersion = {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+};
+
+const MISSING_STORE_VERSION: StoreFileVersion = {
+  dev: 0,
+  ino: 0,
+  mtimeMs: -1,
+  ctimeMs: -1,
+  size: -1,
+};
+
+type StoreCache = {
+  version: StoreFileVersion;
+  data: OAuthStoreFile;
+};
+
+let storeCache: StoreCache | undefined;
+
+function storePath(): string {
+  return join(config.dataDir, 'oauth.json');
+}
+
+function emptyStore(): OAuthStoreFile {
+  return { grants: {}, codes: {}, access: {}, refresh: {} };
+}
+
+function invalidateStoreCache(): void {
+  storeCache = undefined;
+}
+
+function fileVersionFromStat(st: {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+}): StoreFileVersion {
+  return {
+    dev: st.dev,
+    ino: st.ino,
+    mtimeMs: st.mtimeMs,
+    ctimeMs: st.ctimeMs,
+    size: st.size,
+  };
+}
+
+function storeVersionsEqual(a: StoreFileVersion, b: StoreFileVersion): boolean {
+  return (
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.mtimeMs === b.mtimeMs &&
+    a.ctimeMs === b.ctimeMs &&
+    a.size === b.size
+  );
+}
+
+function isGrant(v: unknown): v is OAuthGrant {
+  if (!v || typeof v !== 'object') return false;
+  const g = v as Record<string, unknown>;
+  return (
+    typeof g.id === 'string' &&
+    typeof g.clientId === 'string' &&
+    typeof g.clientName === 'string' &&
+    typeof g.address === 'string' &&
+    typeof g.createdAt === 'string' &&
+    typeof g.lastUsedAt === 'string'
+  );
+}
+
+function isCode(v: unknown): v is OAuthCode {
+  if (!v || typeof v !== 'object') return false;
+  const c = v as Record<string, unknown>;
+  return (
+    typeof c.grantId === 'string' &&
+    typeof c.clientId === 'string' &&
+    typeof c.redirectUri === 'string' &&
+    typeof c.codeChallenge === 'string' &&
+    typeof c.resource === 'string' &&
+    typeof c.address === 'string' &&
+    typeof c.expiresAt === 'number'
+  );
+}
+
+function isAccess(v: unknown): v is OAuthAccess {
+  if (!v || typeof v !== 'object') return false;
+  const a = v as Record<string, unknown>;
+  return (
+    typeof a.grantId === 'string' &&
+    typeof a.address === 'string' &&
+    typeof a.aud === 'string' &&
+    typeof a.expiresAt === 'number'
+  );
+}
+
+function isRefresh(v: unknown): v is OAuthRefresh {
+  return isAccess(v);
+}
+
+function isStoreShape(value: unknown): value is OAuthStoreFile {
+  if (!value || typeof value !== 'object') return false;
+  const s = value as Record<string, unknown>;
+  if (!s.grants || typeof s.grants !== 'object') return false;
+  if (!s.codes || typeof s.codes !== 'object') return false;
+  if (!s.access || typeof s.access !== 'object') return false;
+  if (!s.refresh || typeof s.refresh !== 'object') return false;
+  return (
+    Object.values(s.grants as object).every(isGrant) &&
+    Object.values(s.codes as object).every(isCode) &&
+    Object.values(s.access as object).every(isAccess) &&
+    Object.values(s.refresh as object).every(isRefresh)
+  );
+}
+
+function load(): OAuthStoreFile {
+  const path = storePath();
+  if (!existsSync(path)) {
+    if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
+      return storeCache.data;
+    }
+    storeCache = { version: MISSING_STORE_VERSION, data: emptyStore() };
+    return storeCache.data;
+  }
+  try {
+    const version = fileVersionFromStat(statSync(path));
+    if (storeCache && storeVersionsEqual(storeCache.version, version)) {
+      return storeCache.data;
+    }
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isStoreShape(parsed)) {
+      throw new Error('invalid oauth store shape');
+    }
+    storeCache = { version, data: parsed };
+    return storeCache.data;
+  } catch (err) {
+    invalidateStoreCache();
+    if ((err as Error).message === 'oauth_store_corrupt') throw err;
+    // 损坏 fail-closed：绝不当空库写回，避免抹掉全部授权。
+    throw new Error('oauth_store_corrupt');
+  }
+}
+
+function save(data: OAuthStoreFile): void {
+  invalidateStoreCache();
+  mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(config.dataDir, 0o700);
+  } catch {
+    // bind mount 可能属主不同；文件 mode 仍会设置
+  }
+  const path = storePath();
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+}
+
+export function hashSecret(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+function hashEquals(a: string, b: string): boolean {
+  const ba = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  return ba.length === bb.length && timingSafeEqual(ba, bb);
+}
+
+/** 生成不透明令牌明文（32 字节）及其哈希。 */
+export function generateOpaqueToken(): { token: string; hash: string } {
+  const token = randomBytes(32).toString('base64url');
+  return { token, hash: hashSecret(token) };
+}
+
+export function newGrantId(): string {
+  return randomBytes(16).toString('base64url');
+}
+
+/** 测试用：清空进程内缓存（不删文件）。 */
+export function resetOAuthStoreCacheForTests(): void {
+  invalidateStoreCache();
+}
+
+export function listGrantsForAuth(auth: {
+  kind: 'admin' | 'identity';
+  address?: string;
+}): OAuthGrant[] {
+  const data = load();
+  const all = Object.values(data.grants);
+  if (auth.kind === 'admin') {
+    return all.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  }
+  const address = auth.address!.toLowerCase();
+  return all
+    .filter((g) => g.address.toLowerCase() === address)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+export function getGrant(grantId: string): OAuthGrant | undefined {
+  return load().grants[grantId];
+}
+
+/**
+ * 吊销 grant：删 grant 行及挂在其上的全部 code/access/refresh。
+ * @returns false 表示 grant 不存在
+ */
+export function revokeGrant(grantId: string): boolean {
+  const data = load();
+  if (!data.grants[grantId]) return false;
+  delete data.grants[grantId];
+  for (const [hash, row] of Object.entries(data.codes)) {
+    if (row.grantId === grantId) delete data.codes[hash];
+  }
+  for (const [hash, row] of Object.entries(data.access)) {
+    if (row.grantId === grantId) delete data.access[hash];
+  }
+  for (const [hash, row] of Object.entries(data.refresh)) {
+    if (row.grantId === grantId) delete data.refresh[hash];
+  }
+  save(data);
+  return true;
+}
+
+export function createGrantAndCode(input: {
+  clientId: string;
+  clientName: string;
+  address: string;
+  redirectUri: string;
+  codeChallenge: string;
+  resource: string;
+  now?: number;
+}): { grantId: string; code: string } {
+  const now = input.now ?? Date.now();
+  const data = load();
+  const grantId = newGrantId();
+  const createdAt = new Date(now).toISOString();
+  data.grants[grantId] = {
+    id: grantId,
+    clientId: input.clientId,
+    clientName: input.clientName,
+    address: input.address.toLowerCase(),
+    createdAt,
+    lastUsedAt: createdAt,
+  };
+  const { token: code, hash } = generateOpaqueToken();
+  data.codes[hash] = {
+    grantId,
+    clientId: input.clientId,
+    redirectUri: input.redirectUri,
+    codeChallenge: input.codeChallenge,
+    resource: input.resource,
+    address: input.address.toLowerCase(),
+    expiresAt: now + CODE_TTL_MS,
+  };
+  save(data);
+  return { grantId, code };
+}
+
+export type ConsumeCodeResult =
+  | {
+      ok: true;
+      grantId: string;
+      address: string;
+      resource: string;
+      clientId: string;
+      redirectUri: string;
+      codeChallenge: string;
+    }
+  | { ok: false; reason: 'not_found' | 'expired' };
+
+/** 一次性消费授权码（先删再返回，防重放）。 */
+export function consumeAuthorizationCode(
+  code: string,
+  now = Date.now(),
+): ConsumeCodeResult {
+  const data = load();
+  const hash = hashSecret(code);
+  const row = data.codes[hash];
+  if (!row) return { ok: false, reason: 'not_found' };
+  delete data.codes[hash];
+  save(data);
+  if (row.expiresAt <= now) return { ok: false, reason: 'expired' };
+  return {
+    ok: true,
+    grantId: row.grantId,
+    address: row.address,
+    resource: row.resource,
+    clientId: row.clientId,
+    redirectUri: row.redirectUri,
+    codeChallenge: row.codeChallenge,
+  };
+}
+
+export function issueTokenPair(input: {
+  grantId: string;
+  address: string;
+  aud: string;
+  now?: number;
+}): { accessToken: string; refreshToken: string; expiresIn: number } {
+  const now = input.now ?? Date.now();
+  const data = load();
+  if (!data.grants[input.grantId]) {
+    throw new Error('grant_missing');
+  }
+  data.grants[input.grantId].lastUsedAt = new Date(now).toISOString();
+  const access = generateOpaqueToken();
+  const refresh = generateOpaqueToken();
+  data.access[access.hash] = {
+    grantId: input.grantId,
+    address: input.address.toLowerCase(),
+    aud: input.aud,
+    expiresAt: now + ACCESS_TTL_MS,
+  };
+  data.refresh[refresh.hash] = {
+    grantId: input.grantId,
+    address: input.address.toLowerCase(),
+    aud: input.aud,
+    expiresAt: now + REFRESH_TTL_MS,
+  };
+  save(data);
+  return {
+    accessToken: access.token,
+    refreshToken: refresh.token,
+    expiresIn: Math.floor(ACCESS_TTL_MS / 1000),
+  };
+}
+
+export type RotateRefreshResult =
+  | {
+      ok: true;
+      accessToken: string;
+      refreshToken: string;
+      expiresIn: number;
+      address: string;
+      aud: string;
+      grantId: string;
+    }
+  | { ok: false; reason: 'not_found' | 'expired' | 'grant_missing' };
+
+/** refresh 轮换：旧 refresh 立即作废，签发新 access+refresh。 */
+export function rotateRefreshToken(
+  refreshToken: string,
+  now = Date.now(),
+): RotateRefreshResult {
+  const data = load();
+  const hash = hashSecret(refreshToken);
+  const row = data.refresh[hash];
+  if (!row) return { ok: false, reason: 'not_found' };
+  delete data.refresh[hash];
+  if (row.expiresAt <= now) {
+    save(data);
+    return { ok: false, reason: 'expired' };
+  }
+  if (!data.grants[row.grantId]) {
+    save(data);
+    return { ok: false, reason: 'grant_missing' };
+  }
+  data.grants[row.grantId].lastUsedAt = new Date(now).toISOString();
+  const access = generateOpaqueToken();
+  const refresh = generateOpaqueToken();
+  data.access[access.hash] = {
+    grantId: row.grantId,
+    address: row.address,
+    aud: row.aud,
+    expiresAt: now + ACCESS_TTL_MS,
+  };
+  data.refresh[refresh.hash] = {
+    grantId: row.grantId,
+    address: row.address,
+    aud: row.aud,
+    expiresAt: now + REFRESH_TTL_MS,
+  };
+  save(data);
+  return {
+    ok: true,
+    accessToken: access.token,
+    refreshToken: refresh.token,
+    expiresIn: Math.floor(ACCESS_TTL_MS / 1000),
+    address: row.address,
+    aud: row.aud,
+    grantId: row.grantId,
+  };
+}
+
+/** RFC 7009：吊销 access 或 refresh（未知令牌亦视为成功）。 */
+export function revokeToken(token: string): void {
+  const data = load();
+  const hash = hashSecret(token);
+  let changed = false;
+  if (data.access[hash]) {
+    delete data.access[hash];
+    changed = true;
+  }
+  if (data.refresh[hash]) {
+    delete data.refresh[hash];
+    changed = true;
+  }
+  if (changed) save(data);
+}
+
+export type LookupAccessResult =
+  | { status: 'ok'; address: string; aud: string; grantId: string; expiresAt: number }
+  | { status: 'expired'; aud: string }
+  | { status: 'missing' };
+
+export function lookupAccessToken(
+  token: string,
+  now = Date.now(),
+): LookupAccessResult {
+  const data = load();
+  const hash = hashSecret(token);
+  // 线性扫描以支持常量时间比较（条目少；哈希作键时先直查）
+  const row = data.access[hash];
+  if (!row) {
+    // 防枚举：对不匹配键做一次哑比较
+    hashEquals(hash, hash);
+    return { status: 'missing' };
+  }
+  if (row.expiresAt <= now) return { status: 'expired', aud: row.aud };
+  // grant 已吊销则 access 立即失效
+  if (!data.grants[row.grantId]) return { status: 'missing' };
+  return {
+    status: 'ok',
+    address: row.address,
+    aud: row.aud,
+    grantId: row.grantId,
+    expiresAt: row.expiresAt,
+  };
+}
+
+/** 测试辅助：直接写入过期 access（构造 401 场景）。 */
+export function putAccessTokenForTests(input: {
+  token: string;
+  grantId: string;
+  address: string;
+  aud: string;
+  expiresAt: number;
+  ensureGrant?: { clientId: string; clientName: string };
+}): void {
+  const data = load();
+  if (input.ensureGrant && !data.grants[input.grantId]) {
+    const nowIso = new Date().toISOString();
+    data.grants[input.grantId] = {
+      id: input.grantId,
+      clientId: input.ensureGrant.clientId,
+      clientName: input.ensureGrant.clientName,
+      address: input.address.toLowerCase(),
+      createdAt: nowIso,
+      lastUsedAt: nowIso,
+    };
+  }
+  data.access[hashSecret(input.token)] = {
+    grantId: input.grantId,
+    address: input.address.toLowerCase(),
+    aud: input.aud,
+    expiresAt: input.expiresAt,
+  };
+  save(data);
+}

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -13,7 +13,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { join } from 'node:path';
-import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import { createHash, randomBytes } from 'node:crypto';
 import { config } from './config.ts';
 
 export const CODE_TTL_MS = 10 * 60 * 1000;
@@ -262,12 +262,6 @@ function save(data: OAuthStoreFile): void {
 
 export function hashSecret(value: string): string {
   return createHash('sha256').update(value).digest('hex');
-}
-
-function hashEquals(a: string, b: string): boolean {
-  const ba = Buffer.from(a, 'utf8');
-  const bb = Buffer.from(b, 'utf8');
-  return ba.length === bb.length && timingSafeEqual(ba, bb);
 }
 
 /** 生成不透明令牌明文（32 字节）及其哈希。 */
@@ -586,20 +580,32 @@ export function rotateRefreshToken(
   };
 }
 
-/** RFC 7009：吊销 access 或 refresh（未知令牌亦视为成功）。 */
-export function revokeToken(token: string): void {
+/**
+ * RFC 7009：吊销 access 或 refresh（未知令牌亦 200 成功语义，由路由保证）。
+ * 必须带与 grant 绑定的 clientId；缺失或不匹配时**不删**（灭第三方持票 DoS）。
+ * @returns true 表示确有删除；false 表示未删（未知票 / 无 client / 不匹配）
+ */
+export function revokeToken(token: string, clientId?: string): boolean {
+  if (!clientId) return false;
   const data = load();
   const hash = hashSecret(token);
+  const access = data.access[hash];
+  const refresh = data.refresh[hash];
+  if (!access && !refresh) return false;
+  const grantId = access?.grantId ?? refresh!.grantId;
+  const grant = data.grants[grantId];
+  if (!grant || grant.clientId !== clientId) return false;
   let changed = false;
-  if (data.access[hash]) {
+  if (access) {
     delete data.access[hash];
     changed = true;
   }
-  if (data.refresh[hash]) {
+  if (refresh) {
     delete data.refresh[hash];
     changed = true;
   }
   if (changed) save(data);
+  return changed;
 }
 
 export type LookupAccessResult =
@@ -613,13 +619,8 @@ export function lookupAccessToken(
 ): LookupAccessResult {
   const data = load();
   const hash = hashSecret(token);
-  // 线性扫描以支持常量时间比较（条目少；哈希作键时先直查）
   const row = data.access[hash];
-  if (!row) {
-    // 防枚举：对不匹配键做一次哑比较
-    hashEquals(hash, hash);
-    return { status: 'missing' };
-  }
+  if (!row) return { status: 'missing' };
   if (row.expiresAt <= now) return { status: 'expired', aud: row.aud };
   // grant 已吊销则 access 立即失效
   if (!data.grants[row.grantId]) return { status: 'missing' };

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -178,6 +178,30 @@ function isStoreShape(value: unknown): value is OAuthStoreFile {
   );
 }
 
+/** 清掉 codes/access/refresh 过期行（load/save 时调用）。 */
+function pruneExpired(data: OAuthStoreFile, now = Date.now()): boolean {
+  let changed = false;
+  for (const [hash, row] of Object.entries(data.codes)) {
+    if (row.expiresAt <= now) {
+      delete data.codes[hash];
+      changed = true;
+    }
+  }
+  for (const [hash, row] of Object.entries(data.access)) {
+    if (row.expiresAt <= now) {
+      delete data.access[hash];
+      changed = true;
+    }
+  }
+  for (const [hash, row] of Object.entries(data.refresh)) {
+    if (row.expiresAt <= now) {
+      delete data.refresh[hash];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
 function load(): OAuthStoreFile {
   const path = storePath();
   if (!existsSync(path)) {
@@ -190,11 +214,19 @@ function load(): OAuthStoreFile {
   try {
     const version = fileVersionFromStat(statSync(path));
     if (storeCache && storeVersionsEqual(storeCache.version, version)) {
+      // 缓存命中也做内存 prune（不强制写盘，避免热路径 IO）
+      pruneExpired(storeCache.data);
       return storeCache.data;
     }
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
     if (!isStoreShape(parsed)) {
       throw new Error('invalid oauth store shape');
+    }
+    if (pruneExpired(parsed)) {
+      // 读时发现过期行：就地写回，避免 save→load 递归
+      const written = writeStoreFile(parsed);
+      storeCache = { version: written, data: parsed };
+      return storeCache.data;
     }
     storeCache = { version, data: parsed };
     return storeCache.data;
@@ -206,8 +238,7 @@ function load(): OAuthStoreFile {
   }
 }
 
-function save(data: OAuthStoreFile): void {
-  invalidateStoreCache();
+function writeStoreFile(data: OAuthStoreFile): StoreFileVersion {
   mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
   try {
     chmodSync(config.dataDir, 0o700);
@@ -219,6 +250,14 @@ function save(data: OAuthStoreFile): void {
   writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
   chmodSync(tmp, 0o600);
   renameSync(tmp, path);
+  return fileVersionFromStat(statSync(path));
+}
+
+function save(data: OAuthStoreFile): void {
+  pruneExpired(data);
+  invalidateStoreCache();
+  const version = writeStoreFile(data);
+  storeCache = { version, data };
 }
 
 export function hashSecret(value: string): string {
@@ -255,10 +294,37 @@ export function listGrantsForAuth(auth: {
   if (auth.kind === 'admin') {
     return all.sort((a, b) => b.createdAt.localeCompare(a.createdAt));
   }
-  const address = auth.address!.toLowerCase();
+  if (typeof auth.address !== 'string' || !auth.address) {
+    return [];
+  }
+  const address = auth.address.toLowerCase();
   return all
     .filter((g) => g.address.toLowerCase() === address)
     .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+}
+
+/** 身份删除时级联吊销：该地址下全部 grant + 挂接 token。 */
+export function revokeGrantsForAddress(address: string): number {
+  const data = load();
+  const needle = address.toLowerCase();
+  const grantIds = Object.keys(data.grants).filter(
+    (id) => data.grants[id]!.address.toLowerCase() === needle,
+  );
+  if (grantIds.length === 0) return 0;
+  for (const grantId of grantIds) {
+    delete data.grants[grantId];
+    for (const [hash, row] of Object.entries(data.codes)) {
+      if (row.grantId === grantId) delete data.codes[hash];
+    }
+    for (const [hash, row] of Object.entries(data.access)) {
+      if (row.grantId === grantId) delete data.access[hash];
+    }
+    for (const [hash, row] of Object.entries(data.refresh)) {
+      if (row.grantId === grantId) delete data.refresh[hash];
+    }
+  }
+  save(data);
+  return grantIds.length;
 }
 
 export function getGrant(grantId: string): OAuthGrant | undefined {
@@ -333,7 +399,42 @@ export type ConsumeCodeResult =
     }
   | { ok: false; reason: 'not_found' | 'expired' };
 
-/** 一次性消费授权码（先删再返回，防重放）。 */
+export type CodeRowView = {
+  grantId: string;
+  address: string;
+  resource: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  expiresAt: number;
+};
+
+/** 只读查看授权码（不删除）；供全量校验后再原子消费。 */
+export function peekAuthorizationCode(
+  code: string,
+  now = Date.now(),
+): ConsumeCodeResult {
+  const data = load();
+  const hash = hashSecret(code);
+  const row = data.codes[hash];
+  if (!row) return { ok: false, reason: 'not_found' };
+  if (row.expiresAt <= now) return { ok: false, reason: 'expired' };
+  return {
+    ok: true,
+    grantId: row.grantId,
+    address: row.address,
+    resource: row.resource,
+    clientId: row.clientId,
+    redirectUri: row.redirectUri,
+    codeChallenge: row.codeChallenge,
+  };
+}
+
+/**
+ * 原子消费授权码：仍存在则删除并返回行。
+ * 调用方应先 peek + 全量校验（client/redirect/resource/PKCE），再调用本函数签发。
+ * 拦截者无 verifier 时只能制造一次「合法交换不可用」，不能靠抢删骗过 PKCE。
+ */
 export function consumeAuthorizationCode(
   code: string,
   now = Date.now(),
@@ -342,9 +443,13 @@ export function consumeAuthorizationCode(
   const hash = hashSecret(code);
   const row = data.codes[hash];
   if (!row) return { ok: false, reason: 'not_found' };
+  if (row.expiresAt <= now) {
+    delete data.codes[hash];
+    save(data);
+    return { ok: false, reason: 'expired' };
+  }
   delete data.codes[hash];
   save(data);
-  if (row.expiresAt <= now) return { ok: false, reason: 'expired' };
   return {
     ok: true,
     grantId: row.grantId,
@@ -400,26 +505,60 @@ export type RotateRefreshResult =
       aud: string;
       grantId: string;
     }
-  | { ok: false; reason: 'not_found' | 'expired' | 'grant_missing' };
+  | {
+      ok: false;
+      reason:
+        | 'not_found'
+        | 'expired'
+        | 'grant_missing'
+        | 'aud_mismatch'
+        | 'client_mismatch';
+    };
 
-/** refresh 轮换：旧 refresh 立即作废，签发新 access+refresh。 */
+export type RotateRefreshOptions = {
+  now?: number;
+  /** 期望 aud；不匹配时**不**吞旧票写新行。 */
+  expectedAud?: string;
+  /** RFC 6749 §6：public client 必须带 client_id 且与 grant 绑定。 */
+  clientId?: string;
+};
+
+/**
+ * refresh 轮换：先验 aud/client/过期/grant，全部通过后再删旧票写新行。
+ */
 export function rotateRefreshToken(
   refreshToken: string,
-  now = Date.now(),
+  nowOrOpts: number | RotateRefreshOptions = Date.now(),
 ): RotateRefreshResult {
+  const opts: RotateRefreshOptions =
+    typeof nowOrOpts === 'number' ? { now: nowOrOpts } : nowOrOpts;
+  const now = opts.now ?? Date.now();
   const data = load();
   const hash = hashSecret(refreshToken);
   const row = data.refresh[hash];
   if (!row) return { ok: false, reason: 'not_found' };
-  delete data.refresh[hash];
   if (row.expiresAt <= now) {
+    // 过期行可清掉；不算「轮换成功」
+    delete data.refresh[hash];
     save(data);
     return { ok: false, reason: 'expired' };
   }
   if (!data.grants[row.grantId]) {
-    save(data);
     return { ok: false, reason: 'grant_missing' };
   }
+  if (opts.expectedAud !== undefined && row.aud !== opts.expectedAud) {
+    // aud 不符：保留旧 refresh，禁止先写库再拒
+    return { ok: false, reason: 'aud_mismatch' };
+  }
+  if (opts.clientId !== undefined) {
+    const grant = data.grants[row.grantId]!;
+    if (grant.clientId !== opts.clientId) {
+      return { ok: false, reason: 'client_mismatch' };
+    }
+  }
+
+  // 校验全过：原子删除旧 refresh 并签发
+  delete data.refresh[hash];
   data.grants[row.grantId].lastUsedAt = new Date(now).toISOString();
   const access = generateOpaqueToken();
   const refresh = generateOpaqueToken();

--- a/packages/api/src/lib/oauth-url.ts
+++ b/packages/api/src/lib/oauth-url.ts
@@ -1,0 +1,56 @@
+/**
+ * OAuth / MCP 对外绝对 URL 的单一来源。
+ * 与 #17 PRM 解析一致：显式覆盖 ?? MCP_PUBLIC_URL ?? 请求 origin，禁止第二份逻辑。
+ */
+
+import { config } from './config.ts';
+
+/** 去掉尾斜杠的绝对 origin/base。 */
+export function stripTrailingSlashes(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * 解析对外 base（issuer 与 PRM resource 的共同前缀）。
+ * @param requestOrigin 当前请求的 origin
+ * @param override 调用方/测试显式覆盖（优先于 MCP_PUBLIC_URL）
+ */
+export function resolvePublicBase(requestOrigin?: string, override?: string): string {
+  if (override) return stripTrailingSlashes(override);
+  const configured = config.mcpPublicUrl;
+  if (configured) return stripTrailingSlashes(configured);
+  if (requestOrigin) return stripTrailingSlashes(requestOrigin);
+  throw new Error('oauth_public_base_unresolved');
+}
+
+/** RFC 8707 / MCP resource：`{base}/mcp`，无尾斜杠。 */
+export function resolveResourceUri(requestOrigin?: string, override?: string): string {
+  return `${resolvePublicBase(requestOrigin, override)}/mcp`;
+}
+
+/** AS issuer（无 path 时即 base）。 */
+export function resolveIssuer(requestOrigin?: string, override?: string): string {
+  return resolvePublicBase(requestOrigin, override);
+}
+
+/** 拼 RFC 8414 Authorization Server Metadata 文档。 */
+export function buildAuthorizationServerMetadata(
+  requestOrigin?: string,
+  override?: string,
+): Record<string, unknown> {
+  const issuer = resolveIssuer(requestOrigin, override);
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    revocation_endpoint: `${issuer}/oauth/revoke`,
+    grant_types_supported: ['authorization_code', 'refresh_token'],
+    response_types_supported: ['code'],
+    code_challenge_methods_supported: ['S256'],
+    token_endpoint_auth_methods_supported: ['none'],
+    // RFC 9207：授权响应（含错误）带 iss
+    authorization_response_iss_parameter_supported: true,
+    // CIMD（IANA 已注册）
+    client_id_metadata_document_supported: true,
+  };
+}

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -6,6 +6,7 @@ import { createMiddleware } from 'hono/factory';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { Auth } from './auth.ts';
+import { consumeOAuthReturnCookie } from './oauth-return.ts';
 
 const COOKIE_NAME = 'oae_ui';
 const IDLE_TIMEOUT_MS = 12 * 60 * 60 * 1000;
@@ -317,7 +318,9 @@ export function createUiSessionRoutes(store: UiSessionStore): Hono {
       }
 
       setSessionCookie(c, result.sid, remember);
-      return c.json(result.auth);
+      // OAuth 同意页登录回跳（若有）；一次性消费，不进会话长期状态。
+      const returnTo = consumeOAuthReturnCookie(c);
+      return c.json(returnTo ? { ...result.auth, returnTo } : result.auth);
     } catch {
       // Keep credentials out of the global error logger even if parsing or the
       // backing token resolver fails with an error containing request data.

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -11,8 +11,11 @@
  *   GET  /v1/messages/:id?address=             (admin, or the identity itself)
  *   POST /v1/messages/wait                     (admin, or the identity itself)
  *   POST /v1/send                              (admin, or the identity itself)
- *   POST /mcp                                  (stateless MCP; Bearer admin or oa_)
+ *   POST /mcp                                  (stateless MCP; Bearer admin / oa_ / OAuth access)
  *   GET  /.well-known/oauth-protected-resource (RFC 9728)
+ *   GET  /.well-known/oauth-authorization-server (RFC 8414)
+ *   GET  /authorize → /ui/oauth/authorize      (OAuth 同意页)
+ *   POST /oauth/token | /oauth/revoke
  * Auth: `Authorization: Bearer <key>` — admin keys from API_KEYS env, or a
  * per-identity scoped token issued at identity creation.
  */

--- a/packages/api/src/mcp/http.ts
+++ b/packages/api/src/mcp/http.ts
@@ -16,11 +16,20 @@ import {
   type AuthMetadataOptions,
   type OAuthMetadata,
 } from "@modelcontextprotocol/server";
-import { resolveToken } from "../lib/auth.ts";
+import { resolveAccessToken } from "../lib/auth.ts";
 import { config } from "../lib/config.ts";
 import { JSON_BODY_LIMIT_BYTES } from "../lib/limits.ts";
+import { isPrivateOrLoopbackHost, isPrivateOrLoopbackHostname } from "../lib/net.ts";
+import {
+  buildAuthorizationServerMetadata,
+  resolvePublicBase,
+  resolveResourceUri,
+} from "../lib/oauth-url.ts";
 import { OpenAgentEmailClient, type FetchLike } from "./client.ts";
 import { registerOpenAgentEmailTools } from "./tools.ts";
+
+/** 兼容旧导出名：实现已迁至 lib/net.ts（唯一共享）。 */
+export { isPrivateOrLoopbackHost };
 
 /** MCP 服务实现标识（HTTP 面；stdio 包用自己的 package.json version）。 */
 const MCP_SERVER_INFO = { name: "openagentemail", version: "0.5.0" } as const;
@@ -50,42 +59,15 @@ export function bearerToken(authorization: string | undefined): string | undefin
 }
 
 /**
- * 判断 hostname 是否为 loopback / RFC1918 / CGNAT / ULA。
- * 用于限制 dangerouslyAllowInsecureIssuerUrl，公网 http 一律不放行。
+ * http + 可放行私网/loopback 才允许 insecure issuer。
+ * 永拒段（169.254 / 0.0.0.0，含 v4-mapped）不算私网——与 CIMD SSRF 同一套 lib/net。
  */
-export function isPrivateOrLoopbackHost(hostname: string): boolean {
-  const host = hostname.replace(/^\[(.+)\]$/, "$1").toLowerCase();
-  if (host === "localhost" || host === "::1") return true;
-
-  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
-  if (v4) {
-    const a = Number(v4[1]);
-    const b = Number(v4[2]);
-    const c = Number(v4[3]);
-    const d = Number(v4[4]);
-    if ([a, b, c, d].some((n) => n > 255)) return false;
-    if (a === 127) return true; // 127.0.0.0/8
-    if (a === 10) return true; // 10.0.0.0/8
-    if (a === 192 && b === 168) return true; // 192.168.0.0/16
-    if (a === 172 && b >= 16 && b <= 31) return true; // 172.16.0.0/12
-    if (a === 100 && b >= 64 && b <= 127) return true; // 100.64.0.0/10 CGNAT
-    return false;
-  }
-
-  // IPv6 ULA fd00::/8（首 hextet 以 fd 开头）
-  if (host.includes(":")) {
-    const first = host.split(":").find((p) => p.length > 0) ?? "";
-    return first.startsWith("fd");
-  }
-  return false;
-}
-
-/** http + 私网/loopback 才允许 insecure issuer；公网 http / https 都不开危险开关。 */
 export function allowInsecureIssuerUrl(baseUrl: string): boolean {
   try {
     const url = new URL(baseUrl);
     if (url.protocol !== "http:") return false;
-    return isPrivateOrLoopbackHost(url.hostname);
+    // isPrivateOrLoopbackHostname 已排除 169.254/0.0.0.0（含 v4-mapped）
+    return isPrivateOrLoopbackHostname(url.hostname);
   } catch {
     return false;
   }
@@ -93,20 +75,22 @@ export function allowInsecureIssuerUrl(baseUrl: string): boolean {
 
 /**
  * 拼 RFC 9728 Protected Resource Metadata 选项。
- * - base：优先 MCP_PUBLIC_URL / publicBaseUrl，否则回落请求 origin
- * - oauthMetadata 仅含 issuer（authorization_servers 由此派生）；authorize/token 等 AS
- *   端点属 P3，现在广告出去是撒谎，故不放进元数据
+ * - base：优先 MCP_PUBLIC_URL / publicBaseUrl，否则回落请求 origin（与 oauth-url 同源）
+ * - oauthMetadata 填真 AS 元数据（P3）；PRM.authorization_servers 由 issuer 派生
  */
 export function mcpAuthMetadataOptions(
   requestOrigin: string,
   publicBaseUrl?: string,
 ): AuthMetadataOptions {
-  const base = (publicBaseUrl ?? requestOrigin).replace(/\/+$/, "");
-  // SDK 校验 OAuthMetadata 时 issuer 即可；其余 AS 字段等 P3 真 AS 落地再填。
-  const oauthMetadata = { issuer: base } as OAuthMetadata;
+  // 单一来源：override(publicBaseUrl) ?? MCP_PUBLIC_URL ?? requestOrigin
+  const base = resolvePublicBase(requestOrigin, publicBaseUrl);
+  const oauthMetadata = buildAuthorizationServerMetadata(
+    requestOrigin,
+    publicBaseUrl,
+  ) as OAuthMetadata;
   return {
     oauthMetadata,
-    resourceServerUrl: new URL(`${base}/mcp`),
+    resourceServerUrl: new URL(resolveResourceUri(requestOrigin, publicBaseUrl)),
     resourceName: "openagentemail",
     scopesSupported: ["mcp"],
     dangerouslyAllowInsecureIssuerUrl: allowInsecureIssuerUrl(base),
@@ -123,8 +107,8 @@ function protectedResourceMetadata(
   requestOrigin: string,
   options: McpHttpOptions,
 ): ReturnType<typeof buildOAuthProtectedResourceMetadata> {
-  const publicBase = options.publicBaseUrl ?? config.mcpPublicUrl;
-  const base = mcpAuthMetadataOptions(requestOrigin, publicBase);
+  // publicBaseUrl 仅测试注入；生产走 config.mcpPublicUrl（在 resolvePublicBase 内）
+  const base = mcpAuthMetadataOptions(requestOrigin, options.publicBaseUrl);
   const metaOpts: AuthMetadataOptions = options.resourceServerUrl
     ? { ...base, resourceServerUrl: options.resourceServerUrl }
     : base;
@@ -185,14 +169,20 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
         challengeOpts,
       );
     }
-    const auth = resolveToken(token);
-    if (!auth) {
+    const resource = resolveResourceUri(origin, options.publicBaseUrl);
+    const resolved = resolveAccessToken(token, { resource });
+    if (resolved.status === "forbidden_audience") {
+      // aud 不符 → 403（任务书负例）；其余无效/过期仍 401 + 挑战
+      return c.json({ error: "invalid_audience" }, 403);
+    }
+    if (resolved.status !== "ok") {
       return bearerAuthChallengeResponse(
         new OAuthError(OAuthErrorCode.InvalidToken, "invalid token"),
         challengeOpts,
       );
     }
-    // createMcpHandler 不校验 expiresAt；此处只传透 token 给工具工厂。
+    const auth = resolved.auth;
+    // createMcpHandler 不校验 expiresAt；OAuth 票的过期已在 resolveAccessToken 强制。
     return mcpHandler.fetch(c.req.raw, {
       authInfo: {
         token,

--- a/packages/api/src/mcp/http.ts
+++ b/packages/api/src/mcp/http.ts
@@ -17,8 +17,8 @@ import {
   type OAuthMetadata,
 } from "@modelcontextprotocol/server";
 import { resolveAccessToken } from "../lib/auth.ts";
-import { config } from "../lib/config.ts";
 import { JSON_BODY_LIMIT_BYTES } from "../lib/limits.ts";
+import { getMcpLoopbackBase, runWithMcpLoopbackBase } from "../lib/mcp-loopback.ts";
 import { isPrivateOrLoopbackHost, isPrivateOrLoopbackHostname } from "../lib/net.ts";
 import {
   buildAuthorizationServerMetadata,
@@ -136,17 +136,19 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
   );
 
   // 无状态：每请求新 McpServer；token 经 authInfo 传入工厂。
+  // baseUrl 取自 ALS 中的公共 origin（外部请求 / MCP_PUBLIC_URL），禁止 mcp.internal。
   const mcpHandler = createMcpHandler(
     (ctx) => {
       const token = ctx.authInfo?.token;
       if (!token) {
         throw new Error("mcp factory invoked without authInfo.token");
       }
-      const client = new OpenAgentEmailClient(
-        "http://mcp.internal",
-        token,
-        options.apiFetch,
-      );
+      // 工厂在 runWithMcpLoopbackBase 内调用；构造时读 ALS 公共 base
+      const publicBase = getMcpLoopbackBase();
+      if (!publicBase) {
+        throw new Error("mcp factory: missing loopback public base");
+      }
+      const client = new OpenAgentEmailClient(publicBase, token, options.apiFetch);
       const server = new McpServer(MCP_SERVER_INFO);
       registerOpenAgentEmailTools(server, client);
       return server;
@@ -170,6 +172,7 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
       );
     }
     const resource = resolveResourceUri(origin, options.publicBaseUrl);
+    const publicBase = resolvePublicBase(origin, options.publicBaseUrl);
     const resolved = resolveAccessToken(token, { resource });
     if (resolved.status === "forbidden_audience") {
       // aud 不符 → 403（任务书负例）；其余无效/过期仍 401 + 挑战
@@ -182,14 +185,16 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
       );
     }
     const auth = resolved.auth;
-    // createMcpHandler 不校验 expiresAt；OAuth 票的过期已在 resolveAccessToken 强制。
-    return mcpHandler.fetch(c.req.raw, {
-      authInfo: {
-        token,
-        clientId: auth.kind === "admin" ? "admin" : auth.address,
-        scopes: ["mcp"],
-      },
-    });
+    // 整段工具调度包在公共 base ALS 内，使 /v1 的 c.req.url.origin ≡ aud 推导源
+    return runWithMcpLoopbackBase(publicBase, () =>
+      mcpHandler.fetch(c.req.raw, {
+        authInfo: {
+          token,
+          clientId: auth.kind === "admin" ? "admin" : auth.address,
+          scopes: ["mcp"],
+        },
+      }),
+    );
   });
   app.all("/mcp", (c) => {
     c.header("Allow", "POST");

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -1,0 +1,359 @@
+/**
+ * OAuth 2.1 AS 端点：RFC 8414 元数据、/authorize 入口、token、revoke。
+ * 同意页本身在 /ui/oauth/authorize（cookie path=/ui）。
+ */
+
+import { Hono } from 'hono';
+import { bodyLimit } from 'hono/body-limit';
+import {
+  fetchClientMetadata,
+  matchRedirectUri,
+  type CimdDocument,
+} from '../lib/oauth-cimd.ts';
+import { verifyS256CodeChallenge } from '../lib/oauth-pkce.ts';
+import {
+  consumeAuthorizationCode,
+  issueTokenPair,
+  rotateRefreshToken,
+  revokeToken,
+} from '../lib/oauth-store.ts';
+import {
+  buildAuthorizationServerMetadata,
+  resolveIssuer,
+  resolveResourceUri,
+} from '../lib/oauth-url.ts';
+
+const TOKEN_BODY_LIMIT = 8 * 1024;
+
+export type OAuthRouteOptions = {
+  /** 测试可注入 CIMD fetcher。 */
+  cimdFetcher?: Parameters<typeof fetchClientMetadata>[1] extends infer O
+    ? O extends { fetcher?: infer F }
+      ? F
+      : never
+    : never;
+};
+
+/** 授权错误回跳（RFC 9207：错误分支也带 iss）。 */
+export function buildAuthorizeRedirect(
+  redirectUri: string,
+  params: Record<string, string | undefined>,
+  issuer: string,
+): string {
+  const url = new URL(redirectUri);
+  for (const [k, v] of Object.entries(params)) {
+    if (v !== undefined) url.searchParams.set(k, v);
+  }
+  url.searchParams.set('iss', issuer);
+  return url.href;
+}
+
+function oauthErrorJson(
+  c: { json: (body: unknown, status: 400 | 401) => Response },
+  error: string,
+  description?: string,
+  status: 400 | 401 = 400,
+) {
+  return c.json(
+    {
+      error,
+      ...(description ? { error_description: description } : {}),
+    },
+    status,
+  );
+}
+
+async function parseTokenBody(
+  c: { req: { header: (n: string) => string | undefined; parseBody: () => Promise<unknown>; json: () => Promise<unknown> } },
+): Promise<Record<string, string>> {
+  const ct = c.req.header('content-type') ?? '';
+  if (ct.includes('application/json')) {
+    const body = (await c.req.json()) as Record<string, unknown>;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(body ?? {})) {
+      if (typeof v === 'string') out[k] = v;
+    }
+    return out;
+  }
+  // application/x-www-form-urlencoded（OAuth 默认）
+  const body = (await c.req.parseBody()) as Record<string, unknown>;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(body ?? {})) {
+    if (typeof v === 'string') out[k] = v;
+  }
+  return out;
+}
+
+/**
+ * 注册公开 OAuth 路由（无 UI session）。
+ * /authorize 仅作入口 302 → /ui/oauth/authorize（因 cookie path=/ui）。
+ */
+export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}): void {
+  app.get('/.well-known/oauth-authorization-server', (c) => {
+    const origin = new URL(c.req.url).origin;
+    return c.json(buildAuthorizationServerMetadata(origin));
+  });
+
+  app.get('/authorize', (c) => {
+    const url = new URL(c.req.url);
+    const target = new URL('/ui/oauth/authorize', url.origin);
+    target.search = url.search;
+    return c.redirect(target.href, 302);
+  });
+
+  app.use(
+    '/oauth/token',
+    bodyLimit({
+      maxSize: TOKEN_BODY_LIMIT,
+      onError: (c) => oauthErrorJson(c, 'invalid_request', 'request too large'),
+    }),
+  );
+  app.use(
+    '/oauth/revoke',
+    bodyLimit({
+      maxSize: TOKEN_BODY_LIMIT,
+      onError: (c) => c.json({ error: 'invalid_request' }, 400),
+    }),
+  );
+
+  app.post('/oauth/token', async (c) => {
+    const origin = new URL(c.req.url).origin;
+    const expectedResource = resolveResourceUri(origin);
+    let body: Record<string, string>;
+    try {
+      body = await parseTokenBody(c);
+    } catch {
+      return oauthErrorJson(c, 'invalid_request', 'malformed body');
+    }
+
+    const grantType = body.grant_type;
+    if (grantType === 'authorization_code') {
+      return handleAuthorizationCode(c, body, expectedResource, options);
+    }
+    if (grantType === 'refresh_token') {
+      return handleRefresh(c, body, expectedResource);
+    }
+    return oauthErrorJson(c, 'unsupported_grant_type');
+  });
+
+  app.post('/oauth/revoke', async (c) => {
+    let body: Record<string, string>;
+    try {
+      body = await parseTokenBody(c);
+    } catch {
+      return c.json({ error: 'invalid_request' }, 400);
+    }
+    const token = body.token;
+    // RFC 7009：未知令牌也返回 200
+    if (token) revokeToken(token);
+    return c.body(null, 200);
+  });
+}
+
+async function handleAuthorizationCode(
+  c: { json: (body: unknown, status?: 200 | 400 | 401) => Response },
+  body: Record<string, string>,
+  expectedResource: string,
+  options: OAuthRouteOptions,
+) {
+  const code = body.code;
+  const redirectUri = body.redirect_uri;
+  const clientId = body.client_id;
+  const codeVerifier = body.code_verifier;
+  const resource = body.resource;
+
+  if (!code || !redirectUri || !clientId || !codeVerifier) {
+    return oauthErrorJson(c, 'invalid_request', 'missing required parameters');
+  }
+  if (!resource) {
+    return oauthErrorJson(c, 'invalid_target', 'resource required');
+  }
+  if (resource !== expectedResource) {
+    return oauthErrorJson(c, 'invalid_target', 'resource mismatch');
+  }
+
+  // 再验 CIMD + redirect（防 code 被挪到别的 redirect）
+  const cimd = await fetchClientMetadata(clientId, {
+    fetcher: options.cimdFetcher,
+  });
+  if (!cimd.ok) {
+    return oauthErrorJson(c, 'invalid_client', cimd.reason);
+  }
+  if (!matchRedirectUri(redirectUri, cimd.doc.redirect_uris)) {
+    return oauthErrorJson(c, 'invalid_request', 'redirect_uri mismatch');
+  }
+
+  const consumed = consumeAuthorizationCode(code);
+  if (!consumed.ok) {
+    return oauthErrorJson(c, 'invalid_grant', consumed.reason, 400);
+  }
+  if (consumed.clientId !== clientId) {
+    return oauthErrorJson(c, 'invalid_grant', 'client_id mismatch');
+  }
+  if (!matchRedirectUri(redirectUri, [consumed.redirectUri])) {
+    return oauthErrorJson(c, 'invalid_grant', 'redirect_uri mismatch');
+  }
+  if (consumed.resource !== resource) {
+    return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
+  }
+  if (!verifyS256CodeChallenge(codeVerifier, consumed.codeChallenge)) {
+    return oauthErrorJson(c, 'invalid_grant', 'pkce verification failed');
+  }
+
+  const tokens = issueTokenPair({
+    grantId: consumed.grantId,
+    address: consumed.address,
+    aud: expectedResource,
+  });
+
+  return c.json({
+    access_token: tokens.accessToken,
+    token_type: 'Bearer',
+    expires_in: tokens.expiresIn,
+    refresh_token: tokens.refreshToken,
+  });
+}
+
+function handleRefresh(
+  c: { json: (body: unknown, status?: 200 | 400 | 401) => Response },
+  body: Record<string, string>,
+  expectedResource: string,
+) {
+  const refreshToken = body.refresh_token;
+  const resource = body.resource;
+  if (!refreshToken) {
+    return oauthErrorJson(c, 'invalid_request', 'refresh_token required');
+  }
+  if (!resource) {
+    return oauthErrorJson(c, 'invalid_target', 'resource required');
+  }
+  if (resource !== expectedResource) {
+    return oauthErrorJson(c, 'invalid_target', 'resource mismatch');
+  }
+
+  const rotated = rotateRefreshToken(refreshToken);
+  if (!rotated.ok) {
+    return oauthErrorJson(c, 'invalid_grant', rotated.reason, 400);
+  }
+  if (rotated.aud !== expectedResource) {
+    return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
+  }
+
+  return c.json({
+    access_token: rotated.accessToken,
+    token_type: 'Bearer',
+    expires_in: rotated.expiresIn,
+    refresh_token: rotated.refreshToken,
+  });
+}
+
+/** 供同意页复用：预检授权请求参数。 */
+export async function preflightAuthorizeRequest(
+  query: Record<string, string | undefined>,
+  requestOrigin: string,
+  options: OAuthRouteOptions = {},
+): Promise<
+  | {
+      ok: true;
+      clientId: string;
+      redirectUri: string;
+      codeChallenge: string;
+      state?: string;
+      resource: string;
+      doc: CimdDocument;
+      issuer: string;
+      loopbackWarning: boolean;
+    }
+  | { ok: false; kind: 'redirect'; location: string }
+  | { ok: false; kind: 'page'; status: 400; message: string }
+> {
+  const issuer = resolveIssuer(requestOrigin);
+  const expectedResource = resolveResourceUri(requestOrigin);
+
+  const clientId = query.client_id;
+  const redirectUri = query.redirect_uri;
+  const responseType = query.response_type;
+  const codeChallenge = query.code_challenge;
+  const codeChallengeMethod = query.code_challenge_method;
+  const resource = query.resource;
+  const state = query.state;
+
+  // 无 client_id/redirect_uri：只能错误页（尚无已登记回调）
+  if (!clientId || !redirectUri) {
+    return {
+      ok: false,
+      kind: 'page',
+      status: 400,
+      message: 'Missing client_id or redirect_uri.',
+    };
+  }
+
+  // RFC 6749：MUST NOT 向未登记 redirect_uri 重定向。
+  // 先 CIMD + 精确/loopback 匹配，失败一律错误页；通过后错误分支才可 302+iss。
+  const cimd = await fetchClientMetadata(clientId, {
+    fetcher: options.cimdFetcher,
+  });
+  if (!cimd.ok) {
+    return {
+      ok: false,
+      kind: 'page',
+      status: 400,
+      message: `Invalid client: ${cimd.reason}`,
+    };
+  }
+  if (!matchRedirectUri(redirectUri, cimd.doc.redirect_uris)) {
+    return {
+      ok: false,
+      kind: 'page',
+      status: 400,
+      message: 'redirect_uri is not registered for this client.',
+    };
+  }
+
+  const failRedirect = (error: string, description: string) => ({
+    ok: false as const,
+    kind: 'redirect' as const,
+    location: buildAuthorizeRedirect(
+      redirectUri,
+      { error, error_description: description, ...(state ? { state } : {}) },
+      issuer,
+    ),
+  });
+
+  if (responseType !== 'code') {
+    return failRedirect('unsupported_response_type', 'only code is supported');
+  }
+  if (!codeChallenge) {
+    return failRedirect('invalid_request', 'code_challenge required');
+  }
+  if (codeChallengeMethod !== 'S256') {
+    return failRedirect('invalid_request', 'only S256 code_challenge_method is supported');
+  }
+  if (!resource) {
+    return failRedirect('invalid_target', 'resource required');
+  }
+  if (resource !== expectedResource) {
+    return failRedirect('invalid_target', 'resource does not match this server');
+  }
+
+  const loopbackWarning = cimd.doc.redirect_uris.every((u) => {
+    try {
+      const host = new URL(u).hostname.toLowerCase();
+      return host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+    } catch {
+      return false;
+    }
+  });
+
+  return {
+    ok: true,
+    clientId,
+    redirectUri,
+    codeChallenge,
+    state,
+    resource,
+    doc: cimd.doc,
+    issuer,
+    loopbackWarning,
+  };
+}

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -14,6 +14,7 @@ import { verifyS256CodeChallenge } from '../lib/oauth-pkce.ts';
 import {
   consumeAuthorizationCode,
   issueTokenPair,
+  peekAuthorizationCode,
   rotateRefreshToken,
   revokeToken,
 } from '../lib/oauth-store.ts';
@@ -24,6 +25,9 @@ import {
 } from '../lib/oauth-url.ts';
 
 const TOKEN_BODY_LIMIT = 8 * 1024;
+
+/** refresh 失败对外统一描述（灭 oracle）。 */
+const REFRESH_INVALID_DESC = 'refresh token invalid or expired';
 
 export type OAuthRouteOptions = {
   /** 测试可注入 CIMD fetcher。 */
@@ -63,6 +67,19 @@ function oauthErrorJson(
   );
 }
 
+/** RFC 6749 §5.1：成功 token 响应禁缓存。 */
+function tokenSuccessJson(
+  c: {
+    header: (n: string, v: string) => void;
+    json: (body: unknown, status?: 200) => Response;
+  },
+  body: Record<string, unknown>,
+) {
+  c.header('Cache-Control', 'no-store');
+  c.header('Pragma', 'no-cache');
+  return c.json(body);
+}
+
 async function parseTokenBody(
   c: { req: { header: (n: string) => string | undefined; parseBody: () => Promise<unknown>; json: () => Promise<unknown> } },
 ): Promise<Record<string, string>> {
@@ -85,8 +102,33 @@ async function parseTokenBody(
 }
 
 /**
+ * 浏览器面 revoke：仅当带 Cookie 或 Sec-Fetch-Site 时要求 Origin 同站或
+ * Sec-Fetch-Site: none；纯机器客户端（无这些头）不受影响。
+ */
+function browserRevokeOriginOk(c: {
+  req: { header: (n: string) => string | undefined; url: string };
+}): boolean {
+  const cookie = c.req.header('cookie');
+  const secFetchSite = c.req.header('sec-fetch-site');
+  const hasBrowserSignal =
+    (cookie !== undefined && cookie.length > 0) ||
+    (secFetchSite !== undefined && secFetchSite.length > 0);
+  if (!hasBrowserSignal) return true;
+
+  if (secFetchSite?.toLowerCase() === 'none') return true;
+
+  const origin = c.req.header('origin');
+  if (!origin) return false;
+  try {
+    return new URL(origin).origin === new URL(c.req.url).origin;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * 注册公开 OAuth 路由（无 UI session）。
- * /authorize 仅作入口 302 → /ui/oauth/authorize（因 cookie path=/ui）。
+ * /authorize 仅作入口 302 → 相对 Location /ui/oauth/authorize（反代 https 不降级）。
  */
 export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}): void {
   app.get('/.well-known/oauth-authorization-server', (c) => {
@@ -96,9 +138,8 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
 
   app.get('/authorize', (c) => {
     const url = new URL(c.req.url);
-    const target = new URL('/ui/oauth/authorize', url.origin);
-    target.search = url.search;
-    return c.redirect(target.href, 302);
+    // 相对 Location：经 TLS 反代时不把 scheme 降成请求里的 http
+    return c.redirect(`/ui/oauth/authorize${url.search}`, 302);
   });
 
   app.use(
@@ -128,7 +169,7 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
 
     const grantType = body.grant_type;
     if (grantType === 'authorization_code') {
-      return handleAuthorizationCode(c, body, expectedResource, options);
+      return handleAuthorizationCode(c, body, expectedResource);
     }
     if (grantType === 'refresh_token') {
       return handleRefresh(c, body, expectedResource);
@@ -137,6 +178,9 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
   });
 
   app.post('/oauth/revoke', async (c) => {
+    if (!browserRevokeOriginOk(c)) {
+      return c.json({ error: 'invalid_request', error_description: 'origin required' }, 400);
+    }
     let body: Record<string, string>;
     try {
       body = await parseTokenBody(c);
@@ -150,11 +194,18 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
   });
 }
 
-async function handleAuthorizationCode(
-  c: { json: (body: unknown, status?: 200 | 400 | 401) => Response },
+/**
+ * code 交换：用**存储的** client_id/redirect_uri/resource 校验，
+ * 不为调用方 client_id 发起 CIMD fetch（消灭预授权 SSRF 面）。
+ * 顺序：peek → 全量校验 → 原子消费 → 签发。
+ */
+function handleAuthorizationCode(
+  c: {
+    header: (n: string, v: string) => void;
+    json: (body: unknown, status?: 200 | 400 | 401) => Response;
+  },
   body: Record<string, string>,
   expectedResource: string,
-  options: OAuthRouteOptions,
 ) {
   const code = body.code;
   const redirectUri = body.redirect_uri;
@@ -172,32 +223,30 @@ async function handleAuthorizationCode(
     return oauthErrorJson(c, 'invalid_target', 'resource mismatch');
   }
 
-  // 再验 CIMD + redirect（防 code 被挪到别的 redirect）
-  const cimd = await fetchClientMetadata(clientId, {
-    fetcher: options.cimdFetcher,
-  });
-  if (!cimd.ok) {
-    return oauthErrorJson(c, 'invalid_client', cimd.reason);
-  }
-  if (!matchRedirectUri(redirectUri, cimd.doc.redirect_uris)) {
-    return oauthErrorJson(c, 'invalid_request', 'redirect_uri mismatch');
+  // 先 peek：不删 code，校验失败时合法客户端仍可重试
+  const peeked = peekAuthorizationCode(code);
+  if (!peeked.ok) {
+    return oauthErrorJson(c, 'invalid_grant', peeked.reason, 400);
   }
 
+  // 全部用存储字段比对（调用方 client_id 必须与存储一致）
+  if (peeked.clientId !== clientId) {
+    return oauthErrorJson(c, 'invalid_grant', 'client_id mismatch');
+  }
+  if (!matchRedirectUri(redirectUri, [peeked.redirectUri])) {
+    return oauthErrorJson(c, 'invalid_grant', 'redirect_uri mismatch');
+  }
+  if (peeked.resource !== resource) {
+    return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
+  }
+  if (!verifyS256CodeChallenge(codeVerifier, peeked.codeChallenge)) {
+    return oauthErrorJson(c, 'invalid_grant', 'pkce verification failed');
+  }
+
+  // 校验通过后原子消费（拦截者无 verifier 只能拒一次可用性）
   const consumed = consumeAuthorizationCode(code);
   if (!consumed.ok) {
     return oauthErrorJson(c, 'invalid_grant', consumed.reason, 400);
-  }
-  if (consumed.clientId !== clientId) {
-    return oauthErrorJson(c, 'invalid_grant', 'client_id mismatch');
-  }
-  if (!matchRedirectUri(redirectUri, [consumed.redirectUri])) {
-    return oauthErrorJson(c, 'invalid_grant', 'redirect_uri mismatch');
-  }
-  if (consumed.resource !== resource) {
-    return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
-  }
-  if (!verifyS256CodeChallenge(codeVerifier, consumed.codeChallenge)) {
-    return oauthErrorJson(c, 'invalid_grant', 'pkce verification failed');
   }
 
   const tokens = issueTokenPair({
@@ -206,7 +255,7 @@ async function handleAuthorizationCode(
     aud: expectedResource,
   });
 
-  return c.json({
+  return tokenSuccessJson(c, {
     access_token: tokens.accessToken,
     token_type: 'Bearer',
     expires_in: tokens.expiresIn,
@@ -215,14 +264,22 @@ async function handleAuthorizationCode(
 }
 
 function handleRefresh(
-  c: { json: (body: unknown, status?: 200 | 400 | 401) => Response },
+  c: {
+    header: (n: string, v: string) => void;
+    json: (body: unknown, status?: 200 | 400 | 401) => Response;
+  },
   body: Record<string, string>,
   expectedResource: string,
 ) {
   const refreshToken = body.refresh_token;
   const resource = body.resource;
+  const clientId = body.client_id;
   if (!refreshToken) {
     return oauthErrorJson(c, 'invalid_request', 'refresh_token required');
+  }
+  if (!clientId) {
+    // RFC 6749 §6 public client：必须带 client_id
+    return oauthErrorJson(c, 'invalid_request', 'client_id required');
   }
   if (!resource) {
     return oauthErrorJson(c, 'invalid_target', 'resource required');
@@ -231,15 +288,15 @@ function handleRefresh(
     return oauthErrorJson(c, 'invalid_target', 'resource mismatch');
   }
 
-  const rotated = rotateRefreshToken(refreshToken);
+  const rotated = rotateRefreshToken(refreshToken, {
+    expectedAud: expectedResource,
+    clientId,
+  });
   if (!rotated.ok) {
-    return oauthErrorJson(c, 'invalid_grant', rotated.reason, 400);
-  }
-  if (rotated.aud !== expectedResource) {
-    return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
+    return oauthErrorJson(c, 'invalid_grant', REFRESH_INVALID_DESC, 400);
   }
 
-  return c.json({
+  return tokenSuccessJson(c, {
     access_token: rotated.accessToken,
     token_type: 'Bearer',
     expires_in: rotated.expiresIn,

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -188,8 +188,9 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
       return c.json({ error: 'invalid_request' }, 400);
     }
     const token = body.token;
-    // RFC 7009：未知令牌也返回 200
-    if (token) revokeToken(token);
+    const clientId = body.client_id;
+    // RFC 7009：一律 200；无/错 client_id 不删（灭持票第三方 DoS）
+    if (token) revokeToken(token, clientId);
     return c.body(null, 200);
   });
 }

--- a/packages/api/src/routes/ui-oauth.ts
+++ b/packages/api/src/routes/ui-oauth.ts
@@ -1,0 +1,451 @@
+/**
+ * Dashboard 内 OAuth 同意页与授权管理。
+ * 挂 /ui 体系：requireUiOrigin + uiSessionAuth；风格与现有 UI 一致（服务端 HTML）。
+ */
+
+import { getCookie } from 'hono/cookie';
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { getAuth } from '../lib/auth.ts';
+import {
+  createIdentity,
+  listIdentities,
+  LOCALPART_RE,
+} from '../lib/identities.ts';
+import { redirectUriIsLoopback } from '../lib/oauth-cimd.ts';
+import {
+  createGrantAndCode,
+  getGrant,
+  listGrantsForAuth,
+  revokeGrant,
+} from '../lib/oauth-store.ts';
+import { setOAuthReturnCookie } from '../lib/oauth-return.ts';
+import {
+  UiSessionStore,
+  requireUiOrigin,
+  uiPrivateHeaders,
+  uiSessionAuth,
+  uiSessionBodyLimit,
+} from '../lib/ui-session.ts';
+import {
+  buildAuthorizeRedirect,
+  preflightAuthorizeRequest,
+  type OAuthRouteOptions,
+} from './oauth.ts';
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function clientHostname(clientId: string): string {
+  try {
+    return new URL(clientId).hostname;
+  } catch {
+    return clientId;
+  }
+}
+
+function redirectHostname(redirectUri: string): string {
+  try {
+    return new URL(redirectUri).host;
+  } catch {
+    return redirectUri;
+  }
+}
+
+const PAGE_CSS = `
+:root { color-scheme: dark; --bg:#0c0d12; --card:#161821; --text:#f5f5f5; --muted:#9ca3af; --accent:#fbbf24; --danger:#f87171; --line:#2a2d3a; }
+*{box-sizing:border-box} body{margin:0;font:16px/1.5 Satoshi,system-ui,sans-serif;background:var(--bg);color:var(--text)}
+main{max-width:560px;margin:48px auto;padding:0 20px}
+.brand{display:flex;align-items:center;gap:10px;margin-bottom:24px}
+.brand span{font-weight:700;letter-spacing:-0.02em}
+.card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:24px}
+h1{font-size:1.4rem;margin:0 0 8px;letter-spacing:-0.02em}
+.muted{color:var(--muted);margin:0 0 16px}
+.meta{display:grid;gap:8px;margin:16px 0;padding:12px;border:1px solid var(--line);border-radius:8px;font-size:0.92rem}
+.meta dt{color:var(--muted);font-size:0.8rem} .meta dd{margin:0 0 8px;word-break:break-all}
+.warn{background:#3b2210;color:#fbbf24;border:1px solid #78521f;padding:10px 12px;border-radius:8px;margin:12px 0;font-size:0.9rem}
+label.row{display:flex;gap:8px;align-items:flex-start;margin:10px 0}
+input[type=text],select{width:100%;padding:8px 10px;border-radius:8px;border:1px solid var(--line);background:#0c0d12;color:var(--text);margin-top:4px}
+button,.btn{display:inline-block;padding:10px 16px;border-radius:8px;border:0;font-weight:600;cursor:pointer;text-decoration:none}
+button.primary{background:var(--accent);color:#111}
+button.quiet,.btn.quiet{background:transparent;color:var(--muted);border:1px solid var(--line)}
+button.danger{background:#7f1d1d;color:#fecaca}
+.actions{display:flex;gap:10px;margin-top:20px;flex-wrap:wrap}
+table{width:100%;border-collapse:collapse;font-size:0.92rem}
+th,td{text-align:left;padding:10px 8px;border-bottom:1px solid var(--line);vertical-align:top}
+th{color:var(--muted);font-weight:600;font-size:0.8rem}
+.empty{color:var(--muted);padding:24px 0}
+.error{color:var(--danger)}
+`;
+
+function shell(title: string, body: string): string {
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>${escapeHtml(title)} · OpenAgent.email</title>
+<style>${PAGE_CSS}</style></head><body><main>
+<div class="brand"><span>OpenAgent.email</span></div>
+${body}
+</main></body></html>`;
+}
+
+function htmlResponse(c: Context, html: string, status: 200 | 400 | 401 | 403 = 200) {
+  c.header('Content-Type', 'text/html; charset=utf-8');
+  c.header('Cache-Control', 'no-store');
+  c.header('X-Content-Type-Options', 'nosniff');
+  c.header('Referrer-Policy', 'no-referrer');
+  c.header(
+    'Content-Security-Policy',
+    "default-src 'none'; style-src 'unsafe-inline'; img-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
+  );
+  return c.body(html, status);
+}
+
+/** 未登录：把同意页路径写入 return cookie，再跳 Dashboard 登录。 */
+function redirectToLogin(c: Context): Response {
+  const u = new URL(c.req.url);
+  setOAuthReturnCookie(c, `${u.pathname}${u.search}`);
+  return c.redirect('/ui', 302);
+}
+
+/** 同意仪式仅业主（admin）可执行；表单始终含已有身份 + 当场新建。 */
+function consentFormHtml(input: {
+  clientName: string;
+  clientId: string;
+  redirectUri: string;
+  codeChallenge: string;
+  state?: string;
+  resource: string;
+  loopbackWarning: boolean;
+  identities: { address: string }[];
+  error?: string;
+}): string {
+  const host = clientHostname(input.clientId);
+  const redirectHost = redirectHostname(input.redirectUri);
+  const identityOptions = input.identities
+    .map(
+      (i) =>
+        `<option value="${escapeHtml(i.address)}">${escapeHtml(i.address)}</option>`,
+    )
+    .join('');
+
+  const warn = input.loopbackWarning || redirectUriIsLoopback(input.redirectUri)
+    ? `<p class="warn">This client redirects to a loopback address (<strong>${escapeHtml(redirectHost)}</strong>). Only continue if you started this authorization yourself.</p>`
+    : '';
+
+  return shell(
+    'Authorize',
+    `<section class="card">
+      <h1>Authorize application</h1>
+      <p class="muted"><strong>${escapeHtml(input.clientName)}</strong> wants access to an OpenAgent identity via MCP.</p>
+      <dl class="meta">
+        <dt>Client</dt><dd>${escapeHtml(input.clientName)}</dd>
+        <dt>Client ID host</dt><dd>${escapeHtml(host)}</dd>
+        <dt>Redirect host</dt><dd>${escapeHtml(redirectHost)}</dd>
+        <dt>Client ID</dt><dd>${escapeHtml(input.clientId)}</dd>
+      </dl>
+      ${warn}
+      ${input.error ? `<p class="error">${escapeHtml(input.error)}</p>` : ''}
+      <form method="post" action="/ui/oauth/authorize">
+        <input type="hidden" name="client_id" value="${escapeHtml(input.clientId)}">
+        <input type="hidden" name="redirect_uri" value="${escapeHtml(input.redirectUri)}">
+        <input type="hidden" name="code_challenge" value="${escapeHtml(input.codeChallenge)}">
+        <input type="hidden" name="resource" value="${escapeHtml(input.resource)}">
+        ${input.state ? `<input type="hidden" name="state" value="${escapeHtml(input.state)}">` : ''}
+        <fieldset style="border:0;padding:0;margin:0">
+          <legend class="muted">Choose identity</legend>
+          <label class="row"><input type="radio" name="identity_mode" value="existing" checked>
+            <span>Existing identity<br><select name="address">${identityOptions}</select></span>
+          </label>
+          <label class="row"><input type="radio" name="identity_mode" value="create">
+            <span>Create a new identity<br>
+            <input type="text" name="localpart" placeholder="localpart" pattern="[a-z0-9][a-z0-9._-]{0,62}" autocomplete="off">
+            </span>
+          </label>
+        </fieldset>
+        <div class="actions">
+          <button class="primary" type="submit" name="decision" value="approve">Approve</button>
+          <button class="quiet" type="submit" name="decision" value="deny">Deny</button>
+        </div>
+      </form>
+    </section>`,
+  );
+}
+
+function adminOnlyForbiddenPage(): string {
+  return shell(
+    'Forbidden',
+    `<section class="card"><h1>Admin session required</h1>
+     <p class="error">OAuth consent is owner-only. Sign in with an admin API token.</p>
+     <p><a class="btn quiet" href="/ui">← Back to inbox</a></p></section>`,
+  );
+}
+
+function grantsPageHtml(grants: ReturnType<typeof listGrantsForAuth>): string {
+  const rows =
+    grants.length === 0
+      ? `<p class="empty">No authorized clients yet.</p>`
+      : `<table><thead><tr><th>Client</th><th>Identity</th><th>Authorized</th><th>Last used</th><th></th></tr></thead><tbody>
+        ${grants
+          .map(
+            (g) => `<tr>
+            <td>${escapeHtml(g.clientName)}<br><span class="muted" style="font-size:0.8rem">${escapeHtml(clientHostname(g.clientId))}</span></td>
+            <td>${escapeHtml(g.address)}</td>
+            <td>${escapeHtml(g.createdAt)}</td>
+            <td>${escapeHtml(g.lastUsedAt)}</td>
+            <td>
+              <form method="post" action="/ui/api/oauth/grants/${escapeHtml(g.id)}/revoke">
+                <button class="danger" type="submit">Revoke</button>
+              </form>
+            </td>
+          </tr>`,
+          )
+          .join('')}
+        </tbody></table>`;
+
+  return shell(
+    'Authorized clients',
+    `<section class="card">
+      <h1>Authorized clients</h1>
+      <p class="muted">OAuth grants for MCP clients. Revoking deletes the grant and invalidates all its tokens immediately.</p>
+      <p><a class="btn quiet" href="/ui">← Back to inbox</a></p>
+      ${rows}
+    </section>`,
+  );
+}
+
+export function createUiOAuthPageRoutes(
+  store: UiSessionStore,
+  options: OAuthRouteOptions = {},
+): Hono {
+  const routes = new Hono();
+
+  // 同意页：手工查 session（未登录→登录；非 admin→403）
+  routes.get('/authorize', async (c) => {
+    const sid = getCookie(c, 'oae_ui');
+    const session = sid ? store.authenticate(sid) : null;
+    if (!session) {
+      return redirectToLogin(c);
+    }
+    // 红线：同意仪式仅业主 admin；identity 自批准会把注入面升成 30d 可续期门票
+    if (session.auth.kind !== 'admin') {
+      return htmlResponse(c, adminOnlyForbiddenPage(), 403);
+    }
+
+    const q = c.req.query();
+    const pre = await preflightAuthorizeRequest(q, new URL(c.req.url).origin, options);
+    if (!pre.ok) {
+      if (pre.kind === 'redirect') return c.redirect(pre.location, 302);
+      return htmlResponse(
+        c,
+        shell('Authorization error', `<section class="card"><h1>Authorization error</h1><p class="error">${escapeHtml(pre.message)}</p></section>`),
+        pre.status,
+      );
+    }
+
+    return htmlResponse(
+      c,
+      consentFormHtml({
+        clientName: pre.doc.client_name,
+        clientId: pre.clientId,
+        redirectUri: pre.redirectUri,
+        codeChallenge: pre.codeChallenge,
+        state: pre.state,
+        resource: pre.resource,
+        loopbackWarning: pre.loopbackWarning,
+        identities: listIdentities(),
+      }),
+    );
+  });
+
+  routes.post('/authorize', requireUiOrigin, async (c) => {
+    const sid = getCookie(c, 'oae_ui');
+    const session = sid ? store.authenticate(sid) : null;
+    if (!session) {
+      return redirectToLogin(c);
+    }
+    if (session.auth.kind !== 'admin') {
+      return htmlResponse(c, adminOnlyForbiddenPage(), 403);
+    }
+
+    const form = (await c.req.parseBody()) as Record<string, string>;
+    const origin = new URL(c.req.url).origin;
+    const pre = await preflightAuthorizeRequest(
+      {
+        client_id: form.client_id,
+        redirect_uri: form.redirect_uri,
+        response_type: 'code',
+        code_challenge: form.code_challenge,
+        code_challenge_method: 'S256',
+        resource: form.resource,
+        state: form.state,
+      },
+      origin,
+      options,
+    );
+    if (!pre.ok) {
+      if (pre.kind === 'redirect') return c.redirect(pre.location, 302);
+      return htmlResponse(
+        c,
+        shell('Authorization error', `<p class="error">${escapeHtml(pre.message)}</p>`),
+        pre.status,
+      );
+    }
+
+    if (form.decision === 'deny') {
+      return c.redirect(
+        buildAuthorizeRedirect(
+          pre.redirectUri,
+          {
+            error: 'access_denied',
+            error_description: 'owner denied the request',
+            ...(pre.state ? { state: pre.state } : {}),
+          },
+          pre.issuer,
+        ),
+        302,
+      );
+    }
+
+    let address: string;
+    const mode = form.identity_mode ?? 'existing';
+    if (mode === 'create') {
+      const localpart = (form.localpart ?? '').toLowerCase().trim();
+      if (!LOCALPART_RE.test(localpart)) {
+        return htmlResponse(
+          c,
+          consentFormHtml({
+            clientName: pre.doc.client_name,
+            clientId: pre.clientId,
+            redirectUri: pre.redirectUri,
+            codeChallenge: pre.codeChallenge,
+            state: pre.state,
+            resource: pre.resource,
+            loopbackWarning: pre.loopbackWarning,
+            identities: listIdentities(),
+            error: 'Invalid localpart.',
+          }),
+          400,
+        );
+      }
+      const created = createIdentity({ localpart });
+      if (!created) {
+        return htmlResponse(
+          c,
+          consentFormHtml({
+            clientName: pre.doc.client_name,
+            clientId: pre.clientId,
+            redirectUri: pre.redirectUri,
+            codeChallenge: pre.codeChallenge,
+            state: pre.state,
+            resource: pre.resource,
+            loopbackWarning: pre.loopbackWarning,
+            identities: listIdentities(),
+            error: 'That address is already taken.',
+          }),
+          400,
+        );
+      }
+      address = created.identity.address;
+    } else {
+      address = (form.address ?? '').toLowerCase();
+      const known = listIdentities().some((i) => i.address.toLowerCase() === address);
+      if (!known) {
+        return htmlResponse(
+          c,
+          consentFormHtml({
+            clientName: pre.doc.client_name,
+            clientId: pre.clientId,
+            redirectUri: pre.redirectUri,
+            codeChallenge: pre.codeChallenge,
+            state: pre.state,
+            resource: pre.resource,
+            loopbackWarning: pre.loopbackWarning,
+            identities: listIdentities(),
+            error: 'Unknown identity.',
+          }),
+          400,
+        );
+      }
+    }
+
+    const { code } = createGrantAndCode({
+      clientId: pre.clientId,
+      clientName: pre.doc.client_name,
+      address,
+      redirectUri: pre.redirectUri,
+      codeChallenge: pre.codeChallenge,
+      resource: pre.resource,
+    });
+
+    return c.redirect(
+      buildAuthorizeRedirect(
+        pre.redirectUri,
+        {
+          code,
+          ...(pre.state ? { state: pre.state } : {}),
+        },
+        pre.issuer,
+      ),
+      302,
+    );
+  });
+
+  routes.get('/grants', async (c) => {
+    const sid = getCookie(c, 'oae_ui');
+    const session = sid ? store.authenticate(sid) : null;
+    if (!session) {
+      return redirectToLogin(c);
+    }
+    const grants = listGrantsForAuth(session.auth);
+    return htmlResponse(c, grantsPageHtml(grants));
+  });
+
+  return routes;
+}
+
+/** JSON/表单 API：列表 + 吊销（供管理页与测试）。 */
+export function createUiOAuthApiRoutes(store: UiSessionStore): Hono {
+  const routes = new Hono();
+  routes.use('*', uiPrivateHeaders);
+  routes.use('*', uiSessionBodyLimit);
+  routes.use('*', requireUiOrigin);
+  routes.use('*', uiSessionAuth(store));
+
+  routes.get('/grants', (c) => {
+    const auth = getAuth(c);
+    return c.json({ grants: listGrantsForAuth(auth) });
+  });
+
+  routes.delete('/grants/:id', (c) => {
+    const auth = getAuth(c);
+    const id = c.req.param('id');
+    const grant = getGrant(id);
+    if (!grant) return c.json({ error: 'not_found' }, 404);
+    if (auth.kind === 'identity' && grant.address.toLowerCase() !== auth.address.toLowerCase()) {
+      return c.json({ error: 'forbidden' }, 403);
+    }
+    revokeGrant(id);
+    return c.body(null, 204);
+  });
+
+  // 管理页 HTML 表单 POST 吊销（同 origin + session）
+  routes.post('/grants/:id/revoke', async (c) => {
+    const auth = getAuth(c);
+    const id = c.req.param('id');
+    const grant = getGrant(id);
+    if (!grant) return c.redirect('/ui/oauth/grants', 302);
+    if (auth.kind === 'identity' && grant.address.toLowerCase() !== auth.address.toLowerCase()) {
+      return c.json({ error: 'forbidden' }, 403);
+    }
+    revokeGrant(id);
+    return c.redirect('/ui/oauth/grants', 302);
+  });
+
+  return routes;
+}

--- a/packages/api/src/routes/ui-oauth.ts
+++ b/packages/api/src/routes/ui-oauth.ts
@@ -9,9 +9,11 @@ import type { Context } from 'hono';
 import { getAuth } from '../lib/auth.ts';
 import {
   createIdentity,
+  deleteIdentity,
   listIdentities,
   LOCALPART_RE,
 } from '../lib/identities.ts';
+import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
 import { redirectUriIsLoopback } from '../lib/oauth-cimd.ts';
 import {
   createGrantAndCode,
@@ -104,6 +106,48 @@ function htmlResponse(c: Context, html: string, status: 200 | 400 | 401 | 403 = 
     "default-src 'none'; style-src 'unsafe-inline'; img-src 'none'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
   );
   return c.body(html, status);
+}
+
+/**
+ * 批准/拒绝后的过渡页：200 + meta refresh + 可见链接。
+ * Chrome 会因 CSP form-action 'self' 拦 302 外跳，故不用 302；本页 CSP 不含 form-action。
+ */
+function authorizeHandoffResponse(c: Context, redirectUrl: string): Response {
+  const safe = escapeHtml(redirectUrl);
+  // meta refresh 的 URL 用属性转义；可见链接同
+  const html = `<!doctype html><html lang="zh-CN"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="refresh" content="0;url=${safe}">
+<title>已授权 · OpenAgent.email</title>
+<style>${PAGE_CSS}</style></head><body><main>
+<section class="card">
+  <h1>已授权，正在跳回客户端</h1>
+  <p class="muted">若未自动跳转，请点击下方链接继续。</p>
+  <p><a class="btn primary" href="${safe}">返回客户端</a></p>
+</section>
+</main></body></html>`;
+  c.header('Content-Type', 'text/html; charset=utf-8');
+  c.header('Cache-Control', 'no-store');
+  c.header('X-Content-Type-Options', 'nosniff');
+  c.header('Referrer-Policy', 'no-referrer');
+  // 故意不含 form-action：允许用户点击外链回到客户端
+  c.header(
+    'Content-Security-Policy',
+    "default-src 'none'; style-src 'unsafe-inline'; img-src 'none'; base-uri 'none'; frame-ancestors 'none'",
+  );
+  return c.body(html, 200);
+}
+
+/** 解析同意表单：值必须是 string，File → 400（禁止 cast 出 TypeError 500）。 */
+function parseConsentForm(
+  raw: Record<string, string | File>,
+): { ok: true; form: Record<string, string> } | { ok: false } {
+  const form: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v !== 'string') return { ok: false };
+    form[k] = v;
+  }
+  return { ok: true, form };
 }
 
 /** 未登录：把同意页路径写入 return cookie，再跳 Dashboard 登录。 */
@@ -263,7 +307,8 @@ export function createUiOAuthPageRoutes(
     );
   });
 
-  routes.post('/authorize', requireUiOrigin, async (c) => {
+  // 与其他 /ui/api 一致限体，防超大 multipart
+  routes.post('/authorize', uiSessionBodyLimit, requireUiOrigin, async (c) => {
     const sid = getCookie(c, 'oae_ui');
     const session = sid ? store.authenticate(sid) : null;
     if (!session) {
@@ -273,7 +318,25 @@ export function createUiOAuthPageRoutes(
       return htmlResponse(c, adminOnlyForbiddenPage(), 403);
     }
 
-    const form = (await c.req.parseBody()) as Record<string, string>;
+    let rawBody: Record<string, string | File>;
+    try {
+      rawBody = (await c.req.parseBody()) as Record<string, string | File>;
+    } catch {
+      return htmlResponse(
+        c,
+        shell('Authorization error', `<p class="error">Malformed body.</p>`),
+        400,
+      );
+    }
+    const parsed = parseConsentForm(rawBody);
+    if (!parsed.ok) {
+      return htmlResponse(
+        c,
+        shell('Authorization error', `<p class="error">Invalid form field types.</p>`),
+        400,
+      );
+    }
+    const form = parsed.form;
     const origin = new URL(c.req.url).origin;
     const pre = await preflightAuthorizeRequest(
       {
@@ -289,7 +352,7 @@ export function createUiOAuthPageRoutes(
       options,
     );
     if (!pre.ok) {
-      if (pre.kind === 'redirect') return c.redirect(pre.location, 302);
+      if (pre.kind === 'redirect') return authorizeHandoffResponse(c, pre.location);
       return htmlResponse(
         c,
         shell('Authorization error', `<p class="error">${escapeHtml(pre.message)}</p>`),
@@ -298,7 +361,8 @@ export function createUiOAuthPageRoutes(
     }
 
     if (form.decision === 'deny') {
-      return c.redirect(
+      return authorizeHandoffResponse(
+        c,
         buildAuthorizeRedirect(
           pre.redirectUri,
           {
@@ -308,7 +372,6 @@ export function createUiOAuthPageRoutes(
           },
           pre.issuer,
         ),
-        302,
       );
     }
 
@@ -333,7 +396,8 @@ export function createUiOAuthPageRoutes(
           400,
         );
       }
-      const created = createIdentity({ localpart });
+      // 同意页新建：不发 oa_ 幽灵票；失败时回滚身份
+      const created = createIdentity({ localpart, issueToken: false });
       if (!created) {
         return htmlResponse(
           c,
@@ -347,6 +411,30 @@ export function createUiOAuthPageRoutes(
             loopbackWarning: pre.loopbackWarning,
             identities: listIdentities(),
             error: 'That address is already taken.',
+          }),
+          400,
+        );
+      }
+      try {
+        await provisionIdentityNotifications(created.identity);
+      } catch (err) {
+        deleteIdentity(created.identity.address);
+        const msg =
+          err instanceof NotifyError
+            ? 'Notification provisioning failed; identity was not created.'
+            : 'Failed to provision identity.';
+        return htmlResponse(
+          c,
+          consentFormHtml({
+            clientName: pre.doc.client_name,
+            clientId: pre.clientId,
+            redirectUri: pre.redirectUri,
+            codeChallenge: pre.codeChallenge,
+            state: pre.state,
+            resource: pre.resource,
+            loopbackWarning: pre.loopbackWarning,
+            identities: listIdentities(),
+            error: msg,
           }),
           400,
         );
@@ -383,7 +471,8 @@ export function createUiOAuthPageRoutes(
       resource: pre.resource,
     });
 
-    return c.redirect(
+    return authorizeHandoffResponse(
+      c,
       buildAuthorizeRedirect(
         pre.redirectUri,
         {
@@ -392,7 +481,6 @@ export function createUiOAuthPageRoutes(
         },
         pre.issuer,
       ),
-      302,
     );
   });
 

--- a/packages/api/src/routes/ui-oauth.ts
+++ b/packages/api/src/routes/ui-oauth.ts
@@ -14,7 +14,7 @@ import {
   LOCALPART_RE,
 } from '../lib/identities.ts';
 import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
-import { redirectUriIsLoopback } from '../lib/oauth-cimd.ts';
+import { isAllowedRedirectUri, redirectUriIsLoopback } from '../lib/oauth-cimd.ts';
 import {
   createGrantAndCode,
   getGrant,
@@ -113,6 +113,10 @@ function htmlResponse(c: Context, html: string, status: 200 | 400 | 401 | 403 = 
  * Chrome 会因 CSP form-action 'self' 拦 302 外跳，故不用 302；本页 CSP 不含 form-action。
  */
 function authorizeHandoffResponse(c: Context, redirectUrl: string): Response {
+  // 契约硬化：必须过返工 3 scheme 白名单（https / http-loopback）
+  if (!isAllowedRedirectUri(redirectUrl)) {
+    throw new Error('authorize_handoff_forbidden_redirect');
+  }
   const safe = escapeHtml(redirectUrl);
   // meta refresh 的 URL 用属性转义；可见链接同
   const html = `<!doctype html><html lang="zh-CN"><head><meta charset="utf-8">

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -39,6 +39,7 @@ import {
   taskParticipants,
   taskService,
 } from '../lib/tasks.ts';
+import { consumeOAuthReturnCookie } from '../lib/oauth-return.ts';
 import {
   UiSessionStore,
   uiPrivateHeaders,
@@ -295,7 +296,12 @@ export function createUiApiRoutes(
   routes.use('*', uiPrivateHeaders);
   routes.use('*', uiSessionAuth(store));
 
-  routes.get('/me', (c) => c.json(getAuth(c)));
+  routes.get('/me', (c) => {
+    const auth = getAuth(c);
+    // 已登录用户打开 /ui 时若仍挂着 OAuth return cookie，一并交给前端回跳。
+    const returnTo = consumeOAuthReturnCookie(c);
+    return c.json(returnTo ? { ...auth, returnTo } : auth);
+  });
 
   routes.get('/identities', (c) => {
     const auth = getAuth(c);

--- a/packages/api/src/ui/assets.ts
+++ b/packages/api/src/ui/assets.ts
@@ -1258,6 +1258,17 @@ export const UI_JS = `(function () {
     loginError.textContent = '';
   }
 
+  /* OAuth 同意页回跳：路径由服务端会话接口 JSON 下发（cookie），不读地址栏查询串。 */
+  function consumeReturnTo(payload) {
+    var path = payload && typeof payload.returnTo === 'string' ? payload.returnTo : '';
+    /* 拒绝协议相对路径（两段斜杠开头）；字面量拆开以免触碰资产契约对 // 的禁令。 */
+    if (!path || path.charAt(0) !== '/') return false;
+    if (path.length >= 2 && path.charAt(1) === '/') return false;
+    if (path.indexOf('/ui/') !== 0 && path !== '/ui') return false;
+    window.location.replace(path);
+    return true;
+  }
+
   function isAdmin() {
     return Boolean(state.me) && state.me.kind === 'admin';
   }
@@ -3769,7 +3780,10 @@ export const UI_JS = `(function () {
           : 'Sign-in is temporarily unavailable. Try again.';
         return;
       }
-      state.me = await response.json();
+      var loginPayload = await response.json();
+      state.me = loginPayload;
+      /* 登录成功后若服务端带回 returnTo（OAuth 同意页），优先回跳。 */
+      if (consumeReturnTo(loginPayload)) return;
       showInbox();
       await startSession();
     } catch {
@@ -3887,7 +3901,9 @@ export const UI_JS = `(function () {
       var response = await fetch('/ui/api/me', { credentials: 'same-origin' });
       if (response.status === 401) { showLogin(''); return; }
       if (!response.ok) throw new Error('request_failed');
-      state.me = await response.json();
+      var mePayload = await response.json();
+      state.me = mePayload;
+      if (consumeReturnTo(mePayload)) return;
       showInbox();
       await startSession();
     } catch {

--- a/packages/api/test/mcp-http.test.ts
+++ b/packages/api/test/mcp-http.test.ts
@@ -129,7 +129,7 @@ describe('MCP 元数据 origin / insecure issuer', () => {
     );
   });
 
-  test('loopback / 私网 http 放行 insecure issuer', () => {
+  test('loopback / 私网 http 放行 insecure issuer（与 lib/net 同源）', () => {
     expect(allowInsecureIssuerUrl('http://127.0.0.1:3100')).toBe(true);
     expect(allowInsecureIssuerUrl('http://localhost:3100')).toBe(true);
     expect(allowInsecureIssuerUrl('http://10.1.2.3')).toBe(true);
@@ -138,7 +138,12 @@ describe('MCP 元数据 origin / insecure issuer', () => {
     expect(allowInsecureIssuerUrl('http://100.64.1.2')).toBe(true);
     expect(allowInsecureIssuerUrl('http://[::1]/')).toBe(true);
     expect(allowInsecureIssuerUrl('http://[fd12:3456::1]')).toBe(true);
+    // 语义统一：fe80 链路本地现与 CIMD 一致，算可放行私网
+    expect(allowInsecureIssuerUrl('http://[fe80::1]/')).toBe(true);
     expect(allowInsecureIssuerUrl('https://127.0.0.1')).toBe(false);
+    // 永拒段不算私网：绝不开 insecure issuer
+    expect(allowInsecureIssuerUrl('http://169.254.169.254')).toBe(false);
+    expect(allowInsecureIssuerUrl('http://0.0.0.0')).toBe(false);
   });
 
   test('MCP_PUBLIC_URL / publicBaseUrl 覆盖请求 origin', () => {

--- a/packages/api/test/mcp-http.test.ts
+++ b/packages/api/test/mcp-http.test.ts
@@ -138,8 +138,8 @@ describe('MCP 元数据 origin / insecure issuer', () => {
     expect(allowInsecureIssuerUrl('http://100.64.1.2')).toBe(true);
     expect(allowInsecureIssuerUrl('http://[::1]/')).toBe(true);
     expect(allowInsecureIssuerUrl('http://[fd12:3456::1]')).toBe(true);
-    // 语义统一：fe80 链路本地现与 CIMD 一致，算可放行私网
-    expect(allowInsecureIssuerUrl('http://[fe80::1]/')).toBe(true);
+    // fe80::/10 永拒（与 IPv4 链路本地对齐），不算可放行私网
+    expect(allowInsecureIssuerUrl('http://[fe80::1]/')).toBe(false);
     expect(allowInsecureIssuerUrl('https://127.0.0.1')).toBe(false);
     // 永拒段不算私网：绝不开 insecure issuer
     expect(allowInsecureIssuerUrl('http://169.254.169.254')).toBe(false);

--- a/packages/api/test/oauth-as.test.ts
+++ b/packages/api/test/oauth-as.test.ts
@@ -95,6 +95,15 @@ function authQuery(extra: Record<string, string> = {}) {
   return { q, verifier: v };
 }
 
+/** 同意批准后为 200 过渡页；从可见链接解析回跳 URL。 */
+function redirectFromHandoffHtml(html: string): URL {
+  expect(html).toContain('已授权，正在跳回客户端');
+  const m = /href="([^"]+)"/.exec(html);
+  expect(m).toBeTruthy();
+  const href = m![1]!.replace(/&amp;/g, '&').replace(/&quot;/g, '"');
+  return new URL(href);
+}
+
 beforeEach(() => {
   clearCimdCacheForTests();
   resetOAuthStoreCacheForTests();
@@ -140,28 +149,30 @@ describe('RFC 8414 + PRM issuer 一致', () => {
 });
 
 describe('完整授权流', () => {
-  test('authorize→code→token→/mcp tools/list；refresh 轮换；revoke', async () => {
+  test('authorize→code→token→/mcp tools/list + mail_list_messages；refresh 轮换；revoke', async () => {
     const app = makeApp();
     const { identity } = createIdentity({ localpart: 'oauth-flow' })!;
     const cookie = await loginCookie(app);
     const { q, verifier: v } = authQuery();
 
-    // GET /authorize → 同意页
+    // GET /authorize → 相对 Location 同意页
     const gate = await app.request(`http://localhost/authorize?${q}`, {
       headers: { cookie },
       redirect: 'manual',
     });
     expect(gate.status).toBe(302);
     const consentUrl = gate.headers.get('location')!;
-    expect(consentUrl).toContain('/ui/oauth/authorize?');
+    expect(consentUrl.startsWith('/ui/oauth/authorize?')).toBe(true);
 
-    const consent = await app.request(consentUrl, { headers: { cookie } });
+    const consent = await app.request(`http://localhost${consentUrl}`, {
+      headers: { cookie },
+    });
     expect(consent.status).toBe(200);
     const html = await consent.text();
     expect(html).toContain('Sim Client');
     expect(html).toContain('127.0.0.1');
 
-    // POST 批准
+    // POST 批准 → 200 过渡页（非 302）
     const body = new URLSearchParams({
       client_id: CLIENT_ID,
       redirect_uri: REDIRECT,
@@ -182,8 +193,11 @@ describe('完整授权流', () => {
       body,
       redirect: 'manual',
     });
-    expect(approved.status).toBe(302);
-    const loc = new URL(approved.headers.get('location')!);
+    expect(approved.status).toBe(200);
+    expect(approved.headers.get('content-security-policy') ?? '').not.toContain(
+      'form-action',
+    );
+    const loc = redirectFromHandoffHtml(await approved.text());
     expect(loc.origin + loc.pathname).toBe('http://127.0.0.1:54321/callback');
     expect(loc.searchParams.get('iss')).toBe('http://localhost');
     expect(loc.searchParams.get('state')).toBe('st1');
@@ -204,6 +218,8 @@ describe('完整授权流', () => {
       }),
     });
     expect(tokenRes.status).toBe(200);
+    expect(tokenRes.headers.get('cache-control')).toBe('no-store');
+    expect(tokenRes.headers.get('pragma')).toBe('no-cache');
     const tokens = (await tokenRes.json()) as {
       access_token: string;
       refresh_token: string;
@@ -223,6 +239,38 @@ describe('完整授权流', () => {
     });
     expect(mcp.status).toBe(200);
 
+    // 真打 /v1：OAuth 票读自己邮件（证明 aud/origin 对齐；禁再出现 403 invalid_audience）
+    const v1 = await app.request(
+      `http://localhost/v1/messages?address=${encodeURIComponent(identity.address)}&limit=1`,
+      { headers: { authorization: `Bearer ${tokens.access_token}` } },
+    );
+    expect(v1.status).not.toBe(403);
+    // IMAP 在单测环境常不可达 → 500 可接受；关键是过了 bearerAuth
+    expect([200, 500, 503]).toContain(v1.status);
+
+    // 经 MCP 工具回环再打一次（同源断言）
+    const toolCall = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${tokens.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 11,
+        method: 'tools/call',
+        params: {
+          name: 'mail_list_messages',
+          arguments: { address: identity.address, limit: 1 },
+        },
+      }),
+    });
+    expect(toolCall.status).not.toBe(403);
+    expect(toolCall.status).toBe(200);
+    const toolText = await toolCall.text();
+    expect(toolText).not.toContain('invalid_audience');
+
     // code 重放拒
     const replay = await app.request('http://localhost/oauth/token', {
       method: 'POST',
@@ -238,17 +286,19 @@ describe('完整授权流', () => {
     });
     expect(replay.status).toBe(400);
 
-    // refresh 轮换
+    // refresh 轮换（须带 client_id）
     const refreshed = await app.request('http://localhost/oauth/token', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({
         grant_type: 'refresh_token',
         refresh_token: tokens.refresh_token,
+        client_id: CLIENT_ID,
         resource: RESOURCE,
       }),
     });
     expect(refreshed.status).toBe(200);
+    expect(refreshed.headers.get('cache-control')).toBe('no-store');
     const next = (await refreshed.json()) as {
       access_token: string;
       refresh_token: string;
@@ -262,10 +312,13 @@ describe('完整授权流', () => {
       body: new URLSearchParams({
         grant_type: 'refresh_token',
         refresh_token: tokens.refresh_token,
+        client_id: CLIENT_ID,
         resource: RESOURCE,
       }),
     });
     expect(oldReplay.status).toBe(400);
+    const oldBody = (await oldReplay.json()) as { error_description?: string };
+    expect(oldBody.error_description).toBe('refresh token invalid or expired');
 
     // revoke → 立即 401
     const rev = await app.request('http://localhost/oauth/revoke', {
@@ -284,6 +337,84 @@ describe('完整授权流', () => {
       body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
     });
     expect(after.status).toBe(401);
+  });
+
+  test('删身份后旧 access 401、旧 refresh invalid_grant', async () => {
+    const app = makeApp();
+    const { identity } = createIdentity({ localpart: 'oauth-del' })!;
+    const cookie = await loginCookie(app);
+    const { q, verifier: v } = authQuery();
+    const approved = await app.request('http://localhost/ui/oauth/authorize', {
+      method: 'POST',
+      headers: {
+        cookie,
+        origin: 'http://localhost',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT,
+        code_challenge: q.get('code_challenge')!,
+        resource: RESOURCE,
+        identity_mode: 'existing',
+        address: identity.address,
+        decision: 'approve',
+      }),
+    });
+    const code = redirectFromHandoffHtml(await approved.text()).searchParams.get(
+      'code',
+    )!;
+    const tokenRes = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT,
+        client_id: CLIENT_ID,
+        code_verifier: v,
+        resource: RESOURCE,
+      }),
+    });
+    const tokens = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token: string;
+    };
+
+    const del = await app.request(
+      `http://localhost/v1/identities/${encodeURIComponent(identity.address)}`,
+      {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${adminKey}` },
+      },
+    );
+    expect(del.status).toBe(200);
+
+    const mcp = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${tokens.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(mcp.status).toBe(401);
+
+    const refresh = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        client_id: CLIENT_ID,
+        resource: RESOURCE,
+      }),
+    });
+    expect(refresh.status).toBe(400);
+    const rb = (await refresh.json()) as { error: string; error_description?: string };
+    expect(rb.error).toBe('invalid_grant');
+    expect(rb.error_description).toBe('refresh token invalid or expired');
   });
 });
 
@@ -436,7 +567,10 @@ describe('授权负例', () => {
       }),
       redirect: 'manual',
     });
-    const code = new URL(approved.headers.get('location')!).searchParams.get('code')!;
+    expect(approved.status).toBe(200);
+    const code = redirectFromHandoffHtml(await approved.text()).searchParams.get(
+      'code',
+    )!;
 
     const noVerifier = await app.request('http://localhost/oauth/token', {
       method: 'POST',
@@ -470,7 +604,9 @@ describe('授权负例', () => {
       }),
       redirect: 'manual',
     });
-    const code2 = new URL(approved2.headers.get('location')!).searchParams.get('code')!;
+    const code2 = redirectFromHandoffHtml(await approved2.text()).searchParams.get(
+      'code',
+    )!;
     const badRes = await app.request('http://localhost/oauth/token', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -526,9 +662,10 @@ describe('授权负例', () => {
   });
 
   test('code 过期拒', async () => {
-    const { consumeAuthorizationCode, createGrantAndCode } = await import(
-      '../src/lib/oauth-store.ts'
-    );
+    const { CODE_TTL_MS, consumeAuthorizationCode, createGrantAndCode } =
+      await import('../src/lib/oauth-store.ts');
+    // 用未来时钟消费：避免 save 时 prune 掉「创建即过期」行
+    const issuedAt = Date.now();
     const { code } = createGrantAndCode({
       clientId: CLIENT_ID,
       clientName: 'X',
@@ -536,9 +673,9 @@ describe('授权负例', () => {
       redirectUri: REDIRECT,
       codeChallenge: s256Challenge(verifier()),
       resource: RESOURCE,
-      now: Date.now() - 11 * 60 * 1000,
+      now: issuedAt,
     });
-    const consumed = consumeAuthorizationCode(code);
+    const consumed = consumeAuthorizationCode(code, issuedAt + CODE_TTL_MS + 1);
     expect(consumed.ok).toBe(false);
     if (!consumed.ok) expect(consumed.reason).toBe('expired');
   });
@@ -546,6 +683,7 @@ describe('授权负例', () => {
 
 describe('resolveToken / OAuth 永为 identity', () => {
   test('OAuth 票 → identity；过期 → null；aud 错 → forbidden；无 resource 上下文拒', () => {
+    createIdentity({ localpart: 'res' });
     const tok = 'resolve-token-test-opaque-value1';
     putAccessTokenForTests({
       token: tok,
@@ -582,6 +720,7 @@ describe('resolveToken / OAuth 永为 identity', () => {
 
   test('OAuth 票换 /ui/api/session → 401', async () => {
     const app = makeApp();
+    createIdentity({ localpart: 'ui' });
     const tok = 'ui-session-must-reject-oauth!!!!';
     putAccessTokenForTests({
       token: tok,
@@ -606,6 +745,7 @@ describe('resolveToken / OAuth 永为 identity', () => {
   });
 
   test('admin 不可经 OAuth 获得：构造路径断言', () => {
+    createIdentity({ localpart: 'admin' });
     // 即使 address 碰巧像 admin，kind 仍必须是 identity
     const tok = 'never-admin-oauth-token-value!!';
     putAccessTokenForTests({
@@ -632,14 +772,6 @@ describe('Dashboard 授权管理吊销', () => {
     const cookie = await loginCookie(app);
     const v = verifier();
     const challenge = s256Challenge(v);
-    const q = new URLSearchParams({
-      response_type: 'code',
-      client_id: CLIENT_ID,
-      redirect_uri: REDIRECT,
-      code_challenge: challenge,
-      code_challenge_method: 'S256',
-      resource: RESOURCE,
-    });
     const body = new URLSearchParams({
       client_id: CLIENT_ID,
       redirect_uri: REDIRECT,
@@ -659,7 +791,9 @@ describe('Dashboard 授权管理吊销', () => {
       body,
       redirect: 'manual',
     });
-    const code = new URL(approved.headers.get('location')!).searchParams.get('code')!;
+    const code = redirectFromHandoffHtml(await approved.text()).searchParams.get(
+      'code',
+    )!;
     const tokenRes = await app.request('http://localhost/oauth/token', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
@@ -707,6 +841,5 @@ describe('Dashboard 授权管理吊销', () => {
     });
     expect(page.status).toBe(200);
     expect(await page.text()).toContain('Authorized clients');
-    expect(q.get('client_id')).toBe(CLIENT_ID);
   });
 });

--- a/packages/api/test/oauth-as.test.ts
+++ b/packages/api/test/oauth-as.test.ts
@@ -320,11 +320,51 @@ describe('完整授权流', () => {
     const oldBody = (await oldReplay.json()) as { error_description?: string };
     expect(oldBody.error_description).toBe('refresh token invalid or expired');
 
-    // revoke → 立即 401
-    const rev = await app.request('http://localhost/oauth/revoke', {
+    // revoke：无 client_id / 错 client_id 不删仍 200；对的才删
+    const noClient = await app.request('http://localhost/oauth/revoke', {
       method: 'POST',
       headers: { 'content-type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({ token: next.access_token }),
+    });
+    expect(noClient.status).toBe(200);
+    const stillLive = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${next.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    });
+    expect(stillLive.status).toBe(200);
+
+    const wrongClient = await app.request('http://localhost/oauth/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        token: next.access_token,
+        client_id: 'http://127.0.0.1:9/other-client.json',
+      }),
+    });
+    expect(wrongClient.status).toBe(200);
+    const stillLive2 = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${next.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 3, method: 'tools/list' }),
+    });
+    expect(stillLive2.status).toBe(200);
+
+    const rev = await app.request('http://localhost/oauth/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        token: next.access_token,
+        client_id: CLIENT_ID,
+      }),
     });
     expect(rev.status).toBe(200);
     const after = await app.request('http://localhost/mcp', {
@@ -334,7 +374,7 @@ describe('完整授权流', () => {
         'content-type': 'application/json',
         accept: 'application/json, text/event-stream',
       },
-      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+      body: JSON.stringify({ jsonrpc: '2.0', id: 4, method: 'tools/list' }),
     });
     expect(after.status).toBe(401);
   });

--- a/packages/api/test/oauth-as.test.ts
+++ b/packages/api/test/oauth-as.test.ts
@@ -1,0 +1,712 @@
+/**
+ * P3 OAuth AS：8414 / 授权流 / token / refresh / revoke / 负例。
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-oauth-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-oauth-as-'));
+process.env.UI_ENABLED = 'true';
+
+const { describe, expect, test, beforeEach } = await import('bun:test');
+const { createApp } = await import('../src/app.ts');
+const { createIdentity } = await import('../src/lib/identities.ts');
+const { s256Challenge } = await import('../src/lib/oauth-pkce.ts');
+const {
+  putAccessTokenForTests,
+  resetOAuthStoreCacheForTests,
+} = await import('../src/lib/oauth-store.ts');
+const { clearCimdCacheForTests } = await import('../src/lib/oauth-cimd.ts');
+const {
+  resolveAccessToken,
+  resolveToken,
+  resolveUiSessionToken,
+} = await import('../src/lib/auth.ts');
+const { config } = await import('../src/lib/config.ts');
+
+const adminKey = [...config.apiKeys][0]!;
+const CLIENT_ID = 'http://127.0.0.1:9/cimd.json';
+const REDIRECT = 'http://127.0.0.1:54321/callback';
+const RESOURCE = 'http://localhost/mcp';
+
+function verifier(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+function cimdDoc(redirect = REDIRECT) {
+  return {
+    client_id: CLIENT_ID,
+    client_name: 'Sim Client',
+    redirect_uris: [redirect, 'http://127.0.0.1/callback'],
+    token_endpoint_auth_method: 'none',
+  };
+}
+
+function cimdFetcher(doc = cimdDoc()) {
+  return async () =>
+    new Response(JSON.stringify(doc), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+}
+
+function makeApp() {
+  return createApp({
+    uiEnabled: true,
+    oauth: { cimdFetcher: cimdFetcher() },
+  });
+}
+
+async function loginCookie(app: ReturnType<typeof createApp>, token = adminKey) {
+  const res = await app.request('http://localhost/ui/api/session', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      origin: 'http://localhost',
+    },
+    body: JSON.stringify({ token }),
+  });
+  expect(res.status).toBe(200);
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const m = /oae_ui=([^;]+)/.exec(setCookie);
+  expect(m).toBeTruthy();
+  return `oae_ui=${m![1]}`;
+}
+
+function authQuery(extra: Record<string, string> = {}) {
+  const v = verifier();
+  const q = new URLSearchParams({
+    response_type: 'code',
+    client_id: CLIENT_ID,
+    redirect_uri: REDIRECT,
+    code_challenge: s256Challenge(v),
+    code_challenge_method: 'S256',
+    resource: RESOURCE,
+    state: 'st1',
+    ...extra,
+  });
+  return { q, verifier: v };
+}
+
+beforeEach(() => {
+  clearCimdCacheForTests();
+  resetOAuthStoreCacheForTests();
+});
+
+describe('RFC 8414 + PRM issuer 一致', () => {
+  test('三标志位 + issuer 与 PRM authorization_servers 一致', async () => {
+    const app = makeApp();
+    const asRes = await app.request('http://localhost/.well-known/oauth-authorization-server');
+    expect(asRes.status).toBe(200);
+    const asMeta = (await asRes.json()) as {
+      issuer: string;
+      authorization_endpoint: string;
+      token_endpoint: string;
+      revocation_endpoint: string;
+      code_challenge_methods_supported: string[];
+      authorization_response_iss_parameter_supported: boolean;
+      client_id_metadata_document_supported: boolean;
+      token_endpoint_auth_methods_supported: string[];
+      grant_types_supported: string[];
+    };
+    expect(asMeta.issuer).toBe('http://localhost');
+    expect(asMeta.authorization_endpoint).toBe('http://localhost/authorize');
+    expect(asMeta.token_endpoint).toBe('http://localhost/oauth/token');
+    expect(asMeta.revocation_endpoint).toBe('http://localhost/oauth/revoke');
+    expect(asMeta.code_challenge_methods_supported).toEqual(['S256']);
+    expect(asMeta.authorization_response_iss_parameter_supported).toBe(true);
+    expect(asMeta.client_id_metadata_document_supported).toBe(true);
+    expect(asMeta.token_endpoint_auth_methods_supported).toEqual(['none']);
+    expect(asMeta.grant_types_supported).toEqual([
+      'authorization_code',
+      'refresh_token',
+    ]);
+
+    const prm = await app.request('http://localhost/.well-known/oauth-protected-resource');
+    const prmBody = (await prm.json()) as {
+      resource: string;
+      authorization_servers: string[];
+    };
+    expect(prmBody.resource).toBe(RESOURCE);
+    expect(prmBody.authorization_servers).toContain(asMeta.issuer);
+  });
+});
+
+describe('完整授权流', () => {
+  test('authorize→code→token→/mcp tools/list；refresh 轮换；revoke', async () => {
+    const app = makeApp();
+    const { identity } = createIdentity({ localpart: 'oauth-flow' })!;
+    const cookie = await loginCookie(app);
+    const { q, verifier: v } = authQuery();
+
+    // GET /authorize → 同意页
+    const gate = await app.request(`http://localhost/authorize?${q}`, {
+      headers: { cookie },
+      redirect: 'manual',
+    });
+    expect(gate.status).toBe(302);
+    const consentUrl = gate.headers.get('location')!;
+    expect(consentUrl).toContain('/ui/oauth/authorize?');
+
+    const consent = await app.request(consentUrl, { headers: { cookie } });
+    expect(consent.status).toBe(200);
+    const html = await consent.text();
+    expect(html).toContain('Sim Client');
+    expect(html).toContain('127.0.0.1');
+
+    // POST 批准
+    const body = new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT,
+      code_challenge: q.get('code_challenge')!,
+      resource: RESOURCE,
+      state: 'st1',
+      identity_mode: 'existing',
+      address: identity.address,
+      decision: 'approve',
+    });
+    const approved = await app.request('http://localhost/ui/oauth/authorize', {
+      method: 'POST',
+      headers: {
+        cookie,
+        origin: 'http://localhost',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      redirect: 'manual',
+    });
+    expect(approved.status).toBe(302);
+    const loc = new URL(approved.headers.get('location')!);
+    expect(loc.origin + loc.pathname).toBe('http://127.0.0.1:54321/callback');
+    expect(loc.searchParams.get('iss')).toBe('http://localhost');
+    expect(loc.searchParams.get('state')).toBe('st1');
+    const code = loc.searchParams.get('code');
+    expect(code).toBeTruthy();
+
+    // code → token
+    const tokenRes = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        redirect_uri: REDIRECT,
+        client_id: CLIENT_ID,
+        code_verifier: v,
+        resource: RESOURCE,
+      }),
+    });
+    expect(tokenRes.status).toBe(200);
+    const tokens = (await tokenRes.json()) as {
+      access_token: string;
+      refresh_token: string;
+      expires_in: number;
+    };
+    expect(tokens.expires_in).toBe(3600);
+
+    // /mcp tools/list
+    const mcp = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${tokens.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(mcp.status).toBe(200);
+
+    // code 重放拒
+    const replay = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code!,
+        redirect_uri: REDIRECT,
+        client_id: CLIENT_ID,
+        code_verifier: v,
+        resource: RESOURCE,
+      }),
+    });
+    expect(replay.status).toBe(400);
+
+    // refresh 轮换
+    const refreshed = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        resource: RESOURCE,
+      }),
+    });
+    expect(refreshed.status).toBe(200);
+    const next = (await refreshed.json()) as {
+      access_token: string;
+      refresh_token: string;
+    };
+    expect(next.refresh_token).not.toBe(tokens.refresh_token);
+
+    // 旧 refresh 重放拒
+    const oldReplay = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: tokens.refresh_token,
+        resource: RESOURCE,
+      }),
+    });
+    expect(oldReplay.status).toBe(400);
+
+    // revoke → 立即 401
+    const rev = await app.request('http://localhost/oauth/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({ token: next.access_token }),
+    });
+    expect(rev.status).toBe(200);
+    const after = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${next.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+    });
+    expect(after.status).toBe(401);
+  });
+});
+
+describe('授权负例', () => {
+  test('无 code_challenge / plain / 非 S256 → 回跳 error + iss', async () => {
+    const app = makeApp();
+    const cookie = await loginCookie(app);
+
+    const noPkce = new URLSearchParams({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT,
+      resource: RESOURCE,
+    });
+    const r1 = await app.request(`http://localhost/ui/oauth/authorize?${noPkce}`, {
+      headers: { cookie },
+      redirect: 'manual',
+    });
+    expect(r1.status).toBe(302);
+    const u1 = new URL(r1.headers.get('location')!);
+    expect(u1.searchParams.get('error')).toBe('invalid_request');
+    expect(u1.searchParams.get('iss')).toBe('http://localhost');
+
+    const plain = new URLSearchParams({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT,
+      code_challenge: 'x'.repeat(43),
+      code_challenge_method: 'plain',
+      resource: RESOURCE,
+    });
+    const r2 = await app.request(`http://localhost/ui/oauth/authorize?${plain}`, {
+      headers: { cookie },
+      redirect: 'manual',
+    });
+    const u2 = new URL(r2.headers.get('location')!);
+    expect(u2.searchParams.get('error')).toBe('invalid_request');
+    expect(u2.searchParams.get('iss')).toBe('http://localhost');
+  });
+
+  test('redirect_uri 不匹配拒（错误页，禁止开放重定向）；loopback 异端口放行', async () => {
+    const app = makeApp();
+    const cookie = await loginCookie(app);
+
+    const bad = authQuery({ redirect_uri: 'http://evil.example/callback' });
+    const rBad = await app.request(`http://localhost/ui/oauth/authorize?${bad.q}`, {
+      headers: { cookie },
+      redirect: 'manual',
+    });
+    // 未登记 redirect 不得 302 到攻击者 URI
+    expect(rBad.status).toBe(400);
+    expect(await rBad.text()).toContain('redirect_uri is not registered');
+    expect(rBad.headers.get('location')).toBeNull();
+
+    // 异端口 loopback：文档写无端口，请求带端口 → 同意页 200
+    const app2 = createApp({
+      uiEnabled: true,
+      oauth: {
+        cimdFetcher: cimdFetcher({
+          ...cimdDoc('http://127.0.0.1/callback'),
+          redirect_uris: ['http://127.0.0.1/callback'],
+        }),
+      },
+    });
+    const cookie2 = await loginCookie(app2);
+    const q2 = new URLSearchParams({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      redirect_uri: 'http://127.0.0.1:9999/callback',
+      code_challenge: s256Challenge(verifier()),
+      code_challenge_method: 'S256',
+      resource: RESOURCE,
+    });
+    const rOk2 = await app2.request(`http://localhost/ui/oauth/authorize?${q2}`, {
+      headers: { cookie: cookie2 },
+    });
+    expect(rOk2.status).toBe(200);
+    expect(await rOk2.text()).toContain('Sim Client');
+  });
+
+  test('invalid_client（CIMD fetch 失败）→ 错误页且不 302', async () => {
+    const app = createApp({
+      uiEnabled: true,
+      oauth: {
+        cimdFetcher: async () => new Response('nope', { status: 500 }),
+      },
+    });
+    const cookie = await loginCookie(app);
+    const { q } = authQuery();
+    const res = await app.request(`http://localhost/ui/oauth/authorize?${q}`, {
+      headers: { cookie },
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain('Invalid client');
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  test('identity 会话 POST 批准 → 403', async () => {
+    const app = makeApp();
+    const { token, identity } = createIdentity({ localpart: 'oauth-id-sess' })!;
+    const cookie = await loginCookie(app, token);
+    const v = verifier();
+    const challenge = s256Challenge(v);
+    const body = new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT,
+      code_challenge: challenge,
+      resource: RESOURCE,
+      identity_mode: 'existing',
+      address: identity.address,
+      decision: 'approve',
+    });
+    const res = await app.request('http://localhost/ui/oauth/authorize', {
+      method: 'POST',
+      headers: {
+        cookie,
+        origin: 'http://localhost',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      redirect: 'manual',
+    });
+    expect(res.status).toBe(403);
+    expect(await res.text()).toContain('Admin session required');
+    expect(res.headers.get('location')).toBeNull();
+  });
+
+  test('token：缺 verifier / resource 错；aud 错 → 403；过期 access → 401', async () => {
+    const app = makeApp();
+    const { identity } = createIdentity({ localpart: 'oauth-neg' })!;
+    const cookie = await loginCookie(app);
+    const v = verifier();
+    const challenge = s256Challenge(v);
+    const approved = await app.request('http://localhost/ui/oauth/authorize', {
+      method: 'POST',
+      headers: {
+        cookie,
+        origin: 'http://localhost',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT,
+        code_challenge: challenge,
+        resource: RESOURCE,
+        identity_mode: 'existing',
+        address: identity.address,
+        decision: 'approve',
+      }),
+      redirect: 'manual',
+    });
+    const code = new URL(approved.headers.get('location')!).searchParams.get('code')!;
+
+    const noVerifier = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT,
+        client_id: CLIENT_ID,
+        resource: RESOURCE,
+      }),
+    });
+    expect(noVerifier.status).toBe(400);
+
+    // 用新 code 测 resource 错
+    const approved2 = await app.request('http://localhost/ui/oauth/authorize', {
+      method: 'POST',
+      headers: {
+        cookie,
+        origin: 'http://localhost',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        client_id: CLIENT_ID,
+        redirect_uri: REDIRECT,
+        code_challenge: challenge,
+        resource: RESOURCE,
+        identity_mode: 'existing',
+        address: identity.address,
+        decision: 'approve',
+      }),
+      redirect: 'manual',
+    });
+    const code2 = new URL(approved2.headers.get('location')!).searchParams.get('code')!;
+    const badRes = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: code2,
+        redirect_uri: REDIRECT,
+        client_id: CLIENT_ID,
+        code_verifier: v,
+        resource: 'http://evil.example/mcp',
+      }),
+    });
+    expect(badRes.status).toBe(400);
+
+    putAccessTokenForTests({
+      token: 'wrong-aud-token-value-32bytes-pad!!',
+      grantId: 'g-aud',
+      address: 'aud@test.example',
+      aud: 'http://evil.example/mcp',
+      expiresAt: Date.now() + 60_000,
+      ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
+    });
+    const mcp = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: 'Bearer wrong-aud-token-value-32bytes-pad!!',
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(mcp.status).toBe(403);
+
+    const expiredTok = 'expired-access-token-value-pad-ok!!';
+    putAccessTokenForTests({
+      token: expiredTok,
+      grantId: 'g-exp',
+      address: 'aud@test.example',
+      aud: RESOURCE,
+      expiresAt: Date.now() - 1000,
+      ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
+    });
+    const exp = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${expiredTok}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(exp.status).toBe(401);
+  });
+
+  test('code 过期拒', async () => {
+    const { consumeAuthorizationCode, createGrantAndCode } = await import(
+      '../src/lib/oauth-store.ts'
+    );
+    const { code } = createGrantAndCode({
+      clientId: CLIENT_ID,
+      clientName: 'X',
+      address: 'exp@test.example',
+      redirectUri: REDIRECT,
+      codeChallenge: s256Challenge(verifier()),
+      resource: RESOURCE,
+      now: Date.now() - 11 * 60 * 1000,
+    });
+    const consumed = consumeAuthorizationCode(code);
+    expect(consumed.ok).toBe(false);
+    if (!consumed.ok) expect(consumed.reason).toBe('expired');
+  });
+});
+
+describe('resolveToken / OAuth 永为 identity', () => {
+  test('OAuth 票 → identity；过期 → null；aud 错 → forbidden；无 resource 上下文拒', () => {
+    const tok = 'resolve-token-test-opaque-value1';
+    putAccessTokenForTests({
+      token: tok,
+      grantId: 'g-res',
+      address: 'res@test.example',
+      aud: RESOURCE,
+      expiresAt: Date.now() + 60_000,
+      ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
+    });
+    const auth = resolveToken(tok, { resource: RESOURCE });
+    expect(auth).toEqual({ kind: 'identity', address: 'res@test.example' });
+    // 永非 admin
+    expect(auth?.kind).not.toBe('admin');
+
+    const expired = 'resolve-expired-opaque-value!!!!';
+    putAccessTokenForTests({
+      token: expired,
+      grantId: 'g-res2',
+      address: 'res@test.example',
+      aud: RESOURCE,
+      expiresAt: Date.now() - 1,
+      ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
+    });
+    expect(resolveToken(expired, { resource: RESOURCE })).toBeNull();
+
+    const badAud = resolveAccessToken(tok, { resource: 'http://other/mcp' });
+    expect(badAud.status).toBe('forbidden_audience');
+
+    // 无 MCP_PUBLIC_URL 且未传 resource：完整 resolve 拒 OAuth
+    expect(resolveToken(tok)).toBeNull();
+    // UI 会话 resolver 显式永不认 OAuth（与 MCP_PUBLIC_URL 无关）
+    expect(resolveUiSessionToken(tok)).toBeNull();
+  });
+
+  test('OAuth 票换 /ui/api/session → 401', async () => {
+    const app = makeApp();
+    const tok = 'ui-session-must-reject-oauth!!!!';
+    putAccessTokenForTests({
+      token: tok,
+      grantId: 'g-ui',
+      address: 'ui@test.example',
+      aud: RESOURCE,
+      expiresAt: Date.now() + 60_000,
+      ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
+    });
+    // 即便完整 resolve 在带 resource 时能认出 identity，会话入口也必须 401
+    expect(resolveToken(tok, { resource: RESOURCE })?.kind).toBe('identity');
+    const res = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+      },
+      body: JSON.stringify({ token: tok }),
+    });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'invalid_token' });
+  });
+
+  test('admin 不可经 OAuth 获得：构造路径断言', () => {
+    // 即使 address 碰巧像 admin，kind 仍必须是 identity
+    const tok = 'never-admin-oauth-token-value!!';
+    putAccessTokenForTests({
+      token: tok,
+      grantId: 'g-adm',
+      address: 'admin@test.example',
+      aud: RESOURCE,
+      expiresAt: Date.now() + 60_000,
+      ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
+    });
+    const r = resolveAccessToken(tok, { resource: RESOURCE });
+    expect(r).toEqual({
+      status: 'ok',
+      auth: { kind: 'identity', address: 'admin@test.example' },
+    });
+    expect(config.apiKeys.has(tok)).toBe(false);
+  });
+});
+
+describe('Dashboard 授权管理吊销', () => {
+  test('列表可见；吊销后 token 立即失效', async () => {
+    const app = makeApp();
+    const { identity } = createIdentity({ localpart: 'oauth-grants' })!;
+    const cookie = await loginCookie(app);
+    const v = verifier();
+    const challenge = s256Challenge(v);
+    const q = new URLSearchParams({
+      response_type: 'code',
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      resource: RESOURCE,
+    });
+    const body = new URLSearchParams({
+      client_id: CLIENT_ID,
+      redirect_uri: REDIRECT,
+      code_challenge: challenge,
+      resource: RESOURCE,
+      identity_mode: 'existing',
+      address: identity.address,
+      decision: 'approve',
+    });
+    const approved = await app.request('http://localhost/ui/oauth/authorize', {
+      method: 'POST',
+      headers: {
+        cookie,
+        origin: 'http://localhost',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body,
+      redirect: 'manual',
+    });
+    const code = new URL(approved.headers.get('location')!).searchParams.get('code')!;
+    const tokenRes = await app.request('http://localhost/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        code,
+        redirect_uri: REDIRECT,
+        client_id: CLIENT_ID,
+        code_verifier: v,
+        resource: RESOURCE,
+      }),
+    });
+    const tokens = (await tokenRes.json()) as { access_token: string };
+
+    const list = await app.request('http://localhost/ui/api/oauth/grants', {
+      headers: { cookie },
+    });
+    expect(list.status).toBe(200);
+    const grants = (await list.json()) as { grants: { id: string; clientName: string }[] };
+    expect(grants.grants.length).toBeGreaterThan(0);
+    expect(grants.grants[0]!.clientName).toBe('Sim Client');
+
+    const del = await app.request(
+      `http://localhost/ui/api/oauth/grants/${grants.grants[0]!.id}`,
+      {
+        method: 'DELETE',
+        headers: { cookie, origin: 'http://localhost' },
+      },
+    );
+    expect(del.status).toBe(204);
+
+    const mcp = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${tokens.access_token}`,
+        'content-type': 'application/json',
+        accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(mcp.status).toBe(401);
+
+    const page = await app.request(`http://localhost/ui/oauth/grants`, {
+      headers: { cookie },
+    });
+    expect(page.status).toBe(200);
+    expect(await page.text()).toContain('Authorized clients');
+    expect(q.get('client_id')).toBe(CLIENT_ID);
+  });
+});

--- a/packages/api/test/oauth-cimd.test.ts
+++ b/packages/api/test/oauth-cimd.test.ts
@@ -37,6 +37,21 @@ describe('isBlockedSsrfIp / 私网放行对照', () => {
     expect(isBlockedSsrfIp('0.1.2.3')).toBe(true);
   });
 
+  test('IPv4-mapped 十六进制形与 fe80 / fd00:ec2 永拒', async () => {
+    const { ipv4MappedFromV6, isFe80LinkLocalIpv6, isAwsImdsIpv6 } = await import(
+      '../src/lib/net.ts'
+    );
+    expect(ipv4MappedFromV6('::ffff:a9fe:a9fe')).toBe('169.254.169.254');
+    expect(isBlockedSsrfIp('::ffff:a9fe:a9fe')).toBe(true);
+    expect(isBlockedSsrfIp('::ffff:169.254.169.254')).toBe(true);
+    expect(isFe80LinkLocalIpv6('fe80::1')).toBe(true);
+    expect(isFe80LinkLocalIpv6('febf::1')).toBe(true);
+    expect(isFe80LinkLocalIpv6('fec0::1')).toBe(false);
+    expect(isBlockedSsrfIp('fe80::1')).toBe(true);
+    expect(isAwsImdsIpv6('fd00:ec2::254')).toBe(true);
+    expect(isBlockedSsrfIp('fd00:ec2::254')).toBe(true);
+  });
+
   test('RFC1918 / CGNAT / loopback 不在永拒清单（部署例外放行）', () => {
     expect(isBlockedSsrfIp('10.0.0.1')).toBe(false);
     expect(isBlockedSsrfIp('192.168.1.1')).toBe(false);
@@ -76,14 +91,20 @@ describe('validateClientIdUrl', () => {
   });
 });
 
-describe('matchRedirectUri loopback 端口放宽', () => {
-  test('127.0.0.1 不同端口放行', () => {
+describe('matchRedirectUri RFC8252 端口放宽', () => {
+  test('http + IP 字面量不同端口放行', () => {
     expect(
       matchRedirectUri('http://127.0.0.1:54321/callback', ['http://127.0.0.1/callback']),
     ).toBe(true);
+  });
+
+  test('localhost 主机名与 https 仍精确匹配端口', () => {
     expect(
       matchRedirectUri('http://localhost:9999/callback', ['http://localhost/callback']),
-    ).toBe(true);
+    ).toBe(false);
+    expect(
+      matchRedirectUri('https://127.0.0.1:54321/callback', ['https://127.0.0.1/callback']),
+    ).toBe(false);
   });
 
   test('非 loopback 端口必须精确', () => {

--- a/packages/api/test/oauth-cimd.test.ts
+++ b/packages/api/test/oauth-cimd.test.ts
@@ -19,6 +19,7 @@ const {
   assertClientIdHostSafe,
   clearCimdCacheForTests,
   fetchClientMetadata,
+  isAllowedRedirectUri,
   isBlockedSsrfIp,
   isSsrfBlockedResolvedIp,
   matchRedirectUri,
@@ -91,6 +92,65 @@ describe('validateClientIdUrl', () => {
   });
 });
 
+describe('redirect_uri scheme 白名单', () => {
+  test('https 一律放行；http loopback 放行', () => {
+    expect(isAllowedRedirectUri('https://app.example/cb')).toBe(true);
+    expect(isAllowedRedirectUri('http://127.0.0.1:54321/callback')).toBe(true);
+    expect(isAllowedRedirectUri('http://localhost/callback')).toBe(true);
+    expect(isAllowedRedirectUri('http://[::1]/callback')).toBe(true);
+  });
+
+  test('javascript:/data:/file: 与 http 非 loopback 拒', () => {
+    expect(isAllowedRedirectUri('javascript:alert(1)')).toBe(false);
+    expect(isAllowedRedirectUri('data:text/html,hi')).toBe(false);
+    expect(isAllowedRedirectUri('file:///etc/passwd')).toBe(false);
+    expect(isAllowedRedirectUri('myapp://callback')).toBe(false);
+    // http 仅 loopback：公网与 RFC1918 一律拒（私有 scheme 日后再开）
+    expect(isAllowedRedirectUri('http://example.com/callback')).toBe(false);
+    expect(isAllowedRedirectUri('http://10.0.0.1/callback')).toBe(false);
+  });
+
+  test('CIMD 文档含 javascript: redirect → 拒', async () => {
+    const clientId = 'http://127.0.0.1:9/cimd.json';
+    const r = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            client_id: clientId,
+            client_name: 'Evil',
+            redirect_uris: ['javascript:alert(document.domain)'],
+            token_endpoint_auth_method: 'none',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('redirect_uri_scheme_forbidden');
+  });
+
+  test('CIMD https redirect 正常；http loopback 正常', async () => {
+    const clientId = 'http://127.0.0.1:9/cimd-ok.json';
+    const r = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            client_id: clientId,
+            client_name: 'Ok',
+            redirect_uris: [
+              'https://app.example/oauth/cb',
+              'http://127.0.0.1:9999/callback',
+            ],
+            token_endpoint_auth_method: 'none',
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(r.ok).toBe(true);
+  });
+});
+
 describe('matchRedirectUri RFC8252 端口放宽', () => {
   test('http + IP 字面量不同端口放行', () => {
     expect(
@@ -110,6 +170,12 @@ describe('matchRedirectUri RFC8252 端口放宽', () => {
   test('非 loopback 端口必须精确', () => {
     expect(
       matchRedirectUri('https://app.example:443/cb', ['https://app.example:8443/cb']),
+    ).toBe(false);
+  });
+
+  test('javascript: 即使两侧相同也不匹配', () => {
+    expect(
+      matchRedirectUri('javascript:alert(1)', ['javascript:alert(1)']),
     ).toBe(false);
   });
 });

--- a/packages/api/test/oauth-cimd.test.ts
+++ b/packages/api/test/oauth-cimd.test.ts
@@ -1,0 +1,197 @@
+/**
+ * CIMD 校验器 + SSRF IP 判定单测（注入 fetcher，不起真 HTTP）。
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-oauth-cimd-'));
+process.env.UI_ENABLED = 'false';
+
+const { describe, expect, test, beforeEach } = await import('bun:test');
+const {
+  assertClientIdHostSafe,
+  clearCimdCacheForTests,
+  fetchClientMetadata,
+  isBlockedSsrfIp,
+  isSsrfBlockedResolvedIp,
+  matchRedirectUri,
+  validateClientIdUrl,
+} = await import('../src/lib/oauth-cimd.ts');
+
+beforeEach(() => {
+  clearCimdCacheForTests();
+});
+
+describe('isBlockedSsrfIp / 私网放行对照', () => {
+  test('169.254.0.0/16 与 0.0.0.0/8 永拒', () => {
+    expect(isBlockedSsrfIp('169.254.169.254')).toBe(true);
+    expect(isBlockedSsrfIp('169.254.0.1')).toBe(true);
+    expect(isBlockedSsrfIp('0.0.0.0')).toBe(true);
+    expect(isBlockedSsrfIp('0.1.2.3')).toBe(true);
+  });
+
+  test('RFC1918 / CGNAT / loopback 不在永拒清单（部署例外放行）', () => {
+    expect(isBlockedSsrfIp('10.0.0.1')).toBe(false);
+    expect(isBlockedSsrfIp('192.168.1.1')).toBe(false);
+    expect(isBlockedSsrfIp('172.16.0.1')).toBe(false);
+    expect(isBlockedSsrfIp('100.64.1.2')).toBe(false);
+    expect(isBlockedSsrfIp('127.0.0.1')).toBe(false);
+  });
+
+  test('isSsrfBlockedResolvedIp：永拒仍 blocked；私网放行', () => {
+    expect(isSsrfBlockedResolvedIp('169.254.169.254')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('0.0.0.0')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('10.1.2.3')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('127.0.0.1')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('8.8.8.8')).toBe(false);
+  });
+});
+
+describe('validateClientIdUrl', () => {
+  test('https + path 合法', () => {
+    const r = validateClientIdUrl('https://client.example/oauth/client.json');
+    expect(r.ok).toBe(true);
+  });
+
+  test('缺 path / 含 fragment / userinfo / query / 点段 拒', () => {
+    expect(validateClientIdUrl('https://client.example/').ok).toBe(false);
+    expect(validateClientIdUrl('https://client.example/a#x').ok).toBe(false);
+    expect(validateClientIdUrl('https://u:p@client.example/a').ok).toBe(false);
+    expect(validateClientIdUrl('https://client.example/a?x=1').ok).toBe(false);
+    expect(validateClientIdUrl('https://client.example/./a').ok).toBe(false);
+    expect(validateClientIdUrl('https://client.example/a/../b').ok).toBe(false);
+  });
+
+  test('loopback http 因部署例外放行', () => {
+    expect(validateClientIdUrl('http://127.0.0.1:9/cimd.json').ok).toBe(true);
+    expect(validateClientIdUrl('http://10.0.0.2/cimd.json').ok).toBe(true);
+    expect(validateClientIdUrl('http://example.com/cimd.json').ok).toBe(false);
+  });
+});
+
+describe('matchRedirectUri loopback 端口放宽', () => {
+  test('127.0.0.1 不同端口放行', () => {
+    expect(
+      matchRedirectUri('http://127.0.0.1:54321/callback', ['http://127.0.0.1/callback']),
+    ).toBe(true);
+    expect(
+      matchRedirectUri('http://localhost:9999/callback', ['http://localhost/callback']),
+    ).toBe(true);
+  });
+
+  test('非 loopback 端口必须精确', () => {
+    expect(
+      matchRedirectUri('https://app.example:443/cb', ['https://app.example:8443/cb']),
+    ).toBe(false);
+  });
+});
+
+describe('fetchClientMetadata（注入 fetcher）', () => {
+  const clientId = 'http://127.0.0.1:9/cimd.json';
+
+  test('200 + 合法文档', async () => {
+    const doc = {
+      client_id: clientId,
+      client_name: 'Test Client',
+      redirect_uris: ['http://127.0.0.1/callback'],
+      token_endpoint_auth_method: 'none',
+    };
+    const r = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(JSON.stringify(doc), {
+          status: 200,
+          headers: { 'content-type': 'application/json', 'cache-control': 'max-age=120' },
+        }),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.doc.client_name).toBe('Test Client');
+  });
+
+  test('重定向拒', async () => {
+    const r = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(null, { status: 302, headers: { location: 'http://evil/' } }),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('redirect_forbidden');
+  });
+
+  test('client_id 逐字符不符拒', async () => {
+    const r = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            client_id: 'http://127.0.0.1:9/OTHER.json',
+            client_name: 'X',
+            redirect_uris: ['http://127.0.0.1/callback'],
+          }),
+          { status: 200 },
+        ),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('client_id_mismatch');
+  });
+
+  test('缺必填字段拒', async () => {
+    const r = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(JSON.stringify({ client_id: clientId, client_name: 'X' }), {
+          status: 200,
+        }),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('missing_redirect_uris');
+  });
+
+  test('声明 client_secret* / private_key_jwt 拒', async () => {
+    const secret = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            client_id: clientId,
+            client_name: 'X',
+            redirect_uris: ['http://127.0.0.1/callback'],
+            client_secret: 'nope',
+          }),
+          { status: 200 },
+        ),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(secret.ok).toBe(false);
+
+    const jwt = await fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(
+          JSON.stringify({
+            client_id: clientId,
+            client_name: 'X',
+            redirect_uris: ['http://127.0.0.1/callback'],
+            token_endpoint_auth_method: 'private_key_jwt',
+          }),
+          { status: 200 },
+        ),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+    expect(jwt.ok).toBe(false);
+    if (!jwt.ok) expect(jwt.reason).toBe('auth_method_unsupported');
+  });
+
+  test('解析到 169.254 拒', async () => {
+    const r = await assertClientIdHostSafe('metadata.local', async () => [
+      { address: '169.254.169.254', family: 4 },
+    ]);
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('ssrf_blocked_ip');
+  });
+});


### PR DESCRIPTION
## 什么

ROADMAP #28 / MCP 2026-07-28 升级 P3：极简 OAuth 2.1 Authorization Server，让网页 Agent（ChatGPT/Claude 等）走标准网页授权流接入 `POST /mcp`。stdio 与 oa_/admin token 路径零破坏。

- **RFC 8414** `GET /.well-known/oauth-authorization-server`（`code_challenge_methods_supported:["S256"]`、`authorization_response_iss_parameter_supported:true`、`client_id_metadata_document_supported:true` 等）；issuer/resource/PRM `authorization_servers` 同一来源（`MCP_PUBLIC_URL ?? 请求 origin`，复用 #17 解析）
- **/authorize**：公开入口 302 → `/ui/oauth/authorize`（cookie path=/ui）；同意页挂 Dashboard ui-session，**仅业主 admin 会话可见可批**；显示 client_name + client_id hostname + redirect host（钓鱼防护），localhost redirect 额外警告；业主可选已有身份或当场新建（创建仅 admin）；授权码一次性 10 分钟只存哈希；**全部回跳含错误分支统一带 `iss`（RFC 9207）**；未登记 redirect_uri 一律错误页（禁开放重定向）
- **POST /oauth/token**：authorization_code（PKCE 仅 S256）+ refresh 轮换（旧 refresh 一次性作废）；resource（RFC 8707）在授权与 token 请求双侧校验、绑死本服务 resource URI；opaque 32B 随机只存哈希；access 1h / refresh 30d；**RFC 7009** `POST /oauth/revoke`
- **CIMD 校验器**（draft-ietf-oauth-client-id-metadata-document，SSRF 按 -01 MUST）：https+path/禁 `..`/fragment/userinfo、fetch MUST 200/不跟重定向/10s/5KB、client_id 逐字符一致、必填三字段、禁一切 client_secret*（仅 none）、redirect_uri 精确匹配 + loopback 忽略端口（RFC 8252，Claude Code 动态端口坑）、缓存尊重 cache headers。SSRF：169.254.0.0/16（云 metadata）与 0.0.0.0/8 **永拒**；RFC1918/CGNAT/loopback 按「AS 同部署私网」例外放行（验收在 tailnet 内；**P4 公网部署必须收紧，已记 backlog**）
- **resolveToken 扩展**：OAuth access → 恒 `{kind:'identity'}`（**永不 admin**）；强制 expiresAt + aud 校验（aud 必须匹配外部期望值——请求 resource 或 MCP_PUBLIC_URL，禁止令牌自洽）；`/v1` 与 `/mcp` 同一入口（aud 不符 403 `invalid_audience`）；**UI session 交换永不接 OAuth 票**
- **Dashboard 授权管理页**：`/ui/oauth/grants` 列表（client/身份/授权时间/最近使用）+ 吊销（删 grant + 全部令牌立即失效）
- **存储**：`oauth.json` 照抄 identities.json（单写者、tmp+rename、0600、只存哈希、损坏 fail-closed）

## 明确不做

DCR（/oauth/register）、OIDC discovery、admin 级 OAuth 票、P4 公网暴露（另案等业主拍板）。

## 测试（基线 602 → 本 PR 628 全绿）

- api 546→572（+26：8414 三标志+PRM issuer 一致、全链路 authorize→token→/mcp tools/list、refresh 轮换+重放拒、revoke 立即 401、无/plain/非 S256 PKCE、redirect 不匹配错误页+loopback 异端口放行、CIMD 重定向/逐字符/缺字段/secret/169.254 拒、过期 401、aud 403、code 重放/过期、OAuth≠admin 构造断言、identity 会话批准→403、OAuth 票换 UI session→401、grants 吊销）
- mcp 23 / setup 33 不破；`bun run build` 过；**typecheck 新增=0**

## 审查

- 独立 subagent 三轮：首轮 FAIL（开放重定向+typecheck）→ 修复 → PASS_WITH_NOTES；返工 1（指挥终审 5 项：私网判定去重抽 `lib/net.ts`、批准权收窄 admin、UI session 拒 OAuth 票、补 invalid_client 负例、Progress.md 出仓）后再审 PASS
- dogfood 全链路验收（模拟客户端 CIMD→authorize→token→/mcp→refresh 轮换）由指挥在合并前完成，结果见评论

🤖 worker-27 (cursor-agent) 开发；GC-8G 指挥终审

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth 2.1 authorization for MCP, including PKCE, authorization codes, refresh tokens, revocation, and resource-bound access tokens.
  * Added browser consent, grant management, dashboard revocation, and OAuth discovery metadata.
  * Added secure client metadata and redirect validation.

* **Security**
  * Added audience and expiration checks, hashed token storage, refresh-token rotation, and SSRF protections.

* **Documentation**
  * Documented OAuth APIs, MCP setup, security practices, and supported limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->