### PR TITLE
feat(api): P3.5 scrubbed audit, tool tiers, and MCP rate limits (WriteGuard seatbelts)

### DIFF
--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -52,6 +52,11 @@ UI_ENABLED=true
 # deployment so Bearer tokens are never implied over plaintext HTTP.
 # MCP_PUBLIC_URL=https://mail.example.com
 
+# MCP tools/call per-token rate limits (sliding window per minute; 0 = off).
+# OAuth keys by grantId, oa_ by address; admin is exempt. Defaults: 60 / 20.
+# MCP_RATE_READ_PER_MIN=60
+# MCP_RATE_WRITE_PER_MIN=20
+
 # Per-identity send rate limit, messages per rolling hour (0 = unlimited).
 SEND_RATE_LIMIT=20
 

--- a/.env.example
+++ b/.env.example
@@ -83,6 +83,12 @@ NTFY_ADMIN_PASSWORD=change-me-generate-with-openssl-rand-hex-24
 # deployment so Bearer tokens are never implied over plaintext HTTP.
 # MCP_PUBLIC_URL=https://mail.example.com
 
+# MCP tools/call per-token rate limits (sliding window per minute; 0 = off).
+# OAuth keys by grantId, oa_ by address; admin is exempt. Read/write buckets
+# are independent (write = tier minimal+). Defaults: 60 read / 20 write.
+# MCP_RATE_READ_PER_MIN=60
+# MCP_RATE_WRITE_PER_MIN=20
+
 # Identity store directory (default ./data in the API process). Designed for a
 # single writer process (Compose runs one API); multi-process shared DATA_DIR
 # is unsupported even though each save is atomic on disk.

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -35,6 +35,9 @@ services:
       DASHBOARD_PUBLIC_URL: ${DASHBOARD_PUBLIC_URL:-}
       # Optional public origin for MCP RFC 9728 metadata (overrides request Host).
       MCP_PUBLIC_URL: ${MCP_PUBLIC_URL:-}
+      # MCP tools/call per-token rate limits (per minute; 0 = off). Admin exempt.
+      MCP_RATE_READ_PER_MIN: ${MCP_RATE_READ_PER_MIN:-60}
+      MCP_RATE_WRITE_PER_MIN: ${MCP_RATE_WRITE_PER_MIN:-20}
       # Identity store (json) survives container recreation:
       DATA_DIR: /app/data
       # Per-identity send limit (messages/hour, 0 = off):

--- a/compose.yaml
+++ b/compose.yaml
@@ -196,6 +196,9 @@ services:
       DASHBOARD_PUBLIC_URL: ${DASHBOARD_PUBLIC_URL:-}
       # Optional public origin for MCP RFC 9728 metadata (overrides request Host).
       MCP_PUBLIC_URL: ${MCP_PUBLIC_URL:-}
+      # MCP tools/call per-token rate limits (per minute; 0 = off). Admin exempt.
+      MCP_RATE_READ_PER_MIN: ${MCP_RATE_READ_PER_MIN:-60}
+      MCP_RATE_WRITE_PER_MIN: ${MCP_RATE_WRITE_PER_MIN:-20}
       # Identity store (json) survives container recreation:
       DATA_DIR: /app/data
       # Per-identity send limit (messages/hour, 0 = off):

--- a/docs/security.md
+++ b/docs/security.md
@@ -39,7 +39,7 @@ retention window before reusing one.
 - 外部可控字段（clientId 等）写入前剥控制字符/换行并截断，防 JSONL log 注入。
 - 事件名（与实现一致）：
   - `oauth.authorize.approve` / `oauth.authorize.deny`
-  - `oauth.token.code` / `oauth.token.refresh`
+  - `oauth.token.code` / `oauth.token.refresh`（失败审计取舍①：仅凭证哈希命中已知行才落——含过期/错配/PKCE；`not_found` 含已消费 replay 不写盘，防公网灌爆）
   - `oauth.revoke`（**仅真删 token 时**落盘；未知票 200 且零审计写）
   - `oauth.grant.revoke`
   - `mcp.tools.call`（成功路径仅 tier ≥ minimal；`rate_limited` / `denied` 读写下均记）

--- a/docs/security.md
+++ b/docs/security.md
@@ -36,8 +36,15 @@ retention window before reusing one.
 
 - 落盘：`DATA_DIR/audit.jsonl`（JSONL 追加；单写者；文件 0600 / 目录 0700）。
 - 行字段白名单：`{ts, event, clientId?, grantId?, address?, tool?, tier?, outcome, durationMs?}`——**严禁**参数值、邮件正文、token 任何片段、subject。
-- 事件：`oauth.authorize.approve|deny`、`oauth.token.code|refresh`、`oauth.revoke`、`oauth.grant.revoke`、`mcp.tools.call`（仅 tier ≥ minimal）。
-- 读端点：`GET /v1/audit/events?limit=&event=`（**admin only**；默认 limit 100，上限 1000；只读无删除）。
+- 外部可控字段（clientId 等）写入前剥控制字符/换行并截断，防 JSONL log 注入。
+- 事件名（与实现一致）：
+  - `oauth.authorize.approve` / `oauth.authorize.deny`
+  - `oauth.token.code` / `oauth.token.refresh`
+  - `oauth.revoke`（**仅真删 token 时**落盘；未知票 200 且零审计写）
+  - `oauth.grant.revoke`
+  - `mcp.tools.call`（成功路径仅 tier ≥ minimal；`rate_limited` / `denied` 读写下均记）
+  - `mcp.batch_rejected`（JSON-RPC batch 拒收；计写桶）
+- 读端点：`GET /v1/audit/events?limit=&event=`（**admin only**；默认 limit 100，上限 1000；合并 `audit.jsonl.1` + 当前，**新的在前**；只读无删除）。
 - 增长：单文件 >10MB 时 rotate 为 `audit.jsonl.1`（只留一份备份），再开新文件。
 
 ### 写调用 attribution

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,6 +28,41 @@ retention window before reusing one.
 - CIMD SSRF：当前部署在 loopback/tailnet，放行 RFC1918/CGNAT/loopback；**永拒** `169.254.0.0/16`、`0.0.0.0/8`、`fe80::/10`（与 IPv4 链路本地对齐）、`fd00:ec2::/16`（AWS IMDS IPv6，如 `fd00:ec2::254`）。含 IPv4-mapped（含 URL 规范化后的 `::ffff:a9fe:a9fe` 形）。连接时 lookup 钉死解析结果，消除校验/fetch 间 DNS-rebinding TOCTOU（P4 公网须进一步收紧私网放行）。
 - 授权响应（含错误）一律带 `iss`（RFC 9207）。Dashboard `/ui/oauth/grants` 可整串吊销。
 
+## P3.5 审计 / 工具分层 / MCP 限量（应用层安全带）
+
+对照 Cloudflare WriteGuard：防线在服务器侧，不靠客户端确认框。全部长在应用层——自托管与托管部署人人有份；**stdio MCP 不拦**（operator 本地；REST ACL 兜底），`/v1` 既有行为不变。
+
+### Scrubbed 审计事件
+
+- 落盘：`DATA_DIR/audit.jsonl`（JSONL 追加；单写者；文件 0600 / 目录 0700）。
+- 行字段白名单：`{ts, event, clientId?, grantId?, address?, tool?, tier?, outcome, durationMs?}`——**严禁**参数值、邮件正文、token 任何片段、subject。
+- 事件：`oauth.authorize.approve|deny`、`oauth.token.code|refresh`、`oauth.revoke`、`oauth.grant.revoke`、`mcp.tools.call`（仅 tier ≥ minimal）。
+- 读端点：`GET /v1/audit/events?limit=&event=`（**admin only**；默认 limit 100，上限 1000；只读无删除）。
+- 增长：单文件 >10MB 时 rotate 为 `audit.jsonl.1`（只留一份备份），再开新文件。
+
+### 写调用 attribution
+
+`/mcp` 审计行按 caller 分清：OAuth → `clientId`+`grantId`+`address`；`oa_` → `address`；admin → `address: "admin"`（仅 attribution；REST 侧 actor 行为另案，不在此改）。
+
+### 十五工具四级分层
+
+| 级别 | 工具 | 策略要点 |
+| --- | --- | --- |
+| read | mail_list_messages, mail_read_message, mail_wait_for, mail_list_identities, notify_check, task_list, task_get | 观测 |
+| minimal | mail_mark_seen, task_create | 轻状态变更 |
+| contained | mail_send, task_update, notify_agent, notify_user | 外发 / 唤醒 |
+| critical | mail_new_identity, notify_verify | **OAuth 票 deny-by-default（403）**；`oa_` 走 REST scope；admin 全通 |
+
+新工具须在注册处声明 tier；未声明 → 注册即报错，HTTP 对未知工具名 403（default deny）。
+分层 / 限量 / 写审计**仅强制于 `POST /mcp`**（含拒绝 JSON-RPC batch）；stdio 不拦；`/v1` 既有 REST ACL 不变（OAuth 直打 REST 仍受 identity scope 约束，但不走本表 critical 预检）。
+
+### per-token MCP 限量
+
+- 键：OAuth=`grantId`，`oa_`=`address`，**admin 豁免**（运维面；agent 应用 scoped 票）。
+- 分桶：读（read）/ 写（minimal+）独立；写更严。
+- env：`MCP_RATE_READ_PER_MIN`（默认 60）、`MCP_RATE_WRITE_PER_MIN`（默认 20）。参照 Joe 事故一下午 ~3000 次合法调用——量防线是唯一真底线；20 写/min 挡失控仍够正常 agent。
+- 仅 `tools/call` 计费；`tools/list` 免费。超限 → `429` + `Retry-After`（进 SDK 前拦）。
+
 ## Prompt-injection 防护
 
 Agent 通过 REST / MCP 读外部来信时，正文会进入 LLM 上下文。本项目的主防线是

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -35,7 +35,7 @@ bun run typecheck
 
 All `/v1/*` require `Authorization: Bearer <key>`.
 
-- `POST /mcp` — 无状态 MCP（SDK v2 / 2026-07-28）；**需** `Authorization: Bearer`（admin / `oa_` / OAuth access）；无/坏 token → 401 + `WWW-Authenticate`；OAuth aud 不符 → 403；critical 工具对 OAuth 票 403；超限 429 + `Retry-After`（见 `MCP_RATE_*`）
+- `POST /mcp` — 无状态 MCP（SDK v2 / 2026-07-28）；**需** `Authorization: Bearer`（admin / `oa_` / OAuth access）；无/坏 token → 401 + `WWW-Authenticate`；OAuth aud 不符 → 403；critical 工具对 OAuth 票 403；超限 429 + `Retry-After`（见 `MCP_RATE_*`）；JSON-RPC **batch 数组** → `400 {error:"batch_not_supported"}`（计写桶并审计 `mcp.batch_rejected`）
 - `GET /.well-known/oauth-protected-resource`（及 `/mcp` path-aware 变体）— RFC 9728 PRM；**公开**；`authorization_servers` = AS issuer。可选 env `MCP_PUBLIC_URL` 覆盖对外 origin
 - `GET /.well-known/oauth-authorization-server` — RFC 8414（PKCE S256、CIMD、iss 响应）；**公开**
 - `GET /authorize` → `/ui/oauth/authorize` — OAuth 同意页（Dashboard 会话）；`POST /oauth/token` / `POST /oauth/revoke`；管理页 `/ui/oauth/grants`

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -23,6 +23,8 @@ bun run typecheck
 | `DOMAIN` | — | identity domain (`localpart@DOMAIN`) |
 | `API_KEYS` | — | comma-separated **admin** Bearer keys (full access; agents should use per-identity tokens instead) |
 | `MCP_PUBLIC_URL` | — | optional public origin for PRM / AS issuer / MCP loopback aud（`http(s)://…`，去尾斜杠）；反代后与浏览器所见 origin 不一致时必填 |
+| `MCP_RATE_READ_PER_MIN` | `60` | `/mcp` tools/call 读桶（read 级）每分钟上限；`0` 关闭；OAuth 按 grantId、`oa_` 按 address；admin 豁免 |
+| `MCP_RATE_WRITE_PER_MIN` | `20` | `/mcp` tools/call 写桶（minimal+）每分钟上限；写更严；超限 `429` + `Retry-After` |
 | `IMAP_HOST/PORT/USER/PASS` | `127.0.0.1:993` | catch-all mailbox login |
 | `IMAP_TLS` | `true` | `false` for plaintext/STARTTLS (143) |
 | `SMTP_HOST/PORT/USER/PASS` | `127.0.0.1:587` | catch-all account; From is rewritten to the identity |
@@ -33,11 +35,12 @@ bun run typecheck
 
 All `/v1/*` require `Authorization: Bearer <key>`.
 
-- `POST /mcp` — 无状态 MCP（SDK v2 / 2026-07-28）；**需** `Authorization: Bearer`（admin / `oa_` / OAuth access）；无/坏 token → 401 + `WWW-Authenticate`；OAuth aud 不符 → 403
+- `POST /mcp` — 无状态 MCP（SDK v2 / 2026-07-28）；**需** `Authorization: Bearer`（admin / `oa_` / OAuth access）；无/坏 token → 401 + `WWW-Authenticate`；OAuth aud 不符 → 403；critical 工具对 OAuth 票 403；超限 429 + `Retry-After`（见 `MCP_RATE_*`）
 - `GET /.well-known/oauth-protected-resource`（及 `/mcp` path-aware 变体）— RFC 9728 PRM；**公开**；`authorization_servers` = AS issuer。可选 env `MCP_PUBLIC_URL` 覆盖对外 origin
 - `GET /.well-known/oauth-authorization-server` — RFC 8414（PKCE S256、CIMD、iss 响应）；**公开**
 - `GET /authorize` → `/ui/oauth/authorize` — OAuth 同意页（Dashboard 会话）；`POST /oauth/token` / `POST /oauth/revoke`；管理页 `/ui/oauth/grants`
 - OAuth 存储：`DATA_DIR/oauth.json`（只存哈希；与 identities.json 同模式）
+- `GET /v1/audit/events?limit=&event=` → `{events:[…]}`（**admin only**；scrubbed JSONL `DATA_DIR/audit.jsonl`；见 docs/security.md）
 - `POST /v1/identities` `{name?, localpart?}` → `201 {address, name?, pushContentTier, token}` (409 if taken)
 - `GET /v1/identities` → `{identities:[{address,name?,createdAt,pushContentTier,...}]}`
 - `GET /v1/identities/:address/push-tier` → `{address, pushContentTier, warning?}` (admin any; identity own only)

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -11,6 +11,7 @@ import {
 } from './lib/ui-session.ts';
 import { getMcpLoopbackBase } from './lib/mcp-loopback.ts';
 import { registerMcpHttpRoutes } from './mcp/http.ts';
+import { auditRoute } from './routes/audit.ts';
 import { identitiesRoute } from './routes/identities.ts';
 import { messagesRoute } from './routes/messages.ts';
 import { sendRoute } from './routes/send.ts';
