### PR TITLE
fix(api): disable Bun.serve idleTimeout so MCP wait_for is not cut at 10s

### DIFF
--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -42,10 +42,37 @@ if (config.ntfy.enabled) {
 
 console.log(`[api] listening on :${config.port} (domain ${config.domain})`);
 
+/** 去掉末尾 `/`（根路径除外），避免 `/mcp/` 漏匹配。 */
+function requestPath(req: Request): string {
+  const path = new URL(req.url).pathname;
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
+}
+
+/**
+ * 应用层长轮询入口。进 fetch 后才按请求禁用空闲掐线；
+ * 请求尚未读完（慢上传 / 未完成握手）仍受全局 idleTimeout 约束。
+ */
+function isLongPollRequest(req: Request): boolean {
+  const path = requestPath(req);
+  if (req.method === 'POST' && (path === '/mcp' || path === '/v1/messages/wait' || path === '/v1/tasks')) {
+    return true;
+  }
+  // GET /v1/tasks/:id?wait=true 与 mail_wait_for 同属阻塞等待。
+  if (req.method === 'GET' && /^\/v1\/tasks\/[^/]+$/.test(path)) {
+    return new URL(req.url).searchParams.get('wait') === 'true';
+  }
+  return false;
+}
+
 export default {
   port: config.port,
-  // 禁用 Bun.serve 默认 10s 空闲掐线。mail_wait_for / POST /v1/messages/wait
-  // 等长连接超时由应用层 MCP_MAX_WAIT_SECONDS（默认 60s）治理，不该在 server 层掐断。
-  idleTimeout: 0,
-  fetch: app.fetch,
+  // 短请求保留 Bun 默认 10s，避免公网慢连接无限占 socket。
+  // 长轮询在 fetch 里 server.timeout(req, 0) 按请求豁免。
+  idleTimeout: 10,
+  fetch(req: Request, server: { timeout(request: Request, seconds: number): void }) {
+    if (isLongPollRequest(req)) {
+      server.timeout(req, 0);
+    }
+    return app.fetch(req);
+  },
 };

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -42,37 +42,10 @@ if (config.ntfy.enabled) {
 
 console.log(`[api] listening on :${config.port} (domain ${config.domain})`);
 
-/** 去掉末尾 `/`（根路径除外），避免 `/mcp/` 漏匹配。 */
-function requestPath(req: Request): string {
-  const path = new URL(req.url).pathname;
-  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path;
-}
-
-/**
- * 应用层长轮询入口。进 fetch 后才按请求禁用空闲掐线；
- * 请求尚未读完（慢上传 / 未完成握手）仍受全局 idleTimeout 约束。
- */
-function isLongPollRequest(req: Request): boolean {
-  const path = requestPath(req);
-  if (req.method === 'POST' && (path === '/mcp' || path === '/v1/messages/wait' || path === '/v1/tasks')) {
-    return true;
-  }
-  // GET /v1/tasks/:id?wait=true 与 mail_wait_for 同属阻塞等待。
-  if (req.method === 'GET' && /^\/v1\/tasks\/[^/]+$/.test(path)) {
-    return new URL(req.url).searchParams.get('wait') === 'true';
-  }
-  return false;
-}
-
 export default {
   port: config.port,
-  // 短请求保留 Bun 默认 10s，避免公网慢连接无限占 socket。
-  // 长轮询在 fetch 里 server.timeout(req, 0) 按请求豁免。
-  idleTimeout: 10,
-  fetch(req: Request, server: { timeout(request: Request, seconds: number): void }) {
-    if (isLongPollRequest(req)) {
-      server.timeout(req, 0);
-    }
-    return app.fetch(req);
-  },
+  // 禁用 Bun.serve 默认 10s 空闲掐线。mail_wait_for / POST /v1/messages/wait
+  // 等长连接超时由应用层 MCP_MAX_WAIT_SECONDS（默认 60s）治理，不该在 server 层掐断。
+  idleTimeout: 0,
+  fetch: app.fetch,
 };

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -44,5 +44,8 @@ console.log(`[api] listening on :${config.port} (domain ${config.domain})`);
 
 export default {
   port: config.port,
+  // 禁用 Bun.serve 默认 10s 空闲掐线。mail_wait_for / POST /v1/messages/wait
+  // 等长连接超时由应用层 MCP_MAX_WAIT_SECONDS（默认 60s）治理，不该在 server 层掐断。
+  idleTimeout: 0,
   fetch: app.fetch,
 };

--- a/packages/api/test/idle-timeout.test.ts
+++ b/packages/api/test/idle-timeout.test.ts
@@ -1,6 +1,10 @@
 /**
  * 回归：Bun.serve 默认 idleTimeout=10s 会掐断无字节长连接（公网 mail_wait_for 实测 502）。
  * 生产保留全局 10s；仅对长轮询路径 server.timeout(req, 0)。
+ *
+ * 对照不写死掐断秒数：CI bun 1.2.21 与本机 1.3.x 的定时器粒度不同，
+ * handler 若在 ~2×idleTimeout 时刚好 return，会和掐线抢跑（GH job 95079538125）。
+ * handler 挂住超过观察窗，客户端等「最终被掐」，断言发生在 idleTimeout 之后、上限之前。
  */
 import { describe, expect, test } from 'bun:test';
 
@@ -26,15 +30,28 @@ async function productionDisablesTimeoutPerLongPoll(): Promise<boolean> {
   );
 }
 
+function isClientCeilingAbort(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'TimeoutError';
+}
+
 /**
  * 起一个只 sleep、期间不写任何响应字节的本地服务，模拟 wait 类长连接。
  * disableIdle 为 true 时按生产路径调用 server.timeout(req, 0)。
+ * clientCeilingMs 防止 runner 上永不掐线时挂死；触顶视为未打到 server 层。
  */
 async function requestSilentWait(
   idleTimeout: number,
   silentMs: number,
   disableIdle = false,
-): Promise<{ ok: boolean; status?: number; body?: string; error?: string }> {
+  clientCeilingMs?: number,
+): Promise<{
+  ok: boolean;
+  status?: number;
+  body?: string;
+  error?: string;
+  elapsedMs: number;
+  clientCeiling: boolean;
+}> {
   const server = Bun.serve({
     hostname: '127.0.0.1',
     port: 0,
@@ -46,11 +63,25 @@ async function requestSilentWait(
       return new Response('still-alive');
     },
   });
+  const started = Date.now();
   try {
-    const res = await fetch(server.url);
-    return { ok: res.ok, status: res.status, body: await res.text() };
+    const res = await fetch(server.url, {
+      signal: clientCeilingMs ? AbortSignal.timeout(clientCeilingMs) : undefined,
+    });
+    return {
+      ok: res.ok,
+      status: res.status,
+      body: await res.text(),
+      elapsedMs: Date.now() - started,
+      clientCeiling: false,
+    };
   } catch (err) {
-    return { ok: false, error: String(err) };
+    return {
+      ok: false,
+      error: String(err),
+      elapsedMs: Date.now() - started,
+      clientCeiling: isClientCeilingAbort(err),
+    };
   } finally {
     server.stop(true);
   }
@@ -62,22 +93,26 @@ describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
     expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
   });
 
