### PR TITLE
fix: health pass — ntfy timeout, ui-session persist, MCP schema (closes #9 #22 #23)

### DIFF
--- a/Progress.md
+++ b/Progress.md
@@ -1000,4 +1000,28 @@ PR：https://github.com/openagentemail/openagentemail/pull/31
 
 1. 无需修生产码。对齐 `ui-device-load` 的 `new Function` 假 DOM 模式，把呈现钉在可执行断言上，而不是只 `toContain` 源码字符串。
 
+---
+
+## 健康小单 #9 / #22 / #23（2026-08-13）
+
+日期：2026-08-13  
+分支：`tizerluo/worker-34-health`（基线 `94566013`；禁动 main；禁止自 merge）
+
+### 我们实现了哪些功能？
+
+1. **#9：** `NtfyNotificationService.messages()` 复用 `ntfyFetch` 8s 超时；header 与 body 超时都映射 `NotifyError('notify_unavailable')`。/v1 与 /ui 共享。
+2. **#22：** 无文件的 `loadFromDisk` 也设 `lastSeenPersistedAt`；启动删 `ui-sessions.json.tmp`；`docs/security.md` / README / 注释声明 DATA_DIR 单写者。
+3. **#23：** 共享 MCP summary schema 钉 `source`/`hasOtp`（description 补 hasOtp）；detail 仍不含 seen/snippet。发版 tag 不在本单。
+4. `packages/api bun test` **820 pass**；`packages/mcp bun test` **23 pass**；两边 `bun run build` 全绿。无 UI 改动。
+
+### 我们遇到了哪些错误？
+
+1. 全量套件里 `config.ntfy.enabled` 可能已被别的文件关掉，单测 `messages()` 得到 `notifications_disabled`。测试里显式打开并还原。
+2. 独立自审 P1：Bun 上 `fetch()` 在 header 到达后 resolve，卡住的 NDJSON body 让 `response.text()` 抛超时，原先只包了 fetch → 500。
+
+### 我们是如何解决这些错误的？
+
+1. 超时测试 `Object.assign(config.ntfy, { enabled: true, adminPassword })`，`finally` 还原。
+2. `fetch` / `!ok` / `response.text()` 同一 try，`notifyFetchFailed` 映射；补 body 超时测试。复审 mergeable。
+
 

--- a/RECEIPT-health.md
+++ b/RECEIPT-health.md
@@ -1,0 +1,30 @@
+# RECEIPT — health 小单（#9 / #22 / #23）
+
+日期：2026-08-13  
+分支：`tizerluo/worker-34-health`（基线 `origin/main` `94566013`）  
+禁动 main，禁止自 merge。无 /ui 行为变化，未拍屏。
+
+## 对账
+
+| Issue | 处置 | 证据 / 测试名 |
+|---|---|---|
+| **#9** ntfy `messages()` 无超时 | **fixed** | `messages()` 走 `ntfyFetch`（`NTFY_ADMIN_FETCH_TIMEOUT_MS=8000`）。`fetch` 与 `response.text()` 同一 try，超时/网络失败 → `NotifyError('notify_unavailable')`。`/v1` 与 `/ui` 共用本方法。测试：`messages() fetch timeout maps to NotifyError notify_unavailable`；`messages() body read timeout maps to NotifyError notify_unavailable` |
+| **#22.1** `lastSeenPersistedAt` 文件不存在分支 | **fixed** | `loadFromDisk` 无文件也 `this.lastSeenPersistedAt = now`。测试：`文件不存在的 loadFromDisk 也设置 lastSeenPersistedAt`；`不走 create：从磁盘加载后间隔内 authenticate 不落盘` |
+| **#22.2** 启动清 `.tmp` | **fixed** | `discardStaleTmp`：`loadFromDisk` 开头 `unlinkSync(path + '.tmp')`，失败不阻断启动。测试：`启动时清理 ui-sessions.json.tmp 残留` |
+| **#22.3** DATA_DIR 单写者声明 | **fixed** | `docs/security.md` 新节「DATA_DIR 单写者约定」；`packages/api/README.md` `DATA_DIR` 行；`ui-session.ts` `persistPath` 注释 |
+| **#23** mcp outputSchema | **fixed**（发版 tag 不在本单） | 共享 `packages/api/src/mcp/tools.ts`（stdio 入口已复用）。summary 含 `source`/`hasOtp`（description 补 `hasOtp`）；detail 不含 `seen`/`snippet`/`hasOtp`。测试：`message summary/detail 输出 schema 按 API 真实形状校验并保留字段`（缺 `source`/`hasOtp` fail；detail `readOut.seen/snippet/hasOtp` 为 undefined） |
+
+`cd packages/api && bun test`：**820 pass / 0 fail**；`bun run build`：Bundled 568 modules。  
+`cd packages/mcp && bun test`：**23 pass / 0 fail**；`bun run build`：Bundled 174 modules。
+
+## 独立自审
+
+| 轮 | agent id | 结论 | 过程 |
+|---|---|---|---|
+| 初审 | `26b44d5e-fdcf-46a1-bba1-e12230fdbd03` | **block**；P0=0 P1=1 P2=0 | 对照 `94566013` 未提交 diff。#22/#23 对齐。#9 P1：Bun 上 header 已到时 `fetch()` resolve，`response.text()` 超时抛 `TimeoutError`，当时不在 try 内 → 路由非 NotifyError → 500 |
+| 复审（仅 P1） | 同上 resume | **mergeable**；剩余 P0/P1=0 | `fetch` + `ok` + `text()` 同一 try；新测试 `messages() body read timeout maps to NotifyError notify_unavailable` 真跑 harness。未改文件 |
+
+## 未做
+
+- `@openagentemail/mcp` npm 发版 / tag（#23 原文：下次发版消化，归业主拍板）
+- 网站 docs 镜像 `docs/security.md` 新节（security.md 顶部已注明 canonical 在 website repo）

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,6 +20,10 @@ retention window before reusing one.
 <!-- Canonical copy lives in the website repo (src/content/docs/docs/); mirror
      this note there when publishing. -->
 
+## DATA_DIR 单写者约定
+
+`DATA_DIR` 下所有 store（`identities.json` / `oauth.json` / `audit.jsonl` / `ui-sessions.json`，以及 `sent-registry.json` / `notification-log.jsonl` / `notification-devices.json`）均为**单写者**设计：进程内串行、tmp+rename、文件 0600 / 目录 0700。**不支持**多容器或多进程共享同一 `DATA_DIR`。
+
 ## Inbox identity ACL（#26 PR 2）
 
 Catch-all 信箱里，身份之间的读边界是**精确整邮箱**匹配（禁止子串）。

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -34,7 +34,7 @@ bun run typecheck
 | `IMAP_TLS` | `true` | `false` for plaintext/STARTTLS (143) |
 | `SMTP_HOST/PORT/USER/PASS` | `127.0.0.1:587` | catch-all account; From is rewritten to the identity |
 | `ALLOWED_SEND_DOMAINS` | `DOMAIN` | comma list of allowed `from` domains |
-| `DATA_DIR` | `./data` | identity store (`identities.json`); sent registry (`sent-registry.json`); notification log (`notification-log.jsonl`, 30-day delivery audit, 0600, single writer); paired devices (`notification-devices.json`, 0600, single writer, never stores password/token) |
+| `DATA_DIR` | `./data` | 全部 store 单写者，不支持多容器共享（identities / oauth / audit / ui-sessions / sent-registry / notification-log / notification-devices；0600）。 |
 
 ## Endpoints
 

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -413,14 +413,20 @@ function basic(user: string, password: string): Record<string, string> {
   return { Authorization: `Basic ${Buffer.from(`${user}:${password}`).toString('base64')}` };
 }
 
-/** 管理面 ntfy fetch 超时，避免 delete 挂死设备 registry 队列。 */
-const NTFY_ADMIN_FETCH_TIMEOUT_MS = 8_000;
+/** 管理面 ntfy fetch 超时（含 messages() 缓存读），避免假死实例把 /v1 与 /ui 挂住。 */
+export const NTFY_ADMIN_FETCH_TIMEOUT_MS = 8_000;
 
 async function ntfyFetch(path: string, init: RequestInit): Promise<Response> {
   return fetch(providerUrl(path), {
     ...init,
     signal: AbortSignal.timeout(NTFY_ADMIN_FETCH_TIMEOUT_MS),
   });
+}
+
+/** fetch 超时 / 网络失败统一成现有 NotifyError，避免未捕获 AbortError 变成 500。 */
+function notifyFetchFailed(err: unknown): NotifyError {
+  if (err instanceof NotifyError) return err;
+  return new NotifyError('notify_unavailable');
 }
 
 async function ntfyAdminJson(path: string, body: unknown): Promise<Response> {
@@ -895,11 +901,16 @@ export class NtfyNotificationService implements NotifyService {
     const adminPassword = config.ntfy.adminPassword!;
     const query = new URLSearchParams({ poll: '1' });
     if (since) query.set('since', since);
-    const response = await fetch(providerUrl(`/${encodeURIComponent(physical)}/json?${query.toString()}`), {
-      headers: basic('admin', adminPassword),
-    });
-    if (!response.ok) throw new NotifyError('notify_unavailable');
-    return parseMessages(await response.text());
+    try {
+      // 与管理面 ntfyFetch 同一 8s 超时；header 与 body 阶段都要映射，避免 500。
+      const response = await ntfyFetch(`/${encodeURIComponent(physical)}/json?${query.toString()}`, {
+        headers: basic('admin', adminPassword),
+      });
+      if (!response.ok) throw new NotifyError('notify_unavailable');
+      return parseMessages(await response.text());
+    } catch (err) {
+      throw notifyFetchFailed(err);
+    }
   }
 
   async verify(): Promise<{ ok: true }> {

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -6,6 +6,7 @@ import {
   readFileSync,
   renameSync,
   statSync,
+  unlinkSync,
   writeFileSync,
 } from 'node:fs';
 import { dirname } from 'node:path';
@@ -70,6 +71,7 @@ type SessionStoreOptions = {
   /**
    * 持久化文件路径。生产由 app.ts 传入 DATA_DIR/ui-sessions.json；
    * 省略则纯内存（避免测试文件共享 DATA_DIR 时互相污染）。
+   * DATA_DIR 下本 store 与 identities/oauth/audit 等均为单写者，不支持多容器共享。
    */
   persistPath?: string;
   /** lastSeenAt 落盘节流间隔；默认 LAST_SEEN_PERSIST_INTERVAL_MS。 */
@@ -234,6 +236,11 @@ export class UiSessionStore {
     return this.sessions.size;
   }
 
+  /** 测试辅助：lastSeen 落盘节流时钟（墙钟 ms）。 */
+  lastSeenPersistedAtForTests(): number {
+    return this.lastSeenPersistedAt;
+  }
+
   private resolveSession(session: Session): Auth | null {
     if (session.token !== undefined) return this.resolve(session.token);
     if (this.resolveHash) return this.resolveHash(session.tokenHash);
@@ -272,9 +279,26 @@ export class UiSessionStore {
     return recent;
   }
 
+  /** 进程在 write/rename 之间被杀会留 .tmp；启动时顺手删掉（无明文、无安全影响）。 */
+  private discardStaleTmp(path: string): void {
+    const tmp = `${path}.tmp`;
+    if (!existsSync(tmp)) return;
+    try {
+      unlinkSync(tmp);
+    } catch {
+      // best effort：删不掉不得阻断启动
+    }
+  }
+
   private loadFromDisk(now: number): void {
     const path = this.persistPath;
-    if (!path || !existsSync(path)) return;
+    if (!path) return;
+    this.discardStaleTmp(path);
+    // 文件不存在也要钉节流时钟，否则随后 authenticate 会因 lastSeenPersistedAt=0 立刻写盘
+    if (!existsSync(path)) {
+      this.lastSeenPersistedAt = now;
+      return;
+    }
     let parsed: unknown;
     try {
       parsed = JSON.parse(readFileSync(path, 'utf8'));

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -274,7 +274,7 @@ export function registerOpenAgentEmailTools(
     {
       title: "List Email Messages",
       description:
-        "List messages received by an identity address (newest first), with id/from/to/subject/date/seen/snippet/source." +
+        "List messages received by an identity address (newest first), with id/from/to/subject/date/seen/snippet/hasOtp/source." +
         UNTRUSTED_CONTENT_DESCRIPTION +
         " Non-internal snippets are fenced with the same UNTRUSTED EXTERNAL EMAIL markers as full bodies.",
       inputSchema: {

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -31,6 +31,7 @@ const {
   listNotificationDevices,
   notifyAvailableMessageBytes,
   NotifyError,
+  NTFY_ADMIN_FETCH_TIMEOUT_MS,
   NTFY_REQUEST_MAX_BYTES,
   NtfyNotificationService,
   physicalAgentTopic,
@@ -1518,6 +1519,79 @@ describe('device list and revoke (Bearer)', () => {
         message: expect.stringContaining('Restore ntfy admin access'),
       });
       expect((await listPairedDevices())[0]?.revokeStatus).toBe('active');
+    } finally {
+      Object.assign(config.ntfy, previousNtfy);
+    }
+  });
+});
+
+describe('NtfyNotificationService.messages timeout (#9)', () => {
+  test('messages() fetch timeout maps to NotifyError notify_unavailable', async () => {
+    const previousNtfy = { ...config.ntfy };
+    Object.assign(config.ntfy as { enabled: boolean; adminPassword?: string }, {
+      enabled: true,
+      adminPassword: 'ntfy-admin-secret',
+    });
+
+    const timeoutMs: number[] = [];
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    AbortSignal.timeout = ((ms: number) => {
+      timeoutMs.push(ms);
+      const controller = new AbortController();
+      controller.abort(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+      return controller.signal;
+    }) as typeof AbortSignal.timeout;
+
+    globalThis.fetch = (async (_input, init) => {
+      const signal = init?.signal;
+      if (signal?.aborted) {
+        throw signal.reason ?? new DOMException('The operation was aborted.', 'AbortError');
+      }
+      throw new Error('messages() must pass an already-aborted timeout signal');
+    }) as typeof fetch;
+
+    try {
+      const svc = new NtfyNotificationService();
+      let caught: unknown;
+      try {
+        await svc.messages('user-alerts');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(NotifyError);
+      expect(caught).toMatchObject({ code: 'notify_unavailable' } satisfies Partial<NotifyError>);
+      expect(timeoutMs).toEqual([NTFY_ADMIN_FETCH_TIMEOUT_MS]);
+    } finally {
+      AbortSignal.timeout = originalTimeout;
+      Object.assign(config.ntfy, previousNtfy);
+    }
+  });
+
+  test('messages() body read timeout maps to NotifyError notify_unavailable', async () => {
+    const previousNtfy = { ...config.ntfy };
+    Object.assign(config.ntfy as { enabled: boolean; adminPassword?: string }, {
+      enabled: true,
+      adminPassword: 'ntfy-admin-secret',
+    });
+
+    globalThis.fetch = (async () =>
+      ({
+        ok: true,
+        async text() {
+          throw new DOMException('The operation was aborted due to timeout', 'TimeoutError');
+        },
+      }) as Response) as typeof fetch;
+
+    try {
+      const svc = new NtfyNotificationService();
+      let caught: unknown;
+      try {
+        await svc.messages('user-alerts');
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(NotifyError);
+      expect(caught).toMatchObject({ code: 'notify_unavailable' } satisfies Partial<NotifyError>);
     } finally {
       Object.assign(config.ntfy, previousNtfy);
     }

--- a/packages/api/test/ui-session.test.ts
+++ b/packages/api/test/ui-session.test.ts
@@ -1,6 +1,6 @@
 // config.ts 在 import 时解析 env；裸 env 单跑会 ZodError/TDZ。套件标准前奏。
 import { createHash } from 'node:crypto';
-import { mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -353,6 +353,61 @@ describe('UI session persistence', () => {
     const afterThrottle = readFileSync(path, 'utf8');
     expect(afterThrottle).not.toBe(afterCreate);
     expect(afterThrottle).toContain(`"lastSeenAt": ${t0 + interval}`);
+  });
+
+  test('文件不存在的 loadFromDisk 也设置 lastSeenPersistedAt', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-missing-'));
+    const path = join(dir, 'ui-sessions.json');
+    expect(existsSync(path)).toBe(false);
+    const store = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    expect(store.lastSeenPersistedAtForTests()).toBeGreaterThan(0);
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test('不走 create：从磁盘加载后间隔内 authenticate 不落盘', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-reload-throttle-'));
+    const path = join(dir, 'ui-sessions.json');
+    const interval = 60_000;
+    const t0 = Date.now();
+    const writer = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+      lastSeenPersistIntervalMs: interval,
+    });
+    const created = writer.create(adminToken, '127.0.0.1', t0, true);
+    expect(created.ok).toBe(true);
+    if (!created.ok) throw new Error('expected a session');
+    const afterCreate = readFileSync(path, 'utf8');
+
+    // 新 store 只 loadFromDisk，不走 create；节流时钟应已钉住
+    const reloaded = new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+      lastSeenPersistIntervalMs: interval,
+    });
+    expect(reloaded.lastSeenPersistedAtForTests()).toBeGreaterThan(0);
+    expect(reloaded.authenticate(created.sid, t0 + 1_000)).not.toBeNull();
+    expect(readFileSync(path, 'utf8')).toBe(afterCreate);
+  });
+
+  test('启动时清理 ui-sessions.json.tmp 残留', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'oae-ui-sess-tmp-'));
+    const path = join(dir, 'ui-sessions.json');
+    const tmp = `${path}.tmp`;
+    writeFileSync(tmp, '{"stale":true}', { mode: 0o600 });
+    expect(existsSync(tmp)).toBe(true);
+    new UiSessionStore({
+      resolveToken: adminResolver,
+      resolveTokenHash: adminHashResolver,
+      persistPath: path,
+    });
+    expect(existsSync(tmp)).toBe(false);
   });
 
   test('持久化后 LRU / 容量语义不变', () => {

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -96,6 +96,8 @@ test("读信类工具带 untrustedContentHint，description 钉死 fail-closed �
   // F1：snippet 已围栏，不得再声称 not fenced。
   expect(listDesc).not.toContain("Snippets are not fenced");
   expect(listDesc).toContain("Non-internal snippets are fenced");
+  expect(listDesc).toContain("hasOtp");
+  expect(listDesc).toContain("source");
   // 非读信工具不应误标。
   expect(toolConfigs.get("mail_send")?.annotations?.untrustedContentHint).toBeUndefined();
 });
@@ -222,6 +224,13 @@ test("message summary/detail 输出 schema 按 API 真实形状校验并保留�
   };
   const listParsed = listMessages.safeParse([summary]);
   expect(listParsed.success).toBe(true);
+  // 缺 source / hasOtp 必须失败——严格客户端靠 advertised schema 认字段，不能当 additional。
+  const { source: _source, hasOtp: _hasOtp, ...summaryWithoutSourceOtp } = summary;
+  expect(listMessages.safeParse([summaryWithoutSourceOtp]).success).toBe(false);
+  expect(listMessages.safeParse([{ ...summaryWithoutSourceOtp, source: "external" }]).success).toBe(
+    false,
+  );
+  expect(listMessages.safeParse([{ ...summaryWithoutSourceOtp, hasOtp: true }]).success).toBe(false);
   if (listParsed.success) {
     const rows = listParsed.data as MessageSummary[];
     expect(rows[0]?.hasOtp).toBe(true);


### PR DESCRIPTION
## Summary
- **#9:** `NtfyNotificationService.messages()` uses the existing 8s `ntfyFetch` timeout; header and body timeouts map to `NotifyError('notify_unavailable')` so `/v1` and `/ui` no longer hang or 500.
- **#22:** missing `ui-sessions.json` still sets `lastSeenPersistedAt`; boot deletes leftover `.tmp`; `DATA_DIR` single-writer is declared in `docs/security.md` / README / comments.
- **#23:** shared MCP summary schema pins `source`/`hasOtp`; detail stays list-only (no `seen`/`snippet`). npm publish tag is out of scope.

closes #9
closes #22
closes #23

## Test plan
- [x] `cd packages/api && bun test` (820 pass) + `bun run build`
- [x] `cd packages/mcp && bun test` (23 pass) + `bun run build`
- [x] `messages() fetch timeout maps to NotifyError notify_unavailable`
- [x] `messages() body read timeout maps to NotifyError notify_unavailable`
- [x] `文件不存在的 loadFromDisk 也设置 lastSeenPersistedAt`
- [x] `不走 create：从磁盘加载后间隔内 authenticate 不落盘`
- [x] `启动时清理 ui-sessions.json.tmp 残留`
- [x] MCP `message summary/detail 输出 schema 按 API 真实形状校验并保留字段`
- [ ] CI / CodeRabbit / Codex Local / ZCode 终审（指挥）


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification reliability by handling request, response, and body-read timeouts consistently.
  - Cleaned up stale session temporary files during startup and preserved persistence throttling behavior.
  - Clarified single-writer storage behavior and secure file permissions.

- **Documentation**
  - Added security and configuration guidance for persistent storage.
  - Documented notification and session maintenance updates.
  - Clarified that message listings include OTP availability and source details.

- **Tests**
  - Added coverage for notification timeouts, session recovery, temporary-file cleanup, and message output requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->