### PR TITLE
fix(api): accept CIMD clients that fall back to token auth none

### DIFF
--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -19,6 +19,12 @@ API 进程暴露无状态 MCP 端点 `POST /mcp`（MCP 2026-07-28 / SDK v2）。
 
 网页 Agent（ChatGPT / Claude 等）走标准 OAuth 授权码 + PKCE（仅 S256）+ CIMD。OAuth access token 仅为 **identity** 级（永非 admin），绑定 MCP resource（`…/mcp`）。管理已授权客户端：Dashboard `/ui/configure/clients`（旧书签 `/ui/oauth/grants` 在已登录时 302 到此页）。
 
+CIMD 注册校验只接受公共客户端 `none`（token 端点行为不变，仍只支持 `none` + PKCE）。判定信号：
+
+- `token_endpoint_auth_method` 缺省或为 `none`：放行
+- singular 非 `none`，但 `token_endpoint_auth_methods_supported` **为数组且含 `none`**：按公共客户端 `none` 放行（ChatGPT 连接器常见：singular=`private_key_jwt`，plural 同时含 `none` 与 `private_key_jwt`）
+- plural 缺失、非数组、或不含 `none`：拒绝（`auth_method_unsupported`）
+
 ### Cursor / 通用 MCP `type: http` 示例
 
 ```json

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -21,9 +21,9 @@ API 进程暴露无状态 MCP 端点 `POST /mcp`（MCP 2026-07-28 / SDK v2）。
 
 CIMD 注册校验只接受公共客户端 `none`（token 端点行为不变，仍只支持 `none` + PKCE）。判定信号：
 
-- `token_endpoint_auth_method` 缺省或为 `none`：放行
+- `token_endpoint_auth_method` 缺省或为 `none`：放行（不看 plural）
 - singular 非 `none`，但 `token_endpoint_auth_methods_supported` **为数组且含 `none`**：按公共客户端 `none` 放行（ChatGPT 连接器常见：singular=`private_key_jwt`，plural 同时含 `none` 与 `private_key_jwt`）
-- plural 缺失、非数组、或不含 `none`：拒绝（`auth_method_unsupported`）
+- singular 非 `none` 且 plural 缺失、非数组、或不含 `none`：拒绝（`auth_method_unsupported`）
 
 ### Cursor / 通用 MCP `type: http` 示例
 

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -312,8 +312,16 @@ function validateDocument(
       ? doc.token_endpoint_auth_method
       : 'none';
   if (method !== 'none') {
-    // 声明 private_key_jwt 等一律拒（本 AS 只接受 none）
-    return { ok: false, reason: 'auth_method_unsupported' };
+    // 本 AS token 端点仍只接受 none。singular 非 none 时，仅当 plural
+    // token_endpoint_auth_methods_supported 为数组且含 'none' 才按公共客户端放行
+    //（ChatGPT 连接器：singular=private_key_jwt，plural 同时含 none）。
+    // plural 缺失 / 非数组 / 不含 'none' → 维持拒绝。不另发明 jwks_uri 等条件。
+    const supported = doc.token_endpoint_auth_methods_supported;
+    const canFallbackNone =
+      Array.isArray(supported) && supported.includes('none');
+    if (!canFallbackNone) {
+      return { ok: false, reason: 'auth_method_unsupported' };
+    }
   }
 
   return {

--- a/packages/api/test/oauth-cimd.test.ts
+++ b/packages/api/test/oauth-cimd.test.ts
@@ -241,7 +241,7 @@ describe('fetchClientMetadata（注入 fetcher）', () => {
     if (!r.ok) expect(r.reason).toBe('missing_redirect_uris');
   });
 
-  test('声明 client_secret* / private_key_jwt 拒', async () => {
+  test('声明 client_secret* 仍拒；private_key_jwt 无 none 回退信号仍拒', async () => {
     const secret = await fetchClientMetadata(clientId, {
       fetcher: async () =>
         new Response(
@@ -280,5 +280,66 @@ describe('fetchClientMetadata（注入 fetcher）', () => {
     ]);
     expect(r.ok).toBe(false);
     if (!r.ok) expect(r.reason).toBe('ssrf_blocked_ip');
+  });
+});
+
+/**
+ * ChatGPT CIMD：singular 声明 private_key_jwt，但 plural 数组含 none 时可回退公共客户端。
+ * 判定只看 token_endpoint_auth_methods_supported 是否为数组且含 'none'。
+ */
+describe('CIMD auth_method none 回退（ChatGPT 连接器）', () => {
+  const clientId = 'http://127.0.0.1:9/cimd.json';
+
+  async function fetchDoc(body: Record<string, unknown>) {
+    return fetchClientMetadata(clientId, {
+      fetcher: async () =>
+        new Response(JSON.stringify({ client_id: clientId, ...body }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        }),
+      dnsLookup: async () => [{ address: '127.0.0.1', family: 4 }],
+    });
+  }
+
+  test('private_key_jwt + plural 含 none + jwks_uri → 按 none 放行', async () => {
+    const r = await fetchDoc({
+      client_name: 'ChatGPT',
+      redirect_uris: ['https://chatgpt.com/connector/oauth/callback'],
+      token_endpoint_auth_method: 'private_key_jwt',
+      token_endpoint_auth_methods_supported: ['none', 'private_key_jwt'],
+      jwks_uri: 'https://chatgpt.com/oauth/connector/jwks.json',
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.doc.token_endpoint_auth_method).toBe('none');
+  });
+
+  test('纯 client_secret_basic 无 none 回退信号 → 仍拒', async () => {
+    const r = await fetchDoc({
+      client_name: 'Basic',
+      redirect_uris: ['https://app.example/cb'],
+      token_endpoint_auth_method: 'client_secret_basic',
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe('auth_method_unsupported');
+  });
+
+  test('plural 非数组等畸形 → 仍拒', async () => {
+    const notArray = await fetchDoc({
+      client_name: 'Malformed',
+      redirect_uris: ['https://app.example/cb'],
+      token_endpoint_auth_method: 'private_key_jwt',
+      token_endpoint_auth_methods_supported: 'none',
+    });
+    expect(notArray.ok).toBe(false);
+    if (!notArray.ok) expect(notArray.reason).toBe('auth_method_unsupported');
+
+    const missingNone = await fetchDoc({
+      client_name: 'JwtOnly',
+      redirect_uris: ['https://app.example/cb'],
+      token_endpoint_auth_method: 'private_key_jwt',
+      token_endpoint_auth_methods_supported: ['private_key_jwt'],
+    });
+    expect(missingNone.ok).toBe(false);
+    if (!missingNone.ok) expect(missingNone.reason).toBe('auth_method_unsupported');
   });
 });


### PR DESCRIPTION
## Summary

- ChatGPT 自定义 MCP 连接器 CIMD 的 singular `token_endpoint_auth_method` 常为 `private_key_jwt`，同时 plural `token_endpoint_auth_methods_supported` 数组含 `none`（公共客户端 + PKCE 可回退信号）。旧校验把 singular 非 `none` 一律拒成 `auth_method_unsupported`。
- **判定信号（仅此一条，不另加 jwks_uri 等条件）**：singular 非 `none`，但 `token_endpoint_auth_methods_supported` 为数组且含 `'none'` → 按公共客户端 `none` 放行；plural 缺失 / 非数组 / 不含 `'none'` → 维持拒绝。
- token 端点行为不变（仍只支持 `none` + PKCE）。`client_secret*` 禁、redirect_uri scheme 白名单、私网 fetch 例外均未改。

**出处：** 总指挥 2026-08-17 实测 ChatGPT 连接器 CIMD；独立第三方互证 https://agentics.dk/en/blog/keycloak-cimd-claude-chatgpt

## Test plan

- [x] `packages/api` CIMD 新测：放行（private_key_jwt + plural 含 none + jwks_uri）+ 仍拒（纯 client_secret_basic；plural 非数组 / 不含 none）
- [x] `bun test test/oauth-cimd.test.ts` 24 pass
- [ ] 用真实 ChatGPT 连接器 CIMD URL 走 `/authorize` 不再报 `Invalid client: auth_method_unsupported`
- [ ] token 交换仍走 PKCE `none`，不会误开 `private_key_jwt`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CIMD registration accepts clients declaring a non-`none` token authentication method when supported methods explicitly include `none`.

- **Bug Fixes**
  - Improved validation rejects registrations with missing, malformed, or unsupported authentication method declarations.

- **Documentation**
  - Added guidance explaining CIMD authentication validation and accepted public client configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->