### PR TITLE
fix(setup): validate required MCP tools

### DIFF
--- a/packages/setup/src/verify.ts
+++ b/packages/setup/src/verify.ts
@@ -29,10 +29,11 @@ export function validateToolList(value: unknown): void {
   }
   const names = new Set<string>();
   for (const tool of tools) {
-    if (!tool || typeof tool !== 'object' || typeof (tool as { name?: unknown }).name !== 'string') {
+    const name = tool && typeof tool === 'object' ? (tool as { name?: unknown }).name : undefined;
+    if (typeof name !== 'string' || name.length === 0) {
       throw new CliError('MCP tools/list returned an invalid tool entry', EXIT.MCP_VERIFY_FAILED);
     }
-    names.add((tool as { name: string }).name);
+    names.add(name);
   }
   const missing = REQUIRED_TOOL_NAMES.filter((name) => !names.has(name));
   if (missing.length) {

--- a/packages/setup/src/verify.ts
+++ b/packages/setup/src/verify.ts
@@ -8,14 +8,36 @@ type SpawnMcp = (
   options: Parameters<typeof spawn>[2],
 ) => ChildProcessWithoutNullStreams;
 
+const REQUIRED_TOOL_NAMES = [
+  'mail_list_identities',
+  'mail_list_messages',
+  'mail_read_message',
+  'mail_send',
+  'mail_mark_seen',
+] as const;
+
 export function validateToolList(value: unknown): void {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
     throw new CliError('MCP tools/list returned an invalid response', EXIT.MCP_VERIFY_FAILED);
   }
   const tools = (value as { tools?: unknown }).tools;
-  if (!Array.isArray(tools) || tools.length !== 7) {
+  if (!Array.isArray(tools) || tools.length === 0) {
     throw new CliError(
-      `MCP verification expected 7 tools, received ${Array.isArray(tools) ? tools.length : 0}`,
+      'MCP tools/list returned an empty or invalid tools array',
+      EXIT.MCP_VERIFY_FAILED,
+    );
+  }
+  const names = new Set<string>();
+  for (const tool of tools) {
+    if (!tool || typeof tool !== 'object' || typeof (tool as { name?: unknown }).name !== 'string') {
+      throw new CliError('MCP tools/list returned an invalid tool entry', EXIT.MCP_VERIFY_FAILED);
+    }
+    names.add((tool as { name: string }).name);
+  }
+  const missing = REQUIRED_TOOL_NAMES.filter((name) => !names.has(name));
+  if (missing.length) {
+    throw new CliError(
+      `MCP verification is missing required tools: ${missing.join(', ')}`,
       EXIT.MCP_VERIFY_FAILED,
     );
   }

--- a/packages/setup/test/exits.test.ts
+++ b/packages/setup/test/exits.test.ts
@@ -72,6 +72,10 @@ describe('documented exit codes', () => {
   test('4: MCP tool handshake rejects empty, invalid, and incomplete tool lists', async () => {
     await expectCode(() => validateToolList({ tools: [] }), EXIT.MCP_VERIFY_FAILED);
     await expectCode(() => validateToolList({ tools: [{ name: 42 }] }), EXIT.MCP_VERIFY_FAILED);
+    await expectCode(
+      () => validateToolList({ tools: [...REQUIRED_TOOLS, ''].map((name) => ({ name })) }),
+      EXIT.MCP_VERIFY_FAILED,
+    );
     await expectCode(() => validateToolList({ tools: [{ name: 'only-one' }] }), EXIT.MCP_VERIFY_FAILED);
     await expectCode(
       () => validateToolList({ tools: REQUIRED_TOOLS.filter((name) => name !== 'mail_send').map((name) => ({ name })) }),

--- a/packages/setup/test/exits.test.ts
+++ b/packages/setup/test/exits.test.ts
@@ -11,6 +11,14 @@ import {
 import { CliError, EXIT } from '../src/types.ts';
 import { validateToolList } from '../src/verify.ts';
 
+const REQUIRED_TOOLS = [
+  'mail_list_identities',
+  'mail_list_messages',
+  'mail_read_message',
+  'mail_send',
+  'mail_mark_seen',
+];
+
 async function expectCode(operation: () => unknown | Promise<unknown>, code: number) {
   try {
     await operation();
@@ -61,8 +69,38 @@ describe('documented exit codes', () => {
     );
   });
 
-  test('4: MCP tool handshake is incomplete', async () => {
+  test('4: MCP tool handshake rejects empty, invalid, and incomplete tool lists', async () => {
+    await expectCode(() => validateToolList({ tools: [] }), EXIT.MCP_VERIFY_FAILED);
+    await expectCode(() => validateToolList({ tools: [{ name: 42 }] }), EXIT.MCP_VERIFY_FAILED);
     await expectCode(() => validateToolList({ tools: [{ name: 'only-one' }] }), EXIT.MCP_VERIFY_FAILED);
+    await expectCode(
+      () => validateToolList({ tools: REQUIRED_TOOLS.filter((name) => name !== 'mail_send').map((name) => ({ name })) }),
+      EXIT.MCP_VERIFY_FAILED,
+    );
+  });
+
+  test('MCP tool handshake accepts seven tools when every required mail tool is present', () => {
+    expect(() => validateToolList({
+      tools: [...REQUIRED_TOOLS, 'notify_messages', 'task_list'].map((name) => ({ name })),
+    })).not.toThrow();
+  });
+
+  test('MCP tool handshake accepts fifteen tools including extra notify and task tools', () => {
+    expect(() => validateToolList({
+      tools: [
+        ...REQUIRED_TOOLS,
+        'notify_messages',
+        'notify_register',
+        'task_list',
+        'task_create',
+        'task_get',
+        'task_reply',
+        'mail_delete_messages',
+        'mail_wait',
+        'mail_get_source',
+        'mail_get_message',
+      ].map((name) => ({ name })),
+    })).not.toThrow();
   });
 
   test('5: Docker or Compose is missing', async () => {


### PR DESCRIPTION
## Jakarta A3 P1 — setup `--verify` no longer hard-codes a seven-tool count

Source: Jakarta deployment report / task `a3591e44`.

### Root cause and contract

`npx -y @openagentemail/setup connect … --verify` wrote configuration successfully but exited 4 because `validateToolList` required exactly seven tools. The current MCP server exposes fifteen tools, and tool count is not a compatibility contract.

Verification now accepts a non-empty `tools` array only when every entry has a string name and it includes all required mail operations:

- `mail_list_identities`
- `mail_list_messages`
- `mail_read_message`
- `mail_send`
- `mail_mark_seen`

Additional `notify_*`, `task_*`, and other tools are valid. Empty, malformed, or incomplete responses retain `EXIT.MCP_VERIFY_FAILED` (4); no diagnostic says “expected 7”. This PR does not change the MCP server list, publish setup, create a tag, deploy, or merge.

### Regression evidence

Permanent tests cover:

- empty and malformed tool lists → exit 4;
- missing a required name → exit 4;
- all required names in a seven-tool response → pass;
- fifteen tools with additional notify/task tools → pass.

Negative proof: only production code was temporarily reverted to `tools.length !== 7`; the 15-tool test was unchanged and went red:

```text
(fail) MCP tool handshake accepts fifteen tools including extra notify and task tools
Error name: "CliError"
0 pass / 1 fail
```

After restoration, setup coverage was green:

```text
35 pass / 0 fail / 131 expect() calls
```

### Full-suite comparison

Both runs used `timeout 180 bun test` after package dependencies were installed from lockfiles.

| revision | result |
| --- | --- |
| `origin/main` / `f5242cc` baseline | `929 pass / 1 skip / 3 fail / 6395 expect()` across 933 tests |
| this PR (`702d8c7`) | `931 pass / 1 skip / 3 fail / 6403 expect()` across 935 tests |

The unchanged baseline failures are `phone device ACL`, `UI is enabled by default`, and `UI session persistence`.

### Local verify and self-review

The local API was unavailable (`127.0.0.1:3100` refused both `/health` and `/healthz`), so a real local `connect --verify` could not be run; the contract tests are the evidence for this PR. A final self-review confirmed only `verify.ts` and `exits.test.ts` changed, non-empty/malformed/missing behavior remains exit 4, extras are not constrained by count, and the setup CLI bundle builds successfully.

## R1 — reject empty tool names (`fa165c5`)

CodeRabbit correctly identified that a string-only check accepted `{ name: '' }`. Validation now rejects only zero-length names; it deliberately does not trim names, so existing non-empty names retain their previous semantics. The permanent regression supplies all five required names plus an empty name and requires exit 4.

Negative proof: with only the `name.length === 0` rejection removed, the unchanged targeted test went red:

```text
(fail) documented exit codes > 4: MCP tool handshake rejects empty, invalid, and incomplete tool lists
error: Expected operation to fail
0 pass / 1 fail
```

After restoring the guard:

```text
packages/setup: 35 pass / 0 fail / 133 expect() calls
```

An additional root `timeout 180 bun test` run retained the pre-existing three unrelated environment-dependent failures (`UI is enabled by default`, UI session admin-hash expectation, and phone device ACL); the R1 setup suite is green above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MCP tool verification to reject empty, malformed, and incomplete tool lists.
  * Validates tool names and reports which required tools are missing.
  * Supports valid configurations containing additional tools beyond the required set.

* **Tests**
  * Expanded verification coverage for invalid, incomplete, and valid tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->