### PR TITLE
fix(api): retry mailserver connections after DNS changes

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -177,6 +177,8 @@ services:
       SMTP_PORT: 587
       SMTP_USER: ${MAIL_ACCOUNT:-agent}@${DOMAIN}
       SMTP_PASS: ${MAIL_PASSWORD:?Set MAIL_PASSWORD in .env}
+      # Safety belt: avoid Bun retaining mailserver's old container IP after a rebuild.
+      BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS: "0"
       TASK_SIGNING_SECRET: ${TASK_SIGNING_SECRET:?Set TASK_SIGNING_SECRET in .env (openssl rand -hex 32)}
       # DMS ships a self-signed cert until you configure Let's Encrypt, so
       # certificate verification stays off by default for these private hops.

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -243,7 +243,9 @@ export async function withInbox<T>(
   try {
     client = await connectImapClient(createTrackedClient, {
       beforeRetry: () => {
-        closeOnce();
+        const failedClient = client;
+        client = undefined;
+        closeOnce(failedClient);
         connectionError = undefined;
         failed = false;
       },
@@ -334,7 +336,9 @@ export async function withInboxAbortable<T>(
     // ④ 本阶段起，任何 stall 都会被 abort → close() 掐断
     client = await connectImapClient(createTrackedClient, {
       beforeRetry: () => {
-        closeOnce();
+        const failedClient = client;
+        client = undefined;
+        closeOnce(failedClient);
         if (signal.aborted) throw new Error('scan_aborted');
         connectionError = undefined;
         failed = false;

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -134,6 +134,7 @@ export const TOTAL_KEY_MAX = 5_000;
 
 /** 只构造，不连接 —— 让取消监听能在 connect() 之前就拿到实例引用。 */
 type ImapClientFactory = (endpoint?: MailserverEndpoint) => ImapFlow;
+type MailserverResolver = (hostname: string) => Promise<string>;
 
 function createImapClient(endpoint: MailserverEndpoint = { host: config.imap.host }): ImapFlow {
   return new ImapFlow({
@@ -155,10 +156,14 @@ async function connectImapClient(
   {
     beforeConnect,
     beforeRetry,
+    beforeRetryConnect,
+    resolveMailserver,
     closeOnConnectError = true,
   }: {
     beforeConnect?: (client: ImapFlow) => void;
     beforeRetry?: (error: unknown) => void | Promise<void>;
+    beforeRetryConnect?: () => void;
+    resolveMailserver?: MailserverResolver;
     closeOnConnectError?: boolean;
   } = {},
 ): Promise<ImapFlow> {
@@ -181,7 +186,7 @@ async function connectImapClient(
         throw error;
       }
     },
-    { beforeRetry },
+    { beforeRetry, beforeRetryConnect, resolve: resolveMailserver },
   );
 }
 
@@ -199,17 +204,18 @@ export async function withInbox<T>(
   {
     createClient = createImapClient,
     error = console.error,
-  }: { createClient?: ImapClientFactory; error?: typeof console.error } = {},
+    resolveMailserver,
+  }: { createClient?: ImapClientFactory; error?: typeof console.error; resolveMailserver?: MailserverResolver } = {},
 ): Promise<T> {
   let client: ImapFlow | undefined;
   let failed = false;
-  let closed = false;
+  const closedClients = new WeakSet<ImapFlow>();
   let connectionError: Error | undefined;
-  const closeOnce = () => {
-    if (closed) return;
-    closed = true;
+  const closeOnce = (target = client) => {
+    if (!target || closedClients.has(target)) return;
+    closedClients.add(target);
     try {
-      client?.close();
+      target.close();
     } catch {
       /* already dead */
     }
@@ -222,7 +228,7 @@ export async function withInbox<T>(
       connectionError = err instanceof Error ? err : new Error(String(err));
       failed = true;
       error('[imap] INBOX connection error; closing current operation');
-      closeOnce();
+      closeOnce(candidate);
     });
     return candidate;
   };
@@ -237,10 +243,11 @@ export async function withInbox<T>(
   try {
     client = await connectImapClient(createTrackedClient, {
       beforeRetry: () => {
+        closeOnce();
         connectionError = undefined;
         failed = false;
-        closed = false;
       },
+      resolveMailserver,
       closeOnConnectError: false,
     });
     if (connectionError) throw connectionError;
@@ -254,7 +261,7 @@ export async function withInbox<T>(
     operationError = err;
   } finally {
     lock?.release();
-    if (failed) {
+    if (failed || !client || closedClients.has(client)) {
       closeOnce();
     } else {
       try {
@@ -283,18 +290,19 @@ export async function withInboxAbortable<T>(
   {
     createClient = createImapClient,
     error = console.error,
-  }: { createClient?: ImapClientFactory; error?: typeof console.error } = {},
+    resolveMailserver,
+  }: { createClient?: ImapClientFactory; error?: typeof console.error; resolveMailserver?: MailserverResolver } = {},
 ): Promise<T> {
   // ① 连接前就已取消
   if (signal.aborted) throw new Error('scan_aborted');
   // ② 同步拿到实例引用
   let client: ImapFlow | undefined;
-  let closed = false;
-  const closeOnce = () => {
-    if (closed) return;
-    closed = true;
+  const closedClients = new WeakSet<ImapFlow>();
+  const closeOnce = (target = client) => {
+    if (!target || closedClients.has(target)) return;
+    closedClients.add(target);
     try {
-      client?.close();
+      target.close();
     } catch {
       /* already dead / not connected */
     }
@@ -310,7 +318,7 @@ export async function withInboxAbortable<T>(
       connectionError = err instanceof Error ? err : new Error(String(err));
       failed = true;
       error('[imap] abortable INBOX connection error; closing current operation');
-      closeOnce();
+      closeOnce(candidate);
     });
     return candidate;
   };
@@ -326,11 +334,15 @@ export async function withInboxAbortable<T>(
     // ④ 本阶段起，任何 stall 都会被 abort → close() 掐断
     client = await connectImapClient(createTrackedClient, {
       beforeRetry: () => {
+        closeOnce();
         if (signal.aborted) throw new Error('scan_aborted');
         connectionError = undefined;
         failed = false;
-        closed = false;
       },
+      beforeRetryConnect: () => {
+        if (signal.aborted) throw new Error('scan_aborted');
+      },
+      resolveMailserver,
       closeOnConnectError: false,
     });
     if (connectionError) throw connectionError;
@@ -346,7 +358,7 @@ export async function withInboxAbortable<T>(
   } finally {
     signal.removeEventListener('abort', onAbort);
     lock?.release();
-    if (!failed && !closed) {
+    if (!failed && client && !closedClients.has(client)) {
       try {
         await client!.logout();
       } catch {

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -32,6 +32,10 @@ import { extractHttpLinks, extractOtp, htmlToText, type OtpExtraction } from './
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 import { hasSentMessageId, normalizeMessageId } from './sent-registry.ts';
 import { truncateUtf8Bytes } from './utf8-truncate.ts';
+import {
+  withMailserverReconnect,
+  type MailserverEndpoint,
+} from './mailserver-reconnect.ts';
 
 export type { MailFolder };
 export { InvalidMailCursorError } from './mail-cursor.ts';
@@ -129,9 +133,12 @@ export const PER_MSG_MAX = 200;
 export const TOTAL_KEY_MAX = 5_000;
 
 /** 只构造，不连接 —— 让取消监听能在 connect() 之前就拿到实例引用。 */
-function createImapClient(): ImapFlow {
+type ImapClientFactory = (endpoint?: MailserverEndpoint) => ImapFlow;
+
+function createImapClient(endpoint: MailserverEndpoint = { host: config.imap.host }): ImapFlow {
   return new ImapFlow({
-    host: config.imap.host,
+    host: endpoint.host,
+    ...(endpoint.servername ? { servername: endpoint.servername } : {}),
     port: config.imap.port,
     secure: config.imap.secure,
     auth: { user: config.imap.user, pass: config.imap.pass },
@@ -143,10 +150,43 @@ function createImapClient(): ImapFlow {
   });
 }
 
+async function connectImapClient(
+  createClient: ImapClientFactory = createImapClient,
+  {
+    beforeConnect,
+    beforeRetry,
+    closeOnConnectError = true,
+  }: {
+    beforeConnect?: (client: ImapFlow) => void;
+    beforeRetry?: (error: unknown) => void | Promise<void>;
+    closeOnConnectError?: boolean;
+  } = {},
+): Promise<ImapFlow> {
+  return withMailserverReconnect(
+    config.imap.host,
+    async (endpoint) => {
+      const client = createClient(endpoint);
+      beforeConnect?.(client);
+      try {
+        await client.connect();
+        return client;
+      } catch (error) {
+        if (closeOnConnectError) {
+          try {
+            client.close();
+          } catch {
+            /* already dead */
+          }
+        }
+        throw error;
+      }
+    },
+    { beforeRetry },
+  );
+}
+
 export async function connectImap(): Promise<ImapFlow> {
-  const client = createImapClient();
-  await client.connect();
-  return client;
+  return connectImapClient();
 }
 
 /**
@@ -159,9 +199,9 @@ export async function withInbox<T>(
   {
     createClient = createImapClient,
     error = console.error,
-  }: { createClient?: () => ImapFlow; error?: typeof console.error } = {},
+  }: { createClient?: ImapClientFactory; error?: typeof console.error } = {},
 ): Promise<T> {
-  const client = createClient();
+  let client: ImapFlow | undefined;
   let failed = false;
   let closed = false;
   let connectionError: Error | undefined;
@@ -169,20 +209,25 @@ export async function withInbox<T>(
     if (closed) return;
     closed = true;
     try {
-      client.close();
+      client?.close();
     } catch {
       /* already dead */
     }
   };
-  const onError = (err: unknown) => {
-    connectionError = err instanceof Error ? err : new Error(String(err));
-    failed = true;
-    error('[imap] INBOX connection error; closing current operation');
-    closeOnce();
+  const createTrackedClient: ImapClientFactory = (endpoint) => {
+    const candidate = createClient(endpoint);
+    client = candidate;
+    candidate.on('error', (err) => {
+      if (candidate !== client) return;
+      connectionError = err instanceof Error ? err : new Error(String(err));
+      failed = true;
+      error('[imap] INBOX connection error; closing current operation');
+      closeOnce();
+    });
+    return candidate;
   };
   // Keep this listener for the one-shot client's full lifetime: socket destroy
   // may emit after teardown returns. The client and closure are collected together.
-  client.on('error', onError);
   // Locking is inside the try: getMailboxLock can throw (INBOX missing, socket
   // dropped) and a connected client must never escape without being torn down.
   let lock: Awaited<ReturnType<ImapFlow['getMailboxLock']>> | undefined;
@@ -190,7 +235,14 @@ export async function withInbox<T>(
   let operationError: unknown;
   let operationFailed = false;
   try {
-    await client.connect();
+    client = await connectImapClient(createTrackedClient, {
+      beforeRetry: () => {
+        connectionError = undefined;
+        failed = false;
+        closed = false;
+      },
+      closeOnConnectError: false,
+    });
     if (connectionError) throw connectionError;
     lock = await client.getMailboxLock('INBOX');
     if (connectionError) throw connectionError;
@@ -206,7 +258,7 @@ export async function withInbox<T>(
       closeOnce();
     } else {
       try {
-        await client.logout();
+        await client!.logout();
       } catch {
         closeOnce();
       }
@@ -231,18 +283,18 @@ export async function withInboxAbortable<T>(
   {
     createClient = createImapClient,
     error = console.error,
-  }: { createClient?: () => ImapFlow; error?: typeof console.error } = {},
+  }: { createClient?: ImapClientFactory; error?: typeof console.error } = {},
 ): Promise<T> {
   // ① 连接前就已取消
   if (signal.aborted) throw new Error('scan_aborted');
   // ② 同步拿到实例引用
-  const client = createClient();
+  let client: ImapFlow | undefined;
   let closed = false;
   const closeOnce = () => {
     if (closed) return;
     closed = true;
     try {
-      client.close();
+      client?.close();
     } catch {
       /* already dead / not connected */
     }
@@ -250,11 +302,17 @@ export async function withInboxAbortable<T>(
   const onAbort = () => closeOnce();
   let failed = false;
   let connectionError: Error | undefined;
-  const onError = (err: unknown) => {
-    connectionError = err instanceof Error ? err : new Error(String(err));
-    failed = true;
-    error('[imap] abortable INBOX connection error; closing current operation');
-    closeOnce();
+  const createTrackedClient: ImapClientFactory = (endpoint) => {
+    const candidate = createClient(endpoint);
+    client = candidate;
+    candidate.on('error', (err) => {
+      if (candidate !== client) return;
+      connectionError = err instanceof Error ? err : new Error(String(err));
+      failed = true;
+      error('[imap] abortable INBOX connection error; closing current operation');
+      closeOnce();
+    });
+    return candidate;
   };
   // ③ 先挂监听，再连接
   signal.addEventListener('abort', onAbort, { once: true });
@@ -264,10 +322,17 @@ export async function withInboxAbortable<T>(
   let operationFailed = false;
   // Keep this listener through any late socket-destroy event. This one-shot
   // client is discarded after the call, so the client/closure cycle is collectible.
-  client.on('error', onError);
   try {
     // ④ 本阶段起，任何 stall 都会被 abort → close() 掐断
-    await client.connect();
+    client = await connectImapClient(createTrackedClient, {
+      beforeRetry: () => {
+        if (signal.aborted) throw new Error('scan_aborted');
+        connectionError = undefined;
+        failed = false;
+        closed = false;
+      },
+      closeOnConnectError: false,
+    });
     if (connectionError) throw connectionError;
     if (signal.aborted) throw new Error('scan_aborted');
     lock = await client.getMailboxLock('INBOX');
@@ -283,7 +348,7 @@ export async function withInboxAbortable<T>(
     lock?.release();
     if (!failed && !closed) {
       try {
-        await client.logout();
+        await client!.logout();
       } catch {
         /* fall through to closeOnce */
       }

--- a/packages/api/src/lib/mailserver-reconnect.ts
+++ b/packages/api/src/lib/mailserver-reconnect.ts
@@ -38,6 +38,12 @@ function collectErrorCodes(error: unknown, seen = new Set<unknown>(), codes = ne
 
 function isEsocketConnectFailure(error: unknown): boolean {
   if (errorCode(error) !== 'ESOCKET' || !(error instanceof Error)) return false;
+  const { command, syscall } = error as Error & { command?: unknown; syscall?: unknown };
+  // Bun's Nodemailer keeps the connection phase but replaces ECONNREFUSED with
+  // ESOCKET and a generic "Failed to connect" message.
+  if (command !== undefined || syscall !== undefined) {
+    return command === 'CONN' && syscall === 'connect';
+  }
   const messages = [error.message];
   let cause = error.cause;
   const seen = new Set<unknown>();

--- a/packages/api/src/lib/mailserver-reconnect.ts
+++ b/packages/api/src/lib/mailserver-reconnect.ts
@@ -11,20 +11,47 @@ export interface MailserverEndpoint {
 type RetryOptions = {
   resolve?: (hostname: string) => Promise<string>;
   beforeRetry?: (error: unknown) => void | Promise<void>;
+  /** Runs after fresh DNS resolves and immediately before the retry creates a resource. */
+  beforeRetryConnect?: () => void;
 };
 
 const RETRYABLE_NETWORK_CODES = new Set(['ECONNREFUSED', 'ENETUNREACH', 'EHOSTUNREACH']);
 
-function errorText(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-  const code = typeof (error as NodeJS.ErrnoException).code === 'string'
+function errorCode(error: unknown): string | undefined {
+  return error && typeof error === 'object' && typeof (error as NodeJS.ErrnoException).code === 'string'
     ? (error as NodeJS.ErrnoException).code
-    : '';
-  return `${code} ${error.message} ${error.cause instanceof Error ? errorText(error.cause) : ''}`;
+    : undefined;
+}
+
+function collectErrorCodes(error: unknown, seen = new Set<unknown>(), codes = new Set<string>()): Set<string> {
+  if (!error || typeof error !== 'object' || seen.has(error)) return codes;
+  seen.add(error);
+  const code = errorCode(error);
+  if (code) codes.add(code);
+  const cause = (error as Error & { cause?: unknown }).cause;
+  collectErrorCodes(cause, seen, codes);
+  if (error instanceof AggregateError) {
+    for (const nested of error.errors) collectErrorCodes(nested, seen, codes);
+  }
+  return codes;
+}
+
+function isEsocketConnectFailure(error: unknown): boolean {
+  if (errorCode(error) !== 'ESOCKET' || !(error instanceof Error)) return false;
+  const messages = [error.message];
+  let cause = error.cause;
+  const seen = new Set<unknown>();
+  while (cause instanceof Error && !seen.has(cause)) {
+    seen.add(cause);
+    messages.push(cause.message);
+    cause = cause.cause;
+  }
+  return messages.some((message) => /\bconnect\s+(?:ECONNREFUSED|ENETUNREACH|EHOSTUNREACH)\b/.test(message));
 }
 
 export function isRetryableMailserverConnectionError(error: unknown): boolean {
-  return [...RETRYABLE_NETWORK_CODES].some((code) => errorText(error).includes(code));
+  return [...collectErrorCodes(error)].some((code) => RETRYABLE_NETWORK_CODES.has(code)) ||
+    isEsocketConnectFailure(error);
 }
 
 /**
@@ -48,11 +75,13 @@ export async function resolveFreshMailserverHost(hostname: string): Promise<stri
 /**
  * First attempt deliberately uses the configured hostname. Only a stale-network
  * failure gets one fresh-resolution retry; no resolved address is retained after it.
+ * This wrapper does not own teardown: a `connect` callback must close resources it
+ * creates before rethrowing, because retries replace those resources.
  */
 export async function withMailserverReconnect<T>(
   hostname: string,
   connect: (endpoint: MailserverEndpoint) => Promise<T>,
-  { resolve = resolveFreshMailserverHost, beforeRetry }: RetryOptions = {},
+  { resolve = resolveFreshMailserverHost, beforeRetry, beforeRetryConnect }: RetryOptions = {},
 ): Promise<T> {
   try {
     return await connect({ host: hostname });
@@ -60,6 +89,7 @@ export async function withMailserverReconnect<T>(
     if (!isRetryableMailserverConnectionError(error)) throw error;
     await beforeRetry?.(error);
     const address = await resolve(hostname);
+    beforeRetryConnect?.();
     return connect({ host: address, servername: hostname });
   }
 }

--- a/packages/api/src/lib/mailserver-reconnect.ts
+++ b/packages/api/src/lib/mailserver-reconnect.ts
@@ -1,0 +1,65 @@
+import { resolve4, resolve6 } from 'node:dns/promises';
+import { isIP } from 'node:net';
+
+export interface MailserverEndpoint {
+  /** The address used for this one connection attempt. */
+  host: string;
+  /** Original hostname retained for TLS SNI when host is a freshly resolved IP. */
+  servername?: string;
+}
+
+type RetryOptions = {
+  resolve?: (hostname: string) => Promise<string>;
+  beforeRetry?: (error: unknown) => void | Promise<void>;
+};
+
+const RETRYABLE_NETWORK_CODES = new Set(['ECONNREFUSED', 'ENETUNREACH', 'EHOSTUNREACH']);
+
+function errorText(error: unknown): string {
+  if (!(error instanceof Error)) return String(error);
+  const code = typeof (error as NodeJS.ErrnoException).code === 'string'
+    ? (error as NodeJS.ErrnoException).code
+    : '';
+  return `${code} ${error.message} ${error.cause instanceof Error ? errorText(error.cause) : ''}`;
+}
+
+export function isRetryableMailserverConnectionError(error: unknown): boolean {
+  return [...RETRYABLE_NETWORK_CODES].some((code) => errorText(error).includes(code));
+}
+
+/**
+ * Queries DNS directly instead of using the runtime's hostname-connect cache.
+ * This address is deliberately used for one retry only; callers retain `servername`
+ * so TLS continues to validate the configured hostname rather than the container IP.
+ */
+export async function resolveFreshMailserverHost(hostname: string): Promise<string> {
+  if (isIP(hostname)) return hostname;
+  try {
+    const addresses = await resolve4(hostname);
+    if (addresses[0]) return addresses[0];
+  } catch {
+    // Docker's embedded DNS normally has an A record; try IPv6 before surfacing DNS failure.
+  }
+  const addresses = await resolve6(hostname);
+  if (!addresses[0]) throw new Error(`DNS returned no addresses for ${hostname}`);
+  return addresses[0];
+}
+
+/**
+ * First attempt deliberately uses the configured hostname. Only a stale-network
+ * failure gets one fresh-resolution retry; no resolved address is retained after it.
+ */
+export async function withMailserverReconnect<T>(
+  hostname: string,
+  connect: (endpoint: MailserverEndpoint) => Promise<T>,
+  { resolve = resolveFreshMailserverHost, beforeRetry }: RetryOptions = {},
+): Promise<T> {
+  try {
+    return await connect({ host: hostname });
+  } catch (error) {
+    if (!isRetryableMailserverConnectionError(error)) throw error;
+    await beforeRetry?.(error);
+    const address = await resolve(hostname);
+    return connect({ host: address, servername: hostname });
+  }
+}

--- a/packages/api/src/lib/smtp.ts
+++ b/packages/api/src/lib/smtp.ts
@@ -10,6 +10,10 @@ import { config } from './config.ts';
 import { buildOutboundStampHeaders, stampDate } from './mail-stamp.ts';
 import { htmlToText } from './otp.ts';
 import { recordSentMessageIdAfterSend } from './sent-registry.ts';
+import {
+  withMailserverReconnect,
+  type MailserverEndpoint,
+} from './mailserver-reconnect.ts';
 
 export interface SendInput {
   from: string;
@@ -30,9 +34,9 @@ export function coerceOutboundText(text: string, html?: string): string {
   return htmlToText(html);
 }
 
-export async function sendMail(input: SendInput): Promise<{ messageId: string }> {
-  const transporter = nodemailer.createTransport({
-    host: config.smtp.host,
+function createSmtpTransport(endpoint: MailserverEndpoint) {
+  return nodemailer.createTransport({
+    host: endpoint.host,
     port: config.smtp.port,
     secure: config.smtp.port === 465,
     auth: { user: config.smtp.user, pass: config.smtp.pass },
@@ -40,9 +44,14 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
       // The bundled mailserver starts with a self-signed cert. External public
       // mail servers should set SMTP_TLS_REJECT_UNAUTHORIZED=true.
       rejectUnauthorized: config.smtp.tlsRejectUnauthorized,
+      // A retry dials a freshly resolved IP only once, while TLS still verifies
+      // the configured hostname instead of treating that container IP as identity.
+      ...(endpoint.servername ? { servername: endpoint.servername } : {}),
     },
   });
+}
 
+export async function sendMail(input: SendInput): Promise<{ messageId: string }> {
   // 显式 Date + 毫秒归零：发读两侧 stamp 载荷用同一 ISO 字符串。
   const date = stampDate();
   const text = coerceOutboundText(input.text, input.html);
@@ -55,20 +64,23 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
     config.domain,
   );
 
-  try {
-    const info = await transporter.sendMail({
-      from: input.from,
-      to: input.to,
-      subject: input.subject,
-      text,
-      date,
-      ...(input.html ? { html: input.html } : {}),
-      headers,
-    });
-    // 服务端真正出站成功才登记。登记失败不得否决这次投递（否则 502 重试会重复外发）。
-    recordSentMessageIdAfterSend(info.messageId, input.from);
-    return { messageId: info.messageId };
-  } finally {
-    transporter.close();
-  }
+  return withMailserverReconnect(config.smtp.host, async (endpoint) => {
+    const transporter = createSmtpTransport(endpoint);
+    try {
+      const info = await transporter.sendMail({
+        from: input.from,
+        to: input.to,
+        subject: input.subject,
+        text,
+        date,
+        ...(input.html ? { html: input.html } : {}),
+        headers,
+      });
+      // 服务端真正出站成功才登记。登记失败不得否决这次投递（否则 502 重试会重复外发）。
+      recordSentMessageIdAfterSend(info.messageId, input.from);
+      return { messageId: info.messageId };
+    } finally {
+      transporter.close();
+    }
+  });
 }

--- a/packages/api/test/imap-error-boundary.test.ts
+++ b/packages/api/test/imap-error-boundary.test.ts
@@ -112,6 +112,33 @@ class SuccessfulClient extends EventEmitter {
   }
 }
 
+class RetryClient extends EventEmitter {
+  closeCalls = 0;
+  logoutCalls = 0;
+
+  constructor(private readonly failConnect: boolean) {
+    super();
+  }
+
+  async connect() {
+    if (this.failConnect) {
+      throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    }
+  }
+
+  async getMailboxLock() {
+    return { release() {} };
+  }
+
+  async logout() {
+    this.logoutCalls += 1;
+  }
+
+  close() {
+    this.closeCalls += 1;
+  }
+}
+
 describe('IMAP async error boundaries', () => {
   test('withInbox catches an out-of-band error, fails the operation, and closes once', async () => {
     const client = new OperationErrorClient();
@@ -209,5 +236,57 @@ describe('IMAP async error boundaries', () => {
       async () => undefined,
       { createClient: () => abortable as unknown as ImapFlow, error: () => {} },
     )).rejects.toBe(emitted);
+  });
+
+  test('重试前关闭未 emit error 的失败 client，不遗留连接', async () => {
+    const first = new RetryClient(true);
+    const second = new RetryClient(false);
+    let calls = 0;
+
+    await expect(withInbox(async () => 'ok', {
+      createClient: () => (calls++ === 0 ? first : second) as unknown as ImapFlow,
+      resolveMailserver: async () => '172.18.0.5',
+      error: () => {},
+    })).resolves.toBe('ok');
+
+    expect(first.closeCalls).toBe(1);
+    expect(second.logoutCalls).toBe(1);
+  });
+
+  test('abort during fresh DNS resolution never creates a second client', async () => {
+    const controller = new AbortController();
+    const first = new RetryClient(true);
+    let resolveAddress: ((address: string) => void) | undefined;
+    let startedResolve: (() => void) | undefined;
+    const resolving = new Promise<string>((resolve) => {
+      resolveAddress = resolve;
+    });
+    const resolutionStarted = new Promise<void>((resolve) => {
+      startedResolve = resolve;
+    });
+    let factoryCalls = 0;
+
+    const pending = withInboxAbortable(controller.signal, async () => undefined, {
+      createClient: () => {
+        factoryCalls += 1;
+        return first as unknown as ImapFlow;
+      },
+      resolveMailserver: async () => {
+        startedResolve!();
+        return resolving;
+      },
+      error: () => {},
+    });
+    await resolutionStarted;
+    controller.abort();
+    resolveAddress!('172.18.0.5');
+
+    const rejected = await pending.then(
+      () => undefined,
+      (error) => error,
+    );
+    expect(factoryCalls).toBe(1);
+    expect(first.closeCalls).toBe(1);
+    expect(rejected).toMatchObject({ message: 'scan_aborted' });
   });
 });

--- a/packages/api/test/imap-error-boundary.test.ts
+++ b/packages/api/test/imap-error-boundary.test.ts
@@ -253,6 +253,38 @@ describe('IMAP async error boundaries', () => {
     expect(second.logoutCalls).toBe(1);
   });
 
+  test('常驻回归：关闭后、DNS 完成前的迟到 error 不污染成功重试', async () => {
+    for (const abortable of [false, true]) {
+      const first = new RetryClient(true);
+      const second = new RetryClient(false);
+      const lateError = new Error('late error from closed client');
+      let factoryCalls = 0;
+      let resolverCalls = 0;
+      const createClient = () => (factoryCalls++ === 0 ? first : second) as unknown as ImapFlow;
+      const resolveMailserver = async () => {
+        resolverCalls += 1;
+        // This simulates a socket error emitted by the closed first client while
+        // fresh DNS resolution is still in progress.
+        first.emit('error', lateError);
+        return '172.18.0.5';
+      };
+
+      const result = abortable
+        ? withInboxAbortable(new AbortController().signal, async () => 'ok', {
+          createClient,
+          resolveMailserver,
+          error: () => {},
+        })
+        : withInbox(async () => 'ok', { createClient, resolveMailserver, error: () => {} });
+
+      await expect(result).resolves.toBe('ok');
+      expect(factoryCalls).toBe(2);
+      expect(resolverCalls).toBe(1);
+      expect(first.closeCalls).toBe(1);
+      expect(second.logoutCalls).toBe(1);
+    }
+  });
+
   test('abort during fresh DNS resolution never creates a second client', async () => {
     const controller = new AbortController();
     const first = new RetryClient(true);

--- a/packages/api/test/mailserver-reconnect.test.ts
+++ b/packages/api/test/mailserver-reconnect.test.ts
@@ -29,6 +29,34 @@ describe('mailserver DNS-refresh reconnect', () => {
     ]);
   });
 
+  test('Bun Nodemailer ESOCKET CONN failure re-resolves once and retries', async () => {
+    const resolve = mock(async () => '172.18.0.5');
+    const attempts: { host: string; servername?: string }[] = [];
+    const bunConnectError = Object.assign(new Error('Failed to connect'), {
+      code: 'ESOCKET',
+      command: 'CONN',
+      syscall: 'connect',
+    });
+
+    expect(isRetryableMailserverConnectionError(bunConnectError)).toBe(true);
+    const result = await withMailserverReconnect(
+      'mailserver',
+      async (endpoint) => {
+        attempts.push(endpoint);
+        if (attempts.length === 1) throw bunConnectError;
+        return 'connected';
+      },
+      { resolve },
+    );
+
+    expect(result).toBe('connected');
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(attempts).toEqual([
+      { host: 'mailserver' },
+      { host: '172.18.0.5', servername: 'mailserver' },
+    ]);
+  });
+
   test('auth failures do not resolve or retry', async () => {
     const resolve = mock(async () => '172.18.0.5');
     const connect = mock(async () => {
@@ -88,6 +116,14 @@ describe('mailserver DNS-refresh reconnect', () => {
     expect(isRetryableMailserverConnectionError(Object.assign(
       new Error('SMTP DATA contained ECONNREFUSED'),
       { code: 'ESOCKET' },
+    ))).toBe(false);
+    expect(isRetryableMailserverConnectionError(Object.assign(
+      new Error('Failed to send data'),
+      { code: 'ESOCKET', command: 'DATA', syscall: 'write' },
+    ))).toBe(false);
+    expect(isRetryableMailserverConnectionError(Object.assign(
+      new Error('SMTP DATA contained connect ECONNREFUSED'),
+      { code: 'ESOCKET', command: 'DATA', syscall: 'write' },
     ))).toBe(false);
   });
 });

--- a/packages/api/test/mailserver-reconnect.test.ts
+++ b/packages/api/test/mailserver-reconnect.test.ts
@@ -58,6 +58,36 @@ describe('mailserver DNS-refresh reconnect', () => {
   test('the network-error whitelist includes the required connection failures', () => {
     for (const code of ['ECONNREFUSED', 'ENETUNREACH', 'EHOSTUNREACH']) {
       expect(isRetryableMailserverConnectionError(Object.assign(new Error(code), { code }))).toBe(true);
+      expect(isRetryableMailserverConnectionError(Object.assign(new Error('outer'), {
+        cause: Object.assign(new Error(code), { code }),
+      }))).toBe(true);
+      expect(isRetryableMailserverConnectionError(new AggregateError([
+        Object.assign(new Error(code), { code }),
+      ], 'Happy Eyeballs failed'))).toBe(true);
     }
+  });
+
+  test('SMTP transaction text cannot trigger a reconnect without a connection error code', async () => {
+    const resolve = mock(async () => '172.18.0.5');
+    const transactionError = Object.assign(
+      new Error('SMTP DATA failed after remote text mentioned ECONNREFUSED'),
+      { code: 'EPIPE' },
+    );
+    const connect = mock(async () => { throw transactionError; });
+
+    await expect(withMailserverReconnect('mailserver', connect, { resolve })).rejects.toBe(transactionError);
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  test('ESOCKET retries only when its message identifies a connect-stage network failure', () => {
+    expect(isRetryableMailserverConnectionError(Object.assign(
+      new Error('connect ECONNREFUSED 172.18.0.3:587'),
+      { code: 'ESOCKET' },
+    ))).toBe(true);
+    expect(isRetryableMailserverConnectionError(Object.assign(
+      new Error('SMTP DATA contained ECONNREFUSED'),
+      { code: 'ESOCKET' },
+    ))).toBe(false);
   });
 });

--- a/packages/api/test/mailserver-reconnect.test.ts
+++ b/packages/api/test/mailserver-reconnect.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, mock, test } from 'bun:test';
+import {
+  isRetryableMailserverConnectionError,
+  withMailserverReconnect,
+} from '../src/lib/mailserver-reconnect.ts';
+
+describe('mailserver DNS-refresh reconnect', () => {
+  test('old container IP refusal re-resolves once and preserves hostname for TLS SNI', async () => {
+    const resolve = mock(async () => '172.18.0.5');
+    const attempts: { host: string; servername?: string }[] = [];
+    const result = await withMailserverReconnect(
+      'mailserver',
+      async (endpoint) => {
+        attempts.push(endpoint);
+        if (attempts.length === 1) {
+          // Nodemailer wraps the socket code as ESOCKET but keeps ECONNREFUSED in its message.
+          throw Object.assign(new Error('connect ECONNREFUSED 172.18.0.3:587'), { code: 'ESOCKET' });
+        }
+        return 'connected';
+      },
+      { resolve },
+    );
+
+    expect(result).toBe('connected');
+    expect(resolve).toHaveBeenCalledTimes(1);
+    expect(attempts).toEqual([
+      { host: 'mailserver' },
+      { host: '172.18.0.5', servername: 'mailserver' },
+    ]);
+  });
+
+  test('auth failures do not resolve or retry', async () => {
+    const resolve = mock(async () => '172.18.0.5');
+    const connect = mock(async () => {
+      throw Object.assign(new Error('authentication failed'), { code: 'EAUTH' });
+    });
+
+    await expect(withMailserverReconnect('mailserver', connect, { resolve })).rejects.toMatchObject({
+      code: 'EAUTH',
+    });
+    expect(connect).toHaveBeenCalledTimes(1);
+    expect(resolve).not.toHaveBeenCalled();
+  });
+
+  test('a second network failure escapes without a third attempt', async () => {
+    const resolve = mock(async () => '172.18.0.5');
+    const connect = mock(async () => {
+      throw Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' });
+    });
+
+    await expect(withMailserverReconnect('mailserver', connect, { resolve })).rejects.toMatchObject({
+      code: 'ECONNREFUSED',
+    });
+    expect(connect).toHaveBeenCalledTimes(2);
+    expect(resolve).toHaveBeenCalledTimes(1);
+  });
+
+  test('the network-error whitelist includes the required connection failures', () => {
+    for (const code of ['ECONNREFUSED', 'ENETUNREACH', 'EHOSTUNREACH']) {
+      expect(isRetryableMailserverConnectionError(Object.assign(new Error(code), { code }))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Jakarta A1 P0 — mailserver rebuild leaves API on a stale DNS address

Source: Jakarta deployment report / OAE task `a3591e44` (mailserver-only `docker compose up -d` rebuild).

### Root cause

The API process can retain the previous `mailserver` container IP after Compose recreates only mailserver. New IMAP and SMTP connections then continue to dial the dead address, even though a fresh lookup inside the container returns the new address. Nodemailer also keeps its own DNS cache, so a Compose environment switch alone is insufficient.

### Fix and boundary

- `api` now sets `BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS=0` as a documented safety belt.
- A shared connection helper makes the first attempt with the configured hostname. Only `ECONNREFUSED`, `ENETUNREACH`, or `EHOSTUNREACH` triggers exactly one direct fresh DNS resolution and retry.
- The retry creates a new IMAP client / SMTP transporter and dials the fresh IP only for that attempt. It preserves `servername: mailserver`, so TLS SNI and certificate verification remain hostname-based. No resolved IP is cached or retained.
- The helper is wired through `connectImap`, `withInbox`, and `withInboxAbortable`; therefore `waitForMessage` and watcher reconnects (which use `connectImap`) share the behavior. SMTP `sendMail` shares it too.
- A second failure keeps the existing error path; non-network failures do not retry. No REST success semantics change.

### Regression proof

The permanent core regression starts with the old IP rejection (`ESOCKET` wrapper containing `ECONNREFUSED 172.18.0.3:587`), forces resolution to `172.18.0.5`, and asserts exactly:

```text
[{ host: 'mailserver' }, { host: '172.18.0.5', servername: 'mailserver' }]
```

Negative proof was run by temporarily removing only the production second-connection call while leaving the test unchanged. It went red as required:

```text
error: connect ECONNREFUSED 172.18.0.3:587
(fail) old container IP refusal re-resolves once and preserves hostname for TLS SNI
Expected number of calls: 2
Received number of calls: 1
2 pass / 2 fail
```

After restoring the production line, targeted coverage passed:

```text
29 pass / 0 fail / 81 expect() calls
```

### Full-suite comparison

Both runs used `timeout 180 bun test` after installing each package from its lockfile.

| revision | result |
| --- | --- |
| `origin/main` / `f5242cc` baseline | `929 pass / 1 skip / 3 fail / 6395 expect()` across 933 tests |
| this PR (`4535f25`) | `933 pass / 1 skip / 3 fail / 6407 expect()` across 937 tests |

The three unchanged baseline failures are `phone device ACL`, `UI is enabled by default`, and `UI session persistence`; task-board and the new A1 coverage are green.

### Independent review and debt

An independent read-only review verified the three IMAP construction paths, watcher reuse of `connectImap`, and Nodemailer's internal DNS cache. Its recommendations (fresh resolver, new client/transporter, preserved SNI, no IP persistence, error-list whitelist) are incorporated here.

No new debt recorded. This branch does not deploy, tag, merge, modify mailserver networking, or attempt access to the Jakarta host.

## R1 review fixes (`4f97660`)

### A — failed IMAP clients are closed per instance

`withInbox` and `withInboxAbortable` now track closure in a `WeakSet` per client. Before a retry replaces the current client, it closes that failed client first; a new client therefore has independent teardown state. The reconnect helper documents that resource teardown remains the caller's responsibility.

### B — abort is checked after DNS and before retry construction

The reconnect helper runs a synchronous `beforeRetryConnect` hook after `await resolve(...)` and immediately before the retry callback can create an IMAP client. The abortable IMAP path checks its signal there, so aborting during DNS throws `scan_aborted`, does not construct a second client, and cannot leave it behind.

### C — only connection failures retry

Retry classification now collects structured `code` fields through `cause` and `AggregateError.errors`, matching only `ECONNREFUSED`, `ENETUNREACH`, and `EHOSTUNREACH`. The only message fallback is Nodemailer's documented wrapper: top-level `ESOCKET` with a `connect <whitelisted-code>` message/cause. SMTP transaction errors such as `EPIPE` whose DATA text merely contains `ECONNREFUSED` do not retry and therefore cannot duplicate delivery.

`ETIMEDOUT` / `CONNECT_TIMEOUT` remain intentionally outside this PR's whitelist: the Jakarta incident was `ECONNREFUSED`, while Nodemailer does not safely distinguish connection timeout from SMTP transaction timeout. Broadening it risks duplicate mail delivery.

### R1 negative proofs and validation

Each proof temporarily changed only production code; tests were unchanged:

```text
A: omit beforeRetry closeOnce -> Expected closeCalls 1, Received 0
B: omit post-DNS abort check -> Expected factoryCalls 1, Received 2
C: restore message substring classifier -> Expected connect calls 1, Received 2
```

After restoration: targeted `33 pass / 0 fail / 98 expect()`.

Full suite (`timeout 180 bun test`): `937 pass / 1 skip / 3 fail / 6424 expect()` across 941 tests. The same three pre-existing failures remain: phone device ACL, UI default, and UI session persistence. `f5242cc` baseline remains `929 pass / 1 skip / 3 fail / 6395 expect()` across 933 tests.

## R2 review fix (`f4a0def`)

Before each IMAP retry, both `withInbox` variants now save the failed instance, clear the shared `client` pointer, and then close that saved instance. A socket `error` emitted by the closed client while fresh DNS is resolving is therefore still observed (the listener remains installed for lifecycle safety) but ignored as stale; it cannot poison the successful second connection. The abortable path keeps its abort check after close and before retry construction.

The permanent regression exercises both wrappers: the first client fails with `ECONNREFUSED`, is closed, then emits `error` from the resolver while DNS is in progress; the retry succeeds. Negative proof temporarily removed only the two production pointer-retirement assignments while leaving that test unchanged:

```text
Expected promise that resolves
Received promise that rejected: Promise { <rejected> }
(fail) IMAP async error boundaries > 常驻回归：关闭后、DNS 完成前的迟到 error 不污染成功重试
7 pass / 1 fail
```

After restoration, related coverage: `14 pass / 0 fail / 60 expect()`.

Full suite (`timeout 180 bun test`): `938 pass / 1 skip / 3 fail / 6434 expect()` across 942 tests. The only failures remain the same existing three: `phone device ACL`, `UI is enabled by default`, and `UI session persistence`.

Independent read-only self-review: passed; it verified both retirement orders, the post-close abort ordering, and that the new regression goes red without the retirement assignments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved mailserver connection reliability by refreshing stale DNS addresses and retrying eligible network failures.
  - Preserved secure TLS hostname validation during reconnects.
  - Ensured failed or interrupted IMAP connections are properly closed without duplicate cleanup.
  - Prevented reconnect attempts after an operation is aborted.
  - Reduced connection issues after mailserver container rebuilds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