-  test('对照：idleTimeout=2 且无按请求豁免时，约 4s 无字节会被掐断', async () => {
-    const result = await requestSilentWait(2, 4_000, false);
+  test('对照：无豁免时连接在 idleTimeout 之后、15s 上限之前被 server 层掐断', async () => {
+    const idleSec = 2;
+    const ceilingMs = 15_000;
+    // handler 挂住超过观察窗，避免「刚好 return」和掐线抢跑。
+    const result = await requestSilentWait(idleSec, 20_000, false, ceilingMs);
+    expect(result.clientCeiling).toBe(false);
     expect(result.ok).toBe(false);
     expect(result.body).not.toBe('still-alive');
-  }, 15_000);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(idleSec * 1_000);
+    expect(result.elapsedMs).toBeLessThan(ceilingMs);
+  }, 25_000);
 
   test('生产路径：全局 10s + server.timeout(req, 0) 时，15s+ 无字节仍能完成', async () => {
     const idleTimeout = await readProductionIdleTimeout();
     expect(idleTimeout).toBe(10);
     expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
-    const started = Date.now();
     const result = await requestSilentWait(idleTimeout, 16_000, true);
-    const elapsedMs = Date.now() - started;
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);
     expect(result.body).toBe('still-alive');
-    expect(elapsedMs).toBeGreaterThanOrEqual(15_000);
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(15_000);
   }, 25_000);
 });

