### PR TITLE
test: stabilize sent registry TTL expiry coverage

### DIFF
--- a/packages/api/test/sent-registry.test.ts
+++ b/packages/api/test/sent-registry.test.ts
@@ -84,8 +84,8 @@ describe('sent registry 持久化', () => {
   });
 
   test('过期按 TTL 淘汰', () => {
-    resetSentRegistryForTests({ ttlMs: 10 });
-    recordSentMessageId('<old@test.example>', 'fox@test.example', Date.now() - 50);
+    resetSentRegistryForTests({ ttlMs: 2000 });
+    recordSentMessageId('<old@test.example>', 'fox@test.example', Date.now() - 10_000);
     expect(hasSentMessageId('old@test.example', 'fox@test.example')).toBe(false);
     // 读路径不 prune：条数仍在，等下次写入再淘汰
     expect(sentRegistrySizeForTests()).toBe(1);
@@ -96,8 +96,8 @@ describe('sent registry 持久化', () => {
   });
 
   test('读路径不写盘（过期查询也不 persist）', () => {
-    resetSentRegistryForTests({ ttlMs: 10 });
-    recordSentMessageId('<old@test.example>', 'fox@test.example', Date.now() - 50);
+    resetSentRegistryForTests({ ttlMs: 2000 });
+    recordSentMessageId('<old@test.example>', 'fox@test.example', Date.now() - 10_000);
     let persistCalls = 0;
     setSentRegistryPersistHookForTests(() => {
       persistCalls += 1;


### PR DESCRIPTION
## Fix

Stabilizes the two sent-registry TTL tests without changing production behavior.

The old 10 ms TTL could expire a newly recorded entry before its next assertion under CI load. Both tests now use a 2 s TTL and record the intentionally expired entry 10 s in the past, preserving the same expiry and read-path semantics with a safe assertion window.

## Scope

Only `packages/api/test/sent-registry.test.ts` changed; no production source is modified.

## Validation

- `timeout 180 bun test test/sent-registry.test.ts`: `10 pass / 0 fail / 31 expect()`.
- `timeout 180 bun test`: `942 pass / 1 skip / 3 existing fail / 6454 expect()` across 946 tests. Existing failures: phone device ACL, UI default, UI session persistence.
- Independent read-only self-review passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated expiration test scenarios to use a 2-second time-to-live and timestamps from 10 seconds earlier.
  * Improved test reliability when verifying expiration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->