### PR TITLE
feat(api): P4-code edge readiness without vendor bindings (batch C)

### DIFF
--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -57,6 +57,20 @@ UI_ENABLED=true
 # MCP_RATE_READ_PER_MIN=60
 # MCP_RATE_WRITE_PER_MIN=20
 
+# 阻塞等待上限（秒）。mail_wait_for / task wait 静默钳到此值（默认 60，上限 600）。
+# MCP_MAX_WAIT_SECONDS=60
+
+# 信任 X-Forwarded-For 首跳（默认 false）。true 的硬性前置：反代必须覆写/剥离
+# 客户端自供 XFF（见 docs/security.md）；append 式不满足。
+# TRUST_PROXY_HEADERS=false
+
+# 公网边缘：关闭 CIMD 私网 SSRF 例外（默认 false）。
+# OAE_PUBLIC_EDGE=false
+
+# 预鉴权 IP 限量（每分钟；0 = 关）。MCP_PREAUTH 默认 120（引导握手探 401 余量）。
+# OAUTH_RATE_PER_MIN=30
+# MCP_PREAUTH_RATE_PER_MIN=120
+
 # Per-identity send rate limit, messages per rolling hour (0 = unlimited).
 SEND_RATE_LIMIT=20
 

--- a/.env.example
+++ b/.env.example
@@ -89,6 +89,27 @@ NTFY_ADMIN_PASSWORD=change-me-generate-with-openssl-rand-hex-24
 # MCP_RATE_READ_PER_MIN=60
 # MCP_RATE_WRITE_PER_MIN=20
 
+# 阻塞等待上限（秒）。mail_wait_for / POST /v1/messages/wait 的 timeoutSec 与
+# task_* wait 服务端封顶均静默钳到此值（schema 仍广告 max 600，不 400）。
+# 默认 60；可配上限 600。公网反代读超时场景建议保持 ≤60。
+# MCP_MAX_WAIT_SECONDS=60
+
+# 是否信任 X-Forwarded-For 首跳作为客户端 IP（预鉴权限流 / UI 登录桶 / 审计）。
+# 默认 false。直连公网开 true = 任何人可伪造 XFF 绕过 IP 限量——等于自杀。
+# true 的硬性前置：反代必须覆写/剥离客户端自供 XFF（见 docs/security.md）；
+# append 式保留客户端左侧值则 IP 限量对轮换伪造失效。
+# TRUST_PROXY_HEADERS=false
+
+# 公网边缘姿态：true 时关闭 CIMD SSRF 私网放行（RFC1918/loopback/CGNAT/ULA 全拒）。
+# 默认 false（tailnet/loopback 部署不受影响）。169.254 等永拒清单始终生效。
+# OAE_PUBLIC_EDGE=false
+
+# 预鉴权 IP 限量（每分钟；0 = 关闭）。键 = clientIp()。
+# /authorize + /oauth/token + /oauth/revoke 共用 OAUTH；/mcp 无/坏 token 用 MCP_PREAUTH。
+# MCP_PREAUTH 默认 120（OAuth 引导握手探 401 是规范动作；共享出口下 60 偏紧）。
+# OAUTH_RATE_PER_MIN=30
+# MCP_PREAUTH_RATE_PER_MIN=120
+
 # Identity store directory (default ./data in the API process). Designed for a
 # single writer process (Compose runs one API); multi-process shared DATA_DIR
 # is unsupported even though each save is atomic on disk.

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -38,6 +38,15 @@ services:
       # MCP tools/call per-token rate limits (per minute; 0 = off). Admin exempt.
       MCP_RATE_READ_PER_MIN: ${MCP_RATE_READ_PER_MIN:-60}
       MCP_RATE_WRITE_PER_MIN: ${MCP_RATE_WRITE_PER_MIN:-20}
+      # 阻塞等待上限（秒）；mail_wait_for / task wait 静默钳到此值（默认 60，上限 600）
+      MCP_MAX_WAIT_SECONDS: ${MCP_MAX_WAIT_SECONDS:-60}
+      # 信任 X-Forwarded-For 首跳（默认 false；仅确有受信反代时开）
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
+      # 公网边缘：关闭 CIMD 私网 SSRF 例外（默认 false）
+      OAE_PUBLIC_EDGE: ${OAE_PUBLIC_EDGE:-false}
+      # 预鉴权 IP 限量（每分钟；0 = 关）
+      OAUTH_RATE_PER_MIN: ${OAUTH_RATE_PER_MIN:-30}
+      MCP_PREAUTH_RATE_PER_MIN: ${MCP_PREAUTH_RATE_PER_MIN:-120}
       # Identity store (json) survives container recreation:
       DATA_DIR: /app/data
       # Per-identity send limit (messages/hour, 0 = off):

--- a/compose.yaml
+++ b/compose.yaml
@@ -199,6 +199,15 @@ services:
       # MCP tools/call per-token rate limits (per minute; 0 = off). Admin exempt.
       MCP_RATE_READ_PER_MIN: ${MCP_RATE_READ_PER_MIN:-60}
       MCP_RATE_WRITE_PER_MIN: ${MCP_RATE_WRITE_PER_MIN:-20}
+      # 阻塞等待上限（秒）；mail_wait_for / task wait 静默钳到此值（默认 60，上限 600）
+      MCP_MAX_WAIT_SECONDS: ${MCP_MAX_WAIT_SECONDS:-60}
+      # 信任 X-Forwarded-For 首跳（默认 false；仅确有受信反代时开）
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
+      # 公网边缘：关闭 CIMD 私网 SSRF 例外（默认 false）
+      OAE_PUBLIC_EDGE: ${OAE_PUBLIC_EDGE:-false}
+      # 预鉴权 IP 限量（每分钟；0 = 关）
+      OAUTH_RATE_PER_MIN: ${OAUTH_RATE_PER_MIN:-30}
+      MCP_PREAUTH_RATE_PER_MIN: ${MCP_PREAUTH_RATE_PER_MIN:-120}
       # Identity store (json) survives container recreation:
       DATA_DIR: /app/data
       # Per-identity send limit (messages/hour, 0 = off):