--- a/packages/api/test/idle-timeout.test.ts
+++ b/packages/api/test/idle-timeout.test.ts
@@ -1,0 +1,70 @@
+/**
+ * 回归：Bun.serve 默认 idleTimeout=10s 会掐断无字节长连接（公网 mail_wait_for 实测 502）。
+ * 生产 serve 配置必须显式 idleTimeout: 0；本文件用真 Bun.serve 验证 >15s 静默仍能完成。
+ */
+import { describe, expect, test } from 'bun:test';
+
+const MAIN_PATH = new URL('../src/main.ts', import.meta.url);
+
+/** 从 main.ts 的 default export 钉死生产 idleTimeout，避免误测一份手写副本。 */
+async function readProductionIdleTimeout(): Promise<number> {
+  const src = await Bun.file(MAIN_PATH).text();
+  // 只认 export default 对象里的 idleTimeout，防止注释/其它字面量误匹配。
+  const match = src.match(/export default\s*\{[\s\S]*?\bidleTimeout:\s*(\d+)\b/);
+  if (!match) {
+    throw new Error('packages/api/src/main.ts default export 缺少 idleTimeout');
+  }
+  return Number(match[1]);
+}
+
+/**
+ * 起一个只 sleep、期间不写任何响应字节的本地服务，模拟 wait 类长连接。
+ * 返回 fetch 结果；被 idleTimeout 掐断时走 catch。
+ */
+async function requestSilentWait(
+  idleTimeout: number,
+  silentMs: number,
+): Promise<{ ok: boolean; status?: number; body?: string; error?: string }> {
+  const server = Bun.serve({
+    hostname: '127.0.0.1',
+    port: 0,
+    idleTimeout,
+    fetch: async () => {
+      // 故意不先写字节：复现「handler 仍在跑、连接被 server 层掐」的现场。
+      await Bun.sleep(silentMs);
+      return new Response('still-alive');
+    },
+  });
+  try {
+    const res = await fetch(server.url);
+    return { ok: res.ok, status: res.status, body: await res.text() };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  } finally {
+    server.stop(true);
+  }
+}
+
+describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
+  test('生产 serve 配置显式 idleTimeout: 0（禁用）', async () => {
+    expect(await readProductionIdleTimeout()).toBe(0);
+  });
+
+  test('对照：idleTimeout=2 时约 4s 无字节会被掐断（证明本测试打到 server 层）', async () => {
+    const result = await requestSilentWait(2, 4_000);
+    expect(result.ok).toBe(false);
+    expect(result.body).not.toBe('still-alive');
+  }, 15_000);
+
+  test('生产值 idleTimeout=0：15s+ 无字节长连接仍能正常完成', async () => {
+    const idleTimeout = await readProductionIdleTimeout();
+    expect(idleTimeout).toBe(0);
+    const started = Date.now();
+    const result = await requestSilentWait(idleTimeout, 16_000);
+    const elapsedMs = Date.now() - started;
+    expect(result.ok).toBe(true);
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('still-alive');
+    expect(elapsedMs).toBeGreaterThanOrEqual(15_000);
+  }, 25_000);
+});

