### PR TITLE
fix(api): contain IMAP errors and bound watcher logs

### DIFF
--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -180,11 +180,15 @@ export async function withInbox<T>(
     error('[imap] INBOX connection error; closing current operation');
     closeOnce();
   };
+  // Keep this listener for the one-shot client's full lifetime: socket destroy
+  // may emit after teardown returns. The client and closure are collected together.
   client.on('error', onError);
   // Locking is inside the try: getMailboxLock can throw (INBOX missing, socket
   // dropped) and a connected client must never escape without being torn down.
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
   let result: T | undefined;
+  let operationError: unknown;
+  let operationFailed = false;
   try {
     await client.connect();
     if (connectionError) throw connectionError;
@@ -194,7 +198,8 @@ export async function withInbox<T>(
     if (connectionError) throw connectionError;
   } catch (err) {
     failed = true;
-    throw connectionError ?? err;
+    operationFailed = true;
+    operationError = err;
   } finally {
     lock?.release();
     if (failed) {
@@ -206,9 +211,9 @@ export async function withInbox<T>(
         closeOnce();
       }
     }
-    client.off('error', onError);
   }
   if (connectionError) throw connectionError;
+  if (operationFailed) throw operationError;
   return result as T;
 }
 
@@ -255,6 +260,10 @@ export async function withInboxAbortable<T>(
   signal.addEventListener('abort', onAbort, { once: true });
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
   let result: T | undefined;
+  let operationError: unknown;
+  let operationFailed = false;
+  // Keep this listener through any late socket-destroy event. This one-shot
+  // client is discarded after the call, so the client/closure cycle is collectible.
   client.on('error', onError);
   try {
     // ④ 本阶段起，任何 stall 都会被 abort → close() 掐断
@@ -267,7 +276,8 @@ export async function withInboxAbortable<T>(
     if (connectionError) throw connectionError;
   } catch (err) {
     failed = true;
-    throw connectionError ?? err;
+    operationFailed = true;
+    operationError = err;
   } finally {
     signal.removeEventListener('abort', onAbort);
     lock?.release();
@@ -279,9 +289,9 @@ export async function withInboxAbortable<T>(
       }
     }
     closeOnce();
-    client.off('error', onError);
   }
   if (connectionError) throw connectionError;
+  if (operationFailed) throw operationError;
   return result as T;
 }
 

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -154,38 +154,62 @@ export async function connectImap(): Promise<ImapFlow> {
  * On error the socket is dropped synchronously — a graceful LOGOUT can
  * queue behind a stuck command and re-block the caller.
  */
-export async function withInbox<T>(fn: (client: ImapFlow) => Promise<T>): Promise<T> {
-  const client = await connectImap();
+export async function withInbox<T>(
+  fn: (client: ImapFlow) => Promise<T>,
+  {
+    createClient = createImapClient,
+    error = console.error,
+  }: { createClient?: () => ImapFlow; error?: typeof console.error } = {},
+): Promise<T> {
+  const client = createClient();
   let failed = false;
+  let closed = false;
+  let connectionError: Error | undefined;
+  const closeOnce = () => {
+    if (closed) return;
+    closed = true;
+    try {
+      client.close();
+    } catch {
+      /* already dead */
+    }
+  };
+  const onError = (err: unknown) => {
+    connectionError = err instanceof Error ? err : new Error(String(err));
+    failed = true;
+    error('[imap] INBOX connection error; closing current operation');
+    closeOnce();
+  };
+  client.on('error', onError);
   // Locking is inside the try: getMailboxLock can throw (INBOX missing, socket
   // dropped) and a connected client must never escape without being torn down.
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
+  let result: T | undefined;
   try {
+    await client.connect();
+    if (connectionError) throw connectionError;
     lock = await client.getMailboxLock('INBOX');
-    return await fn(client);
+    if (connectionError) throw connectionError;
+    result = await fn(client);
+    if (connectionError) throw connectionError;
   } catch (err) {
     failed = true;
-    throw err;
+    throw connectionError ?? err;
   } finally {
     lock?.release();
     if (failed) {
-      try {
-        client.close();
-      } catch {
-        /* already dead */
-      }
+      closeOnce();
     } else {
       try {
         await client.logout();
       } catch {
-        try {
-          client.close();
-        } catch {
-          /* already closed */
-        }
+        closeOnce();
       }
     }
+    client.off('error', onError);
   }
+  if (connectionError) throw connectionError;
+  return result as T;
 }
 
 /**
@@ -199,7 +223,10 @@ export async function withInbox<T>(fn: (client: ImapFlow) => Promise<T>): Promis
 export async function withInboxAbortable<T>(
   signal: AbortSignal,
   fn: (client: ImapFlow) => Promise<T>,
-  { createClient = createImapClient }: { createClient?: () => ImapFlow } = {},
+  {
+    createClient = createImapClient,
+    error = console.error,
+  }: { createClient?: () => ImapFlow; error?: typeof console.error } = {},
 ): Promise<T> {
   // ① 连接前就已取消
   if (signal.aborted) throw new Error('scan_aborted');
@@ -216,19 +243,31 @@ export async function withInboxAbortable<T>(
     }
   };
   const onAbort = () => closeOnce();
+  let failed = false;
+  let connectionError: Error | undefined;
+  const onError = (err: unknown) => {
+    connectionError = err instanceof Error ? err : new Error(String(err));
+    failed = true;
+    error('[imap] abortable INBOX connection error; closing current operation');
+    closeOnce();
+  };
   // ③ 先挂监听，再连接
   signal.addEventListener('abort', onAbort, { once: true });
-  let failed = false;
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
+  let result: T | undefined;
+  client.on('error', onError);
   try {
     // ④ 本阶段起，任何 stall 都会被 abort → close() 掐断
     await client.connect();
+    if (connectionError) throw connectionError;
     if (signal.aborted) throw new Error('scan_aborted');
     lock = await client.getMailboxLock('INBOX');
-    return await fn(client);
+    if (connectionError) throw connectionError;
+    result = await fn(client);
+    if (connectionError) throw connectionError;
   } catch (err) {
     failed = true;
-    throw err;
+    throw connectionError ?? err;
   } finally {
     signal.removeEventListener('abort', onAbort);
     lock?.release();
@@ -240,7 +279,10 @@ export async function withInboxAbortable<T>(
       }
     }
     closeOnce();
+    client.off('error', onError);
   }
+  if (connectionError) throw connectionError;
+  return result as T;
 }
 
 /**

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -38,6 +38,7 @@ import {
   STRONG_OTP_CUES,
 } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
+import { truncateUtf8Bytes } from './utf8-truncate.ts';
 
 const RECONNECT_INITIAL_MS = 2_000;
 const RECONNECT_MAX_MS = 120_000;
@@ -46,6 +47,8 @@ const PUBLISH_MAX_ATTEMPTS = 3;
 const PUBLISH_RETRY_INITIAL_MS = 250;
 const PUBLISH_RETRY_MAX_MS = 500;
 const SERVICE_FAILURE_MAX_MS = 10 * 60_000;
+const WATCHER_ERROR_LOG_MAX_BYTES = 512;
+const WATCHER_ERROR_TRUNCATED = '… [truncated]';
 /** Bounded plain-text preview length for tier-3 mail-arrival pushes. */
 export const PUSH_BODY_PREVIEW_CHARS = 280;
 /** Max OTP codes/links included in a tier-3 push (each list). */
@@ -80,6 +83,15 @@ const sleep = (ms: number, signal?: AbortSignal) => new Promise<void>((resolve) 
   const timer = setTimeout(finish, ms);
   signal?.addEventListener('abort', finish, { once: true });
 });
+
+function watcherErrorLogMessage(reason: unknown): string {
+  const message = reason instanceof Error ? reason.message : String(reason);
+  const encoded = Buffer.from(message, 'utf8');
+  if (encoded.length <= WATCHER_ERROR_LOG_MAX_BYTES) return message;
+  const markerBytes = Buffer.byteLength(WATCHER_ERROR_TRUNCATED, 'utf8');
+  return truncateUtf8Bytes(encoded, WATCHER_ERROR_LOG_MAX_BYTES - markerBytes).toString('utf8') +
+    WATCHER_ERROR_TRUNCATED;
+}
 
 async function waitForReconnect(
   wait: typeof sleep,
@@ -143,7 +155,7 @@ class WatcherPublishError extends Error {
   readonly reason: unknown;
 
   constructor(attempts: number, reason: unknown) {
-    super(reason instanceof Error ? reason.message : String(reason));
+    super(watcherErrorLogMessage(reason));
     this.name = 'WatcherPublishError';
     this.attempts = attempts;
     this.reason = reason;
@@ -1367,7 +1379,7 @@ export async function processWatchedMessage(
           if (isNotifyServiceFailure(err.reason)) throw err;
           (options.error ?? console.error)(
             `[notify] IMAP watcher skipped identity ${current.address} after ${err.attempts} publish attempts:`,
-            err.reason instanceof Error ? err.reason.message : String(err.reason),
+            watcherErrorLogMessage(err.reason),
           );
           break;
         }
@@ -1456,14 +1468,14 @@ export async function watchConnection(
               runtime.error(
                 `[notify] CRITICAL IMAP watcher abandoned UID ${message.uid} after notification service ` +
                   `failure persisted for ${unavailableMs}ms (hard limit: ${SERVICE_FAILURE_MAX_MS}ms):`,
-                err.reason instanceof Error ? err.reason.message : String(err.reason),
+                watcherErrorLogMessage(err.reason),
               );
             } else {
               consecutivePublishSkips += 1;
               runtime.error(
                 `[notify] IMAP watcher skipped UID ${message.uid} after ${err.attempts} publish attempts ` +
                   `(consecutive skips: ${consecutivePublishSkips}):`,
-                err.reason instanceof Error ? err.reason.message : String(err.reason),
+                watcherErrorLogMessage(err.reason),
               );
             }
             watermark.serviceFailure = undefined;
@@ -1528,7 +1540,7 @@ export async function runWatcher(
       const onError = (err: unknown) => {
         runtime.warn(
           `[notify] IMAP watcher connection ${runtime.connectionId} error:`,
-          err instanceof Error ? err.message : String(err),
+          watcherErrorLogMessage(err),
         );
         // ImapFlow emits connection errors outside the awaited command chain.
         // Closing makes the active IDLE/search fail into the reconnect guard.
@@ -1548,7 +1560,7 @@ export async function runWatcher(
       if (!signal.aborted) {
         runtime.warn(
           `[notify] IMAP watcher connection ${runtime.connectionId} reconnecting:`,
-          err instanceof Error ? err.message : String(err),
+          watcherErrorLogMessage(err),
         );
       }
     }

--- a/packages/api/test/imap-error-boundary.test.ts
+++ b/packages/api/test/imap-error-boundary.test.ts
@@ -1,0 +1,114 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+
+import { EventEmitter } from 'node:events';
+import type { ImapFlow } from 'imapflow';
+
+const { describe, expect, test } = await import('bun:test');
+const { withInbox, withInboxAbortable } = await import('../src/lib/imap.ts');
+
+class OperationErrorClient extends EventEmitter {
+  closeCalls = 0;
+  logoutCalls = 0;
+  releaseCalls = 0;
+  private rejectOperation?: (error: Error) => void;
+
+  async connect() {}
+
+  async getMailboxLock() {
+    return { release: () => { this.releaseCalls += 1; } };
+  }
+
+  operation(error: Error): Promise<void> {
+    return new Promise((_resolve, reject) => {
+      this.rejectOperation = reject;
+      queueMicrotask(() => this.emit('error', error));
+    });
+  }
+
+  async logout() {
+    this.logoutCalls += 1;
+  }
+
+  close() {
+    this.closeCalls += 1;
+    this.rejectOperation?.(new Error('closed current operation'));
+  }
+}
+
+class ConnectErrorClient extends EventEmitter {
+  closeCalls = 0;
+  logoutCalls = 0;
+  private rejectConnect?: (error: Error) => void;
+
+  constructor(private readonly emitted: Error) {
+    super();
+  }
+
+  connect(): Promise<void> {
+    return new Promise((_resolve, reject) => {
+      this.rejectConnect = reject;
+      queueMicrotask(() => this.emit('error', this.emitted));
+    });
+  }
+
+  async getMailboxLock() {
+    return { release() {} };
+  }
+
+  async logout() {
+    this.logoutCalls += 1;
+  }
+
+  close() {
+    this.closeCalls += 1;
+    this.rejectConnect?.(new Error('closed connect'));
+  }
+}
+
+describe('IMAP async error boundaries', () => {
+  test('withInbox catches an out-of-band error, fails the operation, and closes once', async () => {
+    const client = new OperationErrorClient();
+    const emitted = new Error('async socket failure during operation');
+    const logs: unknown[][] = [];
+
+    await expect(withInbox(
+      (imap) => (imap as unknown as OperationErrorClient).operation(emitted),
+      {
+        createClient: () => client as unknown as ImapFlow,
+        error: (...args) => { logs.push(args); },
+      },
+    )).rejects.toBe(emitted);
+
+    expect(client.closeCalls).toBe(1);
+    expect(client.logoutCalls).toBe(0);
+    expect(client.releaseCalls).toBe(1);
+    expect(client.listenerCount('error')).toBe(0);
+    expect(logs).toEqual([['[imap] INBOX connection error; closing current operation']]);
+  });
+
+  test('withInboxAbortable catches a connect-phase error and preserves closeOnce', async () => {
+    const emitted = new Error('async socket failure during connect');
+    const client = new ConnectErrorClient(emitted);
+    const controller = new AbortController();
+    const logs: unknown[][] = [];
+
+    await expect(withInboxAbortable(
+      controller.signal,
+      async () => undefined,
+      {
+        createClient: () => client as unknown as ImapFlow,
+        error: (...args) => { logs.push(args); },
+      },
+    )).rejects.toBe(emitted);
+
+    expect(client.closeCalls).toBe(1);
+    expect(client.logoutCalls).toBe(0);
+    expect(client.listenerCount('error')).toBe(0);
+    expect(logs).toEqual([['[imap] abortable INBOX connection error; closing current operation']]);
+  });
+});

--- a/packages/api/test/imap-error-boundary.test.ts
+++ b/packages/api/test/imap-error-boundary.test.ts
@@ -70,6 +70,48 @@ class ConnectErrorClient extends EventEmitter {
   }
 }
 
+class TeardownErrorClient extends EventEmitter {
+  closeCalls = 0;
+  logoutCalls = 0;
+
+  constructor(private readonly teardownError: Error) {
+    super();
+  }
+
+  async connect() {}
+
+  async getMailboxLock() {
+    return { release: () => { this.emit('error', this.teardownError); } };
+  }
+
+  async logout() {
+    this.logoutCalls += 1;
+  }
+
+  close() {
+    this.closeCalls += 1;
+  }
+}
+
+class SuccessfulClient extends EventEmitter {
+  closeCalls = 0;
+  logoutCalls = 0;
+
+  async connect() {}
+
+  async getMailboxLock() {
+    return { release() {} };
+  }
+
+  async logout() {
+    this.logoutCalls += 1;
+  }
+
+  close() {
+    this.closeCalls += 1;
+  }
+}
+
 describe('IMAP async error boundaries', () => {
   test('withInbox catches an out-of-band error, fails the operation, and closes once', async () => {
     const client = new OperationErrorClient();
@@ -87,7 +129,7 @@ describe('IMAP async error boundaries', () => {
     expect(client.closeCalls).toBe(1);
     expect(client.logoutCalls).toBe(0);
     expect(client.releaseCalls).toBe(1);
-    expect(client.listenerCount('error')).toBe(0);
+    expect(client.listenerCount('error')).toBe(1);
     expect(logs).toEqual([['[imap] INBOX connection error; closing current operation']]);
   });
 
@@ -108,7 +150,64 @@ describe('IMAP async error boundaries', () => {
 
     expect(client.closeCalls).toBe(1);
     expect(client.logoutCalls).toBe(0);
-    expect(client.listenerCount('error')).toBe(0);
+    expect(client.listenerCount('error')).toBe(1);
     expect(logs).toEqual([['[imap] abortable INBOX connection error; closing current operation']]);
+  });
+
+  test('拆卸期连接错误优先于先发生的操作错误，两个封装口径一致', async () => {
+    const operationError = new Error('operation failed first');
+    const teardownError = new Error('connection failed during teardown');
+
+    const regular = new TeardownErrorClient(teardownError);
+    await expect(withInbox(
+      async () => { throw operationError; },
+      { createClient: () => regular as unknown as ImapFlow, error: () => {} },
+    )).rejects.toBe(teardownError);
+    expect(regular.closeCalls).toBe(1);
+
+    const abortable = new TeardownErrorClient(teardownError);
+    await expect(withInboxAbortable(
+      new AbortController().signal,
+      async () => { throw operationError; },
+      { createClient: () => abortable as unknown as ImapFlow, error: () => {} },
+    )).rejects.toBe(teardownError);
+    expect(abortable.closeCalls).toBe(1);
+  });
+
+  test('封装返回后迟发 error 仍有全生命周期监听，不逃逸且不重复 close', async () => {
+    const lateError = new Error('late socket destroy error');
+
+    const regular = new SuccessfulClient();
+    await withInbox(async () => undefined, {
+      createClient: () => regular as unknown as ImapFlow,
+      error: () => {},
+    });
+    expect(() => regular.emit('error', lateError)).not.toThrow();
+    expect(regular.closeCalls).toBe(1);
+
+    const abortable = new SuccessfulClient();
+    await withInboxAbortable(new AbortController().signal, async () => undefined, {
+      createClient: () => abortable as unknown as ImapFlow,
+      error: () => {},
+    });
+    expect(() => abortable.emit('error', lateError)).not.toThrow();
+    expect(abortable.closeCalls).toBe(1);
+  });
+
+  test('常驻回归：两个封装都接住并原样重抛同一个 emitted Error', async () => {
+    const emitted = new Error('shared emitted error');
+
+    const regular = new OperationErrorClient();
+    await expect(withInbox(
+      (imap) => (imap as unknown as OperationErrorClient).operation(emitted),
+      { createClient: () => regular as unknown as ImapFlow, error: () => {} },
+    )).rejects.toBe(emitted);
+
+    const abortable = new ConnectErrorClient(emitted);
+    await expect(withInboxAbortable(
+      new AbortController().signal,
+      async () => undefined,
+      { createClient: () => abortable as unknown as ImapFlow, error: () => {} },
+    )).rejects.toBe(emitted);
   });
 });

--- a/packages/api/test/imap-match.test.ts
+++ b/packages/api/test/imap-match.test.ts
@@ -9,6 +9,7 @@
 import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { EventEmitter } from 'node:events';
 
 process.env.DOMAIN = 'test.example';
 process.env.API_KEYS = 'admin-key-1';
@@ -23,7 +24,7 @@ const { describe, expect, mock, test } = await import('bun:test');
 // 授权路径的回归需要跑真的 listMessages，所以在导入 imap.ts 之前先替掉 imapflow。
 let fakeMessages: any[] = [];
 
-class FakeImapFlow {
+class FakeImapFlow extends EventEmitter {
   async connect() {}
   async getMailboxLock() {
     return { release() {} };

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -1,6 +1,7 @@
 // 端到端（假 IMAP 服务器）的身份隔离测试：验证 listMessages 这条真实路径上
 // 别人的邮件不会被返回，而不只是内部匹配函数的单测。
 import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
 
 process.env.DOMAIN = 'test.example';
 process.env.API_KEYS = 'admin-key';
@@ -28,11 +29,12 @@ let failMailboxLock = false;
 const createdClients: FakeImapFlow[] = [];
 let deletedUids: number[] = [];
 
-class FakeImapFlow {
+class FakeImapFlow extends EventEmitter {
   closed = false;
   loggedOut = false;
 
   constructor() {
+    super();
     createdClients.push(this);
   }
 

--- a/packages/api/test/notification-watcher.test.ts
+++ b/packages/api/test/notification-watcher.test.ts
@@ -606,6 +606,37 @@ describe('mail-arrival notification watcher', () => {
     expect(outcome).toBe('stopped');
   });
 
+  test('上游超长 error message 写日志时按 512 bytes 截断并保留明确标记', async () => {
+    const controller = new AbortController();
+    const warnings: unknown[][] = [];
+    const upstream = new Error('x'.repeat(5_000));
+    const client = new EventEmitter() as any;
+    client.close = () => {};
+
+    await runWatcher(
+      controller.signal,
+      { publish: async () => ({ target: 'user', title: 'unused', level: 'normal' }) },
+      {
+        connect: async () => client,
+        watch: async () => {
+          client.emit('error', upstream);
+          controller.abort();
+          throw upstream;
+        },
+        wait: async () => {},
+        warn: (...args) => { warnings.push(args); },
+        connectionId: 'imap.test:993',
+        now: () => 0,
+      },
+    );
+
+    expect(warnings).toHaveLength(1);
+    const logged = String(warnings[0]?.[1]);
+    expect(Buffer.byteLength(logged, 'utf8')).toBeLessThanOrEqual(512);
+    expect(logged.endsWith('… [truncated]')).toBe(true);
+    expect(upstream.message).toHaveLength(5_000);
+  });
+
   test('keeps its watermark across reconnects and catches the downtime window', () => {
     const watermark: { uid?: number } = {};
     expect(unseenWatcherUids([10, 11], watermark)).toEqual([]);

--- a/packages/api/test/ui-overview.test.ts
+++ b/packages/api/test/ui-overview.test.ts
@@ -8,6 +8,7 @@
 // 状态机全部走注入的假时钟与可控 promise：真时间只用来做"多久之内跑完"这类
 // 上界断言，绝不用来推进 TTL 或冷却。
 import { describe, expect, mock, test } from 'bun:test';
+import { EventEmitter } from 'node:events';
 import { Hono } from 'hono';
 import type { ImapFlow } from 'imapflow';
 import type { MailboxScanResult, ScanRecord } from '../src/lib/imap.ts';
@@ -41,8 +42,9 @@ let mailboxUids: number[] | null = null;
 let fetchOptionsSeen: unknown[] = [];
 let connections = 0;
 
-class FakeImapFlow {
+class FakeImapFlow extends EventEmitter {
   constructor() {
+    super();
     connections += 1;
   }
   async connect() {}
@@ -1215,7 +1217,7 @@ describe('Overview 缓存状态机', () => {
 
   // A47：截止时间覆盖 connect 与 fetch 两个阶段
   test('connect 与 fetch 两段 stall 都在截止时间被真取消', async () => {
-    class ConnectStallClient {
+    class ConnectStallClient extends EventEmitter {
       closeCalls = 0;
       rejectConnect: ((error: Error) => void) | null = null;
       connect() {
@@ -1240,7 +1242,7 @@ describe('Overview 缓存状态机', () => {
       }
     }
 
-    class FetchStallClient {
+    class FetchStallClient extends EventEmitter {
       closeCalls = 0;
       rejectFetch: ((error: Error) => void) | null = null;
       async connect() {}


### PR DESCRIPTION
Fixes #41
Fixes #45

## Root cause and behavior

`ImapFlow` may emit asynchronous `error` events outside an active `await`. Without a listener Node throws from `node:events`, bypassing surrounding `try/catch`. Both `withInbox()` and `withInboxAbortable()` were exposed, including during connect.

Both wrappers now construct the client synchronously, register `on('error')` before `connect()`, log a fixed diagnostic, preserve the emitted `Error`, and converge on the existing guarded `closeOnce` path. Connection parameters, timeouts, retries, and mailbox behavior are unchanged.

### Teardown error priority

The catch blocks store an operation error without throwing it immediately. Lock release and logout/close teardown finish first; only then does each wrapper select what to throw:

1. a connection error observed at any point, including teardown;
2. otherwise the stored operation error;
3. otherwise the successful result.

Connection errors take priority because they prove the shared transport failed and are the actionable cause for the caller's retry/error boundary. Delaying selection avoids JavaScript's pre-`finally` evaluation of `throw connectionError ?? err`.

### Full-lifetime listener

The `error` listener is intentionally not removed. Socket destruction can emit after `logout()` or `close()` returns; removing the final listener would reopen the same process-crash window as #39. These are one-shot clients that are discarded after each wrapper call. The client and its listener closure form an unreachable collectible cycle together; no global emitter or cross-client registry retains them, so this does not accumulate listeners on a live shared object. The abort listener is still removed normally.

Late errors remain contained and call the same `closeOnce`, so they cannot trigger a duplicate close.

## Bounded watcher logs

All six watcher error conversions use one UTF-8-safe formatter: the internal publish wrapper plus identity skip, service `CRITICAL`, whole-UID skip, connection error, and reconnect paths.

The complete value is capped at 512 bytes, including `… [truncated]`. The existing UTF-8 boundary helper prevents split characters. The upstream error and its original message are not mutated.

## Permanent regression coverage

`test/imap-error-boundary.test.ts` now permanently verifies both wrappers:

- contain an emitted `Error` and rethrow the identical object;
- cover operation and connect phases;
- close exactly once;
- preserve a teardown-emitted connection error over an earlier operation error;
- retain a listener after wrapper settlement so a late socket-destroy error cannot escape.

Removing either production `client.on('error', onError)` makes these committed tests red, so containment no longer depends on a manual reviewer rollback.

## Negative-control evidence

### R1: teardown error was selected too early

The new test against `b387097` expected the teardown connection error but received the earlier operation error:

```text
Expected: Error: connection failed during teardown
Received: Error: operation failed first
0 pass / 3 filtered out / 1 fail
```

Green: both wrappers now return the exact teardown connection error and still close once.

### R1: listener removed before a late destroy event

Against `b387097`, emitting after the wrapper had returned escaped the boundary:

```text
expect(received).not.toThrow()
Error message: "late socket destroy error"
0 pass / 3 filtered out / 1 fail
```

Green: both wrappers retain one lifetime listener; the late event does not throw, and close count remains one.

### Original control: remove `withInbox` listener

Reconfirmed on R1 with production-only single-line rollback and unchanged test:

```text
error: async socket failure during operation
      at emitError (node:events:51:13)
      at <anonymous> (.../test/imap-error-boundary.test.ts:127:16)
```

### Original control: remove `withInboxAbortable` listener

```text
error: async socket failure during connect
      at emitError (node:events:51:13)
      at <anonymous> (.../test/imap-error-boundary.test.ts:149:16)
```

### Original control: restore raw watcher logging

```text
Expected: <= 512
Received: 5000
0 pass / 119 filtered out / 1 fail
```

## Green verification

```text
# Permanent IMAP boundary regressions
bun test test/imap-error-boundary.test.ts
5 pass / 0 fail / 21 expect() calls

# Related IMAP, overview, and watcher suites
bun test test/imap-error-boundary.test.ts test/imap.test.ts test/imap-match.test.ts \
  test/ui-overview.test.ts test/notification-watcher.test.ts
215 pass / 0 fail / 1188 expect() calls

bun run build
Bundled 570 modules

# Current branch c5f4af1 (second full run)
bun test
872 pass / 1 skip / 3 fail / 5898 expect() calls / 876 tests

# origin/main eaba8ee, independent worktree
bun test
866 pass / 1 skip / 3 fail / 5873 expect() calls / 870 tests
```

The same three known environment-coupled failures occur on branch and main: phone-device corrupt-registry ACL, default UI enablement, and UI session persistence. The first R1 full run also hit the known #44 task-board 5000ms wall-clock timeout; its immediate isolated rerun passed (`1 pass / 0 fail`, 3945ms), and the second full run passed that test.

## Scope and debt

R1 changes only deferred error selection, listener lifetime, and permanent boundary regression coverage. Listener registration timing, `closeOnce`, the 512-byte limit and six watcher sites, UTF-8 truncation helper, and test seams remain unchanged.

Recorded debt, intentionally outside #41: standalone `connectImap()` returns a raw client and relies on callers to own an error boundary; a broader connection-owner design remains follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of mailbox connection errors, including prompt cleanup and consistent error propagation.
  * Ensured abortable mailbox operations clean up reliably during connection, locking, and callback failures.
  * Limited watcher error messages to 512 UTF-8 bytes while preserving the original error details.

* **Tests**
  * Added coverage for connection failures, cleanup behavior, logging, abort handling, and oversized error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->