### PR TITLE
docs: clarify doctor checks and delivery queueing

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,28 @@ you control:
 ```bash
 git clone https://github.com/openagentemail/openagentemail.git && cd openagentemail
 cp .env.example .env   # set DOMAIN, API_KEYS, mailbox password, and NTFY_ADMIN_PASSWORD
-docker compose up -d && ./deploy/dns-records.sh   # prints the exact DNS records to create
+docker compose up -d
+sudo ./deploy/dns-records.sh   # prints the exact DNS records to create
 ```
 
 Then verify everything end to end:
 
 ```bash
-./deploy/doctor.sh    # checks DNS, TLS, IMAP/SMTP login, and a round-trip send
+sudo ./deploy/doctor.sh
 ```
+
+`doctor.sh` checks `.env` permissions; MX, A, SPF, DKIM, and DMARC; PTR;
+outbound port 25; DNS blocklists; TLS certificates on 465 and 993; and the
+server-side ntfy verification endpoint. It does not log in over IMAP/SMTP or
+send a round-trip test. Docker Mailserver can create `docker-data/` as root,
+so use `sudo` for these two scripts; an EACCES failure prints the same retry
+instruction instead of pretending the DKIM key is missing.
+
+If no SMTP relay is configured and outbound port 25 is blocked, API
+`queued:true` only means the local mailserver accepted the message. It does
+**not** mean the recipient received it: Postfix can retain the message in its
+queue. Treat doctor's outbound-port-25 result as the delivery prerequisite, or
+configure a relay before relying on direct delivery.
 
 ## Public TLS with Let's Encrypt (opt-in)
 

--- a/deploy/dns-records.sh
+++ b/deploy/dns-records.sh
@@ -36,7 +36,7 @@ DKIM_KEY_FILE="docker-data/dms/config/opendkim/keys/${DOMAIN}/mail.txt"
 
 docker_data_eacces() {
   echo "ERROR: cannot read '$1' (EACCES / permission denied)." >&2
-  echo "请用 sudo 重跑：sudo ./deploy/dns-records.sh" >&2
+  echo "Re-run with sudo: sudo ./deploy/dns-records.sh" >&2
   exit 1
 }
 