--- a/packages/api/test/idle-timeout.test.ts
+++ b/packages/api/test/idle-timeout.test.ts
@@ -13,8 +13,12 @@ const MAIN_PATH = new URL('../src/main.ts', import.meta.url);
 /** 从 main.ts 的 default export 钉死生产 idleTimeout，避免误测一份手写副本。 */
 async function readProductionIdleTimeout(): Promise<number> {
   const src = await Bun.file(MAIN_PATH).text();
-  // 只认 export default 对象里的 idleTimeout，防止注释/其它字面量误匹配。
-  const match = src.match(/export default\s*\{[\s\S]*?\bidleTimeout:\s*(\d+)\b/);
+  // 只切 export default 到首个 `};`，避免误捕块外同名键。
+  const block = src.match(/export default\s*\{[\s\S]*?\};/);
+  if (!block) {
+    throw new Error('packages/api/src/main.ts 缺少 export default 块');
+  }
+  const match = block[0].match(/\bidleTimeout:\s*(\d+)\b/);
   if (!match) {
     throw new Error('packages/api/src/main.ts default export 缺少 idleTimeout');
   }

--- a/packages/api/test/idle-timeout.test.ts
+++ b/packages/api/test/idle-timeout.test.ts
@@ -1,6 +1,6 @@
 /**
  * 回归：Bun.serve 默认 idleTimeout=10s 会掐断无字节长连接（公网 mail_wait_for 实测 502）。
- * 生产 serve 配置必须显式 idleTimeout: 0；本文件用真 Bun.serve 验证 >15s 静默仍能完成。
+ * 生产保留全局 10s；仅对长轮询路径 server.timeout(req, 0)。
  */
 import { describe, expect, test } from 'bun:test';
 
@@ -17,20 +17,31 @@ async function readProductionIdleTimeout(): Promise<number> {
   return Number(match[1]);
 }
 
+/** 钉死生产 fetch 对长轮询调用了 server.timeout(req, 0)。 */
+async function productionDisablesTimeoutPerLongPoll(): Promise<boolean> {
+  const src = await Bun.file(MAIN_PATH).text();
+  return (
+    src.includes('isLongPollRequest') &&
+    /server\.timeout\(\s*req\s*,\s*0\s*\)/.test(src)
+  );
+}
+
 /**
  * 起一个只 sleep、期间不写任何响应字节的本地服务，模拟 wait 类长连接。
- * 返回 fetch 结果；被 idleTimeout 掐断时走 catch。
+ * disableIdle 为 true 时按生产路径调用 server.timeout(req, 0)。
  */
 async function requestSilentWait(
   idleTimeout: number,
   silentMs: number,
+  disableIdle = false,
 ): Promise<{ ok: boolean; status?: number; body?: string; error?: string }> {
   const server = Bun.serve({
     hostname: '127.0.0.1',
     port: 0,
     idleTimeout,
-    fetch: async () => {
+    fetch: async (req, srv) => {
       // 故意不先写字节：复现「handler 仍在跑、连接被 server 层掐」的现场。
+      if (disableIdle) srv.timeout(req, 0);
       await Bun.sleep(silentMs);
       return new Response('still-alive');
     },
@@ -46,21 +57,23 @@ async function requestSilentWait(
 }
 
 describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
-  test('生产 serve 配置显式 idleTimeout: 0（禁用）', async () => {
-    expect(await readProductionIdleTimeout()).toBe(0);
+  test('生产保留全局 idleTimeout=10，长轮询按请求 server.timeout(req, 0)', async () => {
+    expect(await readProductionIdleTimeout()).toBe(10);
+    expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
   });
 
-  test('对照：idleTimeout=2 时约 4s 无字节会被掐断（证明本测试打到 server 层）', async () => {
-    const result = await requestSilentWait(2, 4_000);
+  test('对照：idleTimeout=2 且无按请求豁免时，约 4s 无字节会被掐断', async () => {
+    const result = await requestSilentWait(2, 4_000, false);
     expect(result.ok).toBe(false);
     expect(result.body).not.toBe('still-alive');
   }, 15_000);
 
-  test('生产值 idleTimeout=0：15s+ 无字节长连接仍能正常完成', async () => {
+  test('生产路径：全局 10s + server.timeout(req, 0) 时，15s+ 无字节仍能完成', async () => {
     const idleTimeout = await readProductionIdleTimeout();
-    expect(idleTimeout).toBe(0);
+    expect(idleTimeout).toBe(10);
+    expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
     const started = Date.now();
-    const result = await requestSilentWait(idleTimeout, 16_000);
+    const result = await requestSilentWait(idleTimeout, 16_000, true);
     const elapsedMs = Date.now() - started;
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);

--- a/packages/api/test/idle-timeout.test.ts
+++ b/packages/api/test/idle-timeout.test.ts
@@ -1,6 +1,6 @@
 /**
  * 回归：Bun.serve 默认 idleTimeout=10s 会掐断无字节长连接（公网 mail_wait_for 实测 502）。
- * 生产保留全局 10s；仅对长轮询路径 server.timeout(req, 0)。
+ * 生产 serve 配置必须显式 idleTimeout: 0；本文件用真 Bun.serve 验证 >15s 静默仍能完成。
  *
  * 对照不写死掐断秒数：CI bun 1.2.21 与本机 1.3.x 的定时器粒度不同，
  * handler 若在 ~2×idleTimeout 时刚好 return，会和掐线抢跑（GH job 95079538125）。
@@ -21,28 +21,17 @@ async function readProductionIdleTimeout(): Promise<number> {
   return Number(match[1]);
 }
 
-/** 钉死生产 fetch 对长轮询调用了 server.timeout(req, 0)。 */
-async function productionDisablesTimeoutPerLongPoll(): Promise<boolean> {
-  const src = await Bun.file(MAIN_PATH).text();
-  return (
-    src.includes('isLongPollRequest') &&
-    /server\.timeout\(\s*req\s*,\s*0\s*\)/.test(src)
-  );
-}
-
 function isClientCeilingAbort(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'TimeoutError';
 }
 
 /**
  * 起一个只 sleep、期间不写任何响应字节的本地服务，模拟 wait 类长连接。
- * disableIdle 为 true 时按生产路径调用 server.timeout(req, 0)。
  * clientCeilingMs 防止 runner 上永不掐线时挂死；触顶视为未打到 server 层。
  */
 async function requestSilentWait(
   idleTimeout: number,
   silentMs: number,
-  disableIdle = false,
   clientCeilingMs?: number,
 ): Promise<{
   ok: boolean;
@@ -56,9 +45,8 @@ async function requestSilentWait(
     hostname: '127.0.0.1',
     port: 0,
     idleTimeout,
-    fetch: async (req, srv) => {
+    fetch: async () => {
       // 故意不先写字节：复现「handler 仍在跑、连接被 server 层掐」的现场。
-      if (disableIdle) srv.timeout(req, 0);
       await Bun.sleep(silentMs);
       return new Response('still-alive');
     },
@@ -88,16 +76,15 @@ async function requestSilentWait(
 }
 
 describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
-  test('生产保留全局 idleTimeout=10，长轮询按请求 server.timeout(req, 0)', async () => {
-    expect(await readProductionIdleTimeout()).toBe(10);
-    expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
+  test('生产 serve 配置显式 idleTimeout: 0（禁用）', async () => {
+    expect(await readProductionIdleTimeout()).toBe(0);
   });
 
-  test('对照：无豁免时连接在 idleTimeout 之后、15s 上限之前被 server 层掐断', async () => {
+  test('对照：有限 idleTimeout 时连接在超时之后、15s 上限之前被 server 层掐断', async () => {
     const idleSec = 2;
     const ceilingMs = 15_000;
     // handler 挂住超过观察窗，避免「刚好 return」和掐线抢跑。
-    const result = await requestSilentWait(idleSec, 20_000, false, ceilingMs);
+    const result = await requestSilentWait(idleSec, 20_000, ceilingMs);
     expect(result.clientCeiling).toBe(false);
     expect(result.ok).toBe(false);
     expect(result.body).not.toBe('still-alive');
@@ -105,11 +92,10 @@ describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
     expect(result.elapsedMs).toBeLessThan(ceilingMs);
   }, 25_000);
 
-  test('生产路径：全局 10s + server.timeout(req, 0) 时，15s+ 无字节仍能完成', async () => {
+  test('生产值 idleTimeout=0：15s+ 无字节长连接仍能正常完成', async () => {
     const idleTimeout = await readProductionIdleTimeout();
-    expect(idleTimeout).toBe(10);
-    expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
-    const result = await requestSilentWait(idleTimeout, 16_000, true);
+    expect(idleTimeout).toBe(0);
+    const result = await requestSilentWait(idleTimeout, 16_000);
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);
     expect(result.body).toBe('still-alive');

--- a/packages/api/test/idle-timeout.test.ts
+++ b/packages/api/test/idle-timeout.test.ts
@@ -1,6 +1,6 @@
 /**
  * 回归：Bun.serve 默认 idleTimeout=10s 会掐断无字节长连接（公网 mail_wait_for 实测 502）。
- * 生产 serve 配置必须显式 idleTimeout: 0；本文件用真 Bun.serve 验证 >15s 静默仍能完成。
+ * 生产保留全局 10s；仅对长轮询路径 server.timeout(req, 0)。
  *
  * 对照不写死掐断秒数：CI bun 1.2.21 与本机 1.3.x 的定时器粒度不同，
  * handler 若在 ~2×idleTimeout 时刚好 return，会和掐线抢跑（GH job 95079538125）。
@@ -21,17 +21,28 @@ async function readProductionIdleTimeout(): Promise<number> {
   return Number(match[1]);
 }
 
+/** 钉死生产 fetch 对长轮询调用了 server.timeout(req, 0)。 */
+async function productionDisablesTimeoutPerLongPoll(): Promise<boolean> {
+  const src = await Bun.file(MAIN_PATH).text();
+  return (
+    src.includes('isLongPollRequest') &&
+    /server\.timeout\(\s*req\s*,\s*0\s*\)/.test(src)
+  );
+}
+
 function isClientCeilingAbort(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'TimeoutError';
 }
 
 /**
  * 起一个只 sleep、期间不写任何响应字节的本地服务，模拟 wait 类长连接。
+ * disableIdle 为 true 时按生产路径调用 server.timeout(req, 0)。
  * clientCeilingMs 防止 runner 上永不掐线时挂死；触顶视为未打到 server 层。
  */
 async function requestSilentWait(
   idleTimeout: number,
   silentMs: number,
+  disableIdle = false,
   clientCeilingMs?: number,
 ): Promise<{
   ok: boolean;
@@ -45,8 +56,9 @@ async function requestSilentWait(
     hostname: '127.0.0.1',
     port: 0,
     idleTimeout,
-    fetch: async () => {
+    fetch: async (req, srv) => {
       // 故意不先写字节：复现「handler 仍在跑、连接被 server 层掐」的现场。
+      if (disableIdle) srv.timeout(req, 0);
       await Bun.sleep(silentMs);
       return new Response('still-alive');
     },
@@ -76,15 +88,16 @@ async function requestSilentWait(
 }
 
 describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
-  test('生产 serve 配置显式 idleTimeout: 0（禁用）', async () => {
-    expect(await readProductionIdleTimeout()).toBe(0);
+  test('生产保留全局 idleTimeout=10，长轮询按请求 server.timeout(req, 0)', async () => {
+    expect(await readProductionIdleTimeout()).toBe(10);
+    expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
   });
 
-  test('对照：有限 idleTimeout 时连接在超时之后、15s 上限之前被 server 层掐断', async () => {
+  test('对照：无豁免时连接在 idleTimeout 之后、15s 上限之前被 server 层掐断', async () => {
     const idleSec = 2;
     const ceilingMs = 15_000;
     // handler 挂住超过观察窗，避免「刚好 return」和掐线抢跑。
-    const result = await requestSilentWait(idleSec, 20_000, ceilingMs);
+    const result = await requestSilentWait(idleSec, 20_000, false, ceilingMs);
     expect(result.clientCeiling).toBe(false);
     expect(result.ok).toBe(false);
     expect(result.body).not.toBe('still-alive');
@@ -92,10 +105,11 @@ describe('Bun.serve idleTimeout（长连接不被 server 层掐断）', () => {
     expect(result.elapsedMs).toBeLessThan(ceilingMs);
   }, 25_000);
 
-  test('生产值 idleTimeout=0：15s+ 无字节长连接仍能正常完成', async () => {
+  test('生产路径：全局 10s + server.timeout(req, 0) 时，15s+ 无字节仍能完成', async () => {
     const idleTimeout = await readProductionIdleTimeout();
-    expect(idleTimeout).toBe(0);
-    const result = await requestSilentWait(idleTimeout, 16_000);
+    expect(idleTimeout).toBe(10);
+    expect(await productionDisablesTimeoutPerLongPoll()).toBe(true);
+    const result = await requestSilentWait(idleTimeout, 16_000, true);
     expect(result.ok).toBe(true);
     expect(result.status).toBe(200);
     expect(result.body).toBe('still-alive');


### PR DESCRIPTION
## Summary

**终态：方案 A——全局 `idleTimeout: 0`（业主 2026-08-16 拍板）。** B 方案（按请求 `server.timeout(req, 0)` 豁免）退场。

公网验收：`mail_wait_for timeoutSec:30` 约 10.7s 被掐，OpenResty `upstream prematurely closed connection`，客户端 502。根因是 `Bun.serve` 默认 10s idle，handler 无字节即被 server 层掐断。本 PR 在 `packages/api/src/main.ts` 显式 `idleTimeout: 0`。SSE 心跳未做（MCP 由 SDK `createMcpHandler` 内部产出，无统一写出点）。

### 方案之争终局

两方案各背过一条 Codex P1，业主拍板 A：

- **A**（`49385ee` 口径，现 HEAD）：全局 `idleTimeout: 0`。曾吃 Codex P1 0.88——公网无 server 层空闲保护。
- **B**（`d48ab92`）：全局 10 + `isLongPollRequest` 按请求豁免。曾吃 Codex P1 0.92——豁免在 body 读取前生效，slow-upload 保护自相矛盾。

### OpenResty 双向兜底

- **post-accept 无字节长等**（wait 类）：应用层治理。`waitSchema.timeoutSec` 默认 120、schema max 600；服务端 `clampWaitSeconds` 静默钳到 `MCP_MAX_WAIT_SECONDS`（`packages/api/src/lib/config.ts:167`，zod min 1 max 600，默认 60）；wait 槽位每地址 3 / 全局 8；`TASK_WAIT_MAX_SEC`（`lib/tasks.ts`，600）再封底层 deadline。`routes/tasks.ts:67` 实际读 `config.mcpMaxWaitSeconds`。
- **pre-body 滴灌**：OpenResty `proxy_request_buffering` 未写=默认 on，body 收齐才回源；`client_body_timeout` 默认 60s。再加 CF 边缘。公网客户端到不了 Bun socket。
- **3100 直连**：只绑 `127.0.0.1` + tailnet CGNAT（`100.93.215.93`）；`compose.override.yaml` 钉 loopback，tailnet 来自 `API_BIND` + `compose.yaml` 的 `${API_BIND:-127.0.0.1}`。`API_BIND=0.0.0.0` 在 compose 注释里要求「知道自己在干嘛才开」。

### 闸评记档

- **Codex 漂移**：`a0572fa` 与 `2043973` 逐字节一致（`git diff` 空，tree `42664d2e…`），该闸先 ✅ 0.92 后 ⚠️ P1 0.92。
- **ZCode P2-1 误判**：声称全仓不存在 `MCP_MAX_WAIT_SECONDS`。现场指挥核实：`config.ts:167` 真实存在。本 body 按真实机制写。
- **ZCode P1**：维持「刻意权衡 + OpenResty 兜底」。已知接受风险；若以后 `API_BIND` 公网直绑或反代关掉 request buffering，须重估。

## Verification

- `packages/api` `bun test`：**851 pass / 0 fail**
- `git diff 49385ee HEAD -- packages/api/src/main.ts` 为空（与 A 版 main.ts 逐字节一致）
- 回归钉死生产 `idleTimeout: 0`；对照有限 idle 在超时后、15s 上限前被掐（handler 挂住，不与 ~4s return 抢跑）

## Checklist

- [x] Scope stays focused and avoids unrelated cleanup.
- [x] Tests were added or updated for behavior changes.
- [x] Docs (README / website docs) were updated in the same PR when behavior changed. （内部 serve 配置，无对外 API/文档面变化）
- [x] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