@@ -88,6 +89,7 @@ export function createApp(options: AppOptions = {}): Hono {
   app.route('/v1/send', sendRoute);
   app.route('/v1/notify', notifyRoute);
   app.route('/v1/tasks', tasksRoute);
+  app.route('/v1/audit', auditRoute);
 
   if (options.uiEnabled ?? config.uiEnabled) {
     const uiSessions = new UiSessionStore({

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -1,0 +1,182 @@
+/**
+ * Scrubbed 审计事件（WriteGuard 对照）。
+ *
+ * 落盘：DATA_DIR/audit.jsonl——JSONL **追加写**（与 identities/oauth-store 的
+ * JSON 整文件 tmp+rename 不同，故不抽第三份通用存储工具；纪律仍对齐：
+ * 单写者进程、目录 0700、文件 0600、绝不记录参数值/正文/token 片段）。
+ *
+ * 增长策略：单文件超过 AUDIT_ROTATE_BYTES（10MB）时 rename 为 audit.jsonl.1
+ *（只留一份备份），再开新 audit.jsonl。注释与 docs/security.md 同步。
+ */
+
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { config } from './config.ts';
+
+/** 超过此大小则 rotate（只保留 audit.jsonl.1 一份）。 */
+export const AUDIT_ROTATE_BYTES = 10 * 1024 * 1024;
+
+/** 审计行 outcome：放行 / 策略拒绝 / 限量 / 执行层错误。 */
+export type AuditOutcome = 'ok' | 'denied' | 'rate_limited' | 'error';
+
+/**
+ * Scrubbed 行。字段白名单即红线：禁止扩展出 args/body/token/subject 等。
+ * clientId/grantId/address/tool/tier 均可选——按事件类型填已知标识即可。
+ */
+export type AuditEvent = {
+  ts: string;
+  event: string;
+  clientId?: string;
+  grantId?: string;
+  address?: string;
+  tool?: string;
+  tier?: string;
+  outcome: AuditOutcome;
+  durationMs?: number;
+};
+
+function auditPath(): string {
+  return join(config.dataDir, 'audit.jsonl');
+}
+
+function auditRotatedPath(): string {
+  return join(config.dataDir, 'audit.jsonl.1');
+}
+
+/** 确保 DATA_DIR 0700；单写者约定与 identities 相同。 */
+function ensureDataDir(): void {
+  mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(config.dataDir, 0o700);
+  } catch {
+    // bind mount 属主可能不同；文件 mode 仍会设置
+  }
+}
+
+/** 必要时 rotate：>10MB → audit.jsonl.1（覆盖旧备份），再新建空文件。 */
+function rotateIfNeeded(): void {
+  const path = auditPath();
+  if (!existsSync(path)) return;
+  let size = 0;
+  try {
+    size = statSync(path).size;
+  } catch {
+    return;
+  }
+  if (size <= AUDIT_ROTATE_BYTES) return;
+  const rotated = auditRotatedPath();
+  try {
+    renameSync(path, rotated);
+    chmodSync(rotated, 0o600);
+  } catch {
+    // rotate 失败不阻断主路径；下一次写入再试
+  }
+}
+
+/**
+ * 追加一条 scrubbed 事件。写入失败只打日志，不抛——审计不得拖垮授权/MCP。
+ */
+export function recordAuditEvent(
+  partial: Omit<AuditEvent, 'ts'> & { ts?: string },
+): void {
+  const row: AuditEvent = {
+    ts: partial.ts ?? new Date().toISOString(),
+    event: partial.event,
+    outcome: partial.outcome,
+    ...(partial.clientId !== undefined ? { clientId: partial.clientId } : {}),
+    ...(partial.grantId !== undefined ? { grantId: partial.grantId } : {}),
+    ...(partial.address !== undefined ? { address: partial.address } : {}),
+    ...(partial.tool !== undefined ? { tool: partial.tool } : {}),
+    ...(partial.tier !== undefined ? { tier: partial.tier } : {}),
+    ...(partial.durationMs !== undefined ? { durationMs: partial.durationMs } : {}),
+  };
+
+  try {
+    ensureDataDir();
+    rotateIfNeeded();
+    const path = auditPath();
+    const line = `${JSON.stringify(row)}\n`;
+    if (!existsSync(path)) {
+      // 新建时显式 0600（append 对已存在文件不改 mode）
+      writeFileSync(path, line, { mode: 0o600 });
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // best effort
+      }
+      return;
+    }
+    appendFileSync(path, line, { mode: 0o600 });
+    try {
+      chmodSync(path, 0o600);
+    } catch {
+      // best effort
+    }
+  } catch (err) {
+    console.error('[audit] append failed:', err);
+  }
+}
+
+export type ReadAuditOptions = {
+  /** 默认 100，上限 1000。 */
+  limit?: number;
+  /** 精确匹配 event 字段。 */
+  event?: string;
+};
+
+/**
+ * 读端：从文件尾部取最近 N 条（可选 event 过滤）。只读，无删除 API。
+ */
+export function readAuditEvents(options: ReadAuditOptions = {}): AuditEvent[] {
+  const limit = Math.min(Math.max(options.limit ?? 100, 0), 1000);
+  if (limit === 0) return [];
+  const path = auditPath();
+  if (!existsSync(path)) return [];
+
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return [];
+  }
+
+  const lines = text.split('\n').filter((l) => l.trim().length > 0);
+  const out: AuditEvent[] = [];
+  // 从尾部往前扫，凑够 limit
+  for (let i = lines.length - 1; i >= 0 && out.length < limit; i--) {
+    try {
+      const parsed = JSON.parse(lines[i]!) as AuditEvent;
+      if (options.event && parsed.event !== options.event) continue;
+      if (typeof parsed.ts !== 'string' || typeof parsed.event !== 'string') continue;
+      if (typeof parsed.outcome !== 'string') continue;
+      out.push(parsed);
+    } catch {
+      // 跳过坏行
+    }
+  }
+  // 时间正序返回（旧→新）
+  out.reverse();
+  return out;
+}
+
+/** 测试辅助：清空审计文件（不删 rotate 备份，测试一般用新 DATA_DIR）。 */
+export function resetAuditForTests(): void {
+  const path = auditPath();
+  if (existsSync(path)) {
+    writeFileSync(path, '', { mode: 0o600 });
+    try {
+      chmodSync(path, 0o600);
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -5,8 +5,11 @@
  * JSON 整文件 tmp+rename 不同，故不抽第三份通用存储工具；纪律仍对齐：
  * 单写者进程、目录 0700、文件 0600、绝不记录参数值/正文/token 片段）。
  *
+ * 外部可控字符串（clientId/grantId/address/tool/event）写入前剥控制字符与换行，
+ * 防 JSONL log 注入（\r\n 伪造行）。
+ *
  * 增长策略：单文件超过 AUDIT_ROTATE_BYTES（10MB）时 rename 为 audit.jsonl.1
- *（只留一份备份），再开新 audit.jsonl。注释与 docs/security.md 同步。
+ *（只留一份备份），再开新 audit.jsonl。读端合并 .1 + 当前（新的在前）。
  */
 
 import {
@@ -52,6 +55,15 @@ function auditRotatedPath(): string {
   return join(config.dataDir, 'audit.jsonl.1');
 }
 
+/**
+ * 清洗外部可控字段：去掉 C0 控制字符与 DEL（含 \r\n\t），再截断。
+ * JSON.stringify 本身会转义换行，但落盘前仍剥除，避免伪造「下一行」观感/下游误解析。
+ */
+export function scrubAuditField(value: string, maxLen = 256): string {
+  // eslint-disable-next-line no-control-regex
+  return value.replace(/[\u0000-\u001f\u007f]/g, '').slice(0, maxLen);
+}
+
 /** 确保 DATA_DIR 0700；单写者约定与 identities 相同。 */
 function ensureDataDir(): void {
   mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
@@ -90,13 +102,23 @@ export function recordAuditEvent(
 ): void {
   const row: AuditEvent = {
     ts: partial.ts ?? new Date().toISOString(),
-    event: partial.event,
+    event: scrubAuditField(partial.event, 128),
     outcome: partial.outcome,
-    ...(partial.clientId !== undefined ? { clientId: partial.clientId } : {}),
-    ...(partial.grantId !== undefined ? { grantId: partial.grantId } : {}),
-    ...(partial.address !== undefined ? { address: partial.address } : {}),
-    ...(partial.tool !== undefined ? { tool: partial.tool } : {}),
-    ...(partial.tier !== undefined ? { tier: partial.tier } : {}),
+    ...(partial.clientId !== undefined
+      ? { clientId: scrubAuditField(partial.clientId) }
+      : {}),
+    ...(partial.grantId !== undefined
+      ? { grantId: scrubAuditField(partial.grantId) }
+      : {}),
+    ...(partial.address !== undefined
+      ? { address: scrubAuditField(partial.address) }
+      : {}),
+    ...(partial.tool !== undefined
+      ? { tool: scrubAuditField(partial.tool, 128) }
+      : {}),
+    ...(partial.tier !== undefined
+      ? { tier: scrubAuditField(partial.tier, 32) }
+      : {}),
     ...(partial.durationMs !== undefined ? { durationMs: partial.durationMs } : {}),
   };
 
@@ -133,29 +155,12 @@ export type ReadAuditOptions = {
   event?: string;
 };
 
-/**
- * 读端：从文件尾部取最近 N 条（可选 event 过滤）。只读，无删除 API。
- */
-export function readAuditEvents(options: ReadAuditOptions = {}): AuditEvent[] {
-  const limit = Math.min(Math.max(options.limit ?? 100, 0), 1000);
-  if (limit === 0) return [];
-  const path = auditPath();
-  if (!existsSync(path)) return [];
-
-  let text: string;
-  try {
-    text = readFileSync(path, 'utf8');
-  } catch {
-    return [];
-  }
-
+function parseAuditLines(text: string): AuditEvent[] {
   const lines = text.split('\n').filter((l) => l.trim().length > 0);
   const out: AuditEvent[] = [];
-  // 从尾部往前扫，凑够 limit
-  for (let i = lines.length - 1; i >= 0 && out.length < limit; i--) {
+  for (const line of lines) {
     try {
-      const parsed = JSON.parse(lines[i]!) as AuditEvent;
-      if (options.event && parsed.event !== options.event) continue;
+      const parsed = JSON.parse(line) as AuditEvent;
       if (typeof parsed.ts !== 'string' || typeof parsed.event !== 'string') continue;
       if (typeof parsed.outcome !== 'string') continue;
       out.push(parsed);
@@ -163,20 +168,50 @@ export function readAuditEvents(options: ReadAuditOptions = {}): AuditEvent[] {
       // 跳过坏行
     }
   }
-  // 时间正序返回（旧→新）
-  out.reverse();
   return out;
 }
 
-/** 测试辅助：清空审计文件（不删 rotate 备份，测试一般用新 DATA_DIR）。 */
-export function resetAuditForTests(): void {
-  const path = auditPath();
-  if (existsSync(path)) {
-    writeFileSync(path, '', { mode: 0o600 });
+/**
+ * 读端：合并 audit.jsonl.1（旧）+ audit.jsonl（新），**新的在前**，尊重 limit。
+ * 可选 event 精确过滤。只读，无删除 API。
+ */
+export function readAuditEvents(options: ReadAuditOptions = {}): AuditEvent[] {
+  const limit = Math.min(Math.max(options.limit ?? 100, 0), 1000);
+  if (limit === 0) return [];
+
+  // 时间序：旧文件在前、当前在后；再从尾部取 → 新的优先
+  const chunks: AuditEvent[] = [];
+  for (const path of [auditRotatedPath(), auditPath()]) {
+    if (!existsSync(path)) continue;
     try {
-      chmodSync(path, 0o600);
+      chunks.push(...parseAuditLines(readFileSync(path, 'utf8')));
     } catch {
-      // ignore
+      // 跳过不可读文件
+    }
+  }
+
+  const filtered = options.event
+    ? chunks.filter((e) => e.event === options.event)
+    : chunks;
+
+  // 新的在前：从末尾往回取 limit 条，保持新→旧顺序
+  const newestFirst: AuditEvent[] = [];
+  for (let i = filtered.length - 1; i >= 0 && newestFirst.length < limit; i--) {
+    newestFirst.push(filtered[i]!);
+  }
+  return newestFirst;
+}
+
+/** 测试辅助：清空当前审计文件与 rotate 备份。 */
+export function resetAuditForTests(): void {
+  for (const path of [auditPath(), auditRotatedPath()]) {
+    if (existsSync(path)) {
+      writeFileSync(path, '', { mode: 0o600 });
+      try {
+        chmodSync(path, 0o600);
+      } catch {
+        // ignore
+      }
     }
   }
 }

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -17,12 +17,23 @@ import { createMiddleware } from 'hono/factory';
 import type { Context } from 'hono';
 import { config } from './config.ts';
 import { findIdentity, findIdentityByToken } from './identities.ts';
-import { lookupAccessToken } from './oauth-store.ts';
+import { getGrant, lookupAccessToken } from './oauth-store.ts';
 import { resolveResourceUri } from './oauth-url.ts';
 
 export type Auth =
   | { kind: 'admin' }
   | { kind: 'identity'; address: string };
+
+/**
+ * /mcp 审计与限量用的窄路身份（与 Auth 解耦：/v1 仍只读 auth，行为不变）。
+ * - admin → 标 admin（attribution 记录；REST actor 债另案）
+ * - oa_ identity → address
+ * - OAuth access → clientId + grantId + address
+ */
+export type TokenAttribution =
+  | { kind: 'admin' }
+  | { kind: 'identity'; address: string }
+  | { kind: 'oauth'; address: string; grantId: string; clientId: string };
 
 declare module 'hono' {
   interface ContextVariableMap {
@@ -41,25 +52,34 @@ export type ResolveTokenOptions = {
 };
 
 export type ResolveAccessResult =
-  | { status: 'ok'; auth: Auth }
+  | { status: 'ok'; auth: Auth; attribution: TokenAttribution }
   | { status: 'unauthorized' }
   | { status: 'forbidden_audience' };
 
 /**
  * 解析凭证到授权范围（含 OAuth aud/过期细分）。
  * /v1 与 /mcp 应走此入口，避免分叉。
+ * attribution 仅供 /mcp 审计/分层；/v1 继续只用 auth。
  */
 export function resolveAccessToken(
   token: string,
   options: ResolveTokenOptions = {},
 ): ResolveAccessResult {
   if (config.apiKeys.has(token)) {
-    return { status: 'ok', auth: { kind: 'admin' } };
+    return {
+      status: 'ok',
+      auth: { kind: 'admin' },
+      attribution: { kind: 'admin' },
+    };
   }
 
   const identity = findIdentityByToken(token);
   if (identity) {
-    return { status: 'ok', auth: { kind: 'identity', address: identity.address } };
+    return {
+      status: 'ok',
+      auth: { kind: 'identity', address: identity.address },
+      attribution: { kind: 'identity', address: identity.address },
+    };
   }
 
   const oauth = lookupAccessToken(token, options.now);
@@ -90,9 +110,20 @@ export function resolveAccessToken(
     return { status: 'unauthorized' };
   }
 
+  const grant = getGrant(oauth.grantId);
+  // grant 缺失时 lookupAccessToken 已当 missing；此处防御性回落
+  const clientId = grant?.clientId ?? 'unknown';
+
   return {
     status: 'ok',
+    // /v1 行为：仍是 identity scope，不含 grant 字段
     auth: { kind: 'identity', address: oauth.address },
+    attribution: {
+      kind: 'oauth',
+      address: oauth.address,
+      grantId: oauth.grantId,
+      clientId,
+    },
   };
 }
 

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -154,6 +154,12 @@ const envSchema = z.object({
   // 反向代理 / 公网暴露时应设为 https://…，避免盲信 Host 头。
   MCP_PUBLIC_URL: envUrl(),
 
+  // MCP tools/call 分桶限量（每分钟；0 = 关闭该桶）。admin 豁免。
+  // 默认：读 60 / 写 20——写更严；对照 Joe 事故下午 ~3000 次合法调用，
+  // 20 写/min 仍够正常 agent，却能挡住失控循环。
+  MCP_RATE_READ_PER_MIN: z.coerce.number().int().min(0).default(60),
+  MCP_RATE_WRITE_PER_MIN: z.coerce.number().int().min(0).default(20),
+
   // Per-identity send rate limit (messages per rolling hour). 0 disables.
   SEND_RATE_LIMIT: z.coerce.number().int().min(0).default(20),
 
@@ -238,6 +244,8 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
       ? normalizeUrl(raw.DASHBOARD_PUBLIC_URL)
       : undefined,
     mcpPublicUrl: raw.MCP_PUBLIC_URL ? normalizeUrl(raw.MCP_PUBLIC_URL) : undefined,
+    mcpRateReadPerMin: raw.MCP_RATE_READ_PER_MIN,
+    mcpRateWritePerMin: raw.MCP_RATE_WRITE_PER_MIN,
     sendRateLimit: raw.SEND_RATE_LIMIT,
     retentionDays: raw.RETENTION_DAYS,
     retentionCheckHours: raw.RETENTION_CHECK_HOURS,

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -202,7 +202,11 @@ function pruneExpired(data: OAuthStoreFile, now = Date.now()): boolean {
   return changed;
 }
 
-function load(): OAuthStoreFile {
+/**
+ * @param persistPrune 冷读发现过期行时是否写回磁盘。
+ * 公开 /oauth/revoke 用 false：未知 token 路径必须零磁盘写（防未鉴权写放大）。
+ */
+function load(persistPrune = true): OAuthStoreFile {
   const path = storePath();
   if (!existsSync(path)) {
     if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
@@ -223,10 +227,13 @@ function load(): OAuthStoreFile {
       throw new Error('invalid oauth store shape');
     }
     if (pruneExpired(parsed)) {
-      // 读时发现过期行：就地写回，避免 save→load 递归
-      const written = writeStoreFile(parsed);
-      storeCache = { version: written, data: parsed };
-      return storeCache.data;
+      if (persistPrune) {
+        // 读时发现过期行：就地写回，避免 save→load 递归
+        const written = writeStoreFile(parsed);
+        storeCache = { version: written, data: parsed };
+        return storeCache.data;
+      }
+      // revoke 热路径：只内存 prune，不写盘
     }
     storeCache = { version, data: parsed };
     return storeCache.data;
@@ -583,11 +590,13 @@ export function rotateRefreshToken(
 /**
  * RFC 7009：吊销 access 或 refresh（未知令牌亦 200 成功语义，由路由保证）。
  * 必须带与 grant 绑定的 clientId；缺失或不匹配时**不删**（灭第三方持票 DoS）。
+ * 未知/不匹配路径：**零磁盘写**（load 不 persist prune；不 save）——公开端点防写放大。
  * @returns true 表示确有删除；false 表示未删（未知票 / 无 client / 不匹配）
  */
 export function revokeToken(token: string, clientId?: string): boolean {
   if (!clientId) return false;
-  const data = load();
+  // persistPrune=false：未命中时不得因过期清理写 oauth.json
+  const data = load(false);
   const hash = hashSecret(token);
   const access = data.access[hash];
   const refresh = data.refresh[hash];
@@ -604,6 +613,7 @@ export function revokeToken(token: string, clientId?: string): boolean {
     delete data.refresh[hash];
     changed = true;
   }
+  // 只有真删行才写盘
   if (changed) save(data);
   return changed;
 }

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -1,11 +1,12 @@
 /**
- * Per-address send rate limiting. In-memory sliding window — resets on
+ * Per-address / per-grant rate limiting. In-memory sliding window — resets on
  * process restart, which is acceptable for a guard whose job is to stop a
  * runaway agent or a leaked token from turning the box into a spam cannon,
  * not to enforce billing-grade quotas.
  *
  * Identities each get their own window, so one misbehaving agent can't
- * starve the others.
+ * starve the others. MCP 读写分桶与 send/notifyUser 共用下方 slidingWindow*
+ * helper——禁止再复制第三份窗口逻辑。
  */
 
 export interface RateLimitResult {
@@ -14,27 +15,28 @@ export interface RateLimitResult {
   retryAfterSec: number;
   /** Messages sent within the current window (after counting this one). */
   count: number;
-  /** Handle for releaseSendLimit(), set only when the send was allowed. */
+  /** Handle for release*Limit(), set only when the send was allowed. */
   reservation?: number;
 }
 
-const buckets = new Map<string, number[]>();
-const notifyUserBuckets = new Map<string, number[]>();
-
-export function checkSendLimit(
-  address: string,
+/**
+ * 共享滑动窗口：从 buckets[key] 滤掉过期戳，超限则拒绝并回写；
+ * 否则 push(now) 并返回 reservation。
+ */
+export function slidingWindowCheck(
+  buckets: Map<string, number[]>,
+  key: string,
   limit: number,
-  windowMs = 3_600_000,
-  now = Date.now(),
+  windowMs: number,
+  now: number,
 ): RateLimitResult {
   if (limit <= 0) return { allowed: true, retryAfterSec: 0, count: 0 };
 
-  const key = address.toLowerCase();
   const cutoff = now - windowMs;
   const stamps = (buckets.get(key) ?? []).filter((t) => t > cutoff);
 
   if (stamps.length >= limit) {
-    const retryAfterSec = Math.ceil((stamps[0] + windowMs - now) / 1000);
+    const retryAfterSec = Math.ceil((stamps[0]! + windowMs - now) / 1000);
     buckets.set(key, stamps);
     return { allowed: false, retryAfterSec, count: stamps.length };
   }
@@ -44,20 +46,44 @@ export function checkSendLimit(
   return { allowed: true, retryAfterSec: 0, count: stamps.length, reservation: now };
 }
 
-/**
- * Hand a slot back. Only for failures that never reached the mail server —
- * see isLocalSendFailure(); refunding rejected deliveries would let a caller
- * retry forever without ever spending quota.
- */
-export function releaseSendLimit(address: string, reservation: number | undefined): void {
+/** 退还一次 reservation（仅本地失败、请求未达下游时）。 */
+export function slidingWindowRelease(
+  buckets: Map<string, number[]>,
+  key: string,
+  reservation: number | undefined,
+): void {
   if (reservation === undefined) return;
-  const key = address.toLowerCase();
   const stamps = buckets.get(key);
   if (!stamps) return;
   const index = stamps.lastIndexOf(reservation);
   if (index < 0) return;
   stamps.splice(index, 1);
   if (stamps.length === 0) buckets.delete(key);
+}
+
+const buckets = new Map<string, number[]>();
+const notifyUserBuckets = new Map<string, number[]>();
+/** MCP 读桶（read 级 tools/call）。 */
+const mcpReadBuckets = new Map<string, number[]>();
+/** MCP 写桶（minimal+ 级 tools/call）。 */
+const mcpWriteBuckets = new Map<string, number[]>();
+
+export function checkSendLimit(
+  address: string,
+  limit: number,
+  windowMs = 3_600_000,
+  now = Date.now(),
+): RateLimitResult {
+  return slidingWindowCheck(buckets, address.toLowerCase(), limit, windowMs, now);
+}
+
+/**
+ * Hand a slot back. Only for failures that never reached the mail server —
+ * see isLocalSendFailure(); refunding rejected deliveries would let a caller
+ * retry forever without ever spending quota.
+ */
+export function releaseSendLimit(address: string, reservation: number | undefined): void {
+  slidingWindowRelease(buckets, address.toLowerCase(), reservation);
 }
 
 /** Test helper: wipe all windows. */
@@ -76,37 +102,47 @@ export function checkNotifyUserLimit(
   windowMs = 3_600_000,
   now = Date.now(),
 ): RateLimitResult {
-  if (limit <= 0) return { allowed: true, retryAfterSec: 0, count: 0 };
-
-  const key = address.toLowerCase();
-  const cutoff = now - windowMs;
-  const stamps = (notifyUserBuckets.get(key) ?? []).filter((t) => t > cutoff);
-  if (stamps.length >= limit) {
-    const retryAfterSec = Math.ceil((stamps[0] + windowMs - now) / 1000);
-    notifyUserBuckets.set(key, stamps);
-    return { allowed: false, retryAfterSec, count: stamps.length };
-  }
-
-  stamps.push(now);
-  notifyUserBuckets.set(key, stamps);
-  return { allowed: true, retryAfterSec: 0, count: stamps.length, reservation: now };
+  return slidingWindowCheck(
+    notifyUserBuckets,
+    address.toLowerCase(),
+    limit,
+    windowMs,
+    now,
+  );
 }
 
 /** Return a user-notification slot when no request reached ntfy. */
 export function releaseNotifyUserLimit(address: string, reservation: number | undefined): void {
-  if (reservation === undefined) return;
-  const key = address.toLowerCase();
-  const stamps = notifyUserBuckets.get(key);
-  if (!stamps) return;
-  const index = stamps.lastIndexOf(reservation);
-  if (index < 0) return;
-  stamps.splice(index, 1);
-  if (stamps.length === 0) notifyUserBuckets.delete(key);
+  slidingWindowRelease(notifyUserBuckets, address.toLowerCase(), reservation);
 }
 
 /** Test helper: wipe the independent human-notification budget. */
 export function resetNotifyUserLimits(): void {
   notifyUserBuckets.clear();
+}
+
+export type McpRateBucket = 'read' | 'write';
+
+/**
+ * MCP per-token 限量：OAuth 用 grantId、oa_ 用 address 作 key；
+ * admin 由调用方豁免（不进此函数）。读写两桶独立。
+ * 默认窗口 60s（env 单位是 per-minute）。
+ */
+export function checkMcpRateLimit(
+  key: string,
+  bucket: McpRateBucket,
+  limit: number,
+  windowMs = 60_000,
+  now = Date.now(),
+): RateLimitResult {
+  const map = bucket === 'read' ? mcpReadBuckets : mcpWriteBuckets;
+  return slidingWindowCheck(map, key.toLowerCase(), limit, windowMs, now);
+}
+
+/** 测试辅助：清空 MCP 读写桶。 */
+export function resetMcpRateLimits(): void {
+  mcpReadBuckets.clear();
+  mcpWriteBuckets.clear();
 }
 
 /**

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -127,6 +127,9 @@ export type McpRateBucket = 'read' | 'write';
  * MCP per-token 限量：OAuth 用 grantId、oa_ 用 address 作 key；
  * admin 由调用方豁免（不进此函数）。读写两桶独立。
  * 默认窗口 60s（env 单位是 per-minute）。
+ *
+ * **键原样使用**——不 toLowerCase。grantId 是 base64url 大小写敏感随机串，
+ * 小写化会造成碰撞/错配；address 由调用方先 `.toLowerCase()` 再传入。
  */
 export function checkMcpRateLimit(
   key: string,
@@ -136,7 +139,7 @@ export function checkMcpRateLimit(
   now = Date.now(),
 ): RateLimitResult {
   const map = bucket === 'read' ? mcpReadBuckets : mcpWriteBuckets;
-  return slidingWindowCheck(map, key.toLowerCase(), limit, windowMs, now);
+  return slidingWindowCheck(map, key, limit, windowMs, now);
 }
 
 /** 测试辅助：清空 MCP 读写桶。 */

--- a/packages/api/src/lib/tool-tiers.ts
+++ b/packages/api/src/lib/tool-tiers.ts
@@ -6,9 +6,13 @@
  * - contained：外发/唤醒（发信、通知、推进任务）
  * - critical：建身份 / 验人通道——对 OAuth 票 deny-by-default
  *
- * 新工具必须在注册处声明 tier；未声明 → 注册即 throw（default deny 的编译期形态）。
- * HTTP /mcp 对未知工具名同样 403（防绕过注册表）。
- * stdio 路径不查本表策略（operator 本地；REST ACL 兜底）——见 mcp/http.ts 注释。
+ * 两层表：
+ * - TOOL_TIER_SPEC：策略规格（文档/对照）；**不**预填注册表
+ * - declared：仅由 tools.ts 注册处 `declareToolTier` 写入
+ *
+ * 护栏：`assertToolTierDeclared(name)` 在真正 registerTool 前调用——
+ * 漏调 declare → 注册即 throw。HTTP 预检用 getToolTier：已声明优先，
+ * 否则回落 SPEC（工厂尚未跑时仍能按规格拦）。
  */
 
 export type ToolTier = 'read' | 'minimal' | 'contained' | 'critical';
@@ -20,7 +24,7 @@ const TIER_RANK: Record<ToolTier, number> = {
   critical: 3,
 };
 
-/** 定稿映射（PR 描述同源）；模块加载即入库，供 /mcp 预检（早于 SDK 工厂）。 */
+/** 定稿映射（PR / docs 同源）。不自动写入 declared。 */
 export const TOOL_TIER_SPEC = {
   // read
   mail_list_messages: 'read',
@@ -43,14 +47,11 @@ export const TOOL_TIER_SPEC = {
   notify_verify: 'critical',
 } as const satisfies Record<string, ToolTier>;
 
-/** 进程内注册表：tool name → tier（规格预填 + tools.ts 注册时校验）。 */
-const declared = new Map<string, ToolTier>(
-  Object.entries(TOOL_TIER_SPEC) as [string, ToolTier][],
-);
+/** 进程内注册表：空起步，只接受 declareToolTier。 */
+const declared = new Map<string, ToolTier>();
 
 /**
- * 注册处声明级别。同一 name 重复声明且级别不同 → throw。
- * 未在规格表中的新工具也可声明（须与策略一致）；漏声明则 HTTP default deny。
+ * 注册处声明级别。同一 name 重复且级别不同 → throw。
  */
 export function declareToolTier(name: string, tier: ToolTier): void {
   const existing = declared.get(name);
@@ -60,12 +61,32 @@ export function declareToolTier(name: string, tier: ToolTier): void {
   declared.set(name, tier);
 }
 
-/** 查询已声明级别；未声明返回 undefined（HTTP 侧 default deny）。 */
-export function getToolTier(name: string): ToolTier | undefined {
-  return declared.get(name);
+/**
+ * 注册护栏：name 必须已 declare，否则 throw。
+ * tools.ts 在 server.registerTool 之前调用——漏声明即炸。
+ */
+export function assertToolTierDeclared(name: string): void {
+  if (!declared.has(name)) {
+    throw new Error(`tool ${name}: tier not declared (default deny)`);
+  }
 }
 
-/** 强制取级别；未声明即抛——供注册收尾校验。 */
+/** 是否已在注册处声明（不含 SPEC 回落）。 */
+export function isToolTierDeclared(name: string): boolean {
+  return declared.has(name);
+}
+
+/**
+ * 查询策略级别：已声明优先，否则 SPEC 回落（供 /mcp 预检在工厂前使用）。
+ * 未在 SPEC 且未声明 → undefined（HTTP 403）。
+ */
+export function getToolTier(name: string): ToolTier | undefined {
+  const fromDeclared = declared.get(name);
+  if (fromDeclared) return fromDeclared;
+  return (TOOL_TIER_SPEC as Record<string, ToolTier>)[name];
+}
+
+/** 强制取「已声明」级别；未声明即抛——供注册收尾校验规格表覆盖。 */
 export function requireToolTier(name: string): ToolTier {
   const tier = declared.get(name);
   if (!tier) {
@@ -74,15 +95,22 @@ export function requireToolTier(name: string): ToolTier {
   return tier;
 }
 
-/** tier ≥ minimal 算写调用（审计 + 写桶限量）。 */
+/** tier ≥ minimal 算写调用（成功路径审计 + 写桶限量）。 */
 export function isWriteTier(tier: ToolTier): boolean {
   return TIER_RANK[tier] >= TIER_RANK.minimal;
 }
 
-/** 测试辅助：恢复为规格表（勿长期清空，以免 /mcp 预检误拒）。 */
+/** 测试辅助：清空注册表（不预填 SPEC）。 */
 export function resetToolTiersForTests(): void {
   declared.clear();
-  for (const [name, tier] of Object.entries(TOOL_TIER_SPEC)) {
-    declared.set(name, tier as ToolTier);
+}
+
+/**
+ * 校验规格表内每个工具都已在本次注册中声明。
+ * 漏掉某个 tier() 调用 → throw（与 SPEC 预填不同，此校验真会失败）。
+ */
+export function assertAllSpecTiersDeclared(): void {
+  for (const name of Object.keys(TOOL_TIER_SPEC)) {
+    requireToolTier(name);
   }
 }

--- a/packages/api/src/lib/tool-tiers.ts
+++ b/packages/api/src/lib/tool-tiers.ts
@@ -1,0 +1,88 @@
+/**
+ * MCP 工具四级分层（WriteGuard：按爆炸半径分级，策略按级不按工具写）。
+ *
+ * - read：只读观测
+ * - minimal：轻量状态变更（已读标记、建任务）
+ * - contained：外发/唤醒（发信、通知、推进任务）
+ * - critical：建身份 / 验人通道——对 OAuth 票 deny-by-default
+ *
+ * 新工具必须在注册处声明 tier；未声明 → 注册即 throw（default deny 的编译期形态）。
+ * HTTP /mcp 对未知工具名同样 403（防绕过注册表）。
+ * stdio 路径不查本表策略（operator 本地；REST ACL 兜底）——见 mcp/http.ts 注释。
+ */
+
+export type ToolTier = 'read' | 'minimal' | 'contained' | 'critical';
+
+const TIER_RANK: Record<ToolTier, number> = {
+  read: 0,
+  minimal: 1,
+  contained: 2,
+  critical: 3,
+};
+
+/** 定稿映射（PR 描述同源）；模块加载即入库，供 /mcp 预检（早于 SDK 工厂）。 */
+export const TOOL_TIER_SPEC = {
+  // read
+  mail_list_messages: 'read',
+  mail_read_message: 'read',
+  mail_wait_for: 'read',
+  mail_list_identities: 'read',
+  notify_check: 'read',
+  task_list: 'read',
+  task_get: 'read',
+  // minimal
+  mail_mark_seen: 'minimal',
+  task_create: 'minimal',
+  // contained
+  mail_send: 'contained',
+  task_update: 'contained',
+  notify_agent: 'contained',
+  notify_user: 'contained',
+  // critical：OAuth deny-by-default
+  mail_new_identity: 'critical',
+  notify_verify: 'critical',
+} as const satisfies Record<string, ToolTier>;
+
+/** 进程内注册表：tool name → tier（规格预填 + tools.ts 注册时校验）。 */
+const declared = new Map<string, ToolTier>(
+  Object.entries(TOOL_TIER_SPEC) as [string, ToolTier][],
+);
+
+/**
+ * 注册处声明级别。同一 name 重复声明且级别不同 → throw。
+ * 未在规格表中的新工具也可声明（须与策略一致）；漏声明则 HTTP default deny。
+ */
+export function declareToolTier(name: string, tier: ToolTier): void {
+  const existing = declared.get(name);
+  if (existing !== undefined && existing !== tier) {
+    throw new Error(`tool tier conflict: ${name} (${existing} vs ${tier})`);
+  }
+  declared.set(name, tier);
+}
+
+/** 查询已声明级别；未声明返回 undefined（HTTP 侧 default deny）。 */
+export function getToolTier(name: string): ToolTier | undefined {
+  return declared.get(name);
+}
+
+/** 强制取级别；未声明即抛——供注册收尾校验。 */
+export function requireToolTier(name: string): ToolTier {
+  const tier = declared.get(name);
+  if (!tier) {
+    throw new Error(`tool ${name}: tier not declared (default deny)`);
+  }
+  return tier;
+}
+
+/** tier ≥ minimal 算写调用（审计 + 写桶限量）。 */
+export function isWriteTier(tier: ToolTier): boolean {
+  return TIER_RANK[tier] >= TIER_RANK.minimal;
+}
+
+/** 测试辅助：恢复为规格表（勿长期清空，以免 /mcp 预检误拒）。 */
+export function resetToolTiersForTests(): void {
+  declared.clear();
+  for (const [name, tier] of Object.entries(TOOL_TIER_SPEC)) {
+    declared.set(name, tier as ToolTier);
+  }
+}

--- a/packages/api/src/mcp/http.ts
+++ b/packages/api/src/mcp/http.ts
@@ -1,8 +1,13 @@
 /**
  * 远程无状态 MCP HTTP 传输：POST /mcp + RFC 9728 Protected Resource Metadata。
  *
- * 鉴权走 resolveToken（支持 admin / oa_ identity）；SDK 的 verifyBearerToken
+ * 鉴权走 resolveAccessToken（支持 admin / oa_ identity / OAuth）；SDK 的 verifyBearerToken
  * 因要求 expiresAt，与永久 oa_ 令牌不兼容，故仅复用挑战响应 / 元数据 helpers。
+ *
+ * P3.5 安全带（仅本 HTTP 路径；stdio 不拦——operator 本地上下文，REST ACL 兜底）：
+ * 1) tools/call 进 SDK 前按 tool→tier 策略（critical 对 OAuth deny-by-default）
+ * 2) per-token 读写分桶限量（admin 豁免；tools/list 免费）
+ * 3) tier≥minimal 落 scrubbed 审计（含 attribution）
  */
 import type { Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
@@ -16,7 +21,12 @@ import {
   type AuthMetadataOptions,
   type OAuthMetadata,
 } from "@modelcontextprotocol/server";
-import { resolveAccessToken } from "../lib/auth.ts";
+import { recordAuditEvent, type AuditOutcome } from "../lib/audit.ts";
+import {
+  resolveAccessToken,
+  type TokenAttribution,
+} from "../lib/auth.ts";
+import { config } from "../lib/config.ts";
 import { JSON_BODY_LIMIT_BYTES } from "../lib/limits.ts";
 import { getMcpLoopbackBase, runWithMcpLoopbackBase } from "../lib/mcp-loopback.ts";
 import { isPrivateOrLoopbackHost, isPrivateOrLoopbackHostname } from "../lib/net.ts";
@@ -25,6 +35,12 @@ import {
   resolvePublicBase,
   resolveResourceUri,
 } from "../lib/oauth-url.ts";
+import { checkMcpRateLimit } from "../lib/ratelimit.ts";
+import {
+  getToolTier,
+  isWriteTier,
+  type ToolTier,
+} from "../lib/tool-tiers.ts";
 import { OpenAgentEmailClient, type FetchLike } from "./client.ts";
 import { registerOpenAgentEmailTools } from "./tools.ts";
 
@@ -115,6 +131,38 @@ function protectedResourceMetadata(
   return buildOAuthProtectedResourceMetadata(metaOpts);
 }
 
+/** 从 attribution 拼审计行可选字段（scrubbed：无 token）。 */
+function attributionFields(attr: TokenAttribution): {
+  clientId?: string;
+  grantId?: string;
+  address?: string;
+} {
+  if (attr.kind === "admin") {
+    return { address: "admin" };
+  }
+  if (attr.kind === "identity") {
+    return { address: attr.address };
+  }
+  return {
+    clientId: attr.clientId,
+    grantId: attr.grantId,
+    address: attr.address,
+  };
+}
+
+/** 限量键：OAuth→grantId；oa_→address。admin 不进限量。 */
+function rateLimitKey(attr: TokenAttribution): string | null {
+  if (attr.kind === "admin") return null;
+  if (attr.kind === "oauth") return attr.grantId;
+  return attr.address;
+}
+
+type JsonRpcCall = {
+  method?: string;
+  params?: { name?: string; arguments?: unknown };
+  id?: unknown;
+};
+
 /**
  * 在主 Hono app 上注册 MCP 相关路由（直接挂在父 app，避免与
  * `app.route('/.well-known', agentCardRoute)` 前缀抢路由）。
@@ -185,9 +233,144 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
       );
     }
     const auth = resolved.auth;
+    const attribution = resolved.attribution;
+
+    // 读体一次再建 Request，供 tier/限量预检（body 只能消费一次）
+    const bodyText = await c.req.raw.text();
+    let rpc: JsonRpcCall | undefined;
+    try {
+      const parsed: unknown = JSON.parse(bodyText);
+      // WriteGuard 安全带只认单对象 tools/call；JSON-RPC batch 数组会绕过
+      // tier/限量/审计——此处显式拒绝（stdio 不受影响）。
+      if (Array.isArray(parsed)) {
+        return c.json(
+          { error: "batch_not_supported", error_description: "JSON-RPC batch is not allowed on /mcp" },
+          400,
+        );
+      }
+      if (parsed && typeof parsed === "object") {
+        rpc = parsed as JsonRpcCall;
+      }
+    } catch {
+      // 畸形体交给 SDK 处理
+    }
+
+    if (rpc?.method === "tools/call") {
+      // 审计只存截断后的工具名（防客户端塞超长串）；查找仍用原文
+      const rawToolName =
+        typeof rpc.params?.name === "string" ? rpc.params.name : undefined;
+      const toolName = rawToolName;
+      const toolForAudit =
+        rawToolName !== undefined ? rawToolName.slice(0, 128) : undefined;
+      const started = Date.now();
+      const fields = attributionFields(attribution);
+
+      if (!toolName) {
+        recordAuditEvent({
+          event: "mcp.tools.call",
+          ...fields,
+          outcome: "denied",
+          durationMs: Date.now() - started,
+        });
+        return c.json({ error: "tool_required" }, 400);
+      }
+
+      const tier: ToolTier | undefined = getToolTier(toolName);
+      // 未声明 tier → default deny（与注册即报错互补）
+      if (!tier) {
+        recordAuditEvent({
+          event: "mcp.tools.call",
+          ...fields,
+          tool: toolForAudit,
+          outcome: "denied",
+          durationMs: Date.now() - started,
+        });
+        return c.json({ error: "forbidden_tier", tool: toolForAudit }, 403);
+      }
+
+      // critical：OAuth 票 deny-by-default（网页 Agent 永不许建身份/发验证）
+      // oa_ 继续进 SDK→REST scope（already admin-only 的自然 403）；admin 全通
+      if (tier === "critical" && attribution.kind === "oauth") {
+        recordAuditEvent({
+          event: "mcp.tools.call",
+          ...fields,
+          tool: toolForAudit,
+          tier,
+          outcome: "denied",
+          durationMs: Date.now() - started,
+        });
+        return c.json(
+          { error: "forbidden_tier", tool: toolForAudit, tier: "critical" },
+          403,
+        );
+      }
+
+      // per-token 限量：tools/call 才计费；admin 豁免
+      const rlKey = rateLimitKey(attribution);
+      if (rlKey !== null) {
+        const bucket = tier === "read" ? "read" : "write";
+        const limit =
+          bucket === "read" ? config.mcpRateReadPerMin : config.mcpRateWritePerMin;
+        const rl = checkMcpRateLimit(rlKey, bucket, limit);
+        if (!rl.allowed) {
+          if (isWriteTier(tier)) {
+            recordAuditEvent({
+              event: "mcp.tools.call",
+              ...fields,
+              tool: toolForAudit,
+              tier,
+              outcome: "rate_limited",
+              durationMs: Date.now() - started,
+            });
+          }
+          c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
+          return c.json({ error: "rate_limited", bucket }, 429);
+        }
+      }
+
+      const sdkRequest = new Request(c.req.raw.url, {
+        method: "POST",
+        headers: c.req.raw.headers,
+        body: bodyText,
+      });
+
+      const response = await runWithMcpLoopbackBase(publicBase, () =>
+        mcpHandler.fetch(sdkRequest, {
+          authInfo: {
+            token,
+            clientId: auth.kind === "admin" ? "admin" : auth.address,
+            scopes: ["mcp"],
+          },
+        }),
+      );
+
+      // 仅写调用落审计（tier ≥ minimal）；绝不记录 params
+      // outcome：HTTP≥400 → error；200 含 JSON-RPC isError 仍记 ok（归因/量级用途，非业务成功语义）
+      if (isWriteTier(tier)) {
+        const outcome: AuditOutcome =
+          response.status >= 400 ? "error" : "ok";
+        recordAuditEvent({
+          event: "mcp.tools.call",
+          ...fields,
+          tool: toolForAudit,
+          tier,
+          outcome,
+          durationMs: Date.now() - started,
+        });
+      }
+
+      return response;
+    }
+
+    // tools/list 及其他方法：免费，不审计写调用
+    const sdkRequest = new Request(c.req.raw.url, {
+      method: "POST",
+      headers: c.req.raw.headers,
+      body: bodyText,
+    });
     // 整段工具调度包在公共 base ALS 内，使 /v1 的 c.req.url.origin ≡ aud 推导源
     return runWithMcpLoopbackBase(publicBase, () =>
-      mcpHandler.fetch(c.req.raw, {
+      mcpHandler.fetch(sdkRequest, {
         authInfo: {
           token,
           clientId: auth.kind === "admin" ? "admin" : auth.address,

--- a/packages/api/src/mcp/http.ts
+++ b/packages/api/src/mcp/http.ts
@@ -241,10 +241,36 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
     try {
       const parsed: unknown = JSON.parse(bodyText);
       // WriteGuard 安全带只认单对象 tools/call；JSON-RPC batch 数组会绕过
-      // tier/限量/审计——此处显式拒绝（stdio 不受影响）。
+      // tier/限量/审计——显式拒绝，并计入写桶 + 落 mcp.batch_rejected（防垃圾洪峰白送）。
       if (Array.isArray(parsed)) {
+        const fields = attributionFields(attribution);
+        const rlKey = rateLimitKey(attribution);
+        if (rlKey !== null) {
+          const rl = checkMcpRateLimit(
+            rlKey,
+            "write",
+            config.mcpRateWritePerMin,
+          );
+          if (!rl.allowed) {
+            recordAuditEvent({
+              event: "mcp.batch_rejected",
+              ...fields,
+              outcome: "rate_limited",
+            });
+            c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
+            return c.json({ error: "rate_limited", bucket: "write" }, 429);
+          }
+        }
+        recordAuditEvent({
+          event: "mcp.batch_rejected",
+          ...fields,
+          outcome: "denied",
+        });
         return c.json(
-          { error: "batch_not_supported", error_description: "JSON-RPC batch is not allowed on /mcp" },
+          {
+            error: "batch_not_supported",
+            error_description: "JSON-RPC batch is not allowed on /mcp",
+          },
           400,
         );
       }
@@ -252,7 +278,7 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
         rpc = parsed as JsonRpcCall;
       }
     } catch {
-      // 畸形体交给 SDK 处理
+      // 畸形体交给 SDK 处理（刻意：precheck 只优化合法 JSON；正式拒绝方是 SDK）
     }
 
     if (rpc?.method === "tools/call") {
@@ -313,16 +339,15 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
           bucket === "read" ? config.mcpRateReadPerMin : config.mcpRateWritePerMin;
         const rl = checkMcpRateLimit(rlKey, bucket, limit);
         if (!rl.allowed) {
-          if (isWriteTier(tier)) {
-            recordAuditEvent({
-              event: "mcp.tools.call",
-              ...fields,
-              tool: toolForAudit,
-              tier,
-              outcome: "rate_limited",
-              durationMs: Date.now() - started,
-            });
-          }
+          // 读/写桶超限均落审计（runaway 读取也要可观测；不再按 isWriteTier 过滤）
+          recordAuditEvent({
+            event: "mcp.tools.call",
+            ...fields,
+            tool: toolForAudit,
+            tier,
+            outcome: "rate_limited",
+            durationMs: Date.now() - started,
+          });
           c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
           return c.json({ error: "rate_limited", bucket }, 429);
         }

--- a/packages/api/src/mcp/http.ts
+++ b/packages/api/src/mcp/http.ts
@@ -150,11 +150,14 @@ function attributionFields(attr: TokenAttribution): {
   };
 }
 
-/** 限量键：OAuth→grantId；oa_→address。admin 不进限量。 */
+/**
+ * 限量键：OAuth→grantId（base64url **原样**，大小写敏感）；
+ * oa_→address（小写化）；admin 不进限量。
+ */
 function rateLimitKey(attr: TokenAttribution): string | null {
   if (attr.kind === "admin") return null;
   if (attr.kind === "oauth") return attr.grantId;
-  return attr.address;
+  return attr.address.toLowerCase();
 }
 
 type JsonRpcCall = {
@@ -292,6 +295,25 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
       const fields = attributionFields(attribution);
 
       if (!toolName) {
+        // 无名调用：先计写桶再拒绝（灭免费审计写）
+        const rlKeyMissing = rateLimitKey(attribution);
+        if (rlKeyMissing !== null) {
+          const rl = checkMcpRateLimit(
+            rlKeyMissing,
+            "write",
+            config.mcpRateWritePerMin,
+          );
+          if (!rl.allowed) {
+            recordAuditEvent({
+              event: "mcp.tools.call",
+              ...fields,
+              outcome: "rate_limited",
+              durationMs: Date.now() - started,
+            });
+            c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
+            return c.json({ error: "rate_limited", bucket: "write" }, 429);
+          }
+        }
         recordAuditEvent({
           event: "mcp.tools.call",
           ...fields,
@@ -302,6 +324,30 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
       }
 
       const tier: ToolTier | undefined = getToolTier(toolName);
+
+      // per-token 限量**先于**策略拒绝审计：critical/未知工具 403 也耗配额，
+      // 避免非 admin 反复打拒绝路径白写 audit 且永不计桶。
+      const rlKey = rateLimitKey(attribution);
+      if (rlKey !== null) {
+        // 未知工具按写桶计（探测）；已知则按 read/write 分桶
+        const bucket = tier === "read" ? "read" : "write";
+        const limit =
+          bucket === "read" ? config.mcpRateReadPerMin : config.mcpRateWritePerMin;
+        const rl = checkMcpRateLimit(rlKey, bucket, limit);
+        if (!rl.allowed) {
+          recordAuditEvent({
+            event: "mcp.tools.call",
+            ...fields,
+            tool: toolForAudit,
+            ...(tier ? { tier } : {}),
+            outcome: "rate_limited",
+            durationMs: Date.now() - started,
+          });
+          c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
+          return c.json({ error: "rate_limited", bucket }, 429);
+        }
+      }
+
       // 未声明 tier → default deny（与注册即报错互补）
       if (!tier) {
         recordAuditEvent({
@@ -329,28 +375,6 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
           { error: "forbidden_tier", tool: toolForAudit, tier: "critical" },
           403,
         );
-      }
-
-      // per-token 限量：tools/call 才计费；admin 豁免
-      const rlKey = rateLimitKey(attribution);
-      if (rlKey !== null) {
-        const bucket = tier === "read" ? "read" : "write";
-        const limit =
-          bucket === "read" ? config.mcpRateReadPerMin : config.mcpRateWritePerMin;
-        const rl = checkMcpRateLimit(rlKey, bucket, limit);
-        if (!rl.allowed) {
-          // 读/写桶超限均落审计（runaway 读取也要可观测；不再按 isWriteTier 过滤）
-          recordAuditEvent({
-            event: "mcp.tools.call",
-            ...fields,
-            tool: toolForAudit,
-            tier,
-            outcome: "rate_limited",
-            durationMs: Date.now() - started,
-          });
-          c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
-          return c.json({ error: "rate_limited", bucket }, 429);
-        }
       }
 
       const sdkRequest = new Request(c.req.raw.url, {

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -1,9 +1,18 @@
 /**
  * 15 个 MCP 工具的注册逻辑（stdio 与 HTTP /mcp 共用唯一实现）。
+ * 每个工具在注册处声明 WriteGuard tier（见 lib/tool-tiers.ts）；
+ * 未声明 → HTTP default deny；注册与规格表不一致 → throw。
+ * stdio 不执行 tier 策略（operator 本地；REST ACL 兜底）。
  */
 import type { CallToolResult } from "@modelcontextprotocol/server";
 import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
+import {
+  declareToolTier,
+  requireToolTier,
+  TOOL_TIER_SPEC,
+  type ToolTier,
+} from "../lib/tool-tiers.ts";
 import { ApiError, OpenAgentEmailClient } from "./client.ts";
 import { prepareMailToolMessage } from "./fence.ts";
 
@@ -14,6 +23,14 @@ export function registerOpenAgentEmailTools(
   server: McpServer,
   client: OpenAgentEmailClient,
 ): void {
+  /** 注册处声明级别：须与 TOOL_TIER_SPEC 一致，否则立即 throw。 */
+  function tier(name: keyof typeof TOOL_TIER_SPEC, level: ToolTier): void {
+    if (TOOL_TIER_SPEC[name] !== level) {
+      throw new Error(`tool ${name}: tier ${level} ≠ spec ${TOOL_TIER_SPEC[name]}`);
+    }
+    declareToolTier(name, level);
+  }
+
   const readOnlyAnnotations = {
     readOnlyHint: true,
     destructiveHint: false,
@@ -198,6 +215,7 @@ export function registerOpenAgentEmailTools(
     }
   }
 
+  tier("mail_new_identity", "critical");
   server.registerTool(
     "mail_new_identity",
     {
@@ -233,6 +251,7 @@ export function registerOpenAgentEmailTools(
     ({ name, localpart, canNotifyUser }) => callApi(() => client.createIdentity({ name, localpart, canNotifyUser })),
   );
 
+  tier("mail_list_identities", "read");
   server.registerTool(
     "mail_list_identities",
     {
@@ -244,6 +263,7 @@ export function registerOpenAgentEmailTools(
     () => callApi(async () => ({ identities: await client.listIdentities() })),
   );
 
+  tier("mail_list_messages", "read");
   server.registerTool(
     "mail_list_messages",
     {
@@ -275,6 +295,7 @@ export function registerOpenAgentEmailTools(
       })),
   );
 
+  tier("mail_read_message", "read");
   server.registerTool(
     "mail_read_message",
     {
@@ -294,6 +315,7 @@ export function registerOpenAgentEmailTools(
       ),
   );
 
+  tier("mail_mark_seen", "minimal");
   server.registerTool(
     "mail_mark_seen",
     {
@@ -317,6 +339,7 @@ export function registerOpenAgentEmailTools(
       callApi(() => client.markSeen(address, id, seen ?? true)),
   );
 
+  tier("mail_wait_for", "read");
   server.registerTool(
     "mail_wait_for",
     {
@@ -359,6 +382,7 @@ export function registerOpenAgentEmailTools(
       ),
   );
 
+  tier("mail_send", "contained");
   server.registerTool(
     "mail_send",
     {
@@ -386,6 +410,7 @@ export function registerOpenAgentEmailTools(
     tags: z.array(z.string().min(1).max(64)).max(5).optional().describe("Optional ntfy tags"),
   };
 
+  tier("notify_user", "contained");
   server.registerTool(
     "notify_user",
     {
@@ -400,6 +425,7 @@ export function registerOpenAgentEmailTools(
       callApi(() => client.notifyUser(title, message, level ?? "normal", tags)),
   );
 
+  tier("notify_agent", "contained");
   server.registerTool(
     "notify_agent",
     {
@@ -420,6 +446,7 @@ export function registerOpenAgentEmailTools(
       callApi(() => client.notifyAgent(name, title, message, level ?? "normal", tags)),
   );
 
+  tier("notify_check", "read");
   server.registerTool(
     "notify_check",
     {
@@ -435,6 +462,7 @@ export function registerOpenAgentEmailTools(
     ({ since }) => callApi(async () => ({ messages: await client.notificationCheck(since) })),
   );
 
+  tier("notify_verify", "critical");
   server.registerTool(
     "notify_verify",
     {
@@ -447,6 +475,7 @@ export function registerOpenAgentEmailTools(
     () => callApi(() => client.verifyNotifications()),
   );
 
+  tier("task_create", "minimal");
   server.registerTool(
     "task_create",
     {
@@ -465,6 +494,7 @@ export function registerOpenAgentEmailTools(
     ({ to, subject, body, wait }) => callApi(() => client.createTask(to, subject, body, wait ?? false)),
   );
 
+  tier("task_list", "read");
   server.registerTool(
     "task_list",
     {
@@ -479,6 +509,7 @@ export function registerOpenAgentEmailTools(
     ({ state }) => callApi(async () => ({ tasks: await client.listTasks(state) })),
   );
 
+  tier("task_get", "read");
   server.registerTool(
     "task_get",
     {
@@ -494,6 +525,7 @@ export function registerOpenAgentEmailTools(
     ({ id, wait }) => callApi(() => client.getTask(id, wait ?? false)),
   );
 
+  tier("task_update", "contained");
   server.registerTool(
     "task_update",
     {
@@ -512,4 +544,8 @@ export function registerOpenAgentEmailTools(
     ({ id, state, body, result }) => callApi(() => client.updateTask(id, state, body, result)),
   );
 
+  // 收尾：规格表 15 工具均须已在注册处声明
+  for (const name of Object.keys(TOOL_TIER_SPEC) as (keyof typeof TOOL_TIER_SPEC)[]) {
+    requireToolTier(name);
+  }
 }

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -8,8 +8,9 @@ import type { CallToolResult } from "@modelcontextprotocol/server";
 import { McpServer } from "@modelcontextprotocol/server";
 import { z } from "zod";
 import {
+  assertAllSpecTiersDeclared,
+  assertToolTierDeclared,
   declareToolTier,
-  requireToolTier,
   TOOL_TIER_SPEC,
   type ToolTier,
 } from "../lib/tool-tiers.ts";
@@ -23,12 +24,16 @@ export function registerOpenAgentEmailTools(
   server: McpServer,
   client: OpenAgentEmailClient,
 ): void {
-  /** 注册处声明级别：须与 TOOL_TIER_SPEC 一致，否则立即 throw。 */
+  /**
+   * 注册处声明级别。主力护栏是收尾 assertAllSpecTiersDeclared()——
+   * 漏调本函数则 declared 缺项、收尾必炸（declared 不预填 SPEC）。
+   */
   function tier(name: keyof typeof TOOL_TIER_SPEC, level: ToolTier): void {
     if (TOOL_TIER_SPEC[name] !== level) {
       throw new Error(`tool ${name}: tier ${level} ≠ spec ${TOOL_TIER_SPEC[name]}`);
     }
     declareToolTier(name, level);
+    assertToolTierDeclared(name);
   }
 
   const readOnlyAnnotations = {
@@ -544,8 +549,6 @@ export function registerOpenAgentEmailTools(
     ({ id, state, body, result }) => callApi(() => client.updateTask(id, state, body, result)),
   );
 
-  // 收尾：规格表 15 工具均须已在注册处声明
-  for (const name of Object.keys(TOOL_TIER_SPEC) as (keyof typeof TOOL_TIER_SPEC)[]) {
-    requireToolTier(name);
-  }
+  // 收尾：规格表 15 工具均须已在本次注册中 declare（declared 不预填，漏 tier() 即炸）
+  assertAllSpecTiersDeclared();
 }

--- a/packages/api/src/routes/audit.ts
+++ b/packages/api/src/routes/audit.ts
@@ -1,0 +1,34 @@
+/**
+ * GET /v1/audit/events — scrubbed 审计只读端点（admin only）。
+ */
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { readAuditEvents } from '../lib/audit.ts';
+import { getAuth } from '../lib/auth.ts';
+
+function requireAdmin(c: Context) {
+  if (getAuth(c).kind !== 'admin') {
+    return c.json({ error: 'forbidden: admin key required' }, 403);
+  }
+  return null;
+}
+
+export const auditRoute = new Hono();
+
+auditRoute.get('/events', (c) => {
+  const denied = requireAdmin(c);
+  if (denied) return denied;
+
+  const rawLimit = c.req.query('limit');
+  let limit = 100;
+  if (rawLimit !== undefined && rawLimit !== '') {
+    const n = Number(rawLimit);
+    if (!Number.isFinite(n) || n < 0) {
+      return c.json({ error: 'invalid_request', error_description: 'limit' }, 400);
+    }
+    limit = Math.min(Math.floor(n), 1000);
+  }
+  const event = c.req.query('event') || undefined;
+
+  return c.json({ events: readAuditEvents({ limit, event }) });
+});

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -11,6 +11,7 @@ import {
   type CimdDocument,
 } from '../lib/oauth-cimd.ts';
 import { verifyS256CodeChallenge } from '../lib/oauth-pkce.ts';
+import { recordAuditEvent } from '../lib/audit.ts';
 import {
   consumeAuthorizationCode,
   issueTokenPair,
@@ -190,7 +191,14 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
     const token = body.token;
     const clientId = body.client_id;
     // RFC 7009：一律 200；无/错 client_id 不删（灭持票第三方 DoS）
-    if (token) revokeToken(token, clientId);
+    // 审计只记 clientId / 是否删掉——绝不写 token 任何片段
+    let revoked = false;
+    if (token) revoked = revokeToken(token, clientId);
+    recordAuditEvent({
+      event: 'oauth.revoke',
+      ...(clientId ? { clientId } : {}),
+      outcome: revoked ? 'ok' : 'denied',
+    });
     return c.body(null, 200);
   });
 }
@@ -227,26 +235,64 @@ function handleAuthorizationCode(
   // 先 peek：不删 code，校验失败时合法客户端仍可重试
   const peeked = peekAuthorizationCode(code);
   if (!peeked.ok) {
+    recordAuditEvent({
+      event: 'oauth.token.code',
+      ...(clientId ? { clientId } : {}),
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', peeked.reason, 400);
   }
 
   // 全部用存储字段比对（调用方 client_id 必须与存储一致）
   if (peeked.clientId !== clientId) {
+    recordAuditEvent({
+      event: 'oauth.token.code',
+      clientId,
+      grantId: peeked.grantId,
+      address: peeked.address,
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', 'client_id mismatch');
   }
   if (!matchRedirectUri(redirectUri, [peeked.redirectUri])) {
+    recordAuditEvent({
+      event: 'oauth.token.code',
+      clientId,
+      grantId: peeked.grantId,
+      address: peeked.address,
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', 'redirect_uri mismatch');
   }
   if (peeked.resource !== resource) {
+    recordAuditEvent({
+      event: 'oauth.token.code',
+      clientId,
+      grantId: peeked.grantId,
+      address: peeked.address,
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
   }
   if (!verifyS256CodeChallenge(codeVerifier, peeked.codeChallenge)) {
+    recordAuditEvent({
+      event: 'oauth.token.code',
+      clientId,
+      grantId: peeked.grantId,
+      address: peeked.address,
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', 'pkce verification failed');
   }
 
   // 校验通过后原子消费（拦截者无 verifier 只能拒一次可用性）
   const consumed = consumeAuthorizationCode(code);
   if (!consumed.ok) {
+    recordAuditEvent({
+      event: 'oauth.token.code',
+      clientId,
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', consumed.reason, 400);
   }
 
@@ -254,6 +300,15 @@ function handleAuthorizationCode(
     grantId: consumed.grantId,
     address: consumed.address,
     aud: expectedResource,
+  });
+
+  // scrubbed：只记身份标识，不写 access/refresh 明文
+  recordAuditEvent({
+    event: 'oauth.token.code',
+    clientId: consumed.clientId,
+    grantId: consumed.grantId,
+    address: consumed.address,
+    outcome: 'ok',
   });
 
   return tokenSuccessJson(c, {
@@ -294,8 +349,21 @@ function handleRefresh(
     clientId,
   });
   if (!rotated.ok) {
+    recordAuditEvent({
+      event: 'oauth.token.refresh',
+      clientId,
+      outcome: 'denied',
+    });
     return oauthErrorJson(c, 'invalid_grant', REFRESH_INVALID_DESC, 400);
   }
+
+  recordAuditEvent({
+    event: 'oauth.token.refresh',
+    clientId,
+    grantId: rotated.grantId,
+    address: rotated.address,
+    outcome: 'ok',
+  });
 
   return tokenSuccessJson(c, {
     access_token: rotated.accessToken,

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -190,15 +190,17 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
     }
     const token = body.token;
     const clientId = body.client_id;
-    // RFC 7009：一律 200；无/错 client_id 不删（灭持票第三方 DoS）
-    // 审计只记 clientId / 是否删掉——绝不写 token 任何片段
+    // RFC 7009：一律 200；无/错 client_id 不删（灭第三方持票 DoS）
+    // 未知 token：revokeToken 零磁盘写；审计也只在真删时落盘（公开端点防写放大）
     let revoked = false;
     if (token) revoked = revokeToken(token, clientId);
-    recordAuditEvent({
-      event: 'oauth.revoke',
-      ...(clientId ? { clientId } : {}),
-      outcome: revoked ? 'ok' : 'denied',
-    });
+    if (revoked) {
+      recordAuditEvent({
+        event: 'oauth.revoke',
+        ...(clientId ? { clientId } : {}),
+        outcome: 'ok',
+      });
+    }
     return c.body(null, 200);
   });
 }

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -237,15 +237,19 @@ function handleAuthorizationCode(
   // 先 peek：不删 code，校验失败时合法客户端仍可重试
   const peeked = peekAuthorizationCode(code);
   if (!peeked.ok) {
-    recordAuditEvent({
-      event: 'oauth.token.code',
-      ...(clientId ? { clientId } : {}),
-      outcome: 'denied',
-    });
+    // 取舍①：仅哈希命中已知行才落失败审计（expired=可归因）。
+    // not_found（含已消费后的 replay）不写盘——公网随机灌码不得撑爆 audit.jsonl。
+    if (peeked.reason === 'expired') {
+      recordAuditEvent({
+        event: 'oauth.token.code',
+        clientId,
+        outcome: 'denied',
+      });
+    }
     return oauthErrorJson(c, 'invalid_grant', peeked.reason, 400);
   }
 
-  // 全部用存储字段比对（调用方 client_id 必须与存储一致）
+  // 全部用存储字段比对（调用方 client_id 必须与存储一致）——可归因，全量审计
   if (peeked.clientId !== clientId) {
     recordAuditEvent({
       event: 'oauth.token.code',
@@ -290,9 +294,12 @@ function handleAuthorizationCode(
   // 校验通过后原子消费（拦截者无 verifier 只能拒一次可用性）
   const consumed = consumeAuthorizationCode(code);
   if (!consumed.ok) {
+    // peek 已命中后的消费失败（竞态/replay）——可归因
     recordAuditEvent({
       event: 'oauth.token.code',
       clientId,
+      grantId: peeked.grantId,
+      address: peeked.address,
       outcome: 'denied',
     });
     return oauthErrorJson(c, 'invalid_grant', consumed.reason, 400);
@@ -351,11 +358,14 @@ function handleRefresh(
     clientId,
   });
   if (!rotated.ok) {
-    recordAuditEvent({
-      event: 'oauth.token.refresh',
-      clientId,
-      outcome: 'denied',
-    });
+    // 取舍①：not_found 不落盘；expired / grant_missing / aud|client_mismatch 可归因仍记
+    if (rotated.reason !== 'not_found') {
+      recordAuditEvent({
+        event: 'oauth.token.refresh',
+        clientId,
+        outcome: 'denied',
+      });
+    }
     return oauthErrorJson(c, 'invalid_grant', REFRESH_INVALID_DESC, 400);
   }
 

--- a/packages/api/src/routes/ui-oauth.ts
+++ b/packages/api/src/routes/ui-oauth.ts
@@ -6,6 +6,7 @@
 import { getCookie } from 'hono/cookie';
 import { Hono } from 'hono';
 import type { Context } from 'hono';
+import { recordAuditEvent } from '../lib/audit.ts';
 import { getAuth } from '../lib/auth.ts';
 import {
   createIdentity,
@@ -365,6 +366,12 @@ export function createUiOAuthPageRoutes(
     }
 
     if (form.decision === 'deny') {
+      // scrubbed：只记 clientId，不写 code/token
+      recordAuditEvent({
+        event: 'oauth.authorize.deny',
+        clientId: pre.clientId,
+        outcome: 'denied',
+      });
       return authorizeHandoffResponse(
         c,
         buildAuthorizeRedirect(
@@ -466,13 +473,21 @@ export function createUiOAuthPageRoutes(
       }
     }
 
-    const { code } = createGrantAndCode({
+    const { grantId, code } = createGrantAndCode({
       clientId: pre.clientId,
       clientName: pre.doc.client_name,
       address,
       redirectUri: pre.redirectUri,
       codeChallenge: pre.codeChallenge,
       resource: pre.resource,
+    });
+
+    recordAuditEvent({
+      event: 'oauth.authorize.approve',
+      clientId: pre.clientId,
+      grantId,
+      address,
+      outcome: 'ok',
     });
 
     return authorizeHandoffResponse(
@@ -523,6 +538,13 @@ export function createUiOAuthApiRoutes(store: UiSessionStore): Hono {
       return c.json({ error: 'forbidden' }, 403);
     }
     revokeGrant(id);
+    recordAuditEvent({
+      event: 'oauth.grant.revoke',
+      clientId: grant.clientId,
+      grantId: grant.id,
+      address: grant.address,
+      outcome: 'ok',
+    });
     return c.body(null, 204);
   });
 
@@ -536,6 +558,13 @@ export function createUiOAuthApiRoutes(store: UiSessionStore): Hono {
       return c.json({ error: 'forbidden' }, 403);
     }
     revokeGrant(id);
+    recordAuditEvent({
+      event: 'oauth.grant.revoke',
+      clientId: grant.clientId,
+      grantId: grant.id,
+      address: grant.address,
+      outcome: 'ok',
+    });
     return c.redirect('/ui/oauth/grants', 302);
   });
 

--- a/packages/api/test/audit-tiering.test.ts
+++ b/packages/api/test/audit-tiering.test.ts
@@ -1,7 +1,13 @@
 /**
  * P3.5：scrubbed 审计、attribution、工具分层、MCP 限量。
  */
-import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -20,6 +26,7 @@ const {
   recordAuditEvent,
   readAuditEvents,
   resetAuditForTests,
+  scrubAuditField,
 } = await import('../src/lib/audit.ts');
 const { resolveAccessToken } = await import('../src/lib/auth.ts');
 const { config } = await import('../src/lib/config.ts');
@@ -27,6 +34,7 @@ const { createIdentity } = await import('../src/lib/identities.ts');
 const {
   putAccessTokenForTests,
   resetOAuthStoreCacheForTests,
+  revokeToken,
 } = await import('../src/lib/oauth-store.ts');
 const {
   checkMcpRateLimit,
@@ -37,10 +45,17 @@ const {
   resetRateLimits,
 } = await import('../src/lib/ratelimit.ts');
 const {
+  assertAllSpecTiersDeclared,
+  assertToolTierDeclared,
   declareToolTier,
   getToolTier,
+  isToolTierDeclared,
+  resetToolTiersForTests,
   TOOL_TIER_SPEC,
 } = await import('../src/lib/tool-tiers.ts');
+const { registerOpenAgentEmailTools } = await import('../src/mcp/tools.ts');
+const { McpServer } = await import('@modelcontextprotocol/server');
+const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
 
 const adminKey = [...config.apiKeys][0]!;
 const RESOURCE = 'http://localhost/mcp';
@@ -55,6 +70,7 @@ beforeEach(() => {
   resetAuditForTests();
   resetMcpRateLimits();
   resetOAuthStoreCacheForTests();
+  resetToolTiersForTests();
 });
 
 function mcpCall(
@@ -231,9 +247,29 @@ describe('attribution：三种 caller 落三种行', () => {
 describe('工具分层', () => {
   test('规格表 15 工具均有 tier；注册冲突会 throw', () => {
     expect(Object.keys(TOOL_TIER_SPEC).length).toBe(15);
+    // SPEC 回落：即使 declared 空也能预检
+    resetToolTiersForTests();
+    expect(isToolTierDeclared('mail_new_identity')).toBe(false);
     expect(getToolTier('mail_new_identity')).toBe('critical');
-    expect(getToolTier('mail_list_messages')).toBe('read');
+    declareToolTier('mail_send', 'contained');
     expect(() => declareToolTier('mail_send', 'read')).toThrow(/conflict/);
+  });
+
+  test('注册完整性：未 declare 则 assert 炸；全量注册后规格表覆盖', () => {
+    resetToolTiersForTests();
+    expect(() => assertToolTierDeclared('mail_send')).toThrow(/not declared/);
+    expect(() => assertAllSpecTiersDeclared()).toThrow(/not declared/);
+    declareToolTier('mail_send', 'contained');
+    expect(() => assertAllSpecTiersDeclared()).toThrow(/not declared/);
+
+    resetToolTiersForTests();
+    const server = new McpServer({ name: 'tier-test', version: '0.0.0' });
+    const client = new OpenAgentEmailClient('http://localhost', 't', fetch);
+    registerOpenAgentEmailTools(server, client);
+    for (const name of Object.keys(TOOL_TIER_SPEC)) {
+      expect(isToolTierDeclared(name)).toBe(true);
+    }
+    expect(() => assertAllSpecTiersDeclared()).not.toThrow();
   });
 
   test('critical 被 OAuth 票调 → 403；oa_ 进 REST scope；admin 通预检', async () => {
@@ -284,7 +320,7 @@ describe('工具分层', () => {
     expect(res.status).toBe(403);
   });
 
-  test('JSON-RPC batch 数组拒 400（防绕过 tier/限量/审计）', async () => {
+  test('JSON-RPC batch 拒 400：落 mcp.batch_rejected 并计入写桶', async () => {
     const { identity } = createIdentity({ localpart: 'batch-deny' })!;
     const grantId = 'grant-batch-1';
     const oauthTok = 'oauth-access-batch-test';
@@ -299,6 +335,14 @@ describe('工具分层', () => {
         clientName: 'Batch',
       },
     });
+    const batchBody = JSON.stringify([
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name: 'mail_new_identity', arguments: { localpart: 'x' } },
+      },
+    ]);
     const res = await app.request('/mcp', {
       method: 'POST',
       headers: {
@@ -306,18 +350,35 @@ describe('工具分层', () => {
         'content-type': 'application/json',
         accept: MCP_ACCEPT,
       },
-      body: JSON.stringify([
-        {
-          jsonrpc: '2.0',
-          id: 1,
-          method: 'tools/call',
-          params: { name: 'mail_new_identity', arguments: { localpart: 'x' } },
-        },
-      ]),
+      body: batchBody,
     });
     expect(res.status).toBe(400);
-    const body = (await res.json()) as { error: string };
-    expect(body.error).toBe('batch_not_supported');
+    expect(((await res.json()) as { error: string }).error).toBe(
+      'batch_not_supported',
+    );
+    const rejected = readAuditEvents({ event: 'mcp.batch_rejected', limit: 5 });
+    expect(rejected.length).toBeGreaterThanOrEqual(1);
+    expect(rejected[0]!.outcome).toBe('denied');
+    expect(rejected[0]!.grantId).toBe(grantId);
+
+    // 再灌满写桶后 batch → 429 + rate_limited 审计（无成本洪峰不能白送）
+    resetMcpRateLimits();
+    const writeLimit = config.mcpRateWritePerMin;
+    for (let i = 0; i < writeLimit; i++) {
+      expect(checkMcpRateLimit(grantId, 'write', writeLimit).allowed).toBe(true);
+    }
+    const limited = await app.request('/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${oauthTok}`,
+        'content-type': 'application/json',
+        accept: MCP_ACCEPT,
+      },
+      body: batchBody,
+    });
+    expect(limited.status).toBe(429);
+    const rlRows = readAuditEvents({ event: 'mcp.batch_rejected', limit: 10 });
+    expect(rlRows.some((e) => e.outcome === 'rate_limited')).toBe(true);
   });
 });
 
@@ -378,5 +439,95 @@ describe('MCP per-token 限量', () => {
     expect(checkSendLimit('a@x.com', 1, 60_000, now).allowed).toBe(false);
     expect(checkNotifyUserLimit('a@x.com', 1, 60_000, now).allowed).toBe(true);
     expect(checkNotifyUserLimit('a@x.com', 1, 60_000, now).allowed).toBe(false);
+  });
+
+  test('读桶超限也落 rate_limited 审计', async () => {
+    const { token, identity } = createIdentity({ localpart: 'rate-read' })!;
+    const readLimit = config.mcpRateReadPerMin;
+    const key = identity.address.toLowerCase();
+    for (let i = 0; i < readLimit; i++) {
+      expect(checkMcpRateLimit(key, 'read', readLimit).allowed).toBe(true);
+    }
+    const blocked = await mcpCall(token, 'mail_list_identities');
+    expect(blocked.status).toBe(429);
+    const rows = readAuditEvents({ event: 'mcp.tools.call', limit: 5 });
+    expect(
+      rows.some(
+        (e) =>
+          e.outcome === 'rate_limited' &&
+          e.tier === 'read' &&
+          e.tool === 'mail_list_identities',
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('审计清洗 / 合并读 / revoke 零写', () => {
+  test('带换行的 clientId 不落原始形态', () => {
+    const dirty = 'evil\r\n{"event":"forged"}\nhttp://x';
+    recordAuditEvent({
+      event: 'oauth.revoke',
+      clientId: dirty,
+      outcome: 'ok',
+    });
+    const text = auditFileText();
+    expect(text).not.toContain('\r');
+    expect(text).not.toContain('\n{"event":"forged"}');
+    expect(scrubAuditField(dirty)).toBe('evil{"event":"forged"}http://x');
+    const rows = readAuditEvents({ event: 'oauth.revoke', limit: 1 });
+    expect(rows[0]!.clientId).toBe('evil{"event":"forged"}http://x');
+  });
+
+  test('合并 audit.jsonl.1 + 当前；新的在前', () => {
+    const rotated = join(config.dataDir, 'audit.jsonl.1');
+    const current = join(config.dataDir, 'audit.jsonl');
+    writeFileSync(
+      rotated,
+      `${JSON.stringify({ ts: '2020-01-01T00:00:00.000Z', event: 'old.event', outcome: 'ok' })}\n`,
+      { mode: 0o600 },
+    );
+    writeFileSync(
+      current,
+      `${JSON.stringify({ ts: '2026-01-01T00:00:00.000Z', event: 'new.event', outcome: 'ok' })}\n`,
+      { mode: 0o600 },
+    );
+    const rows = readAuditEvents({ limit: 10 });
+    expect(rows[0]!.event).toBe('new.event');
+    expect(rows.some((e) => e.event === 'old.event')).toBe(true);
+    const limited = readAuditEvents({ limit: 1 });
+    expect(limited).toHaveLength(1);
+    expect(limited[0]!.event).toBe('new.event');
+  });
+
+  test('未知 token revoke：200 且零磁盘写（oauth.json + audit）', async () => {
+    const oauthPath = join(config.dataDir, 'oauth.json');
+    // 确保有一份 oauth 文件可测 mtime
+    putAccessTokenForTests({
+      token: 'seed-for-mtime',
+      grantId: 'g-seed',
+      address: 'seed@test.example',
+      aud: RESOURCE,
+      expiresAt: Date.now() + 60_000,
+      ensureGrant: { clientId: 'http://c', clientName: 'S' },
+    });
+    createIdentity({ localpart: 'seed' });
+    const beforeOauth = statSync(oauthPath);
+    const beforeAuditLen = auditFileText().length;
+
+    expect(revokeToken('totally-unknown-token-xyz', 'http://c')).toBe(false);
+    const rev = await app.request('/oauth/revoke', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        token: 'totally-unknown-token-xyz',
+        client_id: 'http://c',
+      }),
+    });
+    expect(rev.status).toBe(200);
+
+    const afterOauth = statSync(oauthPath);
+    expect(afterOauth.mtimeMs).toBe(beforeOauth.mtimeMs);
+    expect(afterOauth.size).toBe(beforeOauth.size);
+    expect(auditFileText().length).toBe(beforeAuditLen);
   });
 });

--- a/packages/api/test/audit-tiering.test.ts
+++ b/packages/api/test/audit-tiering.test.ts
@@ -499,6 +499,57 @@ describe('审计清洗 / 合并读 / revoke 零写', () => {
     expect(limited[0]!.event).toBe('new.event');
   });
 
+  test('未知 code 换票失败：不落审计（防未鉴权写放大）', async () => {
+    const before = auditFileText().length;
+    const res = await app.request('/oauth/token', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'authorization_code',
+        code: 'totally-unknown-code-zzzz',
+        redirect_uri: 'http://127.0.0.1:54321/callback',
+        client_id: 'http://127.0.0.1:9/cimd.json',
+        code_verifier: 'a'.repeat(64),
+        resource: RESOURCE,
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(auditFileText().length).toBe(before);
+  });
+
+  test('critical 403 前先限量：写桶满则 429 而非白写 denied', async () => {
+    const { identity } = createIdentity({ localpart: 'crit-rl' })!;
+    const grantId = 'GrantCaseSensitive_AbC123';
+    const oauthTok = 'oauth-access-crit-rl';
+    putAccessTokenForTests({
+      token: oauthTok,
+      grantId,
+      address: identity.address,
+      aud: RESOURCE,
+      expiresAt: Date.now() + 3_600_000,
+      ensureGrant: {
+        clientId: 'http://127.0.0.1:9/cimd.json',
+        clientName: 'CritRl',
+      },
+    });
+    const writeLimit = config.mcpRateWritePerMin;
+    // 键必须原样（含大小写）
+    for (let i = 0; i < writeLimit; i++) {
+      expect(checkMcpRateLimit(grantId, 'write', writeLimit).allowed).toBe(true);
+    }
+    const res = await mcpCall(oauthTok, 'mail_new_identity', {
+      localpart: 'should-429',
+    });
+    expect(res.status).toBe(429);
+    const rows = readAuditEvents({ event: 'mcp.tools.call', limit: 5 });
+    expect(rows.some((e) => e.outcome === 'rate_limited' && e.tool === 'mail_new_identity')).toBe(
+      true,
+    );
+    expect(rows.some((e) => e.outcome === 'denied' && e.tool === 'mail_new_identity')).toBe(
+      false,
+    );
+  });
+
   test('未知 token revoke：200 且零磁盘写（oauth.json + audit）', async () => {
     const oauthPath = join(config.dataDir, 'oauth.json');
     // 确保有一份 oauth 文件可测 mtime

--- a/packages/api/test/audit-tiering.test.ts
+++ b/packages/api/test/audit-tiering.test.ts
@@ -1,0 +1,382 @@
+/**
+ * P3.5：scrubbed 审计、attribution、工具分层、MCP 限量。
+ */
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-audit-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-audit-tier-'));
+process.env.UI_ENABLED = 'false';
+
+const { describe, expect, test, beforeEach } = await import('bun:test');
+const { createApp } = await import('../src/app.ts');
+const {
+  recordAuditEvent,
+  readAuditEvents,
+  resetAuditForTests,
+} = await import('../src/lib/audit.ts');
+const { resolveAccessToken } = await import('../src/lib/auth.ts');
+const { config } = await import('../src/lib/config.ts');
+const { createIdentity } = await import('../src/lib/identities.ts');
+const {
+  putAccessTokenForTests,
+  resetOAuthStoreCacheForTests,
+} = await import('../src/lib/oauth-store.ts');
+const {
+  checkMcpRateLimit,
+  checkNotifyUserLimit,
+  checkSendLimit,
+  resetMcpRateLimits,
+  resetNotifyUserLimits,
+  resetRateLimits,
+} = await import('../src/lib/ratelimit.ts');
+const {
+  declareToolTier,
+  getToolTier,
+  TOOL_TIER_SPEC,
+} = await import('../src/lib/tool-tiers.ts');
+
+const adminKey = [...config.apiKeys][0]!;
+const RESOURCE = 'http://localhost/mcp';
+const MCP_ACCEPT = 'application/json, text/event-stream';
+const app = createApp({ uiEnabled: false });
+
+const SECRET_SUBJECT = 'TOPSECRET-SUBJECT-XYZ-999';
+const SECRET_BODY = 'sk-proj-FAKESECRET-IN-ARGS-do-not-log';
+const SECRET_TOKEN_FRAGMENT = 'oa_should_never_appear_in_audit_file';
+
+beforeEach(() => {
+  resetAuditForTests();
+  resetMcpRateLimits();
+  resetOAuthStoreCacheForTests();
+});
+
+function mcpCall(
+  token: string,
+  tool: string,
+  args: Record<string, unknown> = {},
+  id = 1,
+) {
+  return app.request('/mcp', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method: 'tools/call',
+      params: { name: tool, arguments: args },
+    }),
+  });
+}
+
+function auditFileText(): string {
+  const path = join(config.dataDir, 'audit.jsonl');
+  if (!existsSync(path)) return '';
+  return readFileSync(path, 'utf8');
+}
+
+describe('audit JSONL scrubbed + 读端点', () => {
+  test('写事件落盘格式正确；秘密值不进文件', () => {
+    recordAuditEvent({
+      event: 'mcp.tools.call',
+      clientId: 'http://client.example/cimd.json',
+      grantId: 'grant-abc',
+      address: 'bot@test.example',
+      tool: 'mail_send',
+      tier: 'contained',
+      outcome: 'ok',
+      durationMs: 12,
+    });
+    const text = auditFileText();
+    expect(text).toContain('"event":"mcp.tools.call"');
+    expect(text).toContain('"tier":"contained"');
+    expect(text).toContain('"outcome":"ok"');
+    // 红线：文件中不得出现这些秘密字面量
+    expect(text).not.toContain(SECRET_SUBJECT);
+    expect(text).not.toContain(SECRET_BODY);
+    expect(text).not.toContain(SECRET_TOKEN_FRAGMENT);
+    expect(text).not.toContain('arguments');
+  });
+
+  test('含秘密参数的 MCP 写调用后 grep audit.jsonl 无秘密', async () => {
+    const { token, identity } = createIdentity({ localpart: 'audit-scrub' })!;
+    // mail_send 会进 SDK 后可能因 SMTP mock 失败，但审计仍应落盘且 scrubbed
+    await mcpCall(token, 'mail_send', {
+      from: identity.address,
+      to: 'victim@evil.example',
+      subject: SECRET_SUBJECT,
+      text: SECRET_BODY,
+    });
+    const text = auditFileText();
+    expect(text).toContain('mcp.tools.call');
+    expect(text).toContain('mail_send');
+    expect(text).not.toContain(SECRET_SUBJECT);
+    expect(text).not.toContain(SECRET_BODY);
+    expect(text).not.toContain(token);
+    expect(text).not.toContain(SECRET_TOKEN_FRAGMENT);
+  });
+
+  test('GET /v1/audit/events admin-only；limit/event 过滤', async () => {
+    recordAuditEvent({ event: 'oauth.revoke', outcome: 'ok', clientId: 'c1' });
+    recordAuditEvent({
+      event: 'mcp.tools.call',
+      tool: 'mail_send',
+      tier: 'contained',
+      outcome: 'ok',
+      address: 'a@test.example',
+    });
+
+    const { token } = createIdentity({ localpart: 'audit-deny' })!;
+    const idForbidden = await app.request('/v1/audit/events', {
+      headers: { authorization: `Bearer ${token}` },
+    });
+    expect(idForbidden.status).toBe(403);
+
+    const all = await app.request('/v1/audit/events?limit=100', {
+      headers: { authorization: `Bearer ${adminKey}` },
+    });
+    expect(all.status).toBe(200);
+    const allBody = (await all.json()) as { events: { event: string }[] };
+    expect(allBody.events.length).toBeGreaterThanOrEqual(2);
+
+    const filtered = await app.request('/v1/audit/events?event=oauth.revoke', {
+      headers: { authorization: `Bearer ${adminKey}` },
+    });
+    const filteredBody = (await filtered.json()) as {
+      events: { event: string }[];
+    };
+    expect(filteredBody.events.every((e) => e.event === 'oauth.revoke')).toBe(
+      true,
+    );
+
+    const limited = await app.request('/v1/audit/events?limit=1', {
+      headers: { authorization: `Bearer ${adminKey}` },
+    });
+    const limitedBody = (await limited.json()) as { events: unknown[] };
+    expect(limitedBody.events.length).toBe(1);
+  });
+});
+
+describe('attribution：三种 caller 落三种行', () => {
+  test('OAuth / oa_ / admin 写调用审计字段不同', async () => {
+    const { token: oaToken, identity } = createIdentity({
+      localpart: 'attr-oa',
+    })!;
+    const grantId = 'grant-attr-1';
+    const clientId = 'http://127.0.0.1:9/cimd.json';
+    const oauthTok = 'oauth-access-attr-test-token';
+    putAccessTokenForTests({
+      token: oauthTok,
+      grantId,
+      address: identity.address,
+      aud: RESOURCE,
+      expiresAt: Date.now() + 3_600_000,
+      ensureGrant: { clientId, clientName: 'Attr Client' },
+    });
+
+    // 确认 attribution 解析分叉
+    const oaResolved = resolveAccessToken(oaToken, { resource: RESOURCE });
+    expect(oaResolved.status).toBe('ok');
+    if (oaResolved.status === 'ok') {
+      expect(oaResolved.attribution.kind).toBe('identity');
+    }
+    const oauthResolved = resolveAccessToken(oauthTok, { resource: RESOURCE });
+    expect(oauthResolved.status).toBe('ok');
+    if (oauthResolved.status === 'ok') {
+      expect(oauthResolved.attribution.kind).toBe('oauth');
+      if (oauthResolved.attribution.kind === 'oauth') {
+        expect(oauthResolved.attribution.grantId).toBe(grantId);
+        expect(oauthResolved.attribution.clientId).toBe(clientId);
+      }
+    }
+    const adminResolved = resolveAccessToken(adminKey, { resource: RESOURCE });
+    expect(adminResolved.status).toBe('ok');
+    if (adminResolved.status === 'ok') {
+      expect(adminResolved.attribution.kind).toBe('admin');
+    }
+
+    // 用 mail_send（contained）避免 mail_mark_seen 打真实 IMAP；失败也仍落审计
+    const sendArgs = {
+      from: identity.address,
+      to: 'sink@test.example',
+      subject: 'attr',
+      text: 'x',
+    };
+    await mcpCall(oaToken, 'mail_send', sendArgs);
+    await mcpCall(oauthTok, 'mail_send', sendArgs);
+    await mcpCall(adminKey, 'mail_send', sendArgs);
+
+    const events = readAuditEvents({ event: 'mcp.tools.call', limit: 20 });
+    const oaRow = events.find(
+      (e) => e.address === identity.address && !e.grantId && e.tool === 'mail_send',
+    );
+    const oauthRow = events.find((e) => e.grantId === grantId && e.tool === 'mail_send');
+    const adminRow = events.find((e) => e.address === 'admin' && e.tool === 'mail_send');
+    expect(oaRow).toBeTruthy();
+    expect(oauthRow?.clientId).toBe(clientId);
+    expect(adminRow?.tier).toBe('contained');
+  });
+});
+
+describe('工具分层', () => {
+  test('规格表 15 工具均有 tier；注册冲突会 throw', () => {
+    expect(Object.keys(TOOL_TIER_SPEC).length).toBe(15);
+    expect(getToolTier('mail_new_identity')).toBe('critical');
+    expect(getToolTier('mail_list_messages')).toBe('read');
+    expect(() => declareToolTier('mail_send', 'read')).toThrow(/conflict/);
+  });
+
+  test('critical 被 OAuth 票调 → 403；oa_ 进 REST scope；admin 通预检', async () => {
+    const { token: oaToken, identity } = createIdentity({
+      localpart: 'tier-crit',
+    })!;
+    const grantId = 'grant-crit-1';
+    const oauthTok = 'oauth-access-crit-test';
+    putAccessTokenForTests({
+      token: oauthTok,
+      grantId,
+      address: identity.address,
+      aud: RESOURCE,
+      expiresAt: Date.now() + 3_600_000,
+      ensureGrant: {
+        clientId: 'http://127.0.0.1:9/cimd.json',
+        clientName: 'Crit',
+      },
+    });
+
+    const oauthDenied = await mcpCall(oauthTok, 'mail_new_identity', {
+      localpart: 'should-deny',
+    });
+    expect(oauthDenied.status).toBe(403);
+    const deniedBody = (await oauthDenied.json()) as { error: string; tier?: string };
+    expect(deniedBody.error).toBe('forbidden_tier');
+    expect(deniedBody.tier).toBe('critical');
+
+    const audit = readAuditEvents({ event: 'mcp.tools.call', limit: 5 });
+    const deniedRow = audit.find((e) => e.outcome === 'denied' && e.tier === 'critical');
+    expect(deniedRow?.grantId).toBe(grantId);
+
+    // oa_：不被 HTTP critical 拦（进 SDK→REST）；admin-only REST → 工具层错误而非 403 tier
+    const oaRes = await mcpCall(oaToken, 'mail_new_identity', {
+      localpart: 'oa-may-reach-rest',
+    });
+    // 非 HTTP 403 forbidden_tier（可能 200 JSON-RPC isError）
+    expect(oaRes.status).not.toBe(403);
+
+    const adminRes = await mcpCall(adminKey, 'mail_new_identity', {
+      localpart: 'admin-crit-ok',
+    });
+    expect(adminRes.status).toBe(200);
+  });
+
+  test('未知工具 default deny 403', async () => {
+    const res = await mcpCall(adminKey, 'not_a_real_tool', {});
+    expect(res.status).toBe(403);
+  });
+
+  test('JSON-RPC batch 数组拒 400（防绕过 tier/限量/审计）', async () => {
+    const { identity } = createIdentity({ localpart: 'batch-deny' })!;
+    const grantId = 'grant-batch-1';
+    const oauthTok = 'oauth-access-batch-test';
+    putAccessTokenForTests({
+      token: oauthTok,
+      grantId,
+      address: identity.address,
+      aud: RESOURCE,
+      expiresAt: Date.now() + 3_600_000,
+      ensureGrant: {
+        clientId: 'http://127.0.0.1:9/cimd.json',
+        clientName: 'Batch',
+      },
+    });
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${oauthTok}`,
+        'content-type': 'application/json',
+        accept: MCP_ACCEPT,
+      },
+      body: JSON.stringify([
+        {
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'mail_new_identity', arguments: { localpart: 'x' } },
+        },
+      ]),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('batch_not_supported');
+  });
+});
+
+describe('MCP per-token 限量', () => {
+  test('窗口内放行 / 超限 429+Retry-After；读写分桶；admin 豁免', async () => {
+    const { token, identity } = createIdentity({ localpart: 'rate-oa' })!;
+    const writeLimit = config.mcpRateWritePerMin;
+    const key = identity.address.toLowerCase();
+
+    // 预填写桶至上限
+    for (let i = 0; i < writeLimit; i++) {
+      const r = checkMcpRateLimit(key, 'write', writeLimit);
+      expect(r.allowed).toBe(true);
+    }
+
+    const blocked = await mcpCall(token, 'mail_send', {
+      from: identity.address,
+      to: 'sink@test.example',
+      subject: 'rl',
+      text: 'x',
+    });
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get('retry-after')).toBeTruthy();
+    const body = (await blocked.json()) as { error: string; bucket: string };
+    expect(body.error).toBe('rate_limited');
+    expect(body.bucket).toBe('write');
+
+    // 读桶仍独立：写桶满不影响读
+    const readOk = await mcpCall(token, 'mail_list_identities');
+    expect(readOk.status).not.toBe(429);
+
+    // tools/list 免费
+    const list = await app.request('/mcp', {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        accept: MCP_ACCEPT,
+      },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(list.status).toBe(200);
+
+    // admin 豁免：不占桶，写桶预满也不 429
+    resetMcpRateLimits();
+    for (let i = 0; i < writeLimit; i++) {
+      checkMcpRateLimit('admin-should-not-matter', 'write', writeLimit);
+    }
+    const adminCall = await mcpCall(adminKey, 'mail_list_identities');
+    expect(adminCall.status).not.toBe(429);
+  });
+
+  test('抽离后 send/notifyUser 既有语义不变', () => {
+    resetRateLimits();
+    resetNotifyUserLimits();
+    const now = 1_000_000;
+    expect(checkSendLimit('a@x.com', 1, 60_000, now).allowed).toBe(true);
+    expect(checkSendLimit('a@x.com', 1, 60_000, now).allowed).toBe(false);
+    expect(checkNotifyUserLimit('a@x.com', 1, 60_000, now).allowed).toBe(true);
+    expect(checkNotifyUserLimit('a@x.com', 1, 60_000, now).allowed).toBe(false);
+  });
+});

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -95,6 +95,19 @@ describe('notification URL configuration', () => {
     ).toThrow(/http or https/i);
   });
 
+  test('MCP_RATE_* 默认 60/20，可覆盖，0 合法', () => {
+    const defaults = parseConfig(requiredEnv);
+    expect(defaults.mcpRateReadPerMin).toBe(60);
+    expect(defaults.mcpRateWritePerMin).toBe(20);
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        MCP_RATE_READ_PER_MIN: '10',
+        MCP_RATE_WRITE_PER_MIN: '0',
+      }).mcpRateWritePerMin,
+    ).toBe(0);
+  });
+
   test('empty or whitespace optional URL env values are treated as unset', () => {
     // Compose ${DASHBOARD_PUBLIC_URL:-} injects "" when the var is absent.
     expect(() =>

--- a/packages/api/test/oauth-as.test.ts
+++ b/packages/api/test/oauth-as.test.ts
@@ -797,10 +797,13 @@ describe('resolveToken / OAuth 永为 identity', () => {
       ensureGrant: { clientId: CLIENT_ID, clientName: 'X' },
     });
     const r = resolveAccessToken(tok, { resource: RESOURCE });
-    expect(r).toEqual({
-      status: 'ok',
-      auth: { kind: 'identity', address: 'admin@test.example' },
-    });
+    expect(r.status).toBe('ok');
+    if (r.status === 'ok') {
+      // /v1 仍见 identity；attribution 标明 oauth（永不升格 admin）
+      expect(r.auth).toEqual({ kind: 'identity', address: 'admin@test.example' });
+      expect(r.attribution.kind).toBe('oauth');
+      expect(r.attribution.kind === 'oauth' && r.attribution.grantId).toBe('g-adm');
+    }
     expect(config.apiKeys.has(tok)).toBe(false);
   });
 });

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -3,13 +3,17 @@ import {
   MAX_WAITS_PER_ADDRESS,
   MAX_WAITS_TOTAL,
   acquireWaitSlot,
+  checkMcpRateLimit,
   checkNotifyUserLimit,
   checkSendLimit,
   releaseNotifyUserLimit,
   releaseWaitSlot,
+  resetMcpRateLimits,
   resetNotifyUserLimits,
   resetRateLimits,
   resetWaitSlots,
+  slidingWindowCheck,
+  slidingWindowRelease,
 } from '../src/lib/ratelimit.ts';
 
 describe('checkSendLimit', () => {
@@ -71,6 +75,29 @@ describe('checkNotifyUserLimit', () => {
     expect(checkNotifyUserLimit('agent@test.example', 1, 60_000, 10_000).allowed).toBe(false);
     releaseNotifyUserLimit('agent@test.example', granted.reservation);
     expect(checkNotifyUserLimit('agent@test.example', 1, 60_000, 10_000).allowed).toBe(true);
+  });
+});
+
+describe('slidingWindow helper（send/notify/MCP 共用）', () => {
+  test('check + release 不复制第三份窗口逻辑', () => {
+    const map = new Map<string, number[]>();
+    const now = 5_000;
+    const a = slidingWindowCheck(map, 'k', 2, 60_000, now);
+    expect(a.allowed).toBe(true);
+    expect(slidingWindowCheck(map, 'k', 2, 60_000, now).allowed).toBe(true);
+    expect(slidingWindowCheck(map, 'k', 2, 60_000, now).allowed).toBe(false);
+    slidingWindowRelease(map, 'k', a.reservation);
+    expect(slidingWindowCheck(map, 'k', 2, 60_000, now).allowed).toBe(true);
+  });
+});
+
+describe('checkMcpRateLimit 读写分桶', () => {
+  test('read/write 互不占额', () => {
+    resetMcpRateLimits();
+    const now = 2_000;
+    expect(checkMcpRateLimit('g1', 'write', 1, 60_000, now).allowed).toBe(true);
+    expect(checkMcpRateLimit('g1', 'write', 1, 60_000, now).allowed).toBe(false);
+    expect(checkMcpRateLimit('g1', 'read', 1, 60_000, now).allowed).toBe(true);
   });
 });
 

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -99,6 +99,15 @@ describe('checkMcpRateLimit 读写分桶', () => {
     expect(checkMcpRateLimit('g1', 'write', 1, 60_000, now).allowed).toBe(false);
     expect(checkMcpRateLimit('g1', 'read', 1, 60_000, now).allowed).toBe(true);
   });
+
+  test('grantId 键大小写敏感（不做 toLowerCase）', () => {
+    resetMcpRateLimits();
+    const now = 3_000;
+    expect(checkMcpRateLimit('AbC_grant', 'write', 1, 60_000, now).allowed).toBe(true);
+    // 不同大小写 = 不同桶，不得互相占额/错配
+    expect(checkMcpRateLimit('abc_grant', 'write', 1, 60_000, now).allowed).toBe(true);
+    expect(checkMcpRateLimit('AbC_grant', 'write', 1, 60_000, now).allowed).toBe(false);
+  });
 });
 
 // 每个 POST /v1/messages/wait 都会占住一条 IMAP 长连接，最长 600 秒。


### PR DESCRIPTION
## 什么

对照 CF WriteGuard 四件套的 P3.5 应用层安全带（P4 公网开门前必备；自托管用户人人有份）。调研：mini 2026-08-11（§2/§3）。stdio 与 /v1 现有行为零破坏。

1. **scrubbed 审计事件**：`DATA_DIR/audit.jsonl`（JSONL 追加、0600、>10MB→`.1` 单备份 rotate）。事件：OAuth 批准/拒绝、token 换发（code/refresh）、revoke、grant 吊销、MCP 写调用（tier≥minimal）。行格式 `{ts,event,clientId?,grantId?,address?,tool?,tier?,outcome,durationMs}`——**字段白名单即红线：绝不记录参数值/正文/token 片段**（测试含秘密值 grep 断言）。只读端点 `GET /v1/audit/events`（admin only，limit/event 过滤）
2. **写调用 attribution**：`resolveAccessToken` 附加 attribution——OAuth=clientId+grantId+address / oa_=address / admin=admin；/v1 仍只消费 Auth（行为不变）
3. **15 工具四级分层**（read/minimal/contained/critical）：tier 声明长在注册处（`lib/tool-tiers.ts`），冲突声明注册即 throw、未声明 default deny；**critical（mail_new_identity/notify_verify）对 OAuth 票 deny-by-default 403**（网页 Agent 永不许建身份）；oa_ 走现有 REST scope；admin 全通。**JSON-RPC batch 显式拒 400**（会绕过 tier/限量/审计，subagent 初审抓出的 P0）
4. **per-token 限量**：滑动窗口抽到唯一共享 helper（`slidingWindowCheck/Release`），send/notifyUser/MCP 三处复用（消灭第三份复制）；MCP 侧读（60/min）写（20/min）分桶，键=grantId|address，**admin 豁免**（运维面取舍），超限 429+Retry-After，tools/list 免费。env：`MCP_RATE_READ_PER_MIN` / `MCP_RATE_WRITE_PER_MIN`（compose 双文件 + .env 示例透传）

## 测试（基线 631 → 649 全绿；typecheck 新增=0）

api 580→593（+13：scrubbed grep 负例、admin-only、limit/event 过滤、三种 attribution、critical OAuth 403、batch 400、429+Retry-After、读写分桶、admin 豁免、send/notify 回归）；mcp 23 / setup 33 不破；`bun run build` 过。

## 审查与验收

独立 subagent 两轮：初审 **P0**（batch 绕过 tier/限量/审计）→ 拒 batch 修复 → 复审 approve-with-nits。dogfood 验收（OAuth 授权→写调用→audit.jsonl scrubbed 实证、超限 429、critical 被 OAuth 票调 403）由指挥在合并前完成，结果见评论。

🤖 worker-29 (cursor-agent) 开发；GC-8G 指挥终审

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for authentication, OAuth, and MCP activity, with admin-only event retrieval.
  * Added MCP tool security tiers with default-deny behavior for unknown tools.
  * Added separate per-token read and write rate limits for MCP calls.
  * Added caller attribution for authenticated requests and OAuth activity.
* **Documentation**
  * Documented audit logging, tool tiers, rate limits, configuration, and retry behavior.
* **Bug Fixes**
  * Improved handling and rejection of unsupported MCP batch requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->