### PR TITLE
fix(api): prevent watcher livelock and back off reconnects

### DIFF
--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -21,6 +21,7 @@ import {
 import { connectImap, messageRecipients } from './imap.ts';
 import {
   jsonEscapedByteLength,
+  isNotifyServiceFailure,
   notifyAvailableMessageBytes,
   NotifyError,
   type NotifyService,
@@ -44,6 +45,7 @@ const RECONNECT_STABLE_MS = 30_000;
 const PUBLISH_MAX_ATTEMPTS = 3;
 const PUBLISH_RETRY_INITIAL_MS = 250;
 const PUBLISH_RETRY_MAX_MS = 500;
+const SERVICE_FAILURE_MAX_MS = 10 * 60_000;
 /** Bounded plain-text preview length for tier-3 mail-arrival pushes. */
 export const PUSH_BODY_PREVIEW_CHARS = 280;
 /** Max OTP codes/links included in a tier-3 push (each list). */
@@ -89,7 +91,12 @@ export type ProcessWatchedOptions = {
 };
 
 /** In-memory watermark survives a dropped IMAP connection in this process. */
-export type WatcherWatermark = { uid?: number; uidValidity?: bigint };
+export type WatcherWatermark = {
+  uid?: number;
+  uidValidity?: bigint;
+  /** @internal First provider-wide failure for the blocked UID, across reconnects. */
+  serviceFailure?: { uid: number; sinceMs: number };
+};
 
 export type MailContentExtras = {
   subject: string;
@@ -160,6 +167,7 @@ export function unseenWatcherUids(
     // First sight of this mailbox generation, or a recreated INBOX: re-anchor
     // instead of comparing against the previous generation's UIDs.
     watermark.uidValidity = uidValidity;
+    watermark.serviceFailure = undefined;
     if (firstSight) {
       watermark.uid = currentHighWater;
       return [];
@@ -1343,6 +1351,7 @@ type WatchConnectionRuntime = {
   identity: typeof findIdentity;
   wait: typeof sleep;
   error: typeof console.error;
+  now: typeof Date.now;
 };
 
 /** @internal Exported so poison-message batch progression can be regression-tested. */
@@ -1356,6 +1365,7 @@ export async function watchConnection(
     identity: findIdentity,
     wait: sleep,
     error: console.error,
+    now: Date.now,
   },
 ): Promise<void> {
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
@@ -1390,14 +1400,32 @@ export async function watchConnection(
               },
             );
             consecutivePublishSkips = 0;
+            watermark.serviceFailure = undefined;
           } catch (err) {
             if (!(err instanceof WatcherPublishError)) throw err;
-            consecutivePublishSkips += 1;
-            runtime.error(
-              `[notify] IMAP watcher skipped UID ${message.uid} after ${err.attempts} publish attempts ` +
-                `(consecutive skips: ${consecutivePublishSkips}):`,
-              err.reason instanceof Error ? err.reason.message : String(err.reason),
-            );
+            if (isNotifyServiceFailure(err.reason)) {
+              const now = runtime.now();
+              const observed = watermark.serviceFailure;
+              if (!observed || observed.uid !== message.uid) {
+                watermark.serviceFailure = { uid: message.uid, sinceMs: now };
+                throw err;
+              }
+              const unavailableMs = Math.max(0, now - observed.sinceMs);
+              if (unavailableMs < SERVICE_FAILURE_MAX_MS) throw err;
+              runtime.error(
+                `[notify] CRITICAL IMAP watcher abandoned UID ${message.uid} after notification service ` +
+                  `failure persisted for ${unavailableMs}ms (hard limit: ${SERVICE_FAILURE_MAX_MS}ms):`,
+                err.reason instanceof Error ? err.reason.message : String(err.reason),
+              );
+            } else {
+              consecutivePublishSkips += 1;
+              runtime.error(
+                `[notify] IMAP watcher skipped UID ${message.uid} after ${err.attempts} publish attempts ` +
+                  `(consecutive skips: ${consecutivePublishSkips}):`,
+                err.reason instanceof Error ? err.reason.message : String(err.reason),
+              );
+            }
+            watermark.serviceFailure = undefined;
           }
           watermark.uid = Math.max(watermark.uid ?? 0, message.uid);
         }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -88,6 +88,8 @@ export type ProcessWatchedOptions = {
   refreshIdentity?: (address: string) => Identity | undefined;
   /** @internal Retry timer injection; production uses the module sleep helper. */
   wait?: (ms: number) => Promise<void>;
+  /** @internal Identity-level poison logging injection. */
+  error?: typeof console.error;
 };
 
 /** In-memory watermark survives a dropped IMAP connection in this process. */
@@ -1331,6 +1333,14 @@ export async function processWatchedMessage(
         );
         break; // sent
       } catch (err) {
+        if (err instanceof WatcherPublishError) {
+          if (isNotifyServiceFailure(err.reason)) throw err;
+          (options.error ?? console.error)(
+            `[notify] IMAP watcher skipped identity ${current.address} after ${err.attempts} publish attempts:`,
+            err.reason instanceof Error ? err.reason.message : String(err.reason),
+          );
+          break;
+        }
         if (!(err instanceof NotifyError && err.code === 'notify_cancelled')) throw err;
         if (!options.refreshIdentity) break;
         // Downgrade: rebuild at the safer tier. Delete: silent skip.
@@ -1397,6 +1407,7 @@ export async function watchConnection(
                 // O(1) indexed lookup; mtime/invalidate cache still sees tier PUTs.
                 refreshIdentity: (address) => runtime.identity(address),
                 wait: runtime.wait,
+                error: runtime.error,
               },
             );
             consecutivePublishSkips = 0;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -67,7 +67,37 @@ export const PUSH_META_FIELD_MAX_BYTES = 400;
 /** UTF-8 ellipsis used when the body is truncated to stay under the byte budget. */
 const PUSH_BODY_ELLIPSIS = '…';
 const PUSH_BODY_ELLIPSIS_BYTES = Buffer.byteLength(PUSH_BODY_ELLIPSIS, 'utf8');
-const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) => {
+  if (signal?.aborted) {
+    resolve();
+    return;
+  }
+  const finish = () => {
+    clearTimeout(timer);
+    signal?.removeEventListener('abort', finish);
+    resolve();
+  };
+  const timer = setTimeout(finish, ms);
+  signal?.addEventListener('abort', finish, { once: true });
+});
+
+async function waitForReconnect(
+  wait: typeof sleep,
+  ms: number,
+  signal: AbortSignal,
+): Promise<void> {
+  if (signal.aborted) return;
+  let onAbort!: () => void;
+  const aborted = new Promise<void>((resolve) => {
+    onAbort = resolve;
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+  try {
+    await Promise.race([wait(ms, signal), aborted]);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
+  }
+}
 
 export type WatchedMessage = Pick<FetchMessageObject, 'envelope' | 'headers' | 'source'>;
 
@@ -1526,7 +1556,8 @@ export async function runWatcher(
     if (connectedAt !== undefined && runtime.now() - connectedAt >= RECONNECT_STABLE_MS) {
       reconnectMs = RECONNECT_INITIAL_MS;
     }
-    await runtime.wait(reconnectMs);
+    await waitForReconnect(runtime.wait, reconnectMs, signal);
+    if (signal.aborted) break;
     reconnectMs = Math.min(reconnectMs * 2, RECONNECT_MAX_MS);
   }
 }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -38,7 +38,12 @@ import {
 } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 
-const RECONNECT_MS = 3_000;
+const RECONNECT_INITIAL_MS = 2_000;
+const RECONNECT_MAX_MS = 120_000;
+const RECONNECT_STABLE_MS = 30_000;
+const PUBLISH_MAX_ATTEMPTS = 3;
+const PUBLISH_RETRY_INITIAL_MS = 250;
+const PUBLISH_RETRY_MAX_MS = 500;
 /** Bounded plain-text preview length for tier-3 mail-arrival pushes. */
 export const PUSH_BODY_PREVIEW_CHARS = 280;
 /** Max OTP codes/links included in a tier-3 push (each list). */
@@ -79,6 +84,8 @@ export type ProcessWatchedOptions = {
    * deleted (skip publish); when omitted, the matched snapshot is used.
    */
   refreshIdentity?: (address: string) => Identity | undefined;
+  /** @internal Retry timer injection; production uses the module sleep helper. */
+  wait?: (ms: number) => Promise<void>;
 };
 
 /** In-memory watermark survives a dropped IMAP connection in this process. */
@@ -91,6 +98,38 @@ export type MailContentExtras = {
   codes: string[];
   links: string[];
 };
+
+class WatcherPublishError extends Error {
+  readonly attempts: number;
+  readonly reason: unknown;
+
+  constructor(attempts: number, reason: unknown) {
+    super(reason instanceof Error ? reason.message : String(reason));
+    this.name = 'WatcherPublishError';
+    this.attempts = attempts;
+    this.reason = reason;
+  }
+}
+
+async function publishWithRetry(
+  publish: () => ReturnType<NotifyService['publish']>,
+  wait: (ms: number) => Promise<void>,
+): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= PUBLISH_MAX_ATTEMPTS; attempt++) {
+    try {
+      await publish();
+      return;
+    } catch (err) {
+      if (err instanceof NotifyError && err.code === 'notify_cancelled') throw err;
+      lastError = err;
+      if (attempt < PUBLISH_MAX_ATTEMPTS) {
+        await wait(Math.min(PUBLISH_RETRY_INITIAL_MS * 2 ** (attempt - 1), PUBLISH_RETRY_MAX_MS));
+      }
+    }
+  }
+  throw new WatcherPublishError(PUBLISH_MAX_ATTEMPTS, lastError);
+}
 
 /**
  * The first successful connection starts at the mailbox high-water mark so an
@@ -1262,23 +1301,26 @@ export async function processWatchedMessage(
           }
         : undefined;
       try {
-        await dispatch.publish({
-          target: 'user',
-          title: 'openagent.email new mail',
-          message: body,
-          level,
-          tags: ['email'],
-          // Truncate rather than throw: publish errors before UID advance stall
-          // the watcher (F76). Manual /v1/notify keeps the default overflow=error.
-          overflow: 'truncate',
-          source: 'watcher',
-          logicalChannel: 'user-alerts',
-          // tier 3 才把正文/OTP 送出服务器；与 level 正交，供 UI 默认遮蔽。
-          sensitive: tier === 3,
-          identityAddress: current.address,
-          ...(clickUrl ? { click: clickUrl } : {}),
-          ...(beforeSend ? { beforeSend } : {}),
-        });
+        await publishWithRetry(
+          () => dispatch.publish({
+            target: 'user',
+            title: 'openagent.email new mail',
+            message: body,
+            level,
+            tags: ['email'],
+            // Truncate rather than throw: publish errors before UID advance stall
+            // the watcher (F76). Manual /v1/notify keeps the default overflow=error.
+            overflow: 'truncate',
+            source: 'watcher',
+            logicalChannel: 'user-alerts',
+            // tier 3 才把正文/OTP 送出服务器；与 level 正交，供 UI 默认遮蔽。
+            sensitive: tier === 3,
+            identityAddress: current.address,
+            ...(clickUrl ? { click: clickUrl } : {}),
+            ...(beforeSend ? { beforeSend } : {}),
+          }),
+          options.wait ?? sleep,
+        );
         break; // sent
       } catch (err) {
         if (!(err instanceof NotifyError && err.code === 'notify_cancelled')) throw err;
@@ -1296,13 +1338,28 @@ export async function processWatchedMessage(
   }
 }
 
-async function watchConnection(
+type WatchConnectionRuntime = {
+  identities: typeof listIdentities;
+  identity: typeof findIdentity;
+  wait: typeof sleep;
+  error: typeof console.error;
+};
+
+/** @internal Exported so poison-message batch progression can be regression-tested. */
+export async function watchConnection(
   signal: AbortSignal,
   client: ImapFlow,
   dispatch: WatcherDispatch,
   watermark: WatcherWatermark,
+  runtime: WatchConnectionRuntime = {
+    identities: listIdentities,
+    identity: findIdentity,
+    wait: sleep,
+    error: console.error,
+  },
 ): Promise<void> {
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
+  let consecutivePublishSkips = 0;
   try {
     lock = await client.getMailboxLock('INBOX');
     // F111: track the selected mailbox generation so a recreated INBOX
@@ -1319,17 +1376,29 @@ async function watchConnection(
           { envelope: true, headers: ['delivered-to'], source: true },
           { uid: true },
         )) {
-          await processWatchedMessage(
-            message,
-            listIdentities(),
-            config.ntfy.pushPolicy,
-            dispatch,
-            {
-              clickUrl: config.dashboardPublicUrl,
-              // O(1) indexed lookup; mtime/invalidate cache still sees tier PUTs.
-              refreshIdentity: (address) => findIdentity(address),
-            },
-          );
+          try {
+            await processWatchedMessage(
+              message,
+              runtime.identities(),
+              config.ntfy.pushPolicy,
+              dispatch,
+              {
+                clickUrl: config.dashboardPublicUrl,
+                // O(1) indexed lookup; mtime/invalidate cache still sees tier PUTs.
+                refreshIdentity: (address) => runtime.identity(address),
+                wait: runtime.wait,
+              },
+            );
+            consecutivePublishSkips = 0;
+          } catch (err) {
+            if (!(err instanceof WatcherPublishError)) throw err;
+            consecutivePublishSkips += 1;
+            runtime.error(
+              `[notify] IMAP watcher skipped UID ${message.uid} after ${err.attempts} publish attempts ` +
+                `(consecutive skips: ${consecutivePublishSkips}):`,
+              err.reason instanceof Error ? err.reason.message : String(err.reason),
+            );
+          }
           watermark.uid = Math.max(watermark.uid ?? 0, message.uid);
         }
       }