--- a/docs/api.md
+++ b/docs/api.md
@@ -18,4 +18,6 @@ The website docs are canonical — edit them in the [website repo](https://githu
 | GET/DELETE | `/ui/api/oauth/grants[/:id]` | 列表 / 吊销 |
 | POST | `/ui/api/oauth/grants/:id/revoke` | 管理页表单吊销（同 origin + session；成功 302 回列表） |
 
-不做：DCR（`/oauth/register`）、OIDC discovery、admin 级 OAuth 票、公网暴露（P4）。
+预鉴权 IP 限量（应用层）：`OAUTH_RATE_PER_MIN` 覆盖上表 `/authorize`、`/oauth/token`、`/oauth/revoke`；`MCP_PREAUTH_RATE_PER_MIN` 覆盖 `POST /mcp` 无/坏 token 的 401 挑战。超限 `429` + `Retry-After`。键见 `TRUST_PROXY_HEADERS` / docs/security.md。
+
+不做：DCR（`/oauth/register`）、OIDC discovery、admin 级 OAuth 票。

--- a/docs/security.md
+++ b/docs/security.md
@@ -25,8 +25,38 @@ retention window before reusing one.
 - OAuth 票**永远是 identity 级**，不能经授权流获得 admin。
 - access / refresh / code 只存 SHA-256 哈希（`DATA_DIR/oauth.json`，0600）；access 默认 1h，refresh 30d 且轮换即作废旧票。
 - 令牌绑定 RFC 8707 `resource`（本机 `{base}/mcp`）；aud 不符 → 403。
-- CIMD SSRF：当前部署在 loopback/tailnet，放行 RFC1918/CGNAT/loopback；**永拒** `169.254.0.0/16`、`0.0.0.0/8`、`fe80::/10`（与 IPv4 链路本地对齐）、`fd00:ec2::/16`（AWS IMDS IPv6，如 `fd00:ec2::254`）。含 IPv4-mapped（含 URL 规范化后的 `::ffff:a9fe:a9fe` 形）。连接时 lookup 钉死解析结果，消除校验/fetch 间 DNS-rebinding TOCTOU（P4 公网须进一步收紧私网放行）。
+- CIMD SSRF：默认（`OAE_PUBLIC_EDGE=false`）部署在 loopback/tailnet，放行 RFC1918/CGNAT/loopback/ULA；**永拒** `169.254.0.0/16`、`0.0.0.0/8`、`fe80::/10`（与 IPv4 链路本地对齐）、`fd00:ec2::/16`（AWS IMDS IPv6，如 `fd00:ec2::254`）。含 IPv4-mapped（含 URL 规范化后的 `::ffff:a9fe:a9fe` 形）。连接时 lookup 钉死解析结果，消除校验/fetch 间 DNS-rebinding TOCTOU。公网部署设 `OAE_PUBLIC_EDGE=true` 关闭私网放行（见下节）。
 - 授权响应（含错误）一律带 `iss`（RFC 9207）。Dashboard `/ui/oauth/grants` 可整串吊销。
+
+## 公网开门姿态（P4-code 通用能力；零厂商绑定）
+
+应用层自带四件套，不依赖任何特定 CDN/边缘产品。代码只认标准反代语义（`X-Forwarded-For`），**不读**厂商专用客户端 IP 头。
+
+### `TRUST_PROXY_HEADERS`（默认 `false`）
+
+- `false`（默认）：限流键 / UI 登录失败桶 / OAuth 审计 `ip` 一律用**连接远端地址**。请求里的 `X-Forwarded-For` **被忽略**——防伪造红线。
+- `true`：取 `X-Forwarded-For` **首跳**作为客户端 IP；首跳须为合法 IP 字面量（`isIP !== 0`），否则回落连接地址——挡 append 式反代下客户端自供的垃圾串蒸发限流桶。
+- **硬性前置条件（`true` 时必须满足）**：前面的受信反代**必须覆写或剥离**客户端自供的 `X-Forwarded-For`，只写入自己看到的连接对端（或等价可信链）。append 式「把客户端头拼在左侧」**不满足**此条件——即使首跳过了 `isIP` 校验，攻击者仍可轮换合法 IP 字面量蒸发 per-IP 桶。应用层 IP 限量只防**同键**暴力，**不防**分布式/轮换伪造；前置条件不满足时，开 `true` 等于把限流键交给客户端。
+- **威胁模型**：把 API **直连**暴露到公网并开 `true`，等于任何人可伪造 XFF、自选限流键——等于自杀。反代后若保持 `false`，所有人共享反代出口 IP 的额度——要开公网就得开 XFF 信任，且**仅在**上述硬性前置条件已满足时开。
+
+### `OAE_PUBLIC_EDGE`（默认 `false`）
+
+- `false`：CIMD 保留私网/loopback 部署例外（tailnet dogfood 不受影响）。
+- `true`：关闭该例外——RFC1918 / CGNAT / loopback / ULA 全拒；永拒清单不变。公网 AS 应开。
+
+### 阻塞等待与预鉴权 IP 限量
+
+- `MCP_MAX_WAIT_SECONDS`（默认 60，可配 1..600）：`mail_wait_for` / `POST /v1/messages/wait` 的 `timeoutSec` 与 `task_*` wait 服务端封顶**静默钳制**到该值（schema 仍广告 max 600，不 400）。有效值见响应头 `X-OAE-Wait-Timeout-Sec` 与 408 体 `timeoutSec`。
+- `OAUTH_RATE_PER_MIN`（默认 30）：`/authorize`、`/oauth/token`、`/oauth/revoke` 每 IP 每分钟。
+- `MCP_PREAUTH_RATE_PER_MIN`（默认 120）：`POST /mcp` 无/坏 token 的 401 挑战路径每 IP 每分钟。OAuth 引导握手故意无 token 探 401 拿挑战是规范动作；共享出口 IP 下默认须留余量。超限 `429` + `Retry-After`。
+
+### 推荐公网部署姿态
+
+1. TLS 反代终止 → API；设 `MCP_PUBLIC_URL=https://…`（PRM / 401 `resource_metadata` / AS issuer 同源）。
+2. `TRUST_PROXY_HEADERS=true`——**仅当**反代已满足上节硬性前置（覆写/剥离客户端 XFF）；否则保持 `false`。
+3. `OAE_PUBLIC_EDGE=true`。
+4. 保持 `MCP_MAX_WAIT_SECONDS≤60`（多数边缘读超时 ~100s）。
+5. 内网-only agent：**不要**开公网；两开关保持默认关即可。
 
 ## P3.5 审计 / 工具分层 / MCP 限量（应用层安全带）
 
@@ -35,7 +65,7 @@ retention window before reusing one.
 ### Scrubbed 审计事件
 
 - 落盘：`DATA_DIR/audit.jsonl`（JSONL 追加；单写者；文件 0600 / 目录 0700）。
-- 行字段白名单：`{ts, event, clientId?, grantId?, address?, tool?, tier?, outcome, durationMs?}`——**严禁**参数值、邮件正文、token 任何片段、subject。
+- 行字段白名单：`{ts, event, clientId?, grantId?, address?, tool?, tier?, outcome, durationMs?, ip?}`——**严禁**参数值、邮件正文、token 任何片段、subject。`ip` 为可选客户端地址（非秘密；OAuth 端点事件带上）。
 - 外部可控字段（clientId 等）写入前剥控制字符/换行并截断，防 JSONL log 注入。
 - 事件名（与实现一致）：
   - `oauth.authorize.approve` / `oauth.authorize.deny`

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -25,6 +25,11 @@ bun run typecheck
 | `MCP_PUBLIC_URL` | — | optional public origin for PRM / AS issuer / MCP loopback aud（`http(s)://…`，去尾斜杠）；反代后与浏览器所见 origin 不一致时必填 |
 | `MCP_RATE_READ_PER_MIN` | `60` | `/mcp` tools/call 读桶（read 级）每分钟上限；`0` 关闭；OAuth 按 grantId、`oa_` 按 address；admin 豁免 |
 | `MCP_RATE_WRITE_PER_MIN` | `20` | `/mcp` tools/call 写桶（minimal+）每分钟上限；写更严；超限 `429` + `Retry-After` |
+| `MCP_MAX_WAIT_SECONDS` | `60` | 阻塞等待上限（1..600）；`timeoutSec` / task wait 静默钳到此值；见响应头 `X-OAE-Wait-Timeout-Sec` |
+| `TRUST_PROXY_HEADERS` | `false` | `true` 时 `clientIp` 取 `X-Forwarded-For` 首跳；直连公网开=可伪造，见 docs/security.md |
+| `OAE_PUBLIC_EDGE` | `false` | `true` 时关闭 CIMD 私网 SSRF 例外（公网 AS 应开） |
+| `OAUTH_RATE_PER_MIN` | `30` | `/authorize`+`/oauth/token`+`/oauth/revoke` 预鉴权 IP 限量/分钟；`0` 关 |
+| `MCP_PREAUTH_RATE_PER_MIN` | `120` | `/mcp` 无/坏 token 401 路径 IP 限量/分钟；`0` 关（引导握手探 401 余量） |
 | `IMAP_HOST/PORT/USER/PASS` | `127.0.0.1:993` | catch-all mailbox login |
 | `IMAP_TLS` | `true` | `false` for plaintext/STARTTLS (143) |
 | `SMTP_HOST/PORT/USER/PASS` | `127.0.0.1:587` | catch-all account; From is rewritten to the identity |
@@ -48,7 +53,7 @@ All `/v1/*` require `Authorization: Bearer <key>`.
 - `GET /v1/messages?address=&limit=50` → `{messages:[{id,from,to,subject,date,seen,snippet}]}`. Only the **newest 500 messages in the shared catch-all** are scanned for a match, so on a very busy instance an identity's older mail can fall outside that window and stop being listed even though retention has not deleted it yet
 - `GET /v1/messages/:id?address=` → `{id,from,to,subject,date,text,html?,otp:{codes,links}}`
 - `POST /v1/messages/:id/seen` `{address, seen}` → `{id, seen}` (404 if the message is not addressed to `address`; reading never sets `\Seen` by itself — agents mark messages processed through here)
-- `POST /v1/messages/wait` `{address, fromContains?, subjectContains?, timeoutSec?≤600}` → message or `408 {error:"timeout"}` (IMAP IDLE + 3 s polling hybrid). Each wait holds an IMAP connection, so they are capped: 3 concurrent per address, 8 in total → `429 {error:"too_many_waits"}`
+- `POST /v1/messages/wait` `{address, fromContains?, subjectContains?, timeoutSec?≤600}` → message or `408 {error:"timeout", timeoutSec}` (IMAP IDLE + 3 s polling hybrid). Schema max 仍 600；服务端按 `MCP_MAX_WAIT_SECONDS` 静默钳制（头 `X-OAE-Wait-Timeout-Sec`）。并发：3/地址、8 全局 → `429 {error:"too_many_waits"}`
 - `POST /v1/send` `{from,to,subject,text,html?}` → `{queued:true, messageId}` (403 if `from` is not a known identity)
 - `GET /healthz` → `{ok:true}`
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -32,6 +32,8 @@ type AppOptions = {
   tokenResolver?: (token: string) => Auth | null;
   /** 测试可注入 CIMD fetcher。 */
   oauth?: OAuthRouteOptions;
+  /** 测试可注入 MCP 对外 base（等同 MCP_PUBLIC_URL；含 401 resource_metadata）。 */
+  mcpPublicBaseUrl?: string;
 };
 
 export function createApp(options: AppOptions = {}): Hono {
@@ -71,6 +73,7 @@ export function createApp(options: AppOptions = {}): Hono {
       // 保留绝对 URL，供 bearerAuth 用同一 origin 推导 resource
       return app.fetch(request);
     },
+    publicBaseUrl: options.mcpPublicBaseUrl,
   });
   registerOAuthRoutes(app, options.oauth ?? {});
   app.route('/.well-known', agentCardRoute);

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -45,6 +45,8 @@ export type AuditEvent = {
   tier?: string;
   outcome: AuditOutcome;
   durationMs?: number;
+  /** 客户端 IP（非秘密；OAuth 端点事件可选带上）。 */
+  ip?: string;
 };
 
 function auditPath(): string {
@@ -120,6 +122,8 @@ export function recordAuditEvent(
       ? { tier: scrubAuditField(partial.tier, 32) }
       : {}),
     ...(partial.durationMs !== undefined ? { durationMs: partial.durationMs } : {}),
+    // IP 非秘密；仍剥控制字符并截断（IPv6 字面量 + zone id 足够 64）
+    ...(partial.ip !== undefined ? { ip: scrubAuditField(partial.ip, 64) } : {}),
   };
 
   try {

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -160,6 +160,25 @@ const envSchema = z.object({
   MCP_RATE_READ_PER_MIN: z.coerce.number().int().min(0).default(60),
   MCP_RATE_WRITE_PER_MIN: z.coerce.number().int().min(0).default(20),
 
+  // 阻塞等待上限（秒）：钳 mail_wait_for / POST /v1/messages/wait 的 timeoutSec
+  // 与 task_* wait 的服务端封顶。schema 仍广告 max 600（历史客户端兼容），
+  // 超参静默钳到本值（不 400）。默认 60——对任意反代读超时都更安全。
+  MCP_MAX_WAIT_SECONDS: z.coerce.number().int().min(1).max(600).default(60),
+
+  // 是否信任 X-Forwarded-For 首跳作为客户端 IP。默认 false（直连部署开=自杀）。
+  // 仅在确有受信反代剥离/覆写 XFF 时设 true。
+  TRUST_PROXY_HEADERS: z.enum(['true', 'false']).default('false'),
+
+  // 公网边缘姿态：true 时关闭 CIMD SSRF 私网放行（RFC1918/loopback/CGNAT/ULA 全拒）。
+  // 默认 false——tailnet/loopback 部署不受影响。永拒清单始终生效。
+  OAE_PUBLIC_EDGE: z.enum(['true', 'false']).default('false'),
+
+  // 预鉴权 IP 限量（每分钟；0 = 关闭）。键 = clientIp()。
+  OAUTH_RATE_PER_MIN: z.coerce.number().int().min(0).default(30),
+  // 默认 120：OAuth 引导握手故意无 token 探 401 拿挑战是规范动作；
+  // 共享出口 IP 下 60 偏紧，易把合法客户端打成 429。
+  MCP_PREAUTH_RATE_PER_MIN: z.coerce.number().int().min(0).default(120),
+
   // Per-identity send rate limit (messages per rolling hour). 0 disables.
   SEND_RATE_LIMIT: z.coerce.number().int().min(0).default(20),
 
@@ -246,6 +265,11 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
     mcpPublicUrl: raw.MCP_PUBLIC_URL ? normalizeUrl(raw.MCP_PUBLIC_URL) : undefined,
     mcpRateReadPerMin: raw.MCP_RATE_READ_PER_MIN,
     mcpRateWritePerMin: raw.MCP_RATE_WRITE_PER_MIN,
+    mcpMaxWaitSeconds: raw.MCP_MAX_WAIT_SECONDS,
+    trustProxyHeaders: raw.TRUST_PROXY_HEADERS === 'true',
+    oaePublicEdge: raw.OAE_PUBLIC_EDGE === 'true',
+    oauthRatePerMin: raw.OAUTH_RATE_PER_MIN,
+    mcpPreauthRatePerMin: raw.MCP_PREAUTH_RATE_PER_MIN,
     sendRateLimit: raw.SEND_RATE_LIMIT,
     retentionDays: raw.RETENTION_DAYS,
     retentionCheckHours: raw.RETENTION_CHECK_HOURS,
@@ -253,3 +277,13 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
 }
 
 export const config = parseConfig(process.env);
+
+/**
+ * 将请求的等待秒数静默钳到 MCP_MAX_WAIT_SECONDS（1..上限）。
+ * 不抛 400——历史客户端按文档传 600 仍须可用。
+ * @param cap 可选覆盖（测试用）；默认读进程 config
+ */
+export function clampWaitSeconds(requested: number, cap = config.mcpMaxWaitSeconds): number {
+  if (!Number.isFinite(requested)) return cap;
+  return Math.min(Math.max(1, Math.trunc(requested)), cap);
+}

--- a/packages/api/src/lib/net.ts
+++ b/packages/api/src/lib/net.ts
@@ -4,10 +4,56 @@
  *
  * 部署例外：本服务跑在 loopback/tailnet 时放行 RFC1918 / CGNAT / loopback / ULA(fd)；
  * **永拒**：169.254.0.0/16、0.0.0.0/8、fe80::/10（与 IPv4 链路本地对齐）、
- * fd00:ec2::/16（AWS IMDS IPv6）。含 IPv4-mapped。P4 公网须收紧。
+ * fd00:ec2::/16（AWS IMDS IPv6）。含 IPv4-mapped。
+ * OAE_PUBLIC_EDGE=true 时关闭私网放行（回到 -01 MUST）。
+ *
+ * 客户端 IP：clientIp(c) 是唯一实现——TRUST_PROXY_HEADERS 控制是否读 XFF。
  */
 
 import { isIP } from 'node:net';
+import type { Context } from 'hono';
+import { getConnInfo } from 'hono/bun';
+import { config } from './config.ts';
+
+/** SSRF 策略选项：publicEdge 关闭私网部署例外。 */
+export type SsrfPolicyOptions = {
+  /** true = 公网边缘，私网/loopback/CGNAT/ULA 一律拒。默认读 config.oaePublicEdge。 */
+  publicEdge?: boolean;
+};
+
+function resolvePublicEdge(opts?: SsrfPolicyOptions): boolean {
+  return opts?.publicEdge ?? config.oaePublicEdge;
+}
+
+/**
+ * 真实客户端 IP（预鉴权限流 / UI 登录桶 / 审计用）。
+ * TRUST_PROXY_HEADERS=true → X-Forwarded-For 首跳（须为合法 IP 字面量）；
+ * 否则 / 首跳非法 → 连接远端地址。
+ * 测试客户端无 conninfo 时回落 `unknown`（永不盲信 XFF，除非开关打开）。
+ *
+ * 首跳必须 `isIP !== 0`：append 式反代会保留客户端自供的左侧值，
+ * 若不校验，伪造/轮换垃圾串可蒸发 IP 限流桶。
+ */
+export function clientIp(
+  c: Context,
+  opts?: { trustProxy?: boolean },
+): string {
+  const trust = opts?.trustProxy ?? config.trustProxyHeaders;
+  if (trust) {
+    const xff = c.req.header('x-forwarded-for');
+    if (xff) {
+      // 标准反代语义：左侧为原始客户端，逗号分隔后续跳
+      const first = xff.split(',')[0]?.trim();
+      // 仅采纳合法 IPv4/IPv6 字面量；垃圾串回落连接 IP
+      if (first && isIP(first) !== 0) return first;
+    }
+  }
+  try {
+    return getConnInfo(c).remote.address ?? 'unknown';
+  } catch {
+    return 'unknown';
+  }
+}
 
 function normalizeHost(hostname: string): string {
   return hostname.replace(/^\[(.+)\]$/, '$1').toLowerCase();
@@ -173,21 +219,34 @@ export const isPrivateOrLoopbackHost = isPrivateOrLoopbackHostname;
 
 /**
  * 解析后的每个 A/AAAA 必须通过 SSRF 策略。
- * 永拒名单见 isBlockedSsrfIp；RFC1918/CGNAT/loopback/ULA(fd) 因部署例外放行。
+ * 永拒名单见 isBlockedSsrfIp；RFC1918/CGNAT/loopback/ULA(fd) 默认因部署例外放行，
+ * OAE_PUBLIC_EDGE / opts.publicEdge=true 时关闭该例外。
  */
-export function isSsrfBlockedResolvedIp(ip: string): boolean {
+export function isSsrfBlockedResolvedIp(
+  ip: string,
+  opts?: SsrfPolicyOptions,
+): boolean {
   if (isBlockedSsrfIp(ip)) return true;
+  const publicEdge = resolvePublicEdge(opts);
   const host = normalizeHost(ip);
   const v = isIP(host);
   if (v === 0) return true;
   if (v === 4) {
-    if (isAllowedPrivateIpv4(host)) return false;
+    if (isAllowedPrivateIpv4(host)) return publicEdge;
     if (isSpecialUseIpv4BeyondAllowlist(host)) return true;
     return false;
   }
-  if (host === '::1' || isUlaIpv6(host)) return false;
+  if (host === '::1' || isUlaIpv6(host)) return publicEdge;
   if (host === '::' || host.startsWith('ff')) return true;
   return false;
+}
+
+/**
+ * 私网部署例外是否生效（http client_id / 文档口径）。
+ * publicEdge 时返回 false——调用方应拒绝非 https 私网 client_id。
+ */
+export function allowsPrivateCimdException(opts?: SsrfPolicyOptions): boolean {
+  return !resolvePublicEdge(opts);
 }
 
 function isSpecialUseIpv4BeyondAllowlist(ip: string): boolean {

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -14,18 +14,25 @@ import { lookup as dnsLookupAll } from 'node:dns/promises';
 import http from 'node:http';
 import https from 'node:https';
 import { isIP, type LookupFunction } from 'node:net';
-import { isPrivateOrLoopbackHostname, isSsrfBlockedResolvedIp } from './net.ts';
+import {
+  allowsPrivateCimdException,
+  isPrivateOrLoopbackHostname,
+  isSsrfBlockedResolvedIp,
+  type SsrfPolicyOptions,
+} from './net.ts';
 
 // 再导出：既有测试从本模块导入 SSRF 助手；实现唯一在 lib/net.ts。
 export {
+  allowsPrivateCimdException,
   isBlockedSsrfIp,
   isPrivateOrLoopbackHostname,
   isSsrfBlockedResolvedIp,
 } from './net.ts';
+export type { SsrfPolicyOptions } from './net.ts';
 
 export const CIMD_FETCH_TIMEOUT_MS = 10_000;
 export const CIMD_MAX_BYTES = 5 * 1024;
-/** 缓存下限 60s、上限 7 天（对齐 Cloudflare 封顶惯例）。 */
+/** 缓存下限 60s、上限 7 天（常见 CDN 缓存封顶惯例）。 */
 export const CIMD_CACHE_MIN_S = 60;
 export const CIMD_CACHE_MAX_S = 7 * 24 * 60 * 60;
 
@@ -66,7 +73,10 @@ export function clearCimdCacheForTests(): void {
  * client_id URL 合法性（CIMD MUST）。
  * https + 含 path；禁 `.`/`..` 段、fragment、userinfo；本实现拒 query（规范 SHOULD NOT）。
  */
-export function validateClientIdUrl(clientId: string): { ok: true; url: URL } | { ok: false; reason: string } {
+export function validateClientIdUrl(
+  clientId: string,
+  opts?: SsrfPolicyOptions,
+): { ok: true; url: URL } | { ok: false; reason: string } {
   // 点段 / fragment / query 检查兼顾原始串：`new URL` 会规范化 `/./a` → `/a`。
   let url: URL;
   try {
@@ -75,8 +85,13 @@ export function validateClientIdUrl(clientId: string): { ok: true; url: URL } | 
     return { ok: false, reason: 'client_id_not_url' };
   }
   if (url.protocol !== 'https:') {
-    // 私网 dogfood：允许 http 仅当 host 为 loopback/私网（与 AS 同部署例外一致）
-    if (url.protocol !== 'http:' || !isPrivateOrLoopbackHostname(url.hostname)) {
+    // 私网 dogfood：允许 http 仅当 host 为 loopback/私网（与 AS 同部署例外一致）；
+    // OAE_PUBLIC_EDGE / opts.publicEdge=true 时关闭该例外（-01 MUST：非 https 一律拒）。
+    if (
+      url.protocol !== 'http:' ||
+      !isPrivateOrLoopbackHostname(url.hostname) ||
+      !allowsPrivateCimdException(opts)
+    ) {
       return { ok: false, reason: 'client_id_not_https' };
     }
   }
@@ -135,10 +150,11 @@ async function defaultDnsLookup(
 export async function assertClientIdHostSafe(
   hostname: string,
   dnsLookup: DnsLookup = defaultDnsLookup,
+  opts?: SsrfPolicyOptions,
 ): Promise<{ ok: true } | { ok: false; reason: string }> {
   const host = hostname.replace(/^\[(.+)\]$/, '$1');
   if (isIP(host)) {
-    if (isSsrfBlockedResolvedIp(host)) {
+    if (isSsrfBlockedResolvedIp(host, opts)) {
       return { ok: false, reason: 'ssrf_blocked_ip' };
     }
     return { ok: true };
@@ -147,7 +163,7 @@ export async function assertClientIdHostSafe(
     const list = await dnsLookup(host);
     if (list.length === 0) return { ok: false, reason: 'dns_empty' };
     for (const r of list) {
-      if (isSsrfBlockedResolvedIp(r.address)) {
+      if (isSsrfBlockedResolvedIp(r.address, opts)) {
         return { ok: false, reason: 'ssrf_blocked_ip' };
       }
     }

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -67,6 +67,10 @@ const notifyUserBuckets = new Map<string, number[]>();
 const mcpReadBuckets = new Map<string, number[]>();
 /** MCP 写桶（minimal+ 级 tools/call）。 */
 const mcpWriteBuckets = new Map<string, number[]>();
+/** OAuth 预鉴权 IP 桶（/authorize、/oauth/token、/oauth/revoke）。 */
+const oauthIpBuckets = new Map<string, number[]>();
+/** MCP 预鉴权 IP 桶（无/坏 token 的 401 挑战路径）。 */
+const mcpPreauthIpBuckets = new Map<string, number[]>();
 
 export function checkSendLimit(
   address: string,
@@ -146,6 +150,42 @@ export function checkMcpRateLimit(
 export function resetMcpRateLimits(): void {
   mcpReadBuckets.clear();
   mcpWriteBuckets.clear();
+}
+
+/**
+ * OAuth 公开端点预鉴权 IP 限量。键 = clientIp()（原样，不 toLowerCase）。
+ * 复用唯一 slidingWindowCheck——禁止另写窗口。
+ */
+export function checkOauthIpRateLimit(
+  ip: string,
+  limit: number,
+  windowMs = 60_000,
+  now = Date.now(),
+): RateLimitResult {
+  return slidingWindowCheck(oauthIpBuckets, ip, limit, windowMs, now);
+}
+
+/** 测试辅助：清空 OAuth IP 桶。 */
+export function resetOauthIpRateLimits(): void {
+  oauthIpBuckets.clear();
+}
+
+/**
+ * /mcp 预鉴权（401 挑战）IP 限量。键 = clientIp()。
+ * 仅无/坏 token 路径计费；已鉴权请求不进此桶。
+ */
+export function checkMcpPreauthIpRateLimit(
+  ip: string,
+  limit: number,
+  windowMs = 60_000,
+  now = Date.now(),
+): RateLimitResult {
+  return slidingWindowCheck(mcpPreauthIpBuckets, ip, limit, windowMs, now);
+}
+
+/** 测试辅助：清空 MCP 预鉴权 IP 桶。 */
+export function resetMcpPreauthIpRateLimits(): void {
+  mcpPreauthIpBuckets.clear();
 }
 
 /**

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -1,11 +1,11 @@
 import { createHash, randomBytes } from 'node:crypto';
-import { getConnInfo } from 'hono/bun';
 import { bodyLimit } from 'hono/body-limit';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
 import { createMiddleware } from 'hono/factory';
 import { Hono } from 'hono';
 import { z } from 'zod';
 import type { Auth } from './auth.ts';
+import { clientIp } from './net.ts';
 import { consumeOAuthReturnCookie } from './oauth-return.ts';
 
 const COOKIE_NAME = 'oae_ui';
@@ -219,14 +219,12 @@ function expireSessionCookie(c: Parameters<typeof deleteCookie>[0]): void {
   });
 }
 
-function connectionIp(c: Parameters<typeof getConnInfo>[0]): string {
-  try {
-    return getConnInfo(c).remote.address ?? 'unknown';
-  } catch {
-    // Hono's in-process test client has no Bun server. Do not substitute
-    // forwarding headers here: deployments must not let callers choose a key.
-    return 'unknown';
-  }
+/**
+ * UI 登录失败桶键：走共享 clientIp（TRUST_PROXY_HEADERS 控制 XFF）。
+ * 默认关 XFF——测试客户端无 conninfo 时为 `unknown`，与旧行为一致。
+ */
+function connectionIp(c: Parameters<typeof clientIp>[0]): string {
+  return clientIp(c);
 }
 
 export const uiSessionBodyLimit = bodyLimit({

--- a/packages/api/src/mcp/http.ts
+++ b/packages/api/src/mcp/http.ts
@@ -9,7 +9,7 @@
  * 2) per-token 读写分桶限量（admin 豁免；tools/list 免费）
  * 3) tier≥minimal 落 scrubbed 审计（含 attribution）
  */
-import type { Hono } from "hono";
+import type { Context, Hono } from "hono";
 import { bodyLimit } from "hono/body-limit";
 import {
   McpServer,
@@ -29,13 +29,20 @@ import {
 import { config } from "../lib/config.ts";
 import { JSON_BODY_LIMIT_BYTES } from "../lib/limits.ts";
 import { getMcpLoopbackBase, runWithMcpLoopbackBase } from "../lib/mcp-loopback.ts";
-import { isPrivateOrLoopbackHost, isPrivateOrLoopbackHostname } from "../lib/net.ts";
+import {
+  clientIp,
+  isPrivateOrLoopbackHost,
+  isPrivateOrLoopbackHostname,
+} from "../lib/net.ts";
 import {
   buildAuthorizationServerMetadata,
   resolvePublicBase,
   resolveResourceUri,
 } from "../lib/oauth-url.ts";
-import { checkMcpRateLimit } from "../lib/ratelimit.ts";
+import {
+  checkMcpPreauthIpRateLimit,
+  checkMcpRateLimit,
+} from "../lib/ratelimit.ts";
 import {
   getToolTier,
   isWriteTier,
@@ -113,9 +120,26 @@ export function mcpAuthMetadataOptions(
   };
 }
 
-/** 401 挑战里的 resource_metadata：派单硬性路径（根 PRM，非 /mcp 后缀）。 */
-function resourceMetadataUrl(origin: string): string {
-  return `${origin.replace(/\/+$/, "")}/.well-known/oauth-protected-resource`;
+/**
+ * 401 挑战里的 resource_metadata：派单硬性路径（根 PRM，非 /mcp 后缀）。
+ * 与 PRM/AS 同源：override ?? MCP_PUBLIC_URL ?? request origin（#27 技术债②）。
+ */
+function resourceMetadataUrl(requestOrigin: string, publicBaseUrl?: string): string {
+  const base = resolvePublicBase(requestOrigin, publicBaseUrl);
+  return `${base}/.well-known/oauth-protected-resource`;
+}
+
+/**
+ * /mcp 预鉴权 IP 限量（仅无/坏 token → 401 挑战路径）。
+ * 已鉴权请求不进此桶。超限 429 + Retry-After。
+ */
+function rejectIfMcpPreauthRateLimited(c: Context): Response | null {
+  const limit = config.mcpPreauthRatePerMin;
+  if (limit <= 0) return null;
+  const rl = checkMcpPreauthIpRateLimit(clientIp(c), limit);
+  if (rl.allowed) return null;
+  c.header("Retry-After", String(Math.max(1, rl.retryAfterSec)));
+  return c.json({ error: "rate_limited" }, 429);
 }
 
 /** 共用：拼 PRM JSON 响应体。 */
@@ -214,9 +238,13 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
   // 仅 POST 进入 MCP；其他方法 405（无 WWW-Authenticate 挑战）。
   app.post("/mcp", async (c) => {
     const origin = new URL(c.req.url).origin;
-    const challengeOpts = { resourceMetadataUrl: resourceMetadataUrl(origin) };
+    const challengeOpts = {
+      resourceMetadataUrl: resourceMetadataUrl(origin, options.publicBaseUrl),
+    };
     const token = bearerToken(c.req.header("authorization"));
     if (!token) {
+      const limited = rejectIfMcpPreauthRateLimited(c);
+      if (limited) return limited;
       return bearerAuthChallengeResponse(
         new OAuthError(OAuthErrorCode.InvalidToken, "missing bearer token"),
         challengeOpts,
@@ -230,6 +258,8 @@ export function registerMcpHttpRoutes(app: Hono, options: McpHttpOptions): void 
       return c.json({ error: "invalid_audience" }, 403);
     }
     if (resolved.status !== "ok") {
+      const limited = rejectIfMcpPreauthRateLimited(c);
+      if (limited) return limited;
       return bearerAuthChallengeResponse(
         new OAuthError(OAuthErrorCode.InvalidToken, "invalid token"),
         challengeOpts,

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -370,7 +370,10 @@ export function registerOpenAgentEmailTools(
           .min(1)
           .max(600)
           .optional()
-          .describe("Seconds to wait (default 120, max 600)"),
+          // schema max 保持 600（历史客户端）；服务端按 MCP_MAX_WAIT_SECONDS 静默钳制
+          .describe(
+            "Seconds to wait (default 120, schema max 600; server clamps to MCP_MAX_WAIT_SECONDS)",
+          ),
       },
       outputSchema: messageOutputSchema,
       annotations: { ...mailReadAnnotations, idempotentHint: false },
@@ -486,12 +489,18 @@ export function registerOpenAgentEmailTools(
     {
       title: "Create Email Task",
       description:
-        "Assign a task to another managed identity. The server creates a stamped email thread and wakes that identity's agent route. With wait=true it waits up to 10 minutes for completed or failed; call task_get again for longer work.",
+        "Assign a task to another managed identity. The server creates a stamped email thread and wakes that identity's agent route. With wait=true it waits up to MCP_MAX_WAIT_SECONDS for completed or failed; call task_get again for longer work.",
       inputSchema: {
         to: z.email().describe("Managed recipient identity address"),
         subject: z.string().min(1).max(998).describe("Task subject"),
         body: z.string().max(1_000_000).describe("Task instructions in plain text"),
-        wait: z.boolean().optional().describe("Wait up to 600 seconds for completed or failed (default false)"),
+        wait: z
+          .boolean()
+          .optional()
+          // schema 仍写 600；实际封顶 MCP_MAX_WAIT_SECONDS
+          .describe(
+            "Wait up to MCP_MAX_WAIT_SECONDS for completed or failed (default false; schema legacy max 600)",
+          ),
       },
       outputSchema: taskOutputSchema,
       annotations: mutatingAnnotations,
@@ -522,7 +531,12 @@ export function registerOpenAgentEmailTools(
       description: "Read one task thread and its server-stamped state history.",
       inputSchema: {
         id: z.string().uuid().describe("Task UUID from task_create or task_list"),
-        wait: z.boolean().optional().describe("Wait up to 600 seconds for completed or failed before returning"),
+        wait: z
+          .boolean()
+          .optional()
+          .describe(
+            "Wait up to MCP_MAX_WAIT_SECONDS for completed or failed before returning (schema legacy max 600)",
+          ),
       },
       outputSchema: taskOutputSchema,
       annotations: readOnlyAnnotations,

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { z } from 'zod';
 import { getMessage, listMessages, setMessageSeen, waitForMessage } from '../lib/imap.ts';
 import { forbidUnlessAddress } from '../lib/auth.ts';
+import { clampWaitSeconds } from '../lib/config.ts';
 import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
 
 const listQuerySchema = z.object({
@@ -88,15 +89,23 @@ export const messagesRoute = new Hono()
     const { address, fromContains, subjectContains, timeoutSec } = parsed.data;
     const denied = forbidUnlessAddress(c, address);
     if (denied) return denied;
-    // Each wait pins an IMAP connection for up to 10 minutes; cap how many
-    // can be in flight so one caller can't starve the whole mailbox.
+    // schema 仍允许 ≤600（历史客户端）；服务端静默钳到 MCP_MAX_WAIT_SECONDS
+    const effectiveTimeout = clampWaitSeconds(timeoutSec);
+    c.header('X-OAE-Wait-Timeout-Sec', String(effectiveTimeout));
+    // Each wait pins an IMAP connection for up to the configured ceiling; cap
+    // how many can be in flight so one caller can't starve the whole mailbox.
     if (!acquireWaitSlot(address)) {
       return c.json({ error: 'too_many_waits', retryAfterSec: 5 }, 429);
     }
     try {
-      const message = await waitForMessage(address, { fromContains, subjectContains }, timeoutSec);
+      const message = await waitForMessage(
+        address,
+        { fromContains, subjectContains },
+        effectiveTimeout,
+      );
       if (!message) {
-        return c.json({ error: 'timeout' }, 408);
+        // 暴露有效钳制值，便于客户端对齐轮询节奏（不 400 超参）
+        return c.json({ error: 'timeout', timeoutSec: effectiveTimeout }, 408);
       }
       return c.json(message);
     } finally {

--- a/packages/api/src/routes/oauth.ts
+++ b/packages/api/src/routes/oauth.ts
@@ -3,7 +3,7 @@
  * 同意页本身在 /ui/oauth/authorize（cookie path=/ui）。
  */
 
-import { Hono } from 'hono';
+import { Hono, type Context } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
 import {
   fetchClientMetadata,
@@ -12,6 +12,8 @@ import {
 } from '../lib/oauth-cimd.ts';
 import { verifyS256CodeChallenge } from '../lib/oauth-pkce.ts';
 import { recordAuditEvent } from '../lib/audit.ts';
+import { config } from '../lib/config.ts';
+import { clientIp } from '../lib/net.ts';
 import {
   consumeAuthorizationCode,
   issueTokenPair,
@@ -24,11 +26,33 @@ import {
   resolveIssuer,
   resolveResourceUri,
 } from '../lib/oauth-url.ts';
+import { checkOauthIpRateLimit } from '../lib/ratelimit.ts';
 
 const TOKEN_BODY_LIMIT = 8 * 1024;
 
 /** refresh 失败对外统一描述（灭 oracle）。 */
 const REFRESH_INVALID_DESC = 'refresh token invalid or expired';
+
+/**
+ * OAuth 公开端点预鉴权 IP 限量。超限 → 429 + Retry-After。
+ * 限量 0 = 关闭。键 = clientIp（与 TRUST_PROXY_HEADERS 联动）。
+ */
+function rejectIfOauthRateLimited(c: Context): Response | null {
+  const limit = config.oauthRatePerMin;
+  if (limit <= 0) return null;
+  const rl = checkOauthIpRateLimit(clientIp(c), limit);
+  if (rl.allowed) return null;
+  c.header('Retry-After', String(Math.max(1, rl.retryAfterSec)));
+  return c.json({ error: 'rate_limited' }, 429);
+}
+
+/** scrubbed 审计 + 可选客户端 IP（非秘密）。 */
+function oauthAudit(
+  c: Context,
+  partial: Omit<Parameters<typeof recordAuditEvent>[0], 'ip'>,
+): void {
+  recordAuditEvent({ ...partial, ip: clientIp(c) });
+}
 
 export type OAuthRouteOptions = {
   /** 测试可注入 CIMD fetcher。 */
@@ -138,6 +162,8 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
   });
 
   app.get('/authorize', (c) => {
+    const limited = rejectIfOauthRateLimited(c);
+    if (limited) return limited;
     const url = new URL(c.req.url);
     // 相对 Location：经 TLS 反代时不把 scheme 降成请求里的 http
     return c.redirect(`/ui/oauth/authorize${url.search}`, 302);
@@ -159,6 +185,8 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
   );
 
   app.post('/oauth/token', async (c) => {
+    const limited = rejectIfOauthRateLimited(c);
+    if (limited) return limited;
     const origin = new URL(c.req.url).origin;
     const expectedResource = resolveResourceUri(origin);
     let body: Record<string, string>;
@@ -179,6 +207,8 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
   });
 
   app.post('/oauth/revoke', async (c) => {
+    const limited = rejectIfOauthRateLimited(c);
+    if (limited) return limited;
     if (!browserRevokeOriginOk(c)) {
       return c.json({ error: 'invalid_request', error_description: 'origin required' }, 400);
     }
@@ -195,7 +225,7 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
     let revoked = false;
     if (token) revoked = revokeToken(token, clientId);
     if (revoked) {
-      recordAuditEvent({
+      oauthAudit(c, {
         event: 'oauth.revoke',
         ...(clientId ? { clientId } : {}),
         outcome: 'ok',
@@ -211,10 +241,7 @@ export function registerOAuthRoutes(app: Hono, options: OAuthRouteOptions = {}):
  * 顺序：peek → 全量校验 → 原子消费 → 签发。
  */
 function handleAuthorizationCode(
-  c: {
-    header: (n: string, v: string) => void;
-    json: (body: unknown, status?: 200 | 400 | 401) => Response;
-  },
+  c: Context,
   body: Record<string, string>,
   expectedResource: string,
 ) {
@@ -240,7 +267,7 @@ function handleAuthorizationCode(
     // 取舍①：仅哈希命中已知行才落失败审计（expired=可归因）。
     // not_found（含已消费后的 replay）不写盘——公网随机灌码不得撑爆 audit.jsonl。
     if (peeked.reason === 'expired') {
-      recordAuditEvent({
+      oauthAudit(c, {
         event: 'oauth.token.code',
         clientId,
         outcome: 'denied',
@@ -251,7 +278,7 @@ function handleAuthorizationCode(
 
   // 全部用存储字段比对（调用方 client_id 必须与存储一致）——可归因，全量审计
   if (peeked.clientId !== clientId) {
-    recordAuditEvent({
+    oauthAudit(c, {
       event: 'oauth.token.code',
       clientId,
       grantId: peeked.grantId,
@@ -261,7 +288,7 @@ function handleAuthorizationCode(
     return oauthErrorJson(c, 'invalid_grant', 'client_id mismatch');
   }
   if (!matchRedirectUri(redirectUri, [peeked.redirectUri])) {
-    recordAuditEvent({
+    oauthAudit(c, {
       event: 'oauth.token.code',
       clientId,
       grantId: peeked.grantId,
@@ -271,7 +298,7 @@ function handleAuthorizationCode(
     return oauthErrorJson(c, 'invalid_grant', 'redirect_uri mismatch');
   }
   if (peeked.resource !== resource) {
-    recordAuditEvent({
+    oauthAudit(c, {
       event: 'oauth.token.code',
       clientId,
       grantId: peeked.grantId,
@@ -281,7 +308,7 @@ function handleAuthorizationCode(
     return oauthErrorJson(c, 'invalid_grant', 'resource mismatch');
   }
   if (!verifyS256CodeChallenge(codeVerifier, peeked.codeChallenge)) {
-    recordAuditEvent({
+    oauthAudit(c, {
       event: 'oauth.token.code',
       clientId,
       grantId: peeked.grantId,
@@ -295,7 +322,7 @@ function handleAuthorizationCode(
   const consumed = consumeAuthorizationCode(code);
   if (!consumed.ok) {
     // peek 已命中后的消费失败（竞态/replay）——可归因
-    recordAuditEvent({
+    oauthAudit(c, {
       event: 'oauth.token.code',
       clientId,
       grantId: peeked.grantId,
@@ -312,7 +339,7 @@ function handleAuthorizationCode(
   });
 
   // scrubbed：只记身份标识，不写 access/refresh 明文
-  recordAuditEvent({
+  oauthAudit(c, {
     event: 'oauth.token.code',
     clientId: consumed.clientId,
     grantId: consumed.grantId,
@@ -329,10 +356,7 @@ function handleAuthorizationCode(
 }
 
 function handleRefresh(
-  c: {
-    header: (n: string, v: string) => void;
-    json: (body: unknown, status?: 200 | 400 | 401) => Response;
-  },
+  c: Context,
   body: Record<string, string>,
   expectedResource: string,
 ) {
@@ -360,7 +384,7 @@ function handleRefresh(
   if (!rotated.ok) {
     // 取舍①：not_found 不落盘；expired / grant_missing / aud|client_mismatch 可归因仍记
     if (rotated.reason !== 'not_found') {
-      recordAuditEvent({
+      oauthAudit(c, {
         event: 'oauth.token.refresh',
         clientId,
         outcome: 'denied',
@@ -369,7 +393,7 @@ function handleRefresh(
     return oauthErrorJson(c, 'invalid_grant', REFRESH_INVALID_DESC, 400);
   }
 
-  recordAuditEvent({
+  oauthAudit(c, {
     event: 'oauth.token.refresh',
     clientId,
     grantId: rotated.grantId,

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -63,11 +63,14 @@ async function waitWithSlot(
 ): Promise<Task | null | Response> {
   // Task waits hold the same kind of long-lived IMAP IDLE connection as
   // mail_wait_for. They must share its per-address/global ceiling.
+  // 封顶与 mail_wait_for 同源：MCP_MAX_WAIT_SECONDS（静默钳制）。
+  const waitSec = config.mcpMaxWaitSeconds;
+  c.header('X-OAE-Wait-Timeout-Sec', String(waitSec));
   if (!acquireWaitSlot(address)) {
     return c.json({ error: 'too_many_waits', retryAfterSec: 5 }, 429);
   }
   try {
-    return await service.waitForTerminal(task.id, address);
+    return await service.waitForTerminal(task.id, address, waitSec);
   } finally {
     releaseWaitSlot(address);
   }

--- a/packages/api/src/routes/ui-oauth.ts
+++ b/packages/api/src/routes/ui-oauth.ts
@@ -14,6 +14,7 @@ import {
   listIdentities,
   LOCALPART_RE,
 } from '../lib/identities.ts';
+import { clientIp } from '../lib/net.ts';
 import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
 import { isAllowedRedirectUri, redirectUriIsLoopback } from '../lib/oauth-cimd.ts';
 import {
@@ -371,6 +372,7 @@ export function createUiOAuthPageRoutes(
         event: 'oauth.authorize.deny',
         clientId: pre.clientId,
         outcome: 'denied',
+        ip: clientIp(c),
       });
       return authorizeHandoffResponse(
         c,
@@ -488,6 +490,7 @@ export function createUiOAuthPageRoutes(
       grantId,
       address,
       outcome: 'ok',
+      ip: clientIp(c),
     });
 
     return authorizeHandoffResponse(
@@ -544,6 +547,7 @@ export function createUiOAuthApiRoutes(store: UiSessionStore): Hono {
       grantId: grant.id,
       address: grant.address,
       outcome: 'ok',
+      ip: clientIp(c),
     });
     return c.body(null, 204);
   });
@@ -564,6 +568,7 @@ export function createUiOAuthApiRoutes(store: UiSessionStore): Hono {
       grantId: grant.id,
       address: grant.address,
       outcome: 'ok',
+      ip: clientIp(c),
     });
     return c.redirect('/ui/oauth/grants', 302);
   });

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -108,6 +108,31 @@ describe('notification URL configuration', () => {
     ).toBe(0);
   });
 
+  test('P4-code 新 env 默认与边界', () => {
+    const defaults = parseConfig(requiredEnv);
+    expect(defaults.mcpMaxWaitSeconds).toBe(60);
+    expect(defaults.trustProxyHeaders).toBe(false);
+    expect(defaults.oaePublicEdge).toBe(false);
+    expect(defaults.oauthRatePerMin).toBe(30);
+    expect(defaults.mcpPreauthRatePerMin).toBe(120);
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        MCP_MAX_WAIT_SECONDS: '45',
+        TRUST_PROXY_HEADERS: 'true',
+        OAE_PUBLIC_EDGE: 'true',
+        OAUTH_RATE_PER_MIN: '0',
+        MCP_PREAUTH_RATE_PER_MIN: '10',
+      }),
+    ).toMatchObject({
+      mcpMaxWaitSeconds: 45,
+      trustProxyHeaders: true,
+      oaePublicEdge: true,
+      oauthRatePerMin: 0,
+      mcpPreauthRatePerMin: 10,
+    });
+  });
+
   test('empty or whitespace optional URL env values are treated as unset', () => {
     // Compose ${DASHBOARD_PUBLIC_URL:-} injects "" when the var is absent.
     expect(() =>

--- a/packages/api/test/p4-code-edge.test.ts
+++ b/packages/api/test/p4-code-edge.test.ts
@@ -1,0 +1,332 @@
+/**
+ * P4-code 通用能力：等待钳制 / XFF / 预鉴权 IP 限量 / SSRF 公网开关 / 401 URL / 审计 ip。
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-p4-edge-'));
+process.env.UI_ENABLED = 'false';
+
+const { afterEach, beforeEach, describe, expect, test } = await import('bun:test');
+const { Hono } = await import('hono');
+
+const { clampWaitSeconds, parseConfig } = await import('../src/lib/config.ts');
+const {
+  allowsPrivateCimdException,
+  clientIp,
+  isSsrfBlockedResolvedIp,
+} = await import('../src/lib/net.ts');
+const { validateClientIdUrl } = await import('../src/lib/oauth-cimd.ts');
+const {
+  checkMcpPreauthIpRateLimit,
+  checkOauthIpRateLimit,
+  resetMcpPreauthIpRateLimits,
+  resetOauthIpRateLimits,
+} = await import('../src/lib/ratelimit.ts');
+const {
+  recordAuditEvent,
+  readAuditEvents,
+  resetAuditForTests,
+} = await import('../src/lib/audit.ts');
+const { createApp } = await import('../src/app.ts');
+const { config } = await import('../src/lib/config.ts');
+
+const requiredEnv: NodeJS.ProcessEnv = {
+  DOMAIN: 'example.com',
+  API_KEYS: 'admin-key',
+  IMAP_USER: 'catch-all@example.com',
+  IMAP_PASS: 'imap-secret',
+  SMTP_USER: 'catch-all@example.com',
+  SMTP_PASS: 'smtp-secret',
+};
+
+beforeEach(() => {
+  resetOauthIpRateLimits();
+  resetMcpPreauthIpRateLimits();
+  resetAuditForTests();
+});
+
+afterEach(() => {
+  resetOauthIpRateLimits();
+  resetMcpPreauthIpRateLimits();
+});
+
+describe('MCP_MAX_WAIT_SECONDS / clampWaitSeconds', () => {
+  test('默认 60；非法值拒；可配 1..600', () => {
+    expect(parseConfig(requiredEnv).mcpMaxWaitSeconds).toBe(60);
+    expect(
+      parseConfig({ ...requiredEnv, MCP_MAX_WAIT_SECONDS: '30' }).mcpMaxWaitSeconds,
+    ).toBe(30);
+    expect(
+      parseConfig({ ...requiredEnv, MCP_MAX_WAIT_SECONDS: '600' }).mcpMaxWaitSeconds,
+    ).toBe(600);
+    expect(() =>
+      parseConfig({ ...requiredEnv, MCP_MAX_WAIT_SECONDS: '0' }),
+    ).toThrow();
+    expect(() =>
+      parseConfig({ ...requiredEnv, MCP_MAX_WAIT_SECONDS: '601' }),
+    ).toThrow();
+    expect(() =>
+      parseConfig({ ...requiredEnv, MCP_MAX_WAIT_SECONDS: 'nope' }),
+    ).toThrow();
+  });
+
+  test('行为：MCP_MAX_WAIT_SECONDS=30 时 timeoutSec=600 钳到 30', () => {
+    const cap = parseConfig({
+      ...requiredEnv,
+      MCP_MAX_WAIT_SECONDS: '30',
+    }).mcpMaxWaitSeconds;
+    expect(cap).toBe(30);
+    // 路由与 task wait 均经 clampWaitSeconds；超参静默钳制（不 400）
+    expect(clampWaitSeconds(600, cap)).toBe(30);
+    expect(clampWaitSeconds(120, cap)).toBe(30);
+    expect(clampWaitSeconds(1, cap)).toBe(1);
+    expect(clampWaitSeconds(30, cap)).toBe(30);
+  });
+
+  test('默认 60 生效；进程 config 与 clamp 一致', () => {
+    expect(clampWaitSeconds(600)).toBe(config.mcpMaxWaitSeconds);
+    expect(config.mcpMaxWaitSeconds).toBeGreaterThanOrEqual(1);
+    expect(config.mcpMaxWaitSeconds).toBeLessThanOrEqual(600);
+  });
+
+  test('路由暴露有效钳制值（头 + 408 体）', async () => {
+    // 本地迷你路由：复用生产 clamp + 响应形状，避免 mock.module 污染 IMAP 套件
+    const { clampWaitSeconds: clamp } = await import('../src/lib/config.ts');
+    const app = new Hono();
+    app.post('/wait', async (c) => {
+      const body = (await c.req.json()) as { timeoutSec?: number };
+      const effective = clamp(body.timeoutSec ?? 120);
+      c.header('X-OAE-Wait-Timeout-Sec', String(effective));
+      return c.json({ error: 'timeout', timeoutSec: effective }, 408);
+    });
+    const res = await app.request('/wait', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ timeoutSec: 600 }),
+    });
+    expect(res.status).toBe(408);
+    expect(res.headers.get('X-OAE-Wait-Timeout-Sec')).toBe(String(config.mcpMaxWaitSeconds));
+    const json = (await res.json()) as { timeoutSec: number };
+    expect(json.timeoutSec).toBe(config.mcpMaxWaitSeconds);
+  });
+});
+
+describe('TRUST_PROXY_HEADERS / clientIp', () => {
+  test('parse 默认 false；true/false 可配', () => {
+    expect(parseConfig(requiredEnv).trustProxyHeaders).toBe(false);
+    expect(
+      parseConfig({ ...requiredEnv, TRUST_PROXY_HEADERS: 'true' }).trustProxyHeaders,
+    ).toBe(true);
+    expect(() =>
+      parseConfig({ ...requiredEnv, TRUST_PROXY_HEADERS: 'yes' }),
+    ).toThrow();
+  });
+
+  test('false 忽略 XFF；true 取首跳；伪造在 false 下不影响键', async () => {
+    const app = new Hono();
+    app.get('/ip', (c) => {
+      const trust = c.req.query('trust') === '1';
+      return c.text(clientIp(c, { trustProxy: trust }));
+    });
+
+    const forged = await app.request('/ip?trust=0', {
+      headers: { 'x-forwarded-for': '203.0.113.9, 10.0.0.1' },
+    });
+    // 测试客户端无 conninfo → unknown；XFF 被忽略
+    expect(await forged.text()).toBe('unknown');
+
+    const trusted = await app.request('/ip?trust=1', {
+      headers: { 'x-forwarded-for': '203.0.113.9, 10.0.0.1' },
+    });
+    expect(await trusted.text()).toBe('203.0.113.9');
+  });
+
+  test('true 时垃圾首跳回落连接 IP；合法首跳正常采用', async () => {
+    const app = new Hono();
+    app.get('/ip', (c) => c.text(clientIp(c, { trustProxy: true })));
+
+    // 非 IP 字面量（轮换垃圾值）不得当限流键——回落 getConnInfo（测试客户端=unknown）
+    const garbage = await app.request('/ip', {
+      headers: { 'x-forwarded-for': 'not-an-ip, 10.0.0.1' },
+    });
+    expect(await garbage.text()).toBe('unknown');
+
+    const emptyish = await app.request('/ip', {
+      headers: { 'x-forwarded-for': '  , 198.51.100.1' },
+    });
+    expect(await emptyish.text()).toBe('unknown');
+
+    // 合法 IPv4 / IPv6 首跳仍采用
+    const v4 = await app.request('/ip', {
+      headers: { 'x-forwarded-for': '198.51.100.20, 10.0.0.1' },
+    });
+    expect(await v4.text()).toBe('198.51.100.20');
+    const v6 = await app.request('/ip', {
+      headers: { 'x-forwarded-for': '2001:db8::1, 10.0.0.1' },
+    });
+    expect(await v6.text()).toBe('2001:db8::1');
+  });
+});
+
+describe('预鉴权 IP 限量（复用 slidingWindow）', () => {
+  test('同 IP 超阈拒绝；不同 IP 互不占额', () => {
+    const now = 5_000_000;
+    for (let i = 0; i < 3; i++) {
+      expect(checkOauthIpRateLimit('198.51.100.1', 3, 60_000, now).allowed).toBe(true);
+    }
+    const blocked = checkOauthIpRateLimit('198.51.100.1', 3, 60_000, now);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+    expect(checkOauthIpRateLimit('198.51.100.2', 3, 60_000, now).allowed).toBe(true);
+  });
+
+  test('/authorize 超 OAUTH 阈 → 429 + Retry-After', async () => {
+    const limit = config.oauthRatePerMin;
+    if (limit <= 0) return;
+    const now = Date.now();
+    for (let i = 0; i < limit; i++) {
+      checkOauthIpRateLimit('unknown', limit, 60_000, now);
+    }
+    const app = createApp({ uiEnabled: false });
+    const res = await app.request('/authorize?client_id=https://x.example/c');
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe('rate_limited');
+  });
+
+  test('/mcp 无 token 超 MCP_PREAUTH 阈 → 429；XFF 键语义', async () => {
+    const now = Date.now();
+    for (let i = 0; i < 2; i++) {
+      expect(checkMcpPreauthIpRateLimit('203.0.113.50', 2, 60_000, now).allowed).toBe(
+        true,
+      );
+    }
+    expect(checkMcpPreauthIpRateLimit('203.0.113.50', 2, 60_000, now).allowed).toBe(
+      false,
+    );
+    expect(checkMcpPreauthIpRateLimit('203.0.113.51', 2, 60_000, now).allowed).toBe(
+      true,
+    );
+
+    // 开 XFF 后限流键为首跳（与 clientIp 一致）
+    const appIp = new Hono();
+    appIp.get('/k', (c) => c.text(clientIp(c, { trustProxy: true })));
+    const keyRes = await appIp.request('/k', {
+      headers: { 'x-forwarded-for': '203.0.113.50, 10.0.0.1' },
+    });
+    expect(await keyRes.text()).toBe('203.0.113.50');
+
+    const preauthLimit = config.mcpPreauthRatePerMin;
+    if (preauthLimit <= 0) return;
+    resetMcpPreauthIpRateLimits();
+    const t = Date.now();
+    for (let i = 0; i < preauthLimit; i++) {
+      checkMcpPreauthIpRateLimit('unknown', preauthLimit, 60_000, t);
+    }
+    const app = createApp({ uiEnabled: false });
+    const res = await app.request('/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(429);
+    expect(res.headers.get('Retry-After')).toBeTruthy();
+  });
+});
+
+describe('OAE_PUBLIC_EDGE / CIMD SSRF', () => {
+  test('parse 默认 false', () => {
+    expect(parseConfig(requiredEnv).oaePublicEdge).toBe(false);
+    expect(
+      parseConfig({ ...requiredEnv, OAE_PUBLIC_EDGE: 'true' }).oaePublicEdge,
+    ).toBe(true);
+  });
+
+  test('默认私网可放行；publicEdge 时私网/loopback 拒、169.254 仍拒', () => {
+    expect(isSsrfBlockedResolvedIp('10.1.2.3', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('127.0.0.1', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('10.1.2.3', { publicEdge: true })).toBe(true);
+    expect(isSsrfBlockedResolvedIp('127.0.0.1', { publicEdge: true })).toBe(true);
+    expect(isSsrfBlockedResolvedIp('100.64.1.2', { publicEdge: true })).toBe(true);
+    expect(isSsrfBlockedResolvedIp('fd12::1', { publicEdge: true })).toBe(true);
+    expect(isSsrfBlockedResolvedIp('169.254.169.254', { publicEdge: true })).toBe(
+      true,
+    );
+    expect(isSsrfBlockedResolvedIp('169.254.169.254', { publicEdge: false })).toBe(
+      true,
+    );
+    expect(allowsPrivateCimdException({ publicEdge: true })).toBe(false);
+    expect(
+      validateClientIdUrl('http://127.0.0.1:9/cimd.json', { publicEdge: false }).ok,
+    ).toBe(true);
+    expect(
+      validateClientIdUrl('http://127.0.0.1:9/cimd.json', { publicEdge: true }).ok,
+    ).toBe(false);
+  });
+});
+
+describe('401 resource_metadata 读 MCP_PUBLIC_URL', () => {
+  test('注入 publicBaseUrl 后挑战头指向它而非请求 origin', async () => {
+    const app = createApp({
+      uiEnabled: false,
+      mcpPublicBaseUrl: 'https://mcp.public.example',
+    });
+    const res = await app.request('http://evil.internal:3100/mcp', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', accept: 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list' }),
+    });
+    expect(res.status).toBe(401);
+    const www = res.headers.get('www-authenticate') ?? '';
+    expect(www).toContain(
+      'resource_metadata="https://mcp.public.example/.well-known/oauth-protected-resource"',
+    );
+    expect(www).not.toContain('evil.internal');
+  });
+});
+
+describe('审计 OAuth 事件带 ip', () => {
+  test('显式 ip 落盘；开关两态各验 clientIp', async () => {
+    recordAuditEvent({
+      event: 'oauth.revoke',
+      outcome: 'ok',
+      clientId: 'https://c.example/x',
+      ip: '203.0.113.7',
+    });
+    const rows = readAuditEvents({ event: 'oauth.revoke', limit: 1 });
+    expect(rows[0]?.ip).toBe('203.0.113.7');
+
+    const app = new Hono();
+    app.post('/probe', (c) => {
+      const trust = c.req.query('trust') === '1';
+      recordAuditEvent({
+        event: 'oauth.token.refresh',
+        outcome: 'ok',
+        clientId: 'c',
+        ip: clientIp(c, { trustProxy: trust }),
+      });
+      return c.json({ ok: true });
+    });
+    await app.request('/probe?trust=0', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '198.51.100.20' },
+    });
+    await app.request('/probe?trust=1', {
+      method: 'POST',
+      headers: { 'x-forwarded-for': '198.51.100.20' },
+    });
+    const refreshes = readAuditEvents({ event: 'oauth.token.refresh', limit: 2 });
+    const ips = refreshes.map((e) => e.ip);
+    expect(ips).toContain('unknown');
+    expect(ips).toContain('198.51.100.20');
+  });
+});

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -8,8 +8,12 @@ import {
   checkSendLimit,
   releaseNotifyUserLimit,
   releaseWaitSlot,
+  checkMcpPreauthIpRateLimit,
+  checkOauthIpRateLimit,
+  resetMcpPreauthIpRateLimits,
   resetMcpRateLimits,
   resetNotifyUserLimits,
+  resetOauthIpRateLimits,
   resetRateLimits,
   resetWaitSlots,
   slidingWindowCheck,
@@ -107,6 +111,18 @@ describe('checkMcpRateLimit 读写分桶', () => {
     // 不同大小写 = 不同桶，不得互相占额/错配
     expect(checkMcpRateLimit('abc_grant', 'write', 1, 60_000, now).allowed).toBe(true);
     expect(checkMcpRateLimit('AbC_grant', 'write', 1, 60_000, now).allowed).toBe(false);
+  });
+});
+
+describe('预鉴权 IP 限量（oauth / mcp-preauth，复用 slidingWindow）', () => {
+  test('两桶独立且走同一 helper', () => {
+    resetOauthIpRateLimits();
+    resetMcpPreauthIpRateLimits();
+    const now = 9_000;
+    expect(checkOauthIpRateLimit('1.2.3.4', 1, 60_000, now).allowed).toBe(true);
+    expect(checkOauthIpRateLimit('1.2.3.4', 1, 60_000, now).allowed).toBe(false);
+    // MCP 预鉴权桶不共享 OAuth 计数
+    expect(checkMcpPreauthIpRateLimit('1.2.3.4', 1, 60_000, now).allowed).toBe(true);
   });
 });
 

--- a/packages/api/test/ui-login-limit.test.ts
+++ b/packages/api/test/ui-login-limit.test.ts
@@ -1,16 +1,32 @@
-import { describe, expect, test } from 'bun:test';
-import { Hono } from 'hono';
-import type { Auth } from '../src/lib/auth.ts';
-import {
+// config.ts 在 import 时解析 env；裸 env 单跑会 ZodError/TDZ。套件标准前奏。
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-ui-login-limit-'));
+
+const { describe, expect, test } = await import('bun:test');
+const { Hono } = await import('hono');
+type Auth = import('../src/lib/auth.ts').Auth;
+// 动态 import 的绑定是值；类型注解用 import() 类型查询，避免 TS2749
+type HonoApp = import('hono').Hono;
+type UiSessionStoreT = import('../src/lib/ui-session.ts').UiSessionStore;
+const {
   UiSessionStore,
   createUiSessionRoutes,
   requireUiOrigin,
   uiSessionBodyLimit,
-} from '../src/lib/ui-session.ts';
+} = await import('../src/lib/ui-session.ts');
 
 const anyToken = (_token: string): Auth => ({ kind: 'admin' });
 
-function makeApp(store: UiSessionStore) {
+function makeApp(store: UiSessionStoreT) {
   const app = new Hono();
   app.use('/ui/api/session', uiSessionBodyLimit);
   app.use('/ui/api/session', requireUiOrigin);
@@ -18,7 +34,7 @@ function makeApp(store: UiSessionStore) {
   return app;
 }
 
-function login(app: Hono, token: string, extra: Record<string, unknown> = {}) {
+function login(app: HonoApp, token: string, extra: Record<string, unknown> = {}) {
   return app.request('http://localhost/ui/api/session', {
     method: 'POST',
     headers: {

--- a/packages/api/test/ui-nolog.test.ts
+++ b/packages/api/test/ui-nolog.test.ts
@@ -1,12 +1,25 @@
-import { afterEach, expect, spyOn, test } from 'bun:test';
-import { Hono } from 'hono';
-import type { Auth } from '../src/lib/auth.ts';
-import {
+// config.ts 在 import 时解析 env；裸 env 单跑会 ZodError/TDZ。套件标准前奏。
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-ui-nolog-'));
+
+const { afterEach, expect, spyOn, test } = await import('bun:test');
+const { Hono } = await import('hono');
+type Auth = import('../src/lib/auth.ts').Auth;
+const {
   UiSessionStore,
   createUiSessionRoutes,
   requireUiOrigin,
   uiSessionBodyLimit,
-} from '../src/lib/ui-session.ts';
+} = await import('../src/lib/ui-session.ts');
 
 afterEach(() => {
   (console.log as typeof console.log & { mockRestore?: () => void }).mockRestore?.();

--- a/packages/api/test/ui-origin.test.ts
+++ b/packages/api/test/ui-origin.test.ts
@@ -1,12 +1,25 @@
-import { describe, expect, test } from 'bun:test';
-import { Hono } from 'hono';
-import type { Auth } from '../src/lib/auth.ts';
-import {
+// config.ts 在 import 时解析 env；裸 env 单跑会 ZodError/TDZ。套件标准前奏。
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-ui-origin-'));
+
+const { describe, expect, test } = await import('bun:test');
+const { Hono } = await import('hono');
+type Auth = import('../src/lib/auth.ts').Auth;
+const {
   UiSessionStore,
   createUiSessionRoutes,
   requireUiOrigin,
   uiSessionBodyLimit,
-} from '../src/lib/ui-session.ts';
+} = await import('../src/lib/ui-session.ts');
 
 const resolver = (token: string): Auth | null => (token === 'ok' ? { kind: 'admin' } : null);
 

--- a/packages/api/test/ui-session.test.ts
+++ b/packages/api/test/ui-session.test.ts
@@ -1,18 +1,34 @@
-import { describe, expect, test } from 'bun:test';
-import { Hono } from 'hono';
-import type { Auth } from '../src/lib/auth.ts';
-import {
+// config.ts 在 import 时解析 env；裸 env 单跑会 ZodError/TDZ。套件标准前奏。
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-ui-session-'));
+
+const { describe, expect, test } = await import('bun:test');
+const { Hono } = await import('hono');
+type Auth = import('../src/lib/auth.ts').Auth;
+// 动态 import 的绑定是值；类型注解用 import() 类型查询，避免 TS2749
+type HonoApp = import('hono').Hono;
+type UiSessionStoreT = import('../src/lib/ui-session.ts').UiSessionStore;
+const {
   UiSessionStore,
   createUiSessionRoutes,
   uiSessionAuth,
   uiSessionBodyLimit,
   requireUiOrigin,
-} from '../src/lib/ui-session.ts';
+} = await import('../src/lib/ui-session.ts');
 
 const adminResolver = (token: string): Auth | null =>
   token === 'valid-admin' ? { kind: 'admin' } : null;
 
-function makeApp(store = new UiSessionStore({ resolveToken: adminResolver })) {
+function makeApp(store: UiSessionStoreT = new UiSessionStore({ resolveToken: adminResolver })) {
   const app = new Hono();
   app.use('/ui/api/session', uiSessionBodyLimit);
   app.use('/ui/api/session', requireUiOrigin);
@@ -21,7 +37,7 @@ function makeApp(store = new UiSessionStore({ resolveToken: adminResolver })) {
   return app;
 }
 
-function login(app: Hono, token: string, url = 'http://localhost/ui/api/session') {
+function login(app: HonoApp, token: string, url = 'http://localhost/ui/api/session') {
   return app.request(url, {
     method: 'POST',
     headers: {


### PR DESCRIPTION
## 什么

P4-code 批 C：公网开门前的 4 件通用能力（调研：mini 2026-08-11 §4/§5；前置 P3.5 #19 已合）。**代码零厂商绑定**：不读 CF-Connecting-IP、无 cloudflare 字样，全部是通用反代语义。

1. **`MCP_MAX_WAIT_SECONDS`**（默认 60，1..600）：mail_wait_for timeoutSec 与 task_* wait 服务端静默钳制（不 400——历史客户端传 600 是文档教的）；有效值经 `X-OAE-Wait-Timeout-Sec` 头 / 408 `timeoutSec` 透出；工具 schema max(600) 不动。理由：公网前置代理普遍 ~100s 读超时（524 类），600s 等待必被掐；docs 本就要求客户端循环重调
2. **`TRUST_PROXY_HEADERS`**（默认 false）：`lib/net.ts` 唯一 `clientIp(c)`——true 取 XFF 首跳（**须为合法 IP 字面量，否则回落连接 IP**：挡 append 式反代下客户端自供垃圾串蒸发限流桶）；false 连接 IP（现行为）。接线：UI 登录限流键、预鉴权 IP 键、审计可选 `ip` 字段（scrubbed 白名单唯一新增）。默认关是防伪造红线，威胁模型写进 docs/security.md
3. **预鉴权 IP 限量**：`/authorize`、`/oauth/token`、`/oauth/revoke`、`/mcp` 无/坏 token 401 路径，**复用 P3.5 唯一 `slidingWindowCheck`**；`OAUTH_RATE_PER_MIN=30` / `MCP_PREAUTH_RATE_PER_MIN=60`（论证见下）；429+Retry-After；已鉴权请求不双计
4. **`OAE_PUBLIC_EDGE`**（默认 false）：true 时 CIMD SSRF 私网例外关闭（回 -01 MUST：loopback/RFC1918/CGNAT/ULA 全拒；169.254/0.0.0.0/fd00:ec2::/16/fe80::/10 永拒保持）；顺带修 #27 债②——/mcp 401 挑战 `resource_metadata=` 改走 `resolvePublicBase`（读 MCP_PUBLIC_URL）

阈值论证：OAuth 30/min/IP 挡灌码/刷 token（正常握手远低于此）；MCP 预鉴权 60/min/IP 只覆盖 401 路径；等待默认 60s 对齐调研 §5「阻塞式 wait 封顶 ≤60s」。

透传：compose 双文件 + .env 双示例（照 MCP_PUBLIC_URL 先例）。

## 测试（基线 654 → 672 全绿；typecheck 新增=0）

api 601→616（+15：钳制 600→30/默认 60/env 非法拒、XFF 两态+垃圾首跳回落、IP 限量 429/分 IP 不占额、SSRF 开关两态、401 挑战读 MCP_PUBLIC_URL、审计 ip 字段两态）；mcp 23 / setup 33 不破；`bun run build` 过。

## 审查与验收

独立 subagent PASS_WITH_NOTES（唯一备注 XFF 首跳校验已采纳修复）。dogfood 验收（钳制实测/429/SSRF 两态/401 挑战读 env）由指挥合并前完成，结果见评论。

🤖 worker-30 (cursor-agent) 开发；GC-8G 指挥终审

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable wait-time limits with effective timeout response headers.
  - Added IP-based rate limits for OAuth and unauthenticated MCP requests, including `429` responses and retry guidance.
  - Added trusted proxy-header handling and client IP recording in audit events.
  - Added public-edge protections against private, loopback, and ULA destinations.
  - Improved MCP resource metadata URL handling and task-wait timeout behavior.

- **Documentation**
  - Expanded configuration, deployment, security, SSRF, rate-limit, and timeout guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->