### PR TITLE
fix(api): guard IMAP watcher connection errors

### DIFF
--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1358,16 +1358,58 @@ async function watchConnection(
   }
 }
 
-async function runWatcher(signal: AbortSignal, dispatch: WatcherDispatch): Promise<void> {
+type WatcherRuntime = {
+  connect: typeof connectImap;
+  watch: typeof watchConnection;
+  wait: typeof sleep;
+  warn: typeof console.warn;
+  connectionId: string;
+};
+
+/** @internal Exported so the reconnect/error boundary can be regression-tested. */
+export async function runWatcher(
+  signal: AbortSignal,
+  dispatch: WatcherDispatch,
+  runtime: WatcherRuntime = {
+    connect: connectImap,
+    watch: watchConnection,
+    wait: sleep,
+    warn: console.warn,
+    connectionId: `${config.imap.user}@${config.imap.host}:${config.imap.port}`,
+  },
+): Promise<void> {
   const watermark: WatcherWatermark = {};
   while (!signal.aborted) {
     try {
-      const client = await connectImap();
-      await watchConnection(signal, client, dispatch, watermark);
+      const client = await runtime.connect();
+      const onError = (err: unknown) => {
+        runtime.warn(
+          `[notify] IMAP watcher connection ${runtime.connectionId} error:`,
+          err instanceof Error ? err.message : String(err),
+        );
+        // ImapFlow emits connection errors outside the awaited command chain.
+        // Closing makes the active IDLE/search fail into the reconnect guard.
+        try {
+          client.close();
+        } catch {
+          /* already closed */
+        }
+      };
+      client.on('error', onError);
+      try {
+        await runtime.watch(signal, client, dispatch, watermark);
+      } finally {
+        client.off('error', onError);
+      }
     } catch (err) {
-      if (!signal.aborted) console.warn('[notify] IMAP watcher reconnecting:', (err as Error).message);
+      if (!signal.aborted) {
+        runtime.warn(
+          `[notify] IMAP watcher connection ${runtime.connectionId} reconnecting:`,
+          err instanceof Error ? err.message : String(err),
+        );
+      }
     }
-    if (!signal.aborted) await sleep(RECONNECT_MS);
+    if (!signal.aborted) await runtime.wait(RECONNECT_MS);
   }
 }
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1375,7 +1375,7 @@ export async function runWatcher(
     watch: watchConnection,
     wait: sleep,
     warn: console.warn,
-    connectionId: `${config.imap.user}@${config.imap.host}:${config.imap.port}`,
+    connectionId: `${config.imap.host}:${config.imap.port}`,
   },
 ): Promise<void> {
   const watermark: WatcherWatermark = {};

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -5,6 +5,8 @@ process.env.IMAP_PASS = 'imap-secret';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
 
+import { EventEmitter } from 'node:events';
+
 const { describe, expect, test } = await import('bun:test');
 const {
   boundPreviewChars,
@@ -17,6 +19,7 @@ const {
   maskTier2Metadata,
   packPushLinkLines,
   processWatchedMessage,
+  runWatcher,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
   PUSH_MESSAGE_MAX_BYTES,
@@ -82,6 +85,50 @@ async function dispatches(
 }
 
 describe('mail-arrival notification watcher', () => {
+  test('连续 2 轮异步连接错误时 watcher 记录连接、按 3 秒退避并继续，不终止循环', async () => {
+    const controller = new AbortController();
+    const warnings: unknown[][] = [];
+    const waits: number[] = [];
+    let attempts = 0;
+
+    await runWatcher(
+      controller.signal,
+      { publish: async () => ({ target: 'user', title: 'unused', level: 'normal' }) },
+      {
+        connect: async () => new EventEmitter() as any,
+        watch: async (_signal, client) => {
+          attempts += 1;
+          if (attempts > 2) {
+            controller.abort();
+            return;
+          }
+          const error = new Error(`socket timeout ${attempts}`);
+          await new Promise<void>((_resolve, reject) => {
+            client.close = () => reject(error);
+            setTimeout(() => client.emit('error', error), 0);
+          });
+        },
+        wait: async (ms) => {
+          waits.push(ms);
+        },
+        warn: (...args) => {
+          warnings.push(args);
+        },
+        connectionId: 'agent@test.example@imap.test:993',
+      },
+    );
+
+    expect(attempts).toBe(3);
+    expect(waits).toEqual([3_000, 3_000]);
+    expect(warnings).toHaveLength(4);
+    expect(warnings.map((entry) => entry.join(' '))).toEqual([
+      '[notify] IMAP watcher connection agent@test.example@imap.test:993 error: socket timeout 1',
+      '[notify] IMAP watcher connection agent@test.example@imap.test:993 reconnecting: socket timeout 1',
+      '[notify] IMAP watcher connection agent@test.example@imap.test:993 error: socket timeout 2',
+      '[notify] IMAP watcher connection agent@test.example@imap.test:993 reconnecting: socket timeout 2',
+    ]);
+  });
+
   test('keeps its watermark across reconnects and catches the downtime window', () => {
     const watermark: { uid?: number } = {};
     expect(unseenWatcherUids([10, 11], watermark)).toEqual([]);

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -114,7 +114,7 @@ describe('mail-arrival notification watcher', () => {
         warn: (...args) => {
           warnings.push(args);
         },
-        connectionId: 'agent@test.example@imap.test:993',
+        connectionId: 'imap.test:993',
       },
     );
 
@@ -122,10 +122,10 @@ describe('mail-arrival notification watcher', () => {
     expect(waits).toEqual([3_000, 3_000]);
     expect(warnings).toHaveLength(4);
     expect(warnings.map((entry) => entry.join(' '))).toEqual([
-      '[notify] IMAP watcher connection agent@test.example@imap.test:993 error: socket timeout 1',
-      '[notify] IMAP watcher connection agent@test.example@imap.test:993 reconnecting: socket timeout 1',
-      '[notify] IMAP watcher connection agent@test.example@imap.test:993 error: socket timeout 2',
-      '[notify] IMAP watcher connection agent@test.example@imap.test:993 reconnecting: socket timeout 2',
+      '[notify] IMAP watcher connection imap.test:993 error: socket timeout 1',
+      '[notify] IMAP watcher connection imap.test:993 reconnecting: socket timeout 1',
+      '[notify] IMAP watcher connection imap.test:993 error: socket timeout 2',
+      '[notify] IMAP watcher connection imap.test:993 reconnecting: socket timeout 2',
     ]);
   });
 


### PR DESCRIPTION
Fixes #39.

## 根因与修复

IMAP watcher 原有的重连 `try/catch` 已能接住 `connect()`、mailbox lock、search/fetch、消息处理、IDLE 与清理路径上的同步异常或 Promise rejection；缺口是 ImapFlow 在已连接 socket 上通过 EventEmitter 异步发出的 `error`。无人监听的 `error` 会被 Node/Bun 直接抛到事件循环，完全绕过该 `try/catch`，因此能终止 API 进程。

本 PR 在每一轮成功连接后：

- 给该 ImapFlow client 注册临时 `error` 监听器；
- 记录错误信息及连接标识（IMAP host/port，不含用户名）；
- 主动关闭出错连接，使当前 IDLE/search 失败进入现有重连兜底；
- 在连接轮结束时移除监听器；
- 沿用明确、可测试的固定 3000ms 重连退避，然后继续下一轮。

没有改变 SMTP、部署配置或任何对外 API 行为。

## 回归测试

新增测试：`连续 2 轮异步连接错误时 watcher 记录连接、按 3 秒退避并继续，不终止循环`。

测试用真正的异步 `EventEmitter.emit('error')` 模拟事故路径，并验证两轮错误均写入连接标识和错误信息、每轮均按 3000ms 退避、第三轮仍继续运行。

### 负控（临时仅移除生产 error 监听，测试不变）— 红

命令：

```console
$ bun test test/notification-watcher.test.ts -t '连续 2 轮异步连接错误时 watcher 记录连接、按 3 秒退避并继续，不终止循环'
```

输出片段：

```text
51 |     throw er;
                 ^
error: socket timeout 1
      at emitError (node:events:51:13)
(fail) mail-arrival notification watcher > 连续 2 轮异步连接错误时 watcher 记录连接、按 3 秒退避并继续，不终止循环

0 pass
109 filtered out
1 fail
```

### 恢复修复 — 绿

同一命令、同一测试：

```text
(pass) mail-arrival notification watcher > 连续 2 轮异步连接错误时 watcher 记录连接、按 3 秒退避并继续，不终止循环

1 pass
109 filtered out
0 fail
4 expect() calls
```

定向测试文件：

```text
bun test test/notification-watcher.test.ts
110 pass
0 fail
705 expect() calls
```

构建：

```text
bun run build
Bundled 570 modules in 235ms
```

## 全量测试

已先执行 `bun install`（79 installs checked, no changes），再在 `packages/api` 执行：

```console
$ bun test
855 pass
1 skip
3 fail
5822 expect() calls
Ran 859 tests across 46 files. [34.46s]
```

三条失败与 main 的既有全量环境串扰记录一致，均隔离复跑通过：

```text
phone device ACL > corrupt registry with ntfy enabled does not block startup and fail-closes devices
1 pass / 0 fail

UI is enabled by default
1 pass / 0 fail

UI session persistence > 生产 resolveUiSessionTokenByHash：identity 命中；OAuth access hash 永不命中
1 pass / 0 fail
```

## 顺带发现

- `bun run typecheck` 在 main 既有的 `send.ts`、`ui-assets.ts` 和多份旧测试类型错误上失败；本 PR 新增代码没有出现在报错中。按本单边界未顺手修复。
- 全量 `bun test` 的上述三条环境串扰仍存在；隔离均绿，按本单边界未改。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification monitoring reliability by automatically closing failed connections and retrying operations.
  - Added clearer connection-specific error and reconnect warnings.
  - Ensured monitoring continues after consecutive connection failures and stops cleanly when aborted.
  - Improved recovery from repeated asynchronous connection errors while preserving configured reconnect delays.

- **Tests**
  - Added coverage for repeated connection errors, reconnect delays, continued monitoring, and clean shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->