@@ -1339,7 +1408,7 @@ async function watchConnection(
       // heartbeat keeps this watcher correct on servers that occasionally keep
       // an IDLE command open after mail arrives. Socket errors still escape to
       // the outer reconnect loop instead of leaving a stale watcher forever.
-      await Promise.race([client.idle(), sleep(3_000)]);
+      await Promise.race([client.idle(), runtime.wait(3_000)]);
       if (signal.aborted) break;
       const found = await client.search({ all: true }, { uid: true });
       pending = unseenWatcherUids(Array.isArray(found) ? found : [], watermark, uidValidity);
@@ -1364,6 +1433,7 @@ type WatcherRuntime = {
   wait: typeof sleep;
   warn: typeof console.warn;
   connectionId: string;
+  now: typeof Date.now;
 };
 
 /** @internal Exported so the reconnect/error boundary can be regression-tested. */
@@ -1376,12 +1446,16 @@ export async function runWatcher(
     wait: sleep,
     warn: console.warn,
     connectionId: `${config.imap.host}:${config.imap.port}`,
+    now: Date.now,
   },
 ): Promise<void> {
   const watermark: WatcherWatermark = {};
+  let reconnectMs = RECONNECT_INITIAL_MS;
   while (!signal.aborted) {
+    let connectedAt: number | undefined;
     try {
       const client = await runtime.connect();
+      connectedAt = runtime.now();
       const onError = (err: unknown) => {
         runtime.warn(
           `[notify] IMAP watcher connection ${runtime.connectionId} error:`,
@@ -1409,7 +1483,12 @@ export async function runWatcher(
         );
       }
     }
-    if (!signal.aborted) await runtime.wait(RECONNECT_MS);
+    if (signal.aborted) break;
+    if (connectedAt !== undefined && runtime.now() - connectedAt >= RECONNECT_STABLE_MS) {
+      reconnectMs = RECONNECT_INITIAL_MS;
+    }
+    await runtime.wait(reconnectMs);
+    reconnectMs = Math.min(reconnectMs * 2, RECONNECT_MAX_MS);
   }
 }
 

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -115,7 +115,12 @@ export type NotificationDevice = {
   };
 };
 