--- a/deploy/dns-records.sh
+++ b/deploy/dns-records.sh
@@ -46,7 +46,7 @@ require_docker_data_access() {
   local path="docker-data"
   local part
   for part in dms config opendkim keys "$DOMAIN"; do
-    [ -e "$path" ] || return
+    [ -e "$path" ] || return 0
     { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
     path="${path}/${part}"
   done

--- a/deploy/dns-records.sh
+++ b/deploy/dns-records.sh
@@ -34,6 +34,27 @@ fi
 MAIL_HOST="mail.${DOMAIN}"
 DKIM_KEY_FILE="docker-data/dms/config/opendkim/keys/${DOMAIN}/mail.txt"
 
+docker_data_eacces() {
+  echo "ERROR: cannot read '$1' (EACCES / permission denied)." >&2
+  echo "请用 sudo 重跑：sudo ./deploy/dns-records.sh" >&2
+  exit 1
+}
+
+# DMS commonly creates this tree as root. Do not silently claim that DKIM has
+# not been generated when the real problem is that this user cannot read it.
+require_docker_data_access() {
+  local path="docker-data"
+  local part
+  for part in dms config opendkim keys "$DOMAIN"; do
+    [ -e "$path" ] || return
+    { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
+    path="${path}/${part}"
+  done
+  [ ! -e "$DKIM_KEY_FILE" ] || [ -r "$DKIM_KEY_FILE" ] || docker_data_eacces "$DKIM_KEY_FILE"
+}
+
+require_docker_data_access
+
 cat <<EOF
 
 ────────────────────────────────────────────────────────────────────────────
@@ -66,7 +87,7 @@ EOF
 else
   cat <<EOF
    NOT GENERATED YET. Start the stack once, then either re-run this script:
-     docker compose up -d && ./deploy/dns-records.sh
+     docker compose up -d && sudo ./deploy/dns-records.sh
    or generate the key manually:
      docker compose run --rm mailserver setup config dkim domain ${DOMAIN} selector mail
    The record to publish will be in:
@@ -84,6 +105,6 @@ cat <<EOF
    (DO/Vultr: rename the droplet/instance to ${MAIL_HOST}; Hetzner/AWS: set rDNS in console)
 
 ────────────────────────────────────────────────────────────────────────────
- When DNS has propagated, verify everything with:  ./deploy/doctor.sh
+ When DNS has propagated, verify everything with:  sudo ./deploy/doctor.sh
 ────────────────────────────────────────────────────────────────────────────
 EOF

--- a/deploy/dns-records.sh
+++ b/deploy/dns-records.sh
@@ -50,6 +50,8 @@ require_docker_data_access() {
     { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
     path="${path}/${part}"
   done
+  [ -e "$path" ] || return 0
+  { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
   [ ! -e "$DKIM_KEY_FILE" ] || [ -r "$DKIM_KEY_FILE" ] || docker_data_eacces "$DKIM_KEY_FILE"
 }
 

--- a/deploy/doctor.sh
+++ b/deploy/doctor.sh
@@ -51,6 +51,8 @@ require_docker_data_access() {
     { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
     path="${path}/${part}"
   done
+  [ -e "$path" ] || return 0
+  { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
   [ ! -e "$DKIM_KEY_FILE" ] || [ -r "$DKIM_KEY_FILE" ] || docker_data_eacces "$DKIM_KEY_FILE"
 }
 

--- a/deploy/doctor.sh
+++ b/deploy/doctor.sh
@@ -47,7 +47,7 @@ require_docker_data_access() {
   local path="docker-data"
   local part
   for part in dms config opendkim keys "$DOMAIN"; do
-    [ -e "$path" ] || return
+    [ -e "$path" ] || return 0
     { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
     path="${path}/${part}"
   done

--- a/deploy/doctor.sh
+++ b/deploy/doctor.sh
@@ -37,7 +37,7 @@ DKIM_KEY_FILE="docker-data/dms/config/opendkim/keys/${DOMAIN}/${DKIM_SELECTOR}.t
 
 docker_data_eacces() {
   echo "ERROR: cannot read '$1' (EACCES / permission denied)." >&2
-  echo "请用 sudo 重跑：sudo ./deploy/doctor.sh" >&2
+  echo "Re-run with sudo: sudo ./deploy/doctor.sh" >&2
   exit 1
 }
 
@@ -103,7 +103,7 @@ elif [ -n "$MX" ]; then
   hint "set: ${DOMAIN}. MX 10 ${MAIL_HOST}."
 else
   bad "no MX record for ${DOMAIN}"
-  hint "create: ${DOMAIN}. MX 10 ${MAIL_HOST}. (run ./deploy/dns-records.sh)"
+  hint "create: ${DOMAIN}. MX 10 ${MAIL_HOST}. (run sudo ./deploy/dns-records.sh)"
 fi
 
 # ── 2. A record ─────────────────────────────────────────────────────────────
@@ -142,7 +142,7 @@ else
   if [ -f "$DKIM_KEY_FILE" ]; then
     hint "publish the key from ./deploy/dns-records.sh output (it's generated locally already)"
   else
-    hint "start the stack once (docker compose up -d), then run ./deploy/dns-records.sh"
+    hint "start the stack once (docker compose up -d), then run sudo ./deploy/dns-records.sh"
   fi
 fi
 

--- a/deploy/doctor.sh
+++ b/deploy/doctor.sh
@@ -33,6 +33,28 @@ fi
 [ -n "$NTFY_ENABLED" ] || NTFY_ENABLED="true"
 MAIL_HOST="mail.${DOMAIN}"
 DKIM_SELECTOR="mail"
+DKIM_KEY_FILE="docker-data/dms/config/opendkim/keys/${DOMAIN}/${DKIM_SELECTOR}.txt"
+
+docker_data_eacces() {
+  echo "ERROR: cannot read '$1' (EACCES / permission denied)." >&2
+  echo "请用 sudo 重跑：sudo ./deploy/doctor.sh" >&2
+  exit 1
+}
+
+# DMS commonly creates this tree as root. A non-root doctor must fail clearly
+# instead of reporting a readable-on-disk DKIM key as missing.
+require_docker_data_access() {
+  local path="docker-data"
+  local part
+  for part in dms config opendkim keys "$DOMAIN"; do
+    [ -e "$path" ] || return
+    { [ -r "$path" ] && [ -x "$path" ]; } || docker_data_eacces "$path"
+    path="${path}/${part}"
+  done
+  [ ! -e "$DKIM_KEY_FILE" ] || [ -r "$DKIM_KEY_FILE" ] || docker_data_eacces "$DKIM_KEY_FILE"
+}
+
+require_docker_data_access
 
 PASS=0; WARN=0; FAIL=0
 ok()   { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
@@ -115,7 +137,7 @@ if echo "$DKIM" | grep -q 'v=DKIM1'; then
   ok "DKIM public key published"
 else
   bad "no DKIM record at ${DKIM_SELECTOR}._domainkey.${DOMAIN}"
-  if [ -f "docker-data/dms/config/opendkim/keys/${DOMAIN}/${DKIM_SELECTOR}.txt" ]; then
+  if [ -f "$DKIM_KEY_FILE" ]; then
     hint "publish the key from ./deploy/dns-records.sh output (it's generated locally already)"
   else
     hint "start the stack once (docker compose up -d), then run ./deploy/dns-records.sh"


### PR DESCRIPTION
## Jakarta A4 + A5 + A7 — doctor accuracy, Docker-data permissions, queue semantics

### A4: doctor documentation now matches the script

README no longer claims that `doctor.sh` logs in over IMAP/SMTP or sends a round-trip message. Its documented checklist now matches `deploy/doctor.sh`: `.env` permissions; MX/A/SPF/DKIM/DMARC; PTR; outbound TCP 25; DNS blocklists; TLS on 465/993; and the server-side ntfy verification endpoint.

### A5: root-owned Docker data fails clearly

Both `deploy/dns-records.sh` and `deploy/doctor.sh` now inspect each existing path component that leads to DMS's DKIM key. If it is unreadable or not traversable, they emit an EACCES diagnostic including **“请用 sudo 重跑”** and exit non-zero rather than falsely reporting a missing key. README uses `sudo` for both commands and explains why Docker Mailserver can create `docker-data/` as root.

### A7: queue acceptance is not recipient delivery

README now states that, without a relay and with outbound port 25 blocked, API `queued:true` only means the local mailserver accepted the message. It is not proof of recipient delivery: Postfix can retain it in its queue. The operator must use doctor's outbound-25 result or configure a relay.

### Validation / evidence

```text
# isolated temporary repository; docker-data/.../mail.txt mode 000
dns_exit=1
doctor_exit=1
ERROR: cannot read 'docker-data/dms/config/opendkim/keys/example.com/mail.txt' (EACCES / permission denied).
请用 sudo 重跑：sudo ./deploy/dns-records.sh
ERROR: cannot read 'docker-data/dms/config/opendkim/keys/example.com/mail.txt' (EACCES / permission denied).
请用 sudo 重跑：sudo ./deploy/doctor.sh
```

`bash -n deploy/dns-records.sh` and `bash -n deploy/doctor.sh` pass, as does `git diff --check`. Self-review confirms the diff is limited to README and the two requested scripts; no website repository, application behavior, Compose, setup, OTP, release, deployment, or merge is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Quickstart steps for Docker startup, DNS generation, and deployment checks with `sudo`.
  * Documented expanded diagnostics for permissions, DNS, TLS, notifications, and mail delivery prerequisites.
  * Added optional Let’s Encrypt setup guidance, including prerequisites, certificate verification, renewal, persistence, and mailserver reloads.

* **Bug Fixes**
  * Added clearer permission checks and remediation guidance for deployment data and DKIM keys.
  * Improved diagnostic behavior when required files or directories are missing or inaccessible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->