### PR TITLE
fix(api): persist UI sessions so Trust-30d survives api restarts

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -1,6 +1,12 @@
+import { join } from 'node:path';
 import { Hono } from 'hono';
 import { bodyLimit } from 'hono/body-limit';
-import { bearerAuth, resolveUiSessionToken, type Auth } from './lib/auth.ts';
+import {
+  bearerAuth,
+  resolveUiSessionToken,
+  resolveUiSessionTokenByHash,
+  type Auth,
+} from './lib/auth.ts';
 import { config } from './lib/config.ts';
 import { JSON_BODY_LIMIT_BYTES } from './lib/limits.ts';
 import {
@@ -30,6 +36,8 @@ import {
 type AppOptions = {
   uiEnabled?: boolean;
   tokenResolver?: (token: string) => Auth | null;
+  /** 测试可注入：按 tokenHash 反解（与 tokenResolver 配套；默认走生产实现）。 */
+  tokenHashResolver?: (tokenHash: string) => Auth | null;
   /** 测试可注入 CIMD fetcher。 */
   oauth?: OAuthRouteOptions;
   /** 测试可注入 MCP 对外 base（等同 MCP_PUBLIC_URL；含 401 resource_metadata）。 */
@@ -98,6 +106,10 @@ export function createApp(options: AppOptions = {}): Hono {
     const uiSessions = new UiSessionStore({
       // UI 会话默认拒 OAuth access；测试可经 tokenResolver 注入覆盖。
       resolveToken: options.tokenResolver ?? resolveUiSessionToken,
+      // 重启后落盘会话无明文 token，按 hash 反解（与 resolveUiSessionToken 同范围）。
+      resolveTokenHash: options.tokenHashResolver ?? resolveUiSessionTokenByHash,
+      // Trust-30d 必须活过 api 容器重建：落盘 DATA_DIR/ui-sessions.json
+      persistPath: join(config.dataDir, 'ui-sessions.json'),
     });
     registerUiAssets(app);
     app.use('/ui/api/session', uiSessionBodyLimit);

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -13,12 +13,24 @@
  * All /v1/* routes sit behind this.
  */
 
+import { createHash, timingSafeEqual } from 'node:crypto';
 import { createMiddleware } from 'hono/factory';
 import type { Context } from 'hono';
 import { config } from './config.ts';
-import { findIdentity, findIdentityByToken } from './identities.ts';
+import { findIdentity, findIdentityByToken, findIdentityByTokenHash } from './identities.ts';
 import { getGrant, lookupAccessToken } from './oauth-store.ts';
 import { resolveResourceUri } from './oauth-url.ts';
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
+
+/** 常量时间比较两个 hex/字符串哈希（长度不同直接 false）。 */
+function hashEquals(a: string, b: string): boolean {
+  const ba = Buffer.from(a, 'utf8');
+  const bb = Buffer.from(b, 'utf8');
+  return ba.length === bb.length && timingSafeEqual(ba, bb);
+}
 
 export type Auth =
   | { kind: 'admin' }
@@ -150,6 +162,18 @@ export function resolveToken(
 export function resolveUiSessionToken(token: string): Auth | null {
   if (config.apiKeys.has(token)) return { kind: 'admin' };
   const identity = findIdentityByToken(token);
+  return identity ? { kind: 'identity', address: identity.address } : null;
+}
+
+/**
+ * UI session 持久化路径：仅凭 tokenHash 反解 principal（与 resolveUiSessionToken 同范围）。
+ * 重启后内存里不再有明文 token，authenticate 走此入口。
+ */
+export function resolveUiSessionTokenByHash(tokenHash: string): Auth | null {
+  for (const key of config.apiKeys) {
+    if (hashEquals(sha256Hex(key), tokenHash)) return { kind: 'admin' };
+  }
+  const identity = findIdentityByTokenHash(tokenHash);
   return identity ? { kind: 'identity', address: identity.address } : null;
 }
 

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -295,7 +295,15 @@ function hashEquals(a: string, b: string): boolean {
 /** Resolve an identity by its plaintext API token; undefined if no match. */
 export function findIdentityByToken(token: string): Identity | undefined {
   const hash = hashToken(token);
-  return load().find((i) => i.tokenHash && hashEquals(i.tokenHash, hash));
+  return findIdentityByTokenHash(hash);
+}
+
+/**
+ * 按已计算的 SHA-256 hex 反查身份。
+ * 供 UI session 持久化后 authenticate：落盘只存 tokenHash，不再持有明文。
+ */
+export function findIdentityByTokenHash(tokenHash: string): Identity | undefined {
+  return load().find((i) => i.tokenHash && hashEquals(i.tokenHash, tokenHash));
 }
 
 /** Returns the created identity plus its one-time plaintext token, or null if taken. */

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -1,4 +1,14 @@
 import { createHash, randomBytes } from 'node:crypto';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { dirname } from 'node:path';
 import { bodyLimit } from 'hono/body-limit';
 import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
 import { createMiddleware } from 'hono/factory';
@@ -17,14 +27,27 @@ const IP_FAILURE_WINDOW_MS = 5 * 60 * 1000;
 const GLOBAL_FAILURE_WINDOW_MS = 60 * 1000;
 const MAX_IP_FAILURES = 10;
 const MAX_GLOBAL_FAILURES = 60;
+/** authenticate 更新 lastSeenAt 的落盘节流：默认 5 分钟内不重复写盘。 */
+export const LAST_SEEN_PERSIST_INTERVAL_MS = 5 * 60 * 1000;
 
 type Session = {
-  token: string;
+  /** 仅进程内持有；落盘绝不写明文 token。重启后靠 tokenHash 反解。 */
+  token?: string;
   tokenHash: string;
   createdAt: number;
   lastSeenAt: number;
   remembered: boolean;
 };
+
+/** 落盘条目：仅 sidHash → 哈希与时间戳，无 sid/token 原文。 */
+type PersistedSession = {
+  tokenHash: string;
+  createdAt: number;
+  lastSeenAt: number;
+  remembered: boolean;
+};
+
+type PersistedStore = Record<string, PersistedSession>;
 
 type CreateResult =
   | { ok: true; sid: string; auth: Auth; reason?: undefined }
@@ -37,15 +60,27 @@ type CreateResult =
 
 type SessionStoreOptions = {
   resolveToken: (token: string) => Auth | null;
+  /**
+   * 按 tokenHash 反解 principal（持久化会话 authenticate 必用）。
+   * 未提供时：仅进程内带明文 token 的会话可 authenticate（测试常用）。
+   */
+  resolveTokenHash?: (tokenHash: string) => Auth | null;
   maxSessions?: number;
   maxSessionsPerToken?: number;
+  /**
+   * 持久化文件路径。生产由 app.ts 传入 DATA_DIR/ui-sessions.json；
+   * 省略则纯内存（避免测试文件共享 DATA_DIR 时互相污染）。
+   */
+  persistPath?: string;
+  /** lastSeenAt 落盘节流间隔；默认 LAST_SEEN_PERSIST_INTERVAL_MS。 */
+  lastSeenPersistIntervalMs?: number;
 };
 
 function sha256(value: string): string {
   return createHash('sha256').update(value).digest('hex');
 }
 
-function isExpired(session: Session, now: number): boolean {
+function isExpired(session: Pick<Session, 'lastSeenAt' | 'createdAt' | 'remembered'>, now: number): boolean {
   // Remembered sessions ("trust this device") use a single 30-day sliding
   // idle window. There is no extra absolute cap server-side: the persistent
   // cookie's own 30-day Max-Age bounds the lifetime at the browser.
@@ -58,22 +93,48 @@ function isExpired(session: Session, now: number): boolean {
   );
 }
 
+function isPersistedSession(value: unknown): value is PersistedSession {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.tokenHash === 'string' &&
+    typeof row.createdAt === 'number' &&
+    typeof row.lastSeenAt === 'number' &&
+    typeof row.remembered === 'boolean'
+  );
+}
+
+function isPersistedStore(value: unknown): value is PersistedStore {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  return Object.values(value as object).every(isPersistedSession);
+}
+
 export class UiSessionStore {
   private readonly sessions = new Map<string, Session>();
   private readonly ipFailures = new Map<string, number[]>();
   private globalFailures: number[] = [];
   private readonly resolve: (token: string) => Auth | null;
+  private readonly resolveHash: ((tokenHash: string) => Auth | null) | null;
   private readonly maxSessions: number;
   private readonly maxSessionsPerToken: number;
+  private readonly persistPath: string | null;
+  private readonly lastSeenPersistIntervalMs: number;
+  /** 上次因 lastSeenAt 滑动而落盘的时间（按墙钟；节流用）。 */
+  private lastSeenPersistedAt = 0;
 
   constructor(options: SessionStoreOptions) {
     this.resolve = options.resolveToken;
+    this.resolveHash = options.resolveTokenHash ?? null;
     this.maxSessions = options.maxSessions ?? 200;
     this.maxSessionsPerToken = options.maxSessionsPerToken ?? 5;
+    this.persistPath = options.persistPath ?? null;
+    this.lastSeenPersistIntervalMs =
+      options.lastSeenPersistIntervalMs ?? LAST_SEEN_PERSIST_INTERVAL_MS;
+    if (this.persistPath) this.loadFromDisk(Date.now());
   }
 
   create(token: string, ip: string, now = Date.now(), remember = false): CreateResult {
-    this.cleanup(now);
+    const removed = this.cleanup(now);
     token = token.trim();
 
     const ipFailures = this.recentIpFailures(ip, now);
@@ -81,6 +142,7 @@ export class UiSessionStore {
       ipFailures.length >= MAX_IP_FAILURES ||
       this.globalFailures.length >= MAX_GLOBAL_FAILURES
     ) {
+      if (removed) this.persist();
       return { ok: false, reason: 'rate_limited' };
     }
 
@@ -89,6 +151,7 @@ export class UiSessionStore {
       ipFailures.push(now);
       this.ipFailures.set(ip, ipFailures);
       this.globalFailures.push(now);
+      if (removed) this.persist();
       return { ok: false, reason: 'invalid_token' };
     }
 
@@ -104,12 +167,17 @@ export class UiSessionStore {
         oldestPrincipalHash = sidHash;
       }
     }
+    let evicted = false;
     if (principalSessions >= this.maxSessionsPerToken) {
       // The caller just proved they hold this token, so rather than locking
       // them out for hours, drop their own least-recently-used session.
-      if (oldestPrincipalHash) this.sessions.delete(oldestPrincipalHash);
+      if (oldestPrincipalHash) {
+        this.sessions.delete(oldestPrincipalHash);
+        evicted = true;
+      }
     }
     if (this.sessions.size >= this.maxSessions) {
+      if (removed || evicted) this.persist();
       return { ok: false, reason: 'capacity' };
     }
 
@@ -121,6 +189,9 @@ export class UiSessionStore {
       lastSeenAt: now,
       remembered: remember,
     });
+    // create / 驱逐 / 过期清理 → 必落盘；同时重置节流时钟避免紧随的 authenticate 再写一次
+    this.persist();
+    this.lastSeenPersistedAt = now;
     return { ok: true, sid, auth };
   }
 
@@ -131,26 +202,52 @@ export class UiSessionStore {
 
     if (isExpired(session, now)) {
       this.sessions.delete(sidHash);
+      this.persist();
       return null;
     }
 
-    const auth = this.resolve(session.token);
+    const auth = this.resolveSession(session);
     if (!auth) {
       this.sessions.delete(sidHash);
+      this.persist();
       return null;
     }
 
     session.lastSeenAt = now;
+    // 节流：lastSeenAt 滑动不每请求写盘；间隔到了才落盘。
+    if (now - this.lastSeenPersistedAt >= this.lastSeenPersistIntervalMs) {
+      this.persist();
+      this.lastSeenPersistedAt = now;
+    }
     return { auth };
   }
 
   destroy(sid: string): void {
-    this.sessions.delete(sha256(sid));
+    const sidHash = sha256(sid);
+    if (!this.sessions.has(sidHash)) return;
+    this.sessions.delete(sidHash);
+    this.persist();
   }
 
-  private cleanup(now: number): void {
+  /** 测试辅助：当前内存会话数。 */
+  sizeForTests(): number {
+    return this.sessions.size;
+  }
+
+  private resolveSession(session: Session): Auth | null {
+    if (session.token !== undefined) return this.resolve(session.token);
+    if (this.resolveHash) return this.resolveHash(session.tokenHash);
+    return null;
+  }
+
+  /** @returns 是否删除了过期会话（调用方据此决定是否落盘）。 */
+  private cleanup(now: number): boolean {
+    let removed = false;
     for (const [sidHash, session] of this.sessions) {
-      if (isExpired(session, now)) this.sessions.delete(sidHash);
+      if (isExpired(session, now)) {
+        this.sessions.delete(sidHash);
+        removed = true;
+      }
     }
 
     this.globalFailures = this.globalFailures.filter(
@@ -163,6 +260,7 @@ export class UiSessionStore {
       if (recent.length === 0) this.ipFailures.delete(ip);
       else this.ipFailures.set(ip, recent);
     }
+    return removed;
   }
 
   private recentIpFailures(ip: string, now: number): number[] {
@@ -172,6 +270,73 @@ export class UiSessionStore {
     if (recent.length === 0) this.ipFailures.delete(ip);
     else this.ipFailures.set(ip, recent);
     return recent;
+  }
+
+  private loadFromDisk(now: number): void {
+    const path = this.persistPath;
+    if (!path || !existsSync(path)) return;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(readFileSync(path, 'utf8'));
+    } catch {
+      throw new Error('ui_session_store_corrupt');
+    }
+    if (!isPersistedStore(parsed)) {
+      throw new Error('ui_session_store_corrupt');
+    }
+
+    let pruned = false;
+    for (const [sidHash, row] of Object.entries(parsed)) {
+      if (isExpired(row, now)) {
+        pruned = true;
+        continue;
+      }
+      // 重启后无明文 token；authenticate 走 resolveTokenHash
+      this.sessions.set(sidHash, {
+        tokenHash: row.tokenHash,
+        createdAt: row.createdAt,
+        lastSeenAt: row.lastSeenAt,
+        remembered: row.remembered,
+      });
+    }
+    if (pruned) this.persist();
+    // 启动加载后的首批 authenticate 不必立刻再写盘
+    this.lastSeenPersistedAt = now;
+  }
+
+  private persist(): void {
+    const path = this.persistPath;
+    if (!path) return;
+
+    const data: PersistedStore = {};
+    for (const [sidHash, session] of this.sessions) {
+      data[sidHash] = {
+        tokenHash: session.tokenHash,
+        createdAt: session.createdAt,
+        lastSeenAt: session.lastSeenAt,
+        remembered: session.remembered,
+      };
+    }
+
+    const dir = dirname(path);
+    mkdirSync(dir, { recursive: true, mode: 0o700 });
+    try {
+      chmodSync(dir, 0o700);
+    } catch {
+      // bind mount 可能属主不同；文件 mode 仍会设置
+    }
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, JSON.stringify(data, null, 2), { mode: 0o600 });
+    chmodSync(tmp, 0o600);
+    renameSync(tmp, path);
+    try {
+      // rename 后目标文件 mode 可能继承旧 inode；再钉一次 0600
+      if (existsSync(path) && (statSync(path).mode & 0o777) !== 0o600) {
+        chmodSync(path, 0o600);
+      }
+    } catch {
+      // best effort
+    }
   }
 }
 

--- a/packages/api/test/ui-session.test.ts
+++ b/packages/api/test/ui-session.test.ts
@@ -1,5 +1,6 @@
 // config.ts 在 import 时解析 env；裸 env 单跑会 ZodError/TDZ。套件标准前奏。
-import { mkdtempSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -25,8 +26,18 @@ const {
   requireUiOrigin,
 } = await import('../src/lib/ui-session.ts');
 
+const adminToken = 'valid-admin';
+const adminTokenHash = createHash('sha256').update(adminToken).digest('hex');
+
 const adminResolver = (token: string): Auth | null =>
-  token === 'valid-admin' ? { kind: 'admin' } : null;
+  token === adminToken ? { kind: 'admin' } : null;
+
+const adminHashResolver = (tokenHash: string): Auth | null =>
+  tokenHash === adminTokenHash ? { kind: 'admin' } : null;
+
+function sha256Hex(value: string): string {
+  return createHash('sha256').update(value).digest('hex');
+}
 
 function makeApp(store: UiSessionStoreT = new UiSessionStore({ resolveToken: adminResolver })) {
   const app = new Hono();
@@ -209,5 +220,279 @@ describe('UI session cookie', () => {
     if (!rotated.ok) throw new Error('expected a session');
     tokenValid = false;
     expect(store.authenticate(rotated.sid, 2)).toBeNull();
+  });
+});
+
+describe('UI session persistence', () => {
+  test('create → 落盘 → 新 store 加载后 authenticate 命中（tokenHash 反解）', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-persist-'));
+    const path = join(dir, 'ui-sessions.json');
+    // 落盘时间戳须接近墙钟：构造加载用 Date.now()，过旧会被当过期清掉
+    const t0 = Date.now();
+    const storeA = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const created = storeA.create(adminToken, '127.0.0.1', t0, true);
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('expected a session');
+
+    const storeB = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const auth = storeB.authenticate(created.sid, t0 + 60_000);
+    expect(auth).not.toBeNull();
+    expect(auth?.auth).toEqual({ kind: 'admin' });
+  });
+
+  test('落盘文件不含 raw token / sid，且权限为 0600', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-mode-'));
+    const path = join(dir, 'ui-sessions.json');
+    const store = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const created = store.create(adminToken, '127.0.0.1', Date.now(), true);
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('expected a session');
+
+    const raw = readFileSync(path, 'utf8');
+    // 真实明文不得出现在落盘文件中
+    expect(raw).not.toContain(adminToken);
+    expect(raw).not.toContain(created.sid);
+    expect(raw).toContain(adminTokenHash);
+    expect(raw).toContain(sha256Hex(created.sid));
+
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test('重启后 remembered 30d 滑动仍有效；非 remembered 仍受 24h absolute 约束', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-remember-'));
+    const path = join(dir, 'ui-sessions.json');
+    const t0 = Date.now();
+    const writer = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const live = writer.create(adminToken, '127.0.0.1', t0, true);
+    const stale = writer.create(adminToken, '127.0.0.2', t0, false);
+    expect(live.ok && stale.ok).toBe(true);
+    if (!live.ok || !stale.ok) throw new Error('expected sessions');
+
+    // 模拟 api 重启：新 store 从同一文件加载（无明文 token）
+    const reloaded = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    // remembered：越过默认 12h/24h 仍存活
+    expect(reloaded.authenticate(live.sid, t0 + 25 * 60 * 60 * 1000)).not.toBeNull();
+    // 非 remembered：24h absolute 到期
+    expect(reloaded.authenticate(stale.sid, t0 + 25 * 60 * 60 * 1000)).toBeNull();
+  });
+
+  test('过期条目在启动加载时清除并写回磁盘', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-loadprune-'));
+    const path = join(dir, 'ui-sessions.json');
+    const seed = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const old = seed.create(adminToken, '127.0.0.1', 0, true);
+    expect(old.ok).toBe(true);
+    if (!old.ok) throw new Error('expected a session');
+
+    // lastSeenAt=0 + remembered → 自 epoch 起已远超 30d，Date.now() 加载即过期
+    const disk = JSON.parse(readFileSync(path, 'utf8')) as Record<
+      string,
+      { tokenHash: string; createdAt: number; lastSeenAt: number; remembered: boolean }
+    >;
+    for (const row of Object.values(disk)) {
+      row.lastSeenAt = 0;
+      row.createdAt = 0;
+    }
+    writeFileSync(path, JSON.stringify(disk, null, 2));
+
+    const pruned = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    expect(pruned.sizeForTests()).toBe(0);
+    expect(pruned.authenticate(old.sid, Date.now())).toBeNull();
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({});
+  });
+
+  test('lastSeenAt 节流：间隔内不落盘，越过间隔才写', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-throttle-'));
+    const path = join(dir, 'ui-sessions.json');
+    const interval = 60_000;
+    const t0 = Date.now();
+    const store = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+      lastSeenPersistIntervalMs: interval,
+    });
+    const created = store.create(adminToken, '127.0.0.1', t0, true);
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('expected a session');
+
+    const afterCreate = readFileSync(path, 'utf8');
+    expect(store.authenticate(created.sid, t0 + 1_000)).not.toBeNull();
+    expect(readFileSync(path, 'utf8')).toBe(afterCreate); // 节流内未写
+
+    expect(store.authenticate(created.sid, t0 + interval)).not.toBeNull();
+    const afterThrottle = readFileSync(path, 'utf8');
+    expect(afterThrottle).not.toBe(afterCreate);
+    expect(afterThrottle).toContain(`"lastSeenAt": ${t0 + interval}`);
+  });
+
+  test('持久化后 LRU / 容量语义不变', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-lru-'));
+    const path = join(dir, 'ui-sessions.json');
+    const t0 = Date.now();
+    const store = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+      maxSessions: 3,
+      maxSessionsPerToken: 2,
+    });
+    const a = store.create(adminToken, '127.0.0.1', t0);
+    const b = store.create(adminToken, '127.0.0.2', t0 + 1);
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) throw new Error('expected sessions');
+    // 同 principal 第 3 个：驱逐最旧 a
+    const c = store.create(adminToken, '127.0.0.3', t0 + 2);
+    expect(c.ok).toBe(true);
+    expect(store.authenticate(a.sid, t0 + 3)).toBeNull();
+    expect(store.authenticate(b.sid, t0 + 3)).not.toBeNull();
+
+    // 重启后容量/驱逐结果仍在盘上
+    const reloaded = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+      maxSessions: 3,
+      maxSessionsPerToken: 2,
+    });
+    expect(reloaded.sizeForTests()).toBe(2);
+    expect(reloaded.authenticate(a.sid, t0 + 4)).toBeNull();
+    expect(reloaded.authenticate(b.sid, t0 + 4)).not.toBeNull();
+    if (!c.ok) throw new Error('expected c');
+    expect(reloaded.authenticate(c.sid, t0 + 4)).not.toBeNull();
+  });
+
+  test('destroy 必落盘；缺 resolveTokenHash 时重启后无法 authenticate', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-destroy-'));
+    const path = join(dir, 'ui-sessions.json');
+    const t0 = Date.now();
+    const store = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const created = store.create(adminToken, '127.0.0.1', t0);
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('expected a session');
+    store.destroy(created.sid);
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({});
+
+    const again = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    const live = again.create(adminToken, '127.0.0.1', t0 + 1_000);
+    expect(live.ok).toBe(true);
+    if (!live.ok) throw new Error('expected a session');
+
+    const noHash = new UiSessionStore({
+      resolveToken: adminResolver,
+      persistPath: path,
+    });
+    expect(noHash.authenticate(live.sid, t0 + 1_001)).toBeNull();
+  });
+
+  test('损坏的 ui-sessions.json fail-closed：抛错且不装入空库冒充成功', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-corrupt-'));
+    const path = join(dir, 'ui-sessions.json');
+    writeFileSync(path, '{not-json', { mode: 0o600 });
+    expect(
+      () =>
+        new UiSessionStore({
+          resolveToken: adminResolver,
+          resolveTokenHash: adminHashResolver,
+          persistPath: path,
+        }),
+    ).toThrow('ui_session_store_corrupt');
+
+    writeFileSync(path, JSON.stringify({ bad: { tokenHash: 1 } }, null, 2), { mode: 0o600 });
+    expect(
+      () =>
+        new UiSessionStore({
+          resolveToken: adminResolver,
+          resolveTokenHash: adminHashResolver,
+          persistPath: path,
+        }),
+    ).toThrow('ui_session_store_corrupt');
+  });
+
+  test('生产 resolveUiSessionTokenByHash：identity 命中；OAuth access hash 永不命中', async () => {
+    const { createIdentity } = await import('../src/lib/identities.ts');
+    const { resolveUiSessionToken, resolveUiSessionTokenByHash } = await import(
+      '../src/lib/auth.ts'
+    );
+    const { putAccessTokenForTests } = await import('../src/lib/oauth-store.ts');
+
+    const issued = createIdentity({ localpart: 'ui-sess-hash' })!;
+    const idHash = sha256Hex(issued.token);
+    expect(resolveUiSessionTokenByHash(idHash)).toEqual({
+      kind: 'identity',
+      address: 'ui-sess-hash@test.example',
+    });
+    expect(resolveUiSessionTokenByHash(sha256Hex('admin-key'))).toEqual({ kind: 'admin' });
+
+    const oauthTok = 'ui-sess-byhash-must-reject-oauth!!!!';
+    putAccessTokenForTests({
+      token: oauthTok,
+      grantId: 'g-ui-sess-byhash',
+      address: 'ui-sess-hash@test.example',
+      aud: 'http://localhost/mcp',
+      expiresAt: Date.now() + 60_000,
+      ensureGrant: { clientId: 'http://client.test/cid', clientName: 'X' },
+    });
+    // 与明文入口一致：即便 OAuth access 行存在，UI session ByHash 也不认
+    expect(resolveUiSessionToken(oauthTok)).toBeNull();
+    expect(resolveUiSessionTokenByHash(sha256Hex(oauthTok))).toBeNull();
+
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-id-'));
+    const path = join(dir, 'ui-sessions.json');
+    const t0 = Date.now();
+    const storeA = new UiSessionStore({
+      resolveToken: resolveUiSessionToken,
+      resolveTokenHash: resolveUiSessionTokenByHash,
+      persistPath: path,
+    });
+    const created = storeA.create(issued.token, '127.0.0.1', t0, true);
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('expected a session');
+    const storeB = new UiSessionStore({
+      resolveToken: resolveUiSessionToken,
+      resolveTokenHash: resolveUiSessionTokenByHash,
+      persistPath: path,
+    });
+    expect(storeB.authenticate(created.sid, t0 + 1_000)?.auth).toEqual({
+      kind: 'identity',
+      address: 'ui-sess-hash@test.example',
+    });
   });
 });