+type NotifyFailureKind = 'message' | 'service';
+const NOTIFY_FAILURE_KIND = Symbol('notifyFailureKind');
+
 export class NotifyError extends Error {
+  readonly [NOTIFY_FAILURE_KIND]?: NotifyFailureKind;
+
   constructor(
     public readonly code:
       | 'notifications_disabled'
@@ -132,9 +137,17 @@ export class NotifyError extends Error {
       /** 给人看的原因；API 可原样返回。 */
       message?: string;
     },
+    /** @internal Watcher-only failure routing; never serialized by REST handlers. */
+    internal?: { failureKind: NotifyFailureKind },
   ) {
     super(code);
+    this[NOTIFY_FAILURE_KIND] = internal?.failureKind;
   }
+}
+
+/** @internal Distinguishes provider-wide outages from one rejected payload. */
+export function isNotifyServiceFailure(err: unknown): boolean {
+  return err instanceof NotifyError && err[NOTIFY_FAILURE_KIND] === 'service';
 }
 
 type Reader = {
@@ -815,8 +828,12 @@ export function boundJsonEscapedText(text: string, maxEscapedBytes: number): str
 
 export class NtfyNotificationService implements NotifyService {
   private async assertEnabled(): Promise<NotifyState> {
-    if (!config.ntfy.enabled) throw new NotifyError('notifications_disabled');
-    if (!config.ntfy.adminPassword) throw new NotifyError('notifications_unconfigured');
+    if (!config.ntfy.enabled) {
+      throw new NotifyError('notifications_disabled', undefined, { failureKind: 'service' });
+    }
+    if (!config.ntfy.adminPassword) {
+      throw new NotifyError('notifications_unconfigured', undefined, { failureKind: 'service' });
+    }
     return state();
   }
 
@@ -863,12 +880,21 @@ export class NtfyNotificationService implements NotifyService {
     if (input.beforeSend && !input.beforeSend()) {
       throw new NotifyError('notify_cancelled');
     }
-    const response = await fetch(providerUrl('/'), {
-      method: 'POST',
-      headers: { ...bearer(current.publisherToken), 'content-type': 'application/json' },
-      body,
-    });
-    if (!response.ok) throw new NotifyError('notify_unavailable');
+    let response: Response;
+    try {
+      response = await fetch(providerUrl('/'), {
+        method: 'POST',
+        headers: { ...bearer(current.publisherToken), 'content-type': 'application/json' },
+        body,
+      });
+    } catch {
+      throw new NotifyError('notify_unavailable', undefined, { failureKind: 'service' });
+    }
+    if (!response.ok) {
+      throw new NotifyError('notify_unavailable', undefined, {
+        failureKind: response.status >= 500 ? 'service' : 'message',
+      });
+    }
     // 送达优先：ntfy 成功后、返回前写日志。append 失败只告警，不把投递改成失败。
     const logicalTarget = input.target as NotificationLogicalTarget;
     const logicalChannel =

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -147,7 +147,24 @@ export class NotifyError extends Error {
 
 /** @internal Distinguishes provider-wide outages from one rejected payload. */
 export function isNotifyServiceFailure(err: unknown): boolean {
+  // Unmarked errors default to message-level: every new publish-path service
+  // failure must opt in here, or the watcher may consume its blocked UID.
   return err instanceof NotifyError && err[NOTIFY_FAILURE_KIND] === 'service';
+}
+
+/** @internal Shared by publish and watcher status-boundary regression tests. */
+export function isNtfyPublishServiceStatus(status: number): boolean {
+  // Changing the payload cannot repair shared auth/proxy auth, a request
+  // timeout, a retry-later response, rate limiting, or a provider 5xx.
+  return (
+    status >= 500 ||
+    status === 401 ||
+    status === 403 ||
+    status === 407 ||
+    status === 408 ||
+    status === 425 ||
+    status === 429
+  );
 }
 
 type Reader = {
@@ -886,13 +903,16 @@ export class NtfyNotificationService implements NotifyService {
         method: 'POST',
         headers: { ...bearer(current.publisherToken), 'content-type': 'application/json' },
         body,
+        // Match management reads/writes: a hung provider must reach watcher
+        // retry/backoff instead of pinning one UID forever.
+        signal: AbortSignal.timeout(NTFY_ADMIN_FETCH_TIMEOUT_MS),
       });
     } catch {
       throw new NotifyError('notify_unavailable', undefined, { failureKind: 'service' });
     }
     if (!response.ok) {
       throw new NotifyError('notify_unavailable', undefined, {
-        failureKind: response.status >= 500 ? 'service' : 'message',
+        failureKind: isNtfyPublishServiceStatus(response.status) ? 'service' : 'message',
       });
     }
     // 送达优先：ntfy 成功后、返回前写日志。append 失败只告警，不把投递改成失败。

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -156,17 +156,9 @@ export function isNotifyServiceFailure(err: unknown): boolean {
 
 /** @internal Shared by publish and watcher status-boundary regression tests. */
 export function isNtfyPublishServiceStatus(status: number): boolean {
-  // Changing the payload cannot repair shared auth/proxy auth, a request
-  // timeout, a retry-later response, rate limiting, or a provider 5xx.
-  return (
-    status >= 500 ||
-    status === 401 ||
-    status === 403 ||
-    status === 407 ||
-    status === 408 ||
-    status === 425 ||
-    status === 429
-  );
+  // Only known payload rejections may consume a UID. An unrecognized status
+  // can reflect a shared endpoint/proxy/provider fault, so retain by default.
+  return status !== 400 && status !== 413 && status !== 422;
 }
 
 type Reader = {

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -147,9 +147,11 @@ export class NotifyError extends Error {
 
 /** @internal Distinguishes provider-wide outages from one rejected payload. */
 export function isNotifyServiceFailure(err: unknown): boolean {
-  // Unmarked errors default to message-level: every new publish-path service
-  // failure must opt in here, or the watcher may consume its blocked UID.
-  return err instanceof NotifyError && err[NOTIFY_FAILURE_KIND] === 'service';
+  // Only an explicitly classified payload rejection may consume a UID.
+  // Unknown/plain failures retain it and are still bounded by the watcher's
+  // 10-minute CRITICAL fallback instead of silently losing outage traffic.
+  if (err instanceof NotifyError && err.code === 'notify_cancelled') return false;
+  return !(err instanceof NotifyError) || err[NOTIFY_FAILURE_KIND] !== 'message';
 }
 
 /** @internal Shared by publish and watcher status-boundary regression tests. */
@@ -392,6 +394,11 @@ async function writeServerConfig(state: NotifyState): Promise<void> {
 }
 
 let cachedState: NotifyState | undefined;
+
+/** @internal Test seam for exercising notification-store load and recovery. */
+export function resetNotificationStateForTests(): void {
+  cachedState = undefined;
+}
 
 async function state(): Promise<NotifyState> {
   if (!cachedState) cachedState = loadState();

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -6,6 +6,9 @@ process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
 
 import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 
 const { describe, expect, test } = await import('bun:test');
 const {
@@ -30,10 +33,13 @@ const {
 } = await import('../src/lib/notification-watcher.ts');
 const {
   isNtfyPublishServiceStatus,
+  NtfyNotificationService,
   NotifyError,
   jsonEscapedByteLength,
   notifyAvailableMessageBytes,
+  resetNotificationStateForTests,
 } = await import('../src/lib/notify.ts');
+const { config } = await import('../src/lib/config.ts');
 const { hasStrongOtpCue } = await import('../src/lib/otp.ts');
 
 /** Mock publish that honors beforeSend like NtfyNotificationService. */
@@ -127,9 +133,10 @@ describe('mail-arrival notification watcher', () => {
       {
         publish: async (payload) => {
           publishCalls.push(payload.message);
-          // Same public code as an outage, but no internal service marker:
-          // this models ntfy explicitly rejecting this particular request.
-          if (publishCalls.length <= 6) throw new NotifyError('notify_unavailable');
+          // Same public code as an outage, explicitly marked as this payload's rejection.
+          if (publishCalls.length <= 6) {
+            throw new NotifyError('notify_unavailable', undefined, { failureKind: 'message' });
+          }
           return { target: payload.target, title: payload.title, level: payload.level };
         },
       },
@@ -311,6 +318,71 @@ describe('mail-arrival notification watcher', () => {
       await watchConnection(recovered.signal, makeClient(recovered), dispatch, watermark, runtime);
       expect(delivered).toEqual([status]);
       expect(watermark.uid).toBe(41);
+    }
+  });
+
+  test('通知存储损坏抛普通 Error 时保留 UID，修复存储后补投同一封信', async () => {
+    const testDir = mkdtempSync(join(tmpdir(), 'oae-watcher-store-'));
+    const configPath = join(testDir, 'ntfy', 'server.yml');
+    const statePath = join(dirname(configPath), 'notifications.json');
+    const previousNtfy = { ...config.ntfy };
+    const previousFetch = globalThis.fetch;
+    mkdirSync(dirname(configPath), { recursive: true });
+    writeFileSync(statePath, '{corrupt');
+    Object.assign(config.ntfy, {
+      enabled: true,
+      adminPassword: 'ntfy-admin-secret',
+      configPath,
+    });
+    resetNotificationStateForTests();
+
+    const watermark = { uid: 40 };
+    const watched = {
+      ...message('store@example.net', 'From: store@example.net\r\n\r\nYour verification code is 777777'),
+      uid: 41,
+    };
+    const makeClient = (controller: AbortController) => ({
+      mailbox: false,
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => [41],
+      fetch: async function* () { yield watched; },
+      idle: async () => { controller.abort(); },
+      logout: async () => {},
+      close() {},
+    }) as any;
+    const runtime = {
+      identities: () => baseIdentities,
+      identity: (address: string) => baseIdentities.find((entry) => entry.address === address),
+      wait: async () => {},
+      error: () => {},
+      now: () => 0,
+    };
+    const service = new NtfyNotificationService();
+    let fetchCalls = 0;
+    globalThis.fetch = (async () => {
+      fetchCalls += 1;
+      return new Response('', { status: 200 });
+    }) as typeof fetch;
+
+    try {
+      const corrupt = new AbortController();
+      await expect(watchConnection(corrupt.signal, makeClient(corrupt), service, watermark, runtime))
+        .rejects.toThrow('notification_store_corrupt');
+      expect(watermark.uid).toBe(40);
+      expect(fetchCalls).toBe(0);
+
+      unlinkSync(statePath);
+      resetNotificationStateForTests();
+      const repaired = new AbortController();
+      await watchConnection(repaired.signal, makeClient(repaired), service, watermark, runtime);
+
+      expect(fetchCalls).toBe(1);
+      expect(watermark.uid).toBe(41);
+    } finally {
+      globalThis.fetch = previousFetch;
+      Object.assign(config.ntfy, previousNtfy);
+      resetNotificationStateForTests();
+      rmSync(testDir, { recursive: true, force: true });
     }
   });
 

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -126,7 +126,9 @@ describe('mail-arrival notification watcher', () => {
       {
         publish: async (payload) => {
           publishCalls.push(payload.message);
-          if (publishCalls.length <= 6) throw new Error('ntfy poison');
+          // Same public code as an outage, but no internal service marker:
+          // this models ntfy explicitly rejecting this particular request.
+          if (publishCalls.length <= 6) throw new NotifyError('notify_unavailable');
           return { target: payload.target, title: payload.title, level: payload.level };
         },
       },
@@ -140,6 +142,7 @@ describe('mail-arrival notification watcher', () => {
         error: (...args) => {
           errors.push(args);
         },
+        now: () => 0,
       },
     );
 
@@ -147,8 +150,116 @@ describe('mail-arrival notification watcher', () => {
     expect(retryWaits).toEqual([250, 500, 250, 500, 3_000]);
     expect(watermark.uid).toBe(43);
     expect(errors.map((entry) => entry.join(' '))).toEqual([
-      '[notify] IMAP watcher skipped UID 41 after 3 publish attempts (consecutive skips: 1): ntfy poison',
-      '[notify] IMAP watcher skipped UID 42 after 3 publish attempts (consecutive skips: 2): ntfy poison',
+      '[notify] IMAP watcher skipped UID 41 after 3 publish attempts (consecutive skips: 1): notify_unavailable',
+      '[notify] IMAP watcher skipped UID 42 after 3 publish attempts (consecutive skips: 2): notify_unavailable',
+    ]);
+  });
+
+  test('服务中断超过短重试窗口不消耗 UID，恢复后同一封信最终投递', async () => {
+    const watermark = { uid: 40 };
+    const delivered: number[] = [];
+    let now = 0;
+    let publishAttempts = 0;
+    const watched = {
+      ...message('service@example.net', 'From: service@example.net\r\n\r\nYour verification code is 444444'),
+      uid: 41,
+    };
+    const client = (onIdle: () => void) => ({
+      mailbox: false,
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => [41],
+      fetch: async function* () { yield watched; },
+      idle: async () => { onIdle(); },
+      logout: async () => {},
+      close() {},
+    }) as any;
+    const runtime = (onIdle: () => void) => ({
+      identities: () => baseIdentities,
+      identity: (address: string) => baseIdentities.find((entry) => entry.address === address),
+      wait: async () => {},
+      error: () => {},
+      now: () => now,
+    });
+
+    const first = new AbortController();
+    await expect(watchConnection(
+      first.signal,
+      client(() => first.abort()),
+      {
+        publish: async () => {
+          publishAttempts += 1;
+          now += 2_000; // 3 attempts model a 6s outage, well beyond the old 750ms window.
+          throw new NotifyError('notify_unavailable', undefined, { failureKind: 'service' });
+        },
+      },
+      watermark,
+      runtime(() => first.abort()),
+    )).rejects.toThrow('notify_unavailable');
+    expect(publishAttempts).toBe(3);
+    expect(watermark.uid).toBe(40);
+
+    const recovered = new AbortController();
+    await watchConnection(
+      recovered.signal,
+      client(() => recovered.abort()),
+      {
+        publish: async () => {
+          publishAttempts += 1;
+          delivered.push(41);
+          return { target: 'user', title: 'openagent.email new mail', level: 'urgent' };
+        },
+      },
+      watermark,
+      runtime(() => recovered.abort()),
+    );
+
+    expect(delivered).toEqual([41]);
+    expect(publishAttempts).toBe(4);
+    expect(watermark.uid).toBe(41);
+  });
+
+  test('服务中断持续满 10 分钟后高响度跳过并推进水位线', async () => {
+    const watermark = { uid: 40 };
+    const errors: unknown[][] = [];
+    let now = 0;
+    const watched = {
+      ...message('service@example.net', 'From: service@example.net\r\n\r\nYour verification code is 555555'),
+      uid: 41,
+    };
+    const makeClient = (controller: AbortController) => ({
+      mailbox: false,
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => [41],
+      fetch: async function* () { yield watched; },
+      idle: async () => { controller.abort(); },
+      logout: async () => {},
+      close() {},
+    }) as any;
+    const dispatch = {
+      publish: async () => {
+        throw new NotifyError('notify_unavailable', undefined, { failureKind: 'service' });
+      },
+    };
+    const runtime = {
+      identities: () => baseIdentities,
+      identity: (address: string) => baseIdentities.find((entry) => entry.address === address),
+      wait: async () => {},
+      error: (...args: unknown[]) => { errors.push(args); },
+      now: () => now,
+    };
+
+    const first = new AbortController();
+    await expect(watchConnection(first.signal, makeClient(first), dispatch, watermark, runtime))
+      .rejects.toThrow('notify_unavailable');
+    expect(watermark.uid).toBe(40);
+
+    now = 600_000;
+    const expired = new AbortController();
+    await watchConnection(expired.signal, makeClient(expired), dispatch, watermark, runtime);
+
+    expect(watermark.uid).toBe(41);
+    expect(errors.map((entry) => entry.join(' '))).toEqual([
+      '[notify] CRITICAL IMAP watcher abandoned UID 41 after notification service failure persisted for 600000ms (hard limit: 600000ms): notify_unavailable',
     ]);
   });
 

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -158,9 +158,66 @@ describe('mail-arrival notification watcher', () => {
     expect(retryWaits).toEqual([250, 500, 250, 500, 3_000]);
     expect(watermark.uid).toBe(43);
     expect(errors.map((entry) => entry.join(' '))).toEqual([
-      '[notify] IMAP watcher skipped UID 41 after 3 publish attempts (consecutive skips: 1): notify_unavailable',
-      '[notify] IMAP watcher skipped UID 42 after 3 publish attempts (consecutive skips: 2): notify_unavailable',
+      '[notify] IMAP watcher skipped identity target@test.example after 3 publish attempts: notify_unavailable',
+      '[notify] IMAP watcher skipped identity target@test.example after 3 publish attempts: notify_unavailable',
     ]);
+  });
+
+  test('同一封信首个身份消息级拒绝不连坐，后续身份仍投递且 UID 推进', async () => {
+    const controller = new AbortController();
+    const publishCalls: string[] = [];
+    const errors: unknown[][] = [];
+    const watermark = { uid: 40 };
+    const watched = {
+      ...message('multi@example.net', 'From: multi@example.net\r\n\r\nYour verification code is 888888'),
+      uid: 41,
+      envelope: {
+        ...message('multi@example.net', '').envelope,
+        to: [{ address: 'target@test.example' }, { address: 'sender@test.example' }],
+      },
+    };
+    const client = {
+      mailbox: false,
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => [41],
+      fetch: async function* () { yield watched; },
+      idle: async () => { controller.abort(); },
+      logout: async () => {},
+      close() {},
+    } as any;
+
+    await watchConnection(
+      controller.signal,
+      client,
+      {
+        publish: async (payload) => {
+          publishCalls.push(payload.identityAddress!);
+          if (payload.identityAddress === 'target@test.example') {
+            throw new NotifyError('notify_unavailable', undefined, { failureKind: 'message' });
+          }
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+      watermark,
+      {
+        identities: () => baseIdentities,
+        identity: (address) => baseIdentities.find((entry) => entry.address === address),
+        wait: async () => {},
+        error: (...args) => { errors.push(args); },
+        now: () => 0,
+      },
+    );
+
+    expect(publishCalls).toEqual([
+      'target@test.example',
+      'target@test.example',
+      'target@test.example',
+      'sender@test.example',
+    ]);
+    expect(errors.map((entry) => entry.join(' '))).toEqual([
+      '[notify] IMAP watcher skipped identity target@test.example after 3 publish attempts: notify_unavailable',
+    ]);
+    expect(watermark.uid).toBe(41);
   });
 
   test('服务中断超过短重试窗口不消耗 UID，恢复后同一封信最终投递', async () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -20,6 +20,7 @@ const {
   packPushLinkLines,
   processWatchedMessage,
   runWatcher,
+  watchConnection,
   unseenWatcherUids,
   PUSH_BODY_PREVIEW_CHARS,
   PUSH_MESSAGE_MAX_BYTES,
@@ -85,7 +86,73 @@ async function dispatches(
 }
 
 describe('mail-arrival notification watcher', () => {
-  test('连续 2 轮异步连接错误时 watcher 记录连接、按 3 秒退避并继续，不终止循环', async () => {
+  test('连续毒消息有界重试后按 UID 计数跳过，水位线继续越过并投递后续消息', async () => {
+    const controller = new AbortController();
+    const retryWaits: number[] = [];
+    const errors: unknown[][] = [];
+    const publishCalls: string[] = [];
+    const poison = {
+      ...message('bad@example.net', 'From: bad@example.net\r\n\r\nYour verification code is 111111'),
+      uid: 41,
+    };
+    const secondPoison = {
+      ...message('bad2@example.net', 'From: bad2@example.net\r\n\r\nYour verification code is 222222'),
+      uid: 42,
+    };
+    const healthy = {
+      ...message('good@example.net', 'From: good@example.net\r\n\r\nYour verification code is 333333'),
+      uid: 43,
+    };
+    const watermark = { uid: 40 };
+    const client = {
+      mailbox: false,
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => [41, 42, 43],
+      fetch: async function* () {
+        yield poison;
+        yield secondPoison;
+        yield healthy;
+      },
+      idle: async () => {
+        controller.abort();
+      },
+      logout: async () => {},
+      close() {},
+    } as any;
+
+    await watchConnection(
+      controller.signal,
+      client,
+      {
+        publish: async (payload) => {
+          publishCalls.push(payload.message);
+          if (publishCalls.length <= 6) throw new Error('ntfy poison');
+          return { target: payload.target, title: payload.title, level: payload.level };
+        },
+      },
+      watermark,
+      {
+        identities: () => baseIdentities,
+        identity: (address) => baseIdentities.find((entry) => entry.address === address),
+        wait: async (ms) => {
+          retryWaits.push(ms);
+        },
+        error: (...args) => {
+          errors.push(args);
+        },
+      },
+    );
+
+    expect(publishCalls).toHaveLength(7);
+    expect(retryWaits).toEqual([250, 500, 250, 500, 3_000]);
+    expect(watermark.uid).toBe(43);
+    expect(errors.map((entry) => entry.join(' '))).toEqual([
+      '[notify] IMAP watcher skipped UID 41 after 3 publish attempts (consecutive skips: 1): ntfy poison',
+      '[notify] IMAP watcher skipped UID 42 after 3 publish attempts (consecutive skips: 2): ntfy poison',
+    ]);
+  });
+
+  test('连续异步连接错误按 2s 指数退避到 120s 封顶，循环不终止', async () => {
     const controller = new AbortController();
     const warnings: unknown[][] = [];
     const waits: number[] = [];
@@ -98,7 +165,7 @@ describe('mail-arrival notification watcher', () => {
         connect: async () => new EventEmitter() as any,
         watch: async (_signal, client) => {
           attempts += 1;
-          if (attempts > 2) {
+          if (attempts > 8) {
             controller.abort();
             return;
           }
@@ -115,18 +182,53 @@ describe('mail-arrival notification watcher', () => {
           warnings.push(args);
         },
         connectionId: 'imap.test:993',
+        now: () => 0,
       },
     );
 
-    expect(attempts).toBe(3);
-    expect(waits).toEqual([3_000, 3_000]);
-    expect(warnings).toHaveLength(4);
-    expect(warnings.map((entry) => entry.join(' '))).toEqual([
-      '[notify] IMAP watcher connection imap.test:993 error: socket timeout 1',
-      '[notify] IMAP watcher connection imap.test:993 reconnecting: socket timeout 1',
-      '[notify] IMAP watcher connection imap.test:993 error: socket timeout 2',
-      '[notify] IMAP watcher connection imap.test:993 reconnecting: socket timeout 2',
-    ]);
+    expect(attempts).toBe(9);
+    expect(waits).toEqual([2_000, 4_000, 8_000, 16_000, 32_000, 64_000, 120_000, 120_000]);
+    expect(warnings).toHaveLength(16);
+  });
+
+  test('29.999s 短连不重置，连接存活满 30s 才把指数退避重置为 2s', async () => {
+    const controller = new AbortController();
+    const waits: number[] = [];
+    let attempts = 0;
+    let now = 0;
+
+    await runWatcher(
+      controller.signal,
+      { publish: async () => ({ target: 'user', title: 'unused', level: 'normal' }) },
+      {
+        connect: async () => {
+          attempts += 1;
+          if (attempts === 1 || attempts === 4) throw new Error('connect failed');
+          if (attempts === 5) {
+            controller.abort();
+            throw new Error('done');
+          }
+          return new EventEmitter() as any;
+        },
+        watch: async () => {
+          if (attempts === 2) {
+            now += 29_999;
+            throw new Error('short connection closed');
+          }
+          now += 30_000;
+          throw new Error('stable connection closed');
+        },
+        wait: async (ms) => {
+          waits.push(ms);
+        },
+        warn: () => {},
+        connectionId: 'imap.test:993',
+        now: () => now,
+      },
+    );
+
+    expect(attempts).toBe(5);
+    expect(waits).toEqual([2_000, 4_000, 2_000, 4_000]);
   });
 
   test('keeps its watermark across reconnects and catches the downtime window', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -378,6 +378,56 @@ describe('mail-arrival notification watcher', () => {
     }
   });
 
+  test('ntfy 未列出的 404/405 视为服务故障，保留 UID 并在恢复后补投', async () => {
+    for (const status of [404, 405]) {
+      const watermark = { uid: 40 };
+      const delivered: number[] = [];
+      const watched = {
+        ...message('unknown-4xx@example.net', 'From: unknown-4xx@example.net\r\n\r\nYour verification code is 565656'),
+        uid: 41,
+      };
+      const makeClient = (controller: AbortController) => ({
+        mailbox: false,
+        getMailboxLock: async () => ({ release() {} }),
+        search: async () => [41],
+        fetch: async function* () { yield watched; },
+        idle: async () => { controller.abort(); },
+        logout: async () => {},
+        close() {},
+      }) as any;
+      const runtime = {
+        identities: () => baseIdentities,
+        identity: (address: string) => baseIdentities.find((entry) => entry.address === address),
+        wait: async () => {},
+        error: () => {},
+        now: () => 0,
+      };
+      let unavailable = true;
+      const dispatch = {
+        publish: async () => {
+          if (unavailable) {
+            throw new NotifyError('notify_unavailable', undefined, {
+              failureKind: isNtfyPublishServiceStatus(status) ? 'service' : 'message',
+            });
+          }
+          delivered.push(status);
+          return { target: 'user' as const, title: 'openagent.email new mail', level: 'urgent' as const };
+        },
+      };
+
+      const failed = new AbortController();
+      await expect(watchConnection(failed.signal, makeClient(failed), dispatch, watermark, runtime))
+        .rejects.toThrow('notify_unavailable');
+      expect(watermark.uid).toBe(40);
+
+      unavailable = false;
+      const recovered = new AbortController();
+      await watchConnection(recovered.signal, makeClient(recovered), dispatch, watermark, runtime);
+      expect(delivered).toEqual([status]);
+      expect(watermark.uid).toBe(41);
+    }
+  });
+
   test('通知存储损坏抛普通 Error 时保留 UID，修复存储后补投同一封信', async () => {
     const testDir = mkdtempSync(join(tmpdir(), 'oae-watcher-store-'));
     const configPath = join(testDir, 'ntfy', 'server.yml');
@@ -520,6 +570,40 @@ describe('mail-arrival notification watcher', () => {
 
     expect(attempts).toBe(5);
     expect(waits).toEqual([2_000, 4_000, 2_000, 4_000]);
+  });
+
+  test('重连退避期间 abort 会立即结束 watcher，不等待完整延迟', async () => {
+    const controller = new AbortController();
+    let markWaitStarted!: () => void;
+    const waitStarted = new Promise<void>((resolve) => { markWaitStarted = resolve; });
+    const waits: number[] = [];
+
+    const running = runWatcher(
+      controller.signal,
+      { publish: async () => ({ target: 'user', title: 'unused', level: 'normal' }) },
+      {
+        connect: async () => { throw new Error('connect failed'); },
+        watch: async () => {},
+        wait: async (ms) => {
+          waits.push(ms);
+          markWaitStarted();
+          await new Promise<void>(() => {});
+        },
+        warn: () => {},
+        connectionId: 'imap.test:993',
+        now: () => 0,
+      },
+    );
+
+    await waitStarted;
+    controller.abort();
+    const outcome = await Promise.race([
+      running.then(() => 'stopped' as const),
+      new Promise<'still-waiting'>((resolve) => setTimeout(() => resolve('still-waiting'), 50)),
+    ]);
+
+    expect(waits).toEqual([2_000]);
+    expect(outcome).toBe('stopped');
   });
 
   test('keeps its watermark across reconnects and catches the downtime window', () => {

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -29,6 +29,7 @@ const {
   PUSH_OTP_ITEM_MAX,
 } = await import('../src/lib/notification-watcher.ts');
 const {
+  isNtfyPublishServiceStatus,
   NotifyError,
   jsonEscapedByteLength,
   notifyAvailableMessageBytes,
@@ -261,6 +262,56 @@ describe('mail-arrival notification watcher', () => {
     expect(errors.map((entry) => entry.join(' '))).toEqual([
       '[notify] CRITICAL IMAP watcher abandoned UID 41 after notification service failure persisted for 600000ms (hard limit: 600000ms): notify_unavailable',
     ]);
+  });
+
+  test('ntfy 401/403/429 不消耗 UID，服务恢复后逐一补投', async () => {
+    for (const status of [401, 403, 429]) {
+      const watermark = { uid: 40 };
+      const delivered: number[] = [];
+      const watched = {
+        ...message('global-4xx@example.net', 'From: global-4xx@example.net\r\n\r\nYour verification code is 666666'),
+        uid: 41,
+      };
+      const makeClient = (controller: AbortController) => ({
+        mailbox: false,
+        getMailboxLock: async () => ({ release() {} }),
+        search: async () => [41],
+        fetch: async function* () { yield watched; },
+        idle: async () => { controller.abort(); },
+        logout: async () => {},
+        close() {},
+      }) as any;
+      const runtime = {
+        identities: () => baseIdentities,
+        identity: (address: string) => baseIdentities.find((entry) => entry.address === address),
+        wait: async () => {},
+        error: () => {},
+        now: () => 0,
+      };
+      let unavailable = true;
+      const dispatch = {
+        publish: async () => {
+          if (unavailable) {
+            throw new NotifyError('notify_unavailable', undefined, {
+              failureKind: isNtfyPublishServiceStatus(status) ? 'service' : 'message',
+            });
+          }
+          delivered.push(status);
+          return { target: 'user' as const, title: 'openagent.email new mail', level: 'urgent' as const };
+        },
+      };
+
+      const failed = new AbortController();
+      await expect(watchConnection(failed.signal, makeClient(failed), dispatch, watermark, runtime))
+        .rejects.toThrow('notify_unavailable');
+      expect(watermark.uid).toBe(40);
+
+      unavailable = false;
+      const recovered = new AbortController();
+      await watchConnection(recovered.signal, makeClient(recovered), dispatch, watermark, runtime);
+      expect(delivered).toEqual([status]);
+      expect(watermark.uid).toBe(41);
+    }
   });
 
   test('连续异步连接错误按 2s 指数退避到 120s 封顶，循环不终止', async () => {

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -703,6 +703,14 @@ describe('ntfy publish payload budget', () => {
     try {
       for (const response of [
         async () => new Response('', { status: 400 }),
+        async () => new Response('', { status: 413 }),
+        async () => new Response('', { status: 422 }),
+        async () => new Response('', { status: 401 }),
+        async () => new Response('', { status: 403 }),
+        async () => new Response('', { status: 407 }),
+        async () => new Response('', { status: 408 }),
+        async () => new Response('', { status: 425 }),
+        async () => new Response('', { status: 429 }),
         async () => new Response('', { status: 503 }),
         async () => { throw new TypeError('network down'); },
       ]) {
@@ -721,8 +729,61 @@ describe('ntfy publish payload budget', () => {
       'notify_unavailable',
       'notify_unavailable',
       'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
     ]);
-    expect(caught.map(isNotifyServiceFailure)).toEqual([false, true, true]);
+    expect(caught.map(isNotifyServiceFailure)).toEqual([
+      false, false, false,
+      true, true, true, true, true, true, true, true,
+    ]);
+  });
+
+  test('publish aborts a never-settling fetch at the shared 8s deadline and marks it service-level', async () => {
+    const previousNtfy = { ...config.ntfy };
+    const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
+    Object.assign(config.ntfy, { enabled: true, adminPassword: 'ntfy-admin-secret' });
+    const timeoutMs: number[] = [];
+
+    AbortSignal.timeout = ((ms: number) => {
+      timeoutMs.push(ms);
+      const controller = new AbortController();
+      queueMicrotask(() => controller.abort(new DOMException('publish timed out', 'TimeoutError')));
+      return controller.signal;
+    }) as typeof AbortSignal.timeout;
+    globalThis.fetch = ((_input, init) => new Promise<Response>((_resolve, reject) => {
+      const signal = init?.signal;
+      if (!signal) return;
+      const abort = () => reject(signal.reason ?? new DOMException('publish timed out', 'TimeoutError'));
+      if (signal.aborted) abort();
+      else signal.addEventListener('abort', abort, { once: true });
+    })) as unknown as typeof fetch;
+
+    try {
+      const pending = new NtfyNotificationService().publish({
+        target: 'user',
+        title: 'timeout',
+        message: 'timeout',
+        level: 'normal',
+      }).catch((err) => err as unknown);
+      const outcome = await Promise.race([
+        pending,
+        new Promise<'still-pending'>((resolve) => setTimeout(() => resolve('still-pending'), 50)),
+      ]);
+
+      expect(outcome).toBeInstanceOf(NotifyError);
+      expect(outcome).toMatchObject({ code: 'notify_unavailable' });
+      expect(isNotifyServiceFailure(outcome)).toBe(true);
+      expect(timeoutMs).toEqual([NTFY_ADMIN_FETCH_TIMEOUT_MS]);
+    } finally {
+      AbortSignal.timeout = originalTimeout;
+      Object.assign(config.ntfy, previousNtfy);
+    }
   });
 
   test('drops click when serialized JSON would exceed 4000 bytes', withPublishCapture(async (svc, captured) => {

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -690,6 +690,7 @@ describe('ntfy publish payload budget', () => {
 
   test('publish keeps notify_unavailable externally while distinguishing rejection from outage internally', async () => {
     const previousNtfy = { ...config.ntfy };
+    const previousFetch = globalThis.fetch;
     Object.assign(config.ntfy, { enabled: true, adminPassword: 'ntfy-admin-secret' });
     const service = new NtfyNotificationService();
     const input = {
@@ -722,6 +723,7 @@ describe('ntfy publish payload budget', () => {
         }
       }
     } finally {
+      globalThis.fetch = previousFetch;
       Object.assign(config.ntfy, previousNtfy);
     }
 
@@ -746,6 +748,7 @@ describe('ntfy publish payload budget', () => {
 
   test('publish aborts a never-settling fetch at the shared 8s deadline and marks it service-level', async () => {
     const previousNtfy = { ...config.ntfy };
+    const previousFetch = globalThis.fetch;
     const originalTimeout = AbortSignal.timeout.bind(AbortSignal);
     Object.assign(config.ntfy, { enabled: true, adminPassword: 'ntfy-admin-secret' });
     const timeoutMs: number[] = [];
@@ -782,6 +785,7 @@ describe('ntfy publish payload budget', () => {
       expect(timeoutMs).toEqual([NTFY_ADMIN_FETCH_TIMEOUT_MS]);
     } finally {
       AbortSignal.timeout = originalTimeout;
+      globalThis.fetch = previousFetch;
       Object.assign(config.ntfy, previousNtfy);
     }
   });

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -706,6 +706,8 @@ describe('ntfy publish payload budget', () => {
         async () => new Response('', { status: 400 }),
         async () => new Response('', { status: 413 }),
         async () => new Response('', { status: 422 }),
+        async () => new Response('', { status: 404 }),
+        async () => new Response('', { status: 405 }),
         async () => new Response('', { status: 401 }),
         async () => new Response('', { status: 403 }),
         async () => new Response('', { status: 407 }),
@@ -739,9 +741,12 @@ describe('ntfy publish payload budget', () => {
       'notify_unavailable',
       'notify_unavailable',
       'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
     ]);
     expect(caught.map(isNotifyServiceFailure)).toEqual([
       false, false, false,
+      true, true,
       true, true, true, true, true, true, true, true,
     ]);
   });

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -27,6 +27,7 @@ const {
   createNotificationDevice,
   createRuntimeReader,
   initializeNotifications,
+  isNotifyServiceFailure,
   jsonEscapedByteLength,
   listNotificationDevices,
   notifyAvailableMessageBytes,
@@ -686,6 +687,43 @@ describe('ntfy publish payload budget', () => {
       }
     };
   }
+
+  test('publish keeps notify_unavailable externally while distinguishing rejection from outage internally', async () => {
+    const previousNtfy = { ...config.ntfy };
+    Object.assign(config.ntfy, { enabled: true, adminPassword: 'ntfy-admin-secret' });
+    const service = new NtfyNotificationService();
+    const input = {
+      target: 'user' as const,
+      title: 'classification',
+      message: 'classification',
+      level: 'normal' as const,
+    };
+    const caught: unknown[] = [];
+
+    try {
+      for (const response of [
+        async () => new Response('', { status: 400 }),
+        async () => new Response('', { status: 503 }),
+        async () => { throw new TypeError('network down'); },
+      ]) {
+        globalThis.fetch = response as unknown as typeof fetch;
+        try {
+          await service.publish(input);
+        } catch (err) {
+          caught.push(err);
+        }
+      }
+    } finally {
+      Object.assign(config.ntfy, previousNtfy);
+    }
+
+    expect(caught.map((err) => err instanceof NotifyError ? err.code : undefined)).toEqual([
+      'notify_unavailable',
+      'notify_unavailable',
+      'notify_unavailable',
+    ]);
+    expect(caught.map(isNotifyServiceFailure)).toEqual([false, true, true]);
+  });
 
   test('drops click when serialized JSON would exceed 4000 bytes', withPublishCapture(async (svc, captured) => {
     const longClick = `https://dash.example/ui/${'x'.repeat(800)}`;


### PR DESCRIPTION
Fixes #42
Fixes #43

## Root cause and final behavior

This PR fixes two coupled watcher failure modes: poison messages could livelock one UID forever, while shared notification-service failures could be mistaken for poison and permanently consume every affected UID. It also adds capped reconnect backoff without delaying shutdown.

Failure routing is fail-safe:

- Only explicit payload rejections are message-level and may consume a UID after three bounded attempts: HTTP `400` (bad request), `413` (payload too large), and `422` (unprocessable payload). These are the provider responses where changing the individual request payload can repair the failure.
- Every other HTTP status is service-level by default, including unlisted `404`/`405`. Endpoint, method-routing, proxy, auth, rate-limit, timeout, and provider faults cannot be repaired by changing one email payload, so the UID is retained.
- Unknown/plain errors are also service-level. The symbol-keyed internal classification remains non-serialized and the public REST contract is unchanged.
- Message-level failures are isolated inside the matched-identity loop: one rejected identity is logged and skipped without blocking later identities for the same email. Service-level failures still escape and preserve the UID.
- `publish()` retains its 8-second timeout. Service failures retain the UID and use the existing 10-minute `CRITICAL` hard limit.

Reconnect timing remains 2s→120s and resets only after 30 seconds of stable uptime. The production delay now accepts the watcher `AbortSignal`, clears its timer and listener on abort, and `runWatcher` races even injected waits against that signal. Shutdown therefore returns immediately without leaving a 120-second timer alive.

`consecutivePublishSkips` still counts whole-message skips reaching the connection-level fallback. Identity-local payload rejections are logged independently and do not increment it.

## Nine negative controls: red before, green after

### 1. Poison message remains bounded

Production rollback to rethrow the message-level failure:

```text
WatcherPublishError: notify_unavailable
attempts: 3
0 pass / 113 filtered out / 1 fail
```

Green: poison UIDs retry three times, are logged and skipped, and later mail delivers.

### 2. Ordinary service outage preserves and redelivers

```text
Expected promise that rejects
Received promise that resolved
```

Green: UID remains 40 during outage; recovery fetches and delivers UID 41.

### 3. Persistent service outage remains bounded

```text
Expected promise that rejects
Received promise that resolved
0 pass / 112 filtered out / 2 fail
```

Green: the first failure preserves UID 40; at 600000ms it logs `CRITICAL` and advances to 41.

### 4. Shared 401/403/429 failures do not consume UIDs

```text
Expected promise that rejects
Received promise that resolved
0 pass / 114 filtered out / 1 fail
```

Green: each status preserves UID 40, then recovery delivers UID 41.

### 5. A never-settling publish is bounded

```text
Expected constructor: NotifyError
Received value: "still-pending"
0 pass / 48 filtered out / 2 fail
```

Green: deadline `8000` aborts fetch and routes the timeout service-level.

### 6. Notification-store corruption preserves and redelivers

```text
Expected promise that rejects
Received promise that resolved
0 pass / 115 filtered out / 1 fail
```

Green: corruption leaves watermark at 40 and makes no ntfy request; state recovery republishes UID 41 before advancing.

### 7. One identity's payload rejection does not block siblings

```text
expect(received).toEqual(expected)
[
  "target@test.example",
  "target@test.example",
  "target@test.example",
- "sender@test.example",
]
0 pass / 116 filtered out / 1 fail
```

Green: the first identity exhausts three attempts and is logged; the second publishes once; UID advances to 41.

### 8. Unlisted 404/405 statuses preserve and redeliver

The R5 control was run before changing production classification:

```text
Expected promise that rejects
Received promise that resolved: Promise { <resolved> }
0 pass / 117 filtered out / 1 fail
```

Green: both 404 and 405 preserve UID 40, then each recovers, delivers UID 41, and advances only after success.

### 9. Abort interrupts reconnect backoff immediately

The R5 control was run against the old non-interruptible wait:

```text
Expected: "stopped"
Received: "still-waiting"
0 pass / 117 filtered out / 1 fail
```

Green: abort during the initial 2000ms injected wait settles `runWatcher` inside the 50ms observation window; it neither waits out nor schedules the next delay.

### Existing reconnect schedule control (unchanged)

A fixed-3s rollback remains red:

```text
expected: [2000, 4000, 8000, 16000, 32000, 64000, 120000, 120000]
received: [3000, 3000, 3000, 3000, 3000, 3000, 3000, 3000]

expected: [2000, 4000, 2000, 4000]
received: [3000, 3000, 3000, 3000]
```

## Green verification

```text
# nine required controls
8 watcher controls pass / 1 hung-fetch control passes

# complete focused suites
bun test test/notification-watcher.test.ts test/notify.test.ts
169 pass / 0 fail / 972 expect() calls

bun run build
Bundled 570 modules

# full current branch (bb364e9)
bun test
866 pass / 1 skip / 3 fail / 5873 expect() calls / 870 tests

# origin/main d0d5b06 baseline (independent worktree)
bun test
855 pass / 1 skip / 3 fail / 5822 expect() calls / 859 tests
```

The same three known failures occur on branch and main: phone-device corrupt-registry ACL, default UI enablement, and UI session persistence. R5 introduces no full-suite failure.

## Scope and retained debt

R5 changes only the publish-status boundary, abortability of reconnect waiting, and focused regression coverage. The 8-second timeout, failure symbol, unknown-error default, 10-minute cap, backoff values/reset policy, `notify_cancelled`, R4 identity isolation, and existing test seams are unchanged.

Known debt intentionally retained:

1. Message skips are reported only via `console.error`; there is no audit event or metric.
2. Total watermark lag remains unbounded during a long service outage.
3. Disabled/unconfigured notification service still spends three publish attempts before the service path takes over.
4. Publish retries are not idempotent, and the publish catch path loses the original DNS/TLS/timeout cause.
