### PR TITLE
test(api): make task board baseline load tolerant

### DIFF
--- a/packages/api/test/task-board.test.ts
+++ b/packages/api/test/task-board.test.ts
@@ -476,6 +476,7 @@ describe('task board in-memory baseline', () => {
       let pages = 0;
       let cursor: string | undefined;
       let totalApprox = 0;
+      const seenIds: string[] = [];
       do {
         const page = await listTaskBoard(
           { status: 'all', period: '30d', limit: 100, cursor },
@@ -483,6 +484,7 @@ describe('task board in-memory baseline', () => {
         );
         totalApprox = page.totalApprox;
         pages += 1;
+        seenIds.push(...page.tasks.map((task) => task.id));
         cursor = page.nextCursor ?? undefined;
       } while (cursor);
       results[String(size)] = {
@@ -490,13 +492,23 @@ describe('task board in-memory baseline', () => {
         pages,
         totalApprox,
       };
+      const expectedIds = [...catalog]
+        .sort((a, b) => {
+          const dt = Date.parse(b.updatedAt) - Date.parse(a.updatedAt);
+          if (dt !== 0) return dt;
+          return a.id < b.id ? 1 : a.id > b.id ? -1 : 0;
+        })
+        .map((task) => task.id);
+      expect(totalApprox).toBe(size);
+      expect(pages).toBe(size / 100);
+      expect(seenIds).toHaveLength(size);
+      expect(new Set(seenIds).size).toBe(size);
+      expect(seenIds).toEqual(expectedIds);
     }
     console.log('[task-board baseline]', JSON.stringify(results));
-    expect(results['1000']!.totalApprox).toBeGreaterThan(0);
-    expect(results['10000']!.pages).toBeGreaterThan(results['1000']!.pages);
-    // 短缓存只减重复 IMAP 解析；本基准是纯内存 filter/sort/page。
-    expect(results['10000']!.ms).toBeLessThan(30_000);
-  });
+    expect(results['10000']!.pages).toBe(results['1000']!.pages * 10);
+    // 不再断言墙钟：并发负载会制造假红；显式 timeout 只隔离 Bun 默认 5s 掐断。
+  }, 30_000);
 });
 
 describe('concurrent reply under per-task lock', () => {

--- a/packages/api/test/task-board.test.ts
+++ b/packages/api/test/task-board.test.ts
@@ -482,6 +482,7 @@ describe('task board in-memory baseline', () => {
           { status: 'all', period: '30d', limit: 100, cursor },
           { kind: 'admin' },
         );
+        expect(page.totalApprox).toBe(size);
         totalApprox = page.totalApprox;
         pages += 1;
         seenIds.push(...page.tasks.map((task) => task.id));


### PR DESCRIPTION
Fixes #44

## Root cause: the 5-second limit was Bun, not the assertion

Issue #44 described the test as asserting an approximately five-second wall-clock budget. The code and repository configuration show a different failure path:

- the only timing assertion was `results['10000'].ms < 30_000`;
- the `test()` call had no explicit timeout;
- the repository has no `bunfig.toml` or global test-timeout override;
- `packages/api/package.json` runs plain `bun test`.

The observed `5750.33ms` failure against a `5000ms` threshold was therefore Bun's default per-test timeout terminating the case before its 30-second assertion. Merely widening or deleting that assertion would not address the actual false red.

## Load-independent protection

The test still exercises both 1,000 and 10,000 in-memory tasks and traverses every page, but elapsed milliseconds are now diagnostic output only. For each size it asserts:

- `totalApprox` equals the exact catalog size;
- page count equals `size / 100` (10 and 100 pages);
- the collected result has exactly `size` entries;
- every ID is unique, so pagination has no duplicates;
- the complete collected ID sequence equals the expected updated-time/id ordering, so there are no omissions or ordering regressions;
- the 10k case has exactly ten times the page count of the 1k case.

These properties do not change with host contention. They retain the original test's useful scale, filter, sort, cursor, and pagination coverage without treating scheduler load as a product regression.

The case alone receives a 30-second Bun timeout. This is a stall guard, not a performance acceptance threshold: normal observed work is 2.5–6.9 seconds, and no elapsed-time value is asserted. No global timeout is changed, so other hung tests retain Bun's normal protection.

The source includes the required comment explaining that wall-clock assertions caused false reds under concurrent load.

## Double-run evidence

### Isolated file

```text
[task-board baseline] {"1000":{"ms":15,"pages":10,"totalApprox":1000},"10000":{"ms":2521,"pages":100,"totalApprox":10000}}
20 pass / 0 fail / 131 expect() calls
Ran 20 tests across 1 file. [3.13s]
```

### Same file while a full `bun test` ran concurrently

```text
[task-board baseline] {"1000":{"ms":20,"pages":10,"totalApprox":1000},"10000":{"ms":4224,"pages":100,"totalApprox":10000}}
20 pass / 0 fail / 131 expect() calls
Ran 20 tests across 1 file. [5.44s]
```

The 10k work slowed by about 67% under load but remained green because correctness, not scheduler time, is the acceptance criterion. The concurrent full suite also kept this task-board test green.

## Reverse proof

With a temporary local-only production mutation changing `totalApprox` from `filtered.length` to `0`, the new criterion failed immediately. The mutation was restored and is not in this PR.

```text
Expected: 1000
Received: 0
0 pass / 19 filtered out / 1 fail
```

This demonstrates that the replacement assertions still reject a real task-board contract regression.

## Full-suite and baseline comparison

```text
# Current branch 084b448, while the focused file ran concurrently
bun test
872 pass / 1 skip / 3 fail / 5906 expect() calls / 876 tests

# origin/main b85c8d7, independent worktree in this run
bun test
872 pass / 1 skip / 3 fail / 5898 expect() calls / 876 tests
```

The three failures are identical known environment-coupled cases: phone-device corrupt-registry ACL, default UI enablement, and UI session persistence. The task-board case does not appear in the branch failure list.

The baseline's intermittent nature is independently demonstrated by FC's fresh `b85c8d7` run: `871 pass / 1 skip / 4 fail`, with this task timing out at `5750.33ms` against Bun's `5000ms` threshold, while the same file alone passed all 20 tests. This independent baseline run happened to complete the task case inside five seconds, which is precisely why the old gate was nondeterministic.

## Scope and debt

Only `packages/api/test/task-board.test.ts` changes. No task-board production logic, other test, global timeout, configuration, deployment code, or prior issue work is modified.

No new debt was discovered in this scoped change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened task board performance coverage by validating complete, duplicate-free, correctly ordered results across all pages.
  * Added precise checks for total results and page counts.
  * Increased test reliability with an explicit 30-second timeout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->