### PR TITLE
fix(api): make bundled dist self-contained for extracted UI assets (#520-A follow-up)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: |
           bun install
           bun test
+          bun run lint:ui
 
       - name: Typecheck + build packages/mcp
         working-directory: packages/mcp

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "bun run --watch src/main.ts",
     "start": "bun run src/main.ts",
-    "build": "bun build src/main.ts --target bun --outdir dist",
+    "build": "bun build src/main.ts --target bun --outdir dist && bun run scripts/copy-ui-to-dist.ts",
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "lint:ui": "eslint src/ui",

--- a/packages/api/scripts/copy-ui-to-dist.ts
+++ b/packages/api/scripts/copy-ui-to-dist.ts
@@ -1,0 +1,26 @@
+/**
+ * build 后处理：把 UI 真文件拷进 dist（#520-A）。
+ *
+ * `bun build --outdir dist` 只产出扁平 dist/main.js；loader 在 bundle 内按
+ * import.meta.url 解析（dist/），相邻真文件不在那里。本脚本把 19 个 .js +
+ * 4 个 .css 真文件与 4 个字体按 dist/ui/<name> 扁平拷出（文件名全局唯一）。
+ * test/dist-bundle.test.ts 会起真实 dist 进程钉住 /ui 资产路由可用。
+ */
+import { copyFileSync, mkdirSync, readdirSync } from 'node:fs';
+import { dirname, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const srcUi = join(here, '..', 'src', 'ui');
+const distUi = join(here, '..', 'dist', 'ui');
+
+mkdirSync(distUi, { recursive: true });
+for (const dir of ['client', 'client/components', 'client/pages', 'styles', 'fonts']) {
+  // 只拷真资产（.js/.css/.woff2），不带 .ts loader；文件名全局唯一，直接打平。
+  for (const name of readdirSync(join(srcUi, dir))) {
+    const ext = extname(name);
+    if (ext === '.js' || ext === '.css' || ext === '.woff2') {
+      copyFileSync(join(srcUi, dir, name), join(distUi, name));
+    }
+  }
+}

--- a/packages/api/scripts/copy-ui-to-dist.ts
+++ b/packages/api/scripts/copy-ui-to-dist.ts
@@ -15,11 +15,15 @@ const srcUi = join(here, '..', 'src', 'ui');
 const distUi = join(here, '..', 'dist', 'ui');
 
 mkdirSync(distUi, { recursive: true });
+const seen = new Set<string>();
 for (const dir of ['client', 'client/components', 'client/pages', 'styles', 'fonts']) {
   // 只拷真资产（.js/.css/.woff2），不带 .ts loader；文件名全局唯一，直接打平。
   for (const name of readdirSync(join(srcUi, dir))) {
     const ext = extname(name);
     if (ext === '.js' || ext === '.css' || ext === '.woff2') {
+      // 重名即 build 失败：扁平布局靠 basename 唯一，静默覆盖会把产物悄悄换血。
+      if (seen.has(name)) throw new Error(`duplicate UI asset basename: ${name}`);
+      seen.add(name);
       copyFileSync(join(srcUi, dir, name), join(distUi, name));
     }
   }

--- a/packages/api/src/routes/ui-assets.ts
+++ b/packages/api/src/routes/ui-assets.ts
@@ -1,15 +1,15 @@
-import { existsSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import type { Context } from 'hono';
 import type { Hono } from 'hono';
 import { OUTER_CSP, UI_CSS, UI_HTML, UI_JS, UI_LOGO_SVG } from '../ui/assets.ts';
+import { resolveUiAssetUrl } from '../ui/load-ui-asset.ts';
 import { uiShellRegisterPaths } from '../ui/shell-routes.ts';
 
 // Satoshi 字体与官网（website/public/fonts/）同源同文件；缺失时启动即报错，不半死不活。
-// 双布局：源码树相邻（../ui/fonts/）；dist 打平后 dist/ui/<name>（与 UI 真文件同目录）。
+// 双布局与 JS/CSS loader 共用 resolveUiAssetUrl：源码树相邻（../ui/fonts/）；
+// dist 打平后回落 dist/ui/<name>（与 UI 真文件同目录）。
 function readUiFont(name: string): Buffer {
-  const beside = new URL(`../ui/fonts/${name}`, import.meta.url);
-  if (existsSync(beside)) return readFileSync(beside);
-  return readFileSync(new URL(`./ui/${name}`, import.meta.url));
+  return readFileSync(resolveUiAssetUrl(import.meta.url, `../ui/fonts/${name}`, name));
 }
 
 const UI_FONTS: Record<string, Uint8Array> = {

--- a/packages/api/src/routes/ui-assets.ts
+++ b/packages/api/src/routes/ui-assets.ts
@@ -1,15 +1,22 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import type { Context } from 'hono';
 import type { Hono } from 'hono';
 import { OUTER_CSP, UI_CSS, UI_HTML, UI_JS, UI_LOGO_SVG } from '../ui/assets.ts';
 import { uiShellRegisterPaths } from '../ui/shell-routes.ts';
 
 // Satoshi 字体与官网（website/public/fonts/）同源同文件；缺失时启动即报错，不半死不活。
+// 双布局：源码树相邻（../ui/fonts/）；dist 打平后 dist/ui/<name>（与 UI 真文件同目录）。
+function readUiFont(name: string): Buffer {
+  const beside = new URL(`../ui/fonts/${name}`, import.meta.url);
+  if (existsSync(beside)) return readFileSync(beside);
+  return readFileSync(new URL(`./ui/${name}`, import.meta.url));
+}
+
 const UI_FONTS: Record<string, Uint8Array> = {
-  'Satoshi-Regular.woff2': readFileSync(new URL('../ui/fonts/Satoshi-Regular.woff2', import.meta.url)),
-  'Satoshi-Medium.woff2': readFileSync(new URL('../ui/fonts/Satoshi-Medium.woff2', import.meta.url)),
-  'Satoshi-Bold.woff2': readFileSync(new URL('../ui/fonts/Satoshi-Bold.woff2', import.meta.url)),
-  'Satoshi-Black.woff2': readFileSync(new URL('../ui/fonts/Satoshi-Black.woff2', import.meta.url)),
+  'Satoshi-Regular.woff2': readUiFont('Satoshi-Regular.woff2'),
+  'Satoshi-Medium.woff2': readUiFont('Satoshi-Medium.woff2'),
+  'Satoshi-Bold.woff2': readUiFont('Satoshi-Bold.woff2'),
+  'Satoshi-Black.woff2': readUiFont('Satoshi-Black.woff2'),
 };
 
 /** ADR #26：app shell 覆盖的真实 /ui/* 子路径（须在 API/assets/frame/OAuth 之后注册）。 */

--- a/packages/api/src/ui/client/api.ts
+++ b/packages/api/src/ui/client/api.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 api.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const API_JS = readFileSync(new URL('./api.js', import.meta.url), 'utf8');
+export const API_JS = readUiSibling(import.meta.url, 'api.js');

--- a/packages/api/src/ui/client/app.ts
+++ b/packages/api/src/ui/client/app.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 app.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const APP_JS = readFileSync(new URL('./app.js', import.meta.url), 'utf8');
+export const APP_JS = readUiSibling(import.meta.url, 'app.js');

--- a/packages/api/src/ui/client/components/app-nav.ts
+++ b/packages/api/src/ui/client/components/app-nav.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 app-nav.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const APP_NAV_JS = readFileSync(new URL('./app-nav.js', import.meta.url), 'utf8');
+export const APP_NAV_JS = readUiSibling(import.meta.url, 'app-nav.js');

--- a/packages/api/src/ui/client/components/empty-state.ts
+++ b/packages/api/src/ui/client/components/empty-state.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 empty-state.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const EMPTY_STATE_JS = readFileSync(new URL('./empty-state.js', import.meta.url), 'utf8');
+export const EMPTY_STATE_JS = readUiSibling(import.meta.url, 'empty-state.js');

--- a/packages/api/src/ui/client/components/identity-switcher.ts
+++ b/packages/api/src/ui/client/components/identity-switcher.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 identity-switcher.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const IDENTITY_SWITCHER_JS = readFileSync(new URL('./identity-switcher.js', import.meta.url), 'utf8');
+export const IDENTITY_SWITCHER_JS = readUiSibling(import.meta.url, 'identity-switcher.js');

--- a/packages/api/src/ui/client/components/modal.ts
+++ b/packages/api/src/ui/client/components/modal.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 modal.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const MODAL_JS = readFileSync(new URL('./modal.js', import.meta.url), 'utf8');
+export const MODAL_JS = readUiSibling(import.meta.url, 'modal.js');

--- a/packages/api/src/ui/client/components/paginator.ts
+++ b/packages/api/src/ui/client/components/paginator.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 paginator.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const PAGINATOR_JS = readFileSync(new URL('./paginator.js', import.meta.url), 'utf8');
+export const PAGINATOR_JS = readUiSibling(import.meta.url, 'paginator.js');

--- a/packages/api/src/ui/client/components/sensitive-content.ts
+++ b/packages/api/src/ui/client/components/sensitive-content.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 sensitive-content.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const SENSITIVE_CONTENT_JS = readFileSync(new URL('./sensitive-content.js', import.meta.url), 'utf8');
+export const SENSITIVE_CONTENT_JS = readUiSibling(import.meta.url, 'sensitive-content.js');

--- a/packages/api/src/ui/client/dom.ts
+++ b/packages/api/src/ui/client/dom.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 dom.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const DOM_JS = readFileSync(new URL('./dom.js', import.meta.url), 'utf8');
+export const DOM_JS = readUiSibling(import.meta.url, 'dom.js');

--- a/packages/api/src/ui/client/pages/authorized-clients.ts
+++ b/packages/api/src/ui/client/pages/authorized-clients.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 authorized-clients.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const AUTHORIZED_CLIENTS_PAGE_JS = readFileSync(new URL('./authorized-clients.js', import.meta.url), 'utf8');
+export const AUTHORIZED_CLIENTS_PAGE_JS = readUiSibling(import.meta.url, 'authorized-clients.js');

--- a/packages/api/src/ui/client/pages/identities.ts
+++ b/packages/api/src/ui/client/pages/identities.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 identities.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const IDENTITIES_PAGE_JS = readFileSync(new URL('./identities.js', import.meta.url), 'utf8');
+export const IDENTITIES_PAGE_JS = readUiSibling(import.meta.url, 'identities.js');

--- a/packages/api/src/ui/client/pages/inbox.ts
+++ b/packages/api/src/ui/client/pages/inbox.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 inbox.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const INBOX_PAGE_JS = readFileSync(new URL('./inbox.js', import.meta.url), 'utf8');
+export const INBOX_PAGE_JS = readUiSibling(import.meta.url, 'inbox.js');

--- a/packages/api/src/ui/client/pages/notifications.ts
+++ b/packages/api/src/ui/client/pages/notifications.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 notifications.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const NOTIFICATIONS_PAGE_JS = readFileSync(new URL('./notifications.js', import.meta.url), 'utf8');
+export const NOTIFICATIONS_PAGE_JS = readUiSibling(import.meta.url, 'notifications.js');

--- a/packages/api/src/ui/client/pages/overview.ts
+++ b/packages/api/src/ui/client/pages/overview.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 overview.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const OVERVIEW_PAGE_JS = readFileSync(new URL('./overview.js', import.meta.url), 'utf8');
+export const OVERVIEW_PAGE_JS = readUiSibling(import.meta.url, 'overview.js');

--- a/packages/api/src/ui/client/pages/plan.ts
+++ b/packages/api/src/ui/client/pages/plan.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 plan.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const PLAN_PAGE_JS = readFileSync(new URL('./plan.js', import.meta.url), 'utf8');
+export const PLAN_PAGE_JS = readUiSibling(import.meta.url, 'plan.js');

--- a/packages/api/src/ui/client/pages/push-devices.ts
+++ b/packages/api/src/ui/client/pages/push-devices.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 push-devices.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const PUSH_DEVICES_PAGE_JS = readFileSync(new URL('./push-devices.js', import.meta.url), 'utf8');
+export const PUSH_DEVICES_PAGE_JS = readUiSibling(import.meta.url, 'push-devices.js');

--- a/packages/api/src/ui/client/pages/tasks.ts
+++ b/packages/api/src/ui/client/pages/tasks.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 tasks.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../../load-ui-asset.ts';
 
-export const TASKS_PAGE_JS = readFileSync(new URL('./tasks.js', import.meta.url), 'utf8');
+export const TASKS_PAGE_JS = readUiSibling(import.meta.url, 'tasks.js');

--- a/packages/api/src/ui/client/router.ts
+++ b/packages/api/src/ui/client/router.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 router.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const ROUTER_JS = readFileSync(new URL('./router.js', import.meta.url), 'utf8');
+export const ROUTER_JS = readUiSibling(import.meta.url, 'router.js');

--- a/packages/api/src/ui/client/store.ts
+++ b/packages/api/src/ui/client/store.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 store.js（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/app.js 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const STORE_JS = readFileSync(new URL('./store.js', import.meta.url), 'utf8');
+export const STORE_JS = readUiSibling(import.meta.url, 'store.js');

--- a/packages/api/src/ui/load-ui-asset.ts
+++ b/packages/api/src/ui/load-ui-asset.ts
@@ -13,8 +13,14 @@ import { existsSync, readFileSync } from 'node:fs';
  * 单布局行为一致：缺文件=启动即报错，不半死不活）。
  */
 
+/** 扁平回落名只许安全字符（路径段自守，防未来传参变成穿越点）。 */
+const SAFE_FLAT_NAME = /^[A-Za-z0-9._-]+$/;
+
 /** 布局探测：先试相对模块的相邻路径，不存在再回落扁平 <moduleDir>/ui/<flatName>。 */
 export function resolveUiAssetUrl(moduleUrl: string, siblingPath: string, flatName: string): URL {
+  if (!SAFE_FLAT_NAME.test(flatName)) {
+    throw new Error(`invalid flat asset name: ${JSON.stringify(flatName)}`);
+  }
   const beside = new URL(siblingPath, moduleUrl);
   if (existsSync(beside)) return beside;
   return new URL(`./ui/${flatName}`, moduleUrl);

--- a/packages/api/src/ui/load-ui-asset.ts
+++ b/packages/api/src/ui/load-ui-asset.ts
@@ -12,8 +12,14 @@ import { existsSync, readFileSync } from 'node:fs';
  * 先试相邻布局，不存在再回落 ui/<name>；两处都缺才抛 ENOENT（与原先
  * 单布局行为一致：缺文件=启动即报错，不半死不活）。
  */
+
+/** 布局探测：先试相对模块的相邻路径，不存在再回落扁平 <moduleDir>/ui/<flatName>。 */
+export function resolveUiAssetUrl(moduleUrl: string, siblingPath: string, flatName: string): URL {
+  const beside = new URL(siblingPath, moduleUrl);
+  if (existsSync(beside)) return beside;
+  return new URL(`./ui/${flatName}`, moduleUrl);
+}
+
 export function readUiSibling(moduleUrl: string, fileName: string): string {
-  const beside = new URL(`./${fileName}`, moduleUrl);
-  if (existsSync(beside)) return readFileSync(beside, 'utf8');
-  return readFileSync(new URL(`./ui/${fileName}`, moduleUrl), 'utf8');
+  return readFileSync(resolveUiAssetUrl(moduleUrl, `./${fileName}`, fileName), 'utf8');
 }

--- a/packages/api/src/ui/load-ui-asset.ts
+++ b/packages/api/src/ui/load-ui-asset.ts
@@ -1,0 +1,19 @@
+import { existsSync, readFileSync } from 'node:fs';
+
+/**
+ * 启动时读入 UI 真文件（#520-A）。兼容两种磁盘布局：
+ *
+ *   源码树：真文件与 .ts 相邻（src/ui/**）——dev、test 与 Docker（COPY . .
+ *           后直接 `bun run src/main.ts`）都走这条路径。
+ *   dist：  `bun run build` 扁平打包成单一 dist/main.js，import.meta.url 在
+ *           bundle 内解析到 dist/；构建脚本会把真文件按 <dist>/ui/<basename>
+ *           拷出（19 个 .js + 4 个 .css 文件名全局唯一，可扁平存放）。
+ *
+ * 先试相邻布局，不存在再回落 ui/<name>；两处都缺才抛 ENOENT（与原先
+ * 单布局行为一致：缺文件=启动即报错，不半死不活）。
+ */
+export function readUiSibling(moduleUrl: string, fileName: string): string {
+  const beside = new URL(`./${fileName}`, moduleUrl);
+  if (existsSync(beside)) return readFileSync(beside, 'utf8');
+  return readFileSync(new URL(`./ui/${fileName}`, moduleUrl), 'utf8');
+}

--- a/packages/api/src/ui/styles/base.ts
+++ b/packages/api/src/ui/styles/base.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 base.css（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/styles.css 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const BASE_CSS = readFileSync(new URL('./base.css', import.meta.url), 'utf8');
+export const BASE_CSS = readUiSibling(import.meta.url, 'base.css');

--- a/packages/api/src/ui/styles/layout.ts
+++ b/packages/api/src/ui/styles/layout.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 layout.css（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/styles.css 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const LAYOUT_CSS = readFileSync(new URL('./layout.css', import.meta.url), 'utf8');
+export const LAYOUT_CSS = readUiSibling(import.meta.url, 'layout.css');

--- a/packages/api/src/ui/styles/pages.ts
+++ b/packages/api/src/ui/styles/pages.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 pages.css（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/styles.css 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const PAGES_CSS = readFileSync(new URL('./pages.css', import.meta.url), 'utf8');
+export const PAGES_CSS = readUiSibling(import.meta.url, 'pages.css');

--- a/packages/api/src/ui/styles/tokens.ts
+++ b/packages/api/src/ui/styles/tokens.ts
@@ -3,6 +3,6 @@
  * 内容维护在相邻真文件 tokens.css（ESLint 管辖）；本模块仅启动时读入，
  * 拼接产物字节由 /ui/styles.css 金标测试钉死。
  */
-import { readFileSync } from 'node:fs';
+import { readUiSibling } from '../load-ui-asset.ts';
 
-export const TOKENS_CSS = readFileSync(new URL('./tokens.css', import.meta.url), 'utf8');
+export const TOKENS_CSS = readUiSibling(import.meta.url, 'tokens.css');

--- a/packages/api/test/dist-bundle.test.ts
+++ b/packages/api/test/dist-bundle.test.ts
@@ -1,0 +1,95 @@
+/**
+ * dist 产物冒烟（#520-A，Codex P1 修复的钉子）：`bun run build` 产物必须
+ * 自包含可启动——UI 真文件（.js/.css）与字体已被 copy-ui-to-dist.ts 打进
+ * dist/ui/，loader 在 bundle 内回落该目录。缺文件=模块加载即 ENOENT，本
+ * 测试从真实进程 + 真实端口抓证据，防回归（含 Docker/发布完整性风险）。
+ */
+import { describe, expect, test } from 'bun:test';
+import { spawn } from 'node:child_process';
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+
+const { UI_JS, UI_CSS } = await import('../src/ui/assets.ts');
+const sha256 = (s: string) => new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
+
+const pkgDir = join(import.meta.dir, '..');
+const dist = join(pkgDir, 'dist');
+
+async function waitForServer(port: number, deadlineMs: number): Promise<void> {
+  const started = Date.now();
+  for (;;) {
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (res.ok) return;
+    } catch {
+      /* not up yet */
+    }
+    if (Date.now() - started > deadlineMs) throw new Error('dist server did not come up');
+    await Bun.sleep(200);
+  }
+}
+
+describe('dist bundle is self-contained (#520-A)', () => {
+  test('built dist/main.js serves byte-gold /ui/app.js, /ui/styles.css and fonts', async () => {
+    rmSync(dist, { recursive: true, force: true });
+    mkdirSync(dist, { recursive: false });
+
+    const build = Bun.spawnSync(['bun', 'run', 'build'], { cwd: pkgDir });
+    if (build.exitCode !== 0) throw new Error(`bun run build failed:\n${build.stderr}`);
+
+    // dist/ui 清单：19 js + 4 css + 4 字体 = 27，且只有真资产（不带 .ts）。
+    const distUi = readdirSync(join(dist, 'ui')).sort();
+    expect(distUi).toEqual([
+      ...[...readdirSync(join(pkgDir, 'src/ui/client')).filter((f) => f.endsWith('.js'))],
+      ...readdirSync(join(pkgDir, 'src/ui/client/components')).filter((f) => f.endsWith('.js')),
+      ...readdirSync(join(pkgDir, 'src/ui/client/pages')).filter((f) => f.endsWith('.js')),
+      ...readdirSync(join(pkgDir, 'src/ui/styles')).filter((f) => f.endsWith('.css')),
+      ...readdirSync(join(pkgDir, 'src/ui/fonts')),
+    ].sort());
+
+    const PORT = '39321';
+    const child = spawn('bun', ['dist/main.js'], {
+      cwd: pkgDir,
+      env: {
+        ...process.env,
+        // 显式钉住：全量并发下其它测试可能把 UI_ENABLED 等改写进本进程 env。
+        UI_ENABLED: 'true',
+        PORT,
+        DATA_DIR: join(pkgDir, 'test', '.tmp-dist-data'),
+        NTFY_ENABLED: 'false',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let bootLog = '';
+    const onOut = (chunk: Buffer | string) => (bootLog += chunk);
+    child.stdout.on('data', onOut);
+    child.stderr.on('data', onOut);
+
+    try {
+      await waitForServer(Number(PORT), 20000);
+
+      const js = await fetch(`http://127.0.0.1:${PORT}/ui/app.js`);
+      expect(js.status).toBe(200);
+      const css = await fetch(`http://127.0.0.1:${PORT}/ui/styles.css`);
+      expect(css.status).toBe(200);
+      const font = await fetch(`http://127.0.0.1:${PORT}/ui/fonts/Satoshi-Regular.woff2`);
+      expect(font.status).toBe(200);
+      await font.body?.cancel();
+
+      expect(sha256(await js.text())).toBe(sha256(UI_JS));
+      expect(sha256(await css.text())).toBe(sha256(UI_CSS));
+    } finally {
+      child.kill('SIGKILL');
+      await new Promise((resolve) => child.once('exit', resolve));
+      rmSync(join(pkgDir, 'test', '.tmp-dist-data'), { recursive: true, force: true });
+      if (!child.killed) throw new Error('dist server failed to stop: ' + bootLog);
+    }
+  }, 60000);
+});

--- a/packages/api/test/dist-bundle.test.ts
+++ b/packages/api/test/dist-bundle.test.ts
@@ -6,6 +6,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
 import { readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -36,6 +37,19 @@ async function waitForServer(port: number, deadlineMs: number, getBootLog: () =>
   }
 }
 
+async function freePort(): Promise<number> {
+  // 探测一个当下空闲的端口（绑定后立即释放，交给 dist 进程使用）；
+  // 免并行 CI 下硬编码端口碰撞。
+  for (let candidate = 24_000 + Math.floor(Math.random() * 20_000); ; candidate++) {
+    const ok = await new Promise<boolean>((resolve) => {
+      const probe = createServer();
+      probe.once('error', () => resolve(false));
+      probe.listen(candidate, '127.0.0.1', () => probe.close(() => resolve(true)));
+    });
+    if (ok) return candidate;
+  }
+}
+
 describe('dist bundle is self-contained (#520-A)', () => {
   test('built dist/main.js serves byte-gold /ui/app.js, /ui/styles.css and fonts', async () => {
     rmSync(dist, { recursive: true, force: true });
@@ -53,7 +67,7 @@ describe('dist bundle is self-contained (#520-A)', () => {
       ...readdirSync(join(pkgDir, 'src/ui/fonts')),
     ].sort());
 
-    const PORT = '39321';
+    const PORT = String(await freePort());
     const child = spawn('bun', ['dist/main.js'], {
       cwd: pkgDir,
       env: {

--- a/packages/api/test/dist-bundle.test.ts
+++ b/packages/api/test/dist-bundle.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, test } from 'bun:test';
 import { spawn } from 'node:child_process';
-import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { readdirSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 
 process.env.DOMAIN = 'test.example';
@@ -22,7 +22,7 @@ const sha256 = (s: string) => new Bun.CryptoHasher('sha256').update(Buffer.from(
 const pkgDir = join(import.meta.dir, '..');
 const dist = join(pkgDir, 'dist');
 
-async function waitForServer(port: number, deadlineMs: number): Promise<void> {
+async function waitForServer(port: number, deadlineMs: number, getBootLog: () => string): Promise<void> {
   const started = Date.now();
   for (;;) {
     try {
@@ -31,7 +31,7 @@ async function waitForServer(port: number, deadlineMs: number): Promise<void> {
     } catch {
       /* not up yet */
     }
-    if (Date.now() - started > deadlineMs) throw new Error('dist server did not come up');
+    if (Date.now() - started > deadlineMs) throw new Error(`dist server did not come up; boot log:\n${getBootLog()}`);
     await Bun.sleep(200);
   }
 }
@@ -39,7 +39,6 @@ async function waitForServer(port: number, deadlineMs: number): Promise<void> {
 describe('dist bundle is self-contained (#520-A)', () => {
   test('built dist/main.js serves byte-gold /ui/app.js, /ui/styles.css and fonts', async () => {
     rmSync(dist, { recursive: true, force: true });
-    mkdirSync(dist, { recursive: false });
 
     const build = Bun.spawnSync(['bun', 'run', 'build'], { cwd: pkgDir });
     if (build.exitCode !== 0) throw new Error(`bun run build failed:\n${build.stderr}`);
@@ -73,7 +72,7 @@ describe('dist bundle is self-contained (#520-A)', () => {
     child.stderr.on('data', onOut);
 
     try {
-      await waitForServer(Number(PORT), 20000);
+      await waitForServer(Number(PORT), 20000, () => bootLog);
 
       const js = await fetch(`http://127.0.0.1:${PORT}/ui/app.js`);
       expect(js.status).toBe(200);
@@ -89,7 +88,6 @@ describe('dist bundle is self-contained (#520-A)', () => {
       child.kill('SIGKILL');
       await new Promise((resolve) => child.once('exit', resolve));
       rmSync(join(pkgDir, 'test', '.tmp-dist-data'), { recursive: true, force: true });
-      if (!child.killed) throw new Error('dist server failed to stop: ' + bootLog);
     }
   }, 60000);
 });


### PR DESCRIPTION
## What

Follow-up to #61 (merged at `3629dd1` before this fix landed on the branch). The Codex Local gate flagged a **P1** on `48e35e5` that is still on `main`: `bun run build` produced a flat `dist/main.js`, but the extracted UI real files (and fonts) were not shipped into `dist/` — the loaders resolved `import.meta.url` beside the bundle and died with ENOENT at module load, so the bundled build was no longer self-contained/runnable.

## Fix (3cc3efa)

- **Two-layout loaders** (`src/ui/load-ui-asset.ts` + 23 call sites + fonts in `routes/ui-assets.ts`): try the sibling file first (source tree / Docker `COPY . .`), then fall back to flat `ui/<name>` next to the bundle. Missing both still fails at startup (fail-fast preserved).
- **`scripts/copy-ui-to-dist.ts`** appended to `build`: copies exactly the 19 `.js` + 4 `.css` real files + 4 Satoshi fonts into `dist/ui/` (27 entries, basenames globally unique, no `.ts`).
- **`test/dist-bundle.test.ts`**: boots the real built `dist/main.js` on a real port and pins the dist/ui manifest plus HTTP 200 + byte-gold sha256 for `/ui/app.js`, `/ui/styles.css` and a font. Env pins (`UI_ENABLED`/`DATA_DIR`/`NTFY_ENABLED`) keep it green under the full-suite run.

## Self-review P2s addressed (9272322)

- dropped an always-true `child.killed` assertion; boot log now surfaces on startup timeout; removed a redundant pre-build mkdir
- `ci.yml`: `bun run lint:ui` now runs in CI after `bun test` (eval/new-function bans bite in CI, ~2s)

## Verification

- `bun run gold:ui` vs current `origin/main` (`3629dd1`): **ALL BYTE-IDENTICAL** (4 buffer pairs: exports + HTTP bodies for app.js 200848B / styles.css 39429B)
- Full suite: failure set unchanged vs main (the same 3 pre-existing order-dependent failures, each green in isolation); all new tests pass (`ui-real-files` 4 + `dist-bundle` 1)
- `tsc --noEmit`: same 116 pre-existing errors as main (only a line-number shift in `ui-assets.ts`); `bun run build` + `lint:ui` green
- Subagent self-review: P0=0 / P1=0 / P2=4 (this PR fixes 2 of them; the other 2 are accepted as-is: minor loader duplication, CI bun-version watch — first CI run on 1.2.21 is the remaining check)

No behavior change; CSP/XSS/Origin contracts untouched. Merge belongs to the 总指挥 per #520-A.