### PR TITLE
fix(otp): ignore ISO dates in delimited codes

### DIFF
--- a/packages/api/src/lib/otp.ts
+++ b/packages/api/src/lib/otp.ts
@@ -81,6 +81,7 @@ function buildStrongOtpCueRe(cues: readonly string[]): RegExp {
 }
 
 const STRONG_OTP_CUE = buildStrongOtpCueRe(STRONG_OTP_CUES);
+const ISO_DATE_FORM = /^\d{4}-\d{2}-\d{2}$/;
 
 /**
  * True when text contains a strong OTP cue (F71 list; case-folded for Latin).
@@ -365,6 +366,9 @@ export function extractCodes(text: string): string[] {
   for (const match of text.matchAll(delimitedOtpCaptureRe())) {
     const form = match[1]!;
     const idx = match.index ?? 0;
+    // Three groups shaped YYYY-MM-DD are dates, not OTPs, even when a nearby
+    // real code supplies the strong cue for this window (Jakarta A6).
+    if (ISO_DATE_FORM.test(form)) continue;
     const window = keywordWindow(text, idx, form.length);
     if (!STRONG_OTP_CUE.test(window)) continue;
     if (!seen.has(form)) {

--- a/packages/api/test/otp.test.ts
+++ b/packages/api/test/otp.test.ts
@@ -136,6 +136,14 @@ describe('extractCodes', () => {
     expect(extractCodes('call 555-1234')).toEqual([]);
   });
 
+  test('ISO date beside a real OTP is never extracted as a code (Jakarta A6)', () => {
+    const codes = extractCodes('Your verification code is 593018 (real-sender test, 2026-08-19).');
+    expect(codes).toContain('593018');
+    expect(codes).not.toContain('2026-08-19');
+    expect(codes).not.toContain('2026');
+    expect(codes).not.toContain('08-19');
+  });
+
   test('single-digit chains need strong cues (F132)', () => {
     // Providers render codes spaced for readability: `1 2 3 4 5 6`.
     expect(extractCodes('Your verification code is 1 2 3 4 5 6')).toEqual(['1 2 3 4 5 6']);


### PR DESCRIPTION
## Jakarta A6 P3 — do not extract ISO dates as OTPs

The observed sample has a valid numeric OTP (`593018`) next to `(real-sender test, 2026-08-19)`. The root cause is the **delimited OTP** pass: its strong-cue window sees `code` near the real OTP, then treats the three digit groups `2026-08-19` as a `4-2-2` delimited OTP.

### Fix

Only the delimited output pass now skips ASCII ISO `YYYY-MM-DD` forms before strong-cue evaluation. Continuous OTP extraction and every other delimited form remain unchanged. The permanent regression asserts the real `593018` remains present and that neither the complete date nor its date fragments appear.

### Red/green evidence

Negative proof: with only the production ISO-date exclusion removed and the new test unchanged:

```text
(fail) extractCodes > ISO date beside a real OTP is never extracted as a code (Jakarta A6)
Expected to not contain: "2026-08-19"
Received: [ "593018", "2026-08-19" ]
0 pass / 1 fail
```

After restoring the guard:

```text
packages/api/test/otp.test.ts: 88 pass / 0 fail / 381 expect() calls
```

Full `timeout 180 bun test`:

| revision | result |
| --- | --- |
| `main` / `f5242cc` baseline | `929 pass / 1 skip / 3 fail / 6395 expect()` across 933 tests |
| this PR (`b96af37`) | `930 pass / 1 skip / 3 fail / 6399 expect()` across 934 tests |

The unchanged baseline failures are phone-device corrupt-registry startup, `UI is enabled by default`, and the UI-session admin-hash expectation. Self-review confirms the diff is limited to `otp.ts` and its regression test; no IMAP/SMTP/setup/Compose changes, release, deployment, or merge are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved one-time passcode detection to avoid incorrectly extracting ISO-formatted dates or their numeric components as OTP codes, even when a valid code appears nearby.

* **Tests**
  * Added coverage confirming genuine six-digit OTPs are retained while date values are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->