### PR DESCRIPTION
## Summary

- **根因一句话：** Dashboard「Trust this device for 30 days」的 cookie/remember 链路本身完全正确（生产实测 `Max-Age=2592000; Path=/ui; HttpOnly; Secure; SameSite=Strict`），但 `UiSessionStore` 是纯内存 `Map`——api 容器每次重建/重启都清空全部会话。该功能自 cf4397e（07-28）上线两周恰逢合并高发期，用户隔天回来必然已跨过至少一次重建，所以「从未被记住」。
- 将 UI session 持久化到 `DATA_DIR/ui-sessions.json`（单写者、tmp+rename 原子写、0600），只存 `sidHash → { tokenHash, createdAt, lastSeenAt, remembered }`——**raw token / sid 原文绝不落盘**（测试含明文凭据 grep 断言）。
- 新增 `resolveUiSessionTokenByHash`（admin API keys + identity，**永不查 OAuth**，与 `resolveUiSessionToken` 同范围）；重启后落盘会话无明文 token，authenticate 按 hash 反解 principal。
- `authenticate` 的 lastSeenAt 滑动默认 5 分钟节流写盘（store 级时钟）；create / destroy / 过期清理 / 启动 prune 必落盘。最坏崩溃丢 ≤5 分钟滑动窗口，远小于「整库随重启清空」。
- 行为不变量全部保持：容量上限 / LRU 驱逐、remembered=30d 滑动、非 remember 的浏览器会话 cookie 语义（关浏览器仍需重登）、cookie 属性不动。
- 损坏文件 fail-closed：启动抛 `ui_session_store_corrupt`，不当空库写回（对齐 identities/oauth 姿态）。

## Test plan

- [x] \cd packages/api && bun test` → **626 pass**（基线 617 + 新增 9），typecheck 新增错误 = 0
- [x] 持久化 round-trip / 0600 / 无明文断言 / 加载 prune / 节流边界 / LRU 回归 / corrupt fail-closed / identity ByHash + OAuth 永不命中
- [ ] dogfood：勾 Trust-30d 登录 → 重建 api 容器 → 同浏览器 cookie 仍可进 Dashboard；不勾 Trust → 关闭重开需重输（对照）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UI sessions now persist across application restarts.
  * Session tokens are stored securely as hashes rather than plaintext.
  * Expired sessions are automatically removed, with improved session and rate-limit state handling.
  * Session data is protected with validated storage, secure file permissions, and atomic updates.

* **Bug Fixes**
  * Improved authentication reliability after restarts.
  * Added safer handling for missing or corrupted session data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->