### PR TITLE
feat(ui): release phase-one operating desk

### DIFF
--- a/packages/api/src/lib/notification-log.ts
+++ b/packages/api/src/lib/notification-log.ts
@@ -39,8 +39,9 @@ export type NotificationSource = 'watcher' | 'manual' | 'task' | 'verify';
 export type NotificationLevel = 'urgent' | 'normal' | 'low';
 export type NotificationLogicalTarget = 'user' | `agent:${string}`;
 export type NotificationLogicalChannel = 'user-alerts' | 'user-low' | `agent:${string}`;
+export type NotificationDelivery = 'sent' | 'failed';
 
-/** 落盘行。delivery 恒为 sent：未成功的 publish 根本不会出现在这里。 */
+/** 落盘行：成功与失败均记录，以便值班台显示当天未送达的紧急推送。 */
 export type NotificationLogRecord = {
   schemaVersion: typeof NOTIFICATION_LOG_SCHEMA_VERSION;
   id: string;
@@ -54,7 +55,7 @@ export type NotificationLogRecord = {
   tags: string[];
   sensitive: boolean;
   identityAddress?: string;
-  delivery: 'sent';
+  delivery: NotificationDelivery;
 };
 
 export type NotificationLogQuery = {
@@ -83,6 +84,7 @@ export type NotificationSummary = {
   byLevel: { urgent: number; normal: number; low: number };
   byChannel: Record<string, number>;
   lastSuccessfulAt: string | null;
+  failedUrgentCount: number;
 };
 
 /** 中间损坏：不得把残缺日志当完整审计返回。 */
@@ -205,7 +207,7 @@ function parseRecord(raw: unknown): NotificationLogRecord | null {
   if (typeof row.title !== 'string' || typeof row.message !== 'string') return null;
   if (!Array.isArray(row.tags) || row.tags.some((tag) => typeof tag !== 'string')) return null;
   if (typeof row.sensitive !== 'boolean') return null;
-  if (row.delivery !== 'sent') return null;
+  if (row.delivery !== 'sent' && row.delivery !== 'failed') return null;
   if (row.identityAddress !== undefined && typeof row.identityAddress !== 'string') return null;
   const record: NotificationLogRecord = {
     schemaVersion: NOTIFICATION_LOG_SCHEMA_VERSION,
@@ -219,7 +221,7 @@ function parseRecord(raw: unknown): NotificationLogRecord | null {
     message: row.message,
     tags: row.tags as string[],
     sensitive: row.sensitive,
-    delivery: 'sent',
+    delivery: row.delivery,
   };
   if (typeof row.identityAddress === 'string' && row.identityAddress.includes('@')) {
     record.identityAddress = row.identityAddress.toLowerCase();
@@ -517,10 +519,11 @@ export type AppendNotificationInput = {
   tags?: string[];
   sensitive?: boolean;
   identityAddress?: string;
+  delivery?: NotificationDelivery;
 };
 
 /**
- * 在 ntfy 成功响应后调用。串行入队；写盘失败抛给调用方，由 publish 改成告警而非失败。
+ * 在推送成功或失败后调用。串行入队；写盘失败不改变原有推送结果。
  */
 export function appendNotificationLog(input: AppendNotificationInput): Promise<NotificationLogRecord> {
   return enqueue(() => {
@@ -538,7 +541,7 @@ export function appendNotificationLog(input: AppendNotificationInput): Promise<N
       message: input.message,
       tags: Array.isArray(input.tags) ? input.tags.slice(0, 16) : [],
       sensitive: Boolean(input.sensitive),
-      delivery: 'sent',
+      delivery: input.delivery === 'failed' ? 'failed' : 'sent',
     };
     if (input.identityAddress && input.identityAddress.includes('@')) {
       record.identityAddress = input.identityAddress.toLowerCase();
@@ -730,21 +733,28 @@ export function summarizeNotificationLog(options: {
     const byLevel = { urgent: 0, normal: 0, low: 0 };
     const byChannel: Record<string, number> = {};
     let lastSuccessfulAt: string | null = null;
+    let failedUrgentCount = 0;
     for (const row of rows) {
+      if (row.delivery === 'failed') {
+        if (row.level === 'urgent') failedUrgentCount += 1;
+        continue;
+      }
       byLevel[row.level] += 1;
       byChannel[row.logicalChannel] = (byChannel[row.logicalChannel] ?? 0) + 1;
       if (!lastSuccessfulAt || row.publishedAt > lastSuccessfulAt) lastSuccessfulAt = row.publishedAt;
     }
+    const total = byLevel.urgent + byLevel.normal + byLevel.low;
     return {
       date: bounds.date,
       tz: options.tz,
       from: bounds.from,
       to: bounds.to,
-      total: rows.length,
+      total,
       ringCount: byLevel.urgent,
       byLevel,
       byChannel,
       lastSuccessfulAt,
+      failedUrgentCount,
     };
   });
 }
@@ -754,7 +764,8 @@ export function lastSuccessfulAt(channel?: NotificationLogicalChannel): Promise<
     const now = nowMs();
     const records = loadRecordsOrThrow();
     const { rows } = applyWindow(records, { channel, limit: 20 }, now);
-    return rows[0]?.publishedAt ?? null;
+    const sent = rows.find((row) => row.delivery === 'sent');
+    return sent?.publishedAt ?? null;
   });
 }
 

--- a/packages/api/src/lib/notify.ts
+++ b/packages/api/src/lib/notify.ts
@@ -854,6 +854,45 @@ export class NtfyNotificationService implements NotifyService {
   }
 
   async publish(input: NotifyInput): Promise<{ target: NotifyTarget; title: string; level: NotifyLevel }> {
+    try {
+      return await this.publishOnce(input);
+    } catch (err) {
+      /* 只把已发往 provider、但未送达的 urgent 推送记进值班台；配置/大小/取消
+         都不是投递失败。 */
+      if (input.level === 'urgent' && err instanceof NotifyError && err.code === 'notify_unavailable') {
+        await this.recordUrgentFailure(input);
+      }
+      throw err;
+    }
+  }
+
+  private async recordUrgentFailure(input: NotifyInput): Promise<void> {
+    const logicalTarget = input.target as NotificationLogicalTarget;
+    const logicalChannel = input.logicalChannel ?? logicalChannelFor(logicalTarget, input.level);
+    try {
+      await appendNotificationLog({
+        source: input.source ?? 'manual',
+        logicalTarget,
+        logicalChannel,
+        level: input.level,
+        title: input.title,
+        /* 不把未送达的正文再落盘；Home 只需要服务端计数。 */
+        message: '',
+        tags: input.tags,
+        sensitive: Boolean(input.sensitive),
+        identityAddress: input.identityAddress,
+        delivery: 'failed',
+      });
+    } catch (logError) {
+      notificationLogHealthAlert('append_failed_delivery_failure', {
+        source: input.source ?? 'manual',
+        logicalChannel,
+        error: (logError as Error).message,
+      });
+    }
+  }
+
+  private async publishOnce(input: NotifyInput): Promise<{ target: NotifyTarget; title: string; level: NotifyLevel }> {
     const current = await this.assertEnabled();
     const topic = await physicalTopic(input.target, input.level);
     // ntfy rejects bodies near ~4096 bytes. Prefer keeping click; if the

--- a/packages/api/src/ui/client/api.js
+++ b/packages/api/src/ui/client/api.js
@@ -52,7 +52,7 @@
     state.tasks = [];
     state.tasksStatus = 'idle';
     state.tasksMessage = '';
-    state.tasksFilter = 'active';
+    state.tasksFilter = 'input-required';
     state.tasksPeriod = '30d';
     state.tasksLimit = 20;
     state.tasksNextCursor = '';
@@ -66,12 +66,25 @@
     state.taskDetailMessage = '';
   }
 
+  function clearHomeState() {
+    state.homeStatus = 'idle';
+    state.homeMessage = '';
+    state.homeWaitingTasks = [];
+    state.homeWaitingTotal = 0;
+    state.homeStuckTasks = [];
+    state.homeFailedUrgentCount = 0;
+    state.homeUrgentSentCount = null;
+    state.homeUnseenCount = null;
+    state.homeUpdatedAt = 0;
+  }
+
   function showLogin(message) {
     cancelOverview();
     cancelNotifyLoad();
     cancelTasksLoad();
     clearNotifyState();
     clearTasksState();
+    clearHomeState();
     closeAllModals();
     inboxView.hidden = true;
     loginView.hidden = false;
@@ -103,8 +116,7 @@
 
   function configureSession() {
     inboxView.dataset.session = isAdmin() ? 'admin' : 'identity';
-    /* 地址返回按钮只适用于管理员的现有 Home 数据面。 */
-    backToOverview.hidden = !isAdmin();
+    backToOverview.hidden = false;
     createIdentityButton.hidden = !isAdmin();
     configureIdentitiesCreate.hidden = !isAdmin();
   }
@@ -153,7 +165,8 @@
       });
       if (openedGen !== modalGeneration) return;
       showTokenModal(payload.token);
-      loadOverviewCycle({ refresh: false });
+      await refreshInboxIdentities();
+      loadHome({ refresh: false });
     } catch (error) {
       if (openedGen !== modalGeneration) return;
       if (error.status === 409) {
@@ -176,7 +189,8 @@
       );
       if (openedGen !== modalGeneration) return;
       showTokenModal(payload.token, 'Rotated Token');
-      loadOverviewCycle({ refresh: false });
+      refreshInboxIdentities();
+      loadHome({ refresh: false });
     } catch (error) {
       if (openedGen !== modalGeneration) return;
       if (error.message !== 'session_expired') {
@@ -222,7 +236,7 @@
         } else {
           enterOverview({ announce: address + ' deleted. Back to Home.' });
         }
-        loadOverviewCycle({ refresh: false });
+        loadHome({ refresh: false });
       } catch (error) {
         if (openedGen !== modalGeneration) return;
         if (error.message !== 'session_expired') {
@@ -327,16 +341,16 @@
       // F126: render the pending state immediately — the modal background is
       // not inert, so a row recreated mid-flight must come back disabled, or
       // keyboard users can start a competing PUT on the replacement select.
-      if (state.scope === 'overview') renderOverviewRows();
+      if (state.scope === 'overview') renderOverview();
       try {
         await savePushContentTier(address, tier, confirmRisk);
         selectEl.dataset.currentTier = String(tier);
         announce('Push content set to tier ' + tier + ' for ' + address + '.');
-        renderOverviewRows();
+        renderOverview();
         // Restart overview only while still on Overview: unstick Refresh after
         // bumpIdentityEpoch, but do not revive overview polling after openAddress.
         if (state.scope === 'overview') {
-          loadOverviewCycle({ refresh: false });
+          loadHome({ refresh: false });
         }
       } catch (error) {
         if (
@@ -359,14 +373,14 @@
           } else {
             selectEl.value = String(recovered.authoritative);
             selectEl.dataset.currentTier = String(recovered.authoritative);
-            renderOverviewRows();
+            renderOverview();
           }
         }
       } finally {
         delete state.tierPending[address];
         selectEl.disabled = false;
         // Re-render so a select recreated mid-flight drops disabled correctly.
-        if (state.scope === 'overview') renderOverviewRows();
+        if (state.scope === 'overview') renderOverview();
       }
     }
 

--- a/packages/api/src/ui/client/app.js
+++ b/packages/api/src/ui/client/app.js
@@ -571,6 +571,7 @@
     renderIdentities();
     renderFolderNav();
     renderMessages();
+    if (state.scope === 'overview') renderOverview();
     clearDetail();
     if (state.activeAddress) await refreshMessages();
   }
@@ -645,11 +646,6 @@
     state.identityFilter = identitySearch.value;
     renderIdentities();
   });
-  overviewSearch.addEventListener('input', function () {
-    state.overviewFilter = overviewSearch.value;
-    renderOverview();
-    announce(sortedModels().length + ' addresses match your filter.');
-  });
   mobileIdentity.addEventListener('change', function () {
     if (mobileIdentity.value) activateAddress(mobileIdentity.value);
   });
@@ -659,9 +655,7 @@
     refreshMessages();
   });
   overviewRefresh.addEventListener('click', function () {
-    state.overviewPolls = 0;
-    state.overviewLoadingSince = 0;
-    loadOverviewCycle({ refresh: true });
+    loadHome({ refresh: true });
   });
   notifyRefresh.addEventListener('click', function () {
     loadNotificationLog({ force: true });
@@ -793,8 +787,6 @@
     copyValue(devicePairPassword.textContent, devicePairPassword, devicePairCopy);
   });
   configureClientsRefresh.addEventListener('click', function () { loadConfigureClients(); });
-
-  buildSortControls();
 
   (async function start() {
     configureLoginGate();

--- a/packages/api/src/ui/client/pages/notifications.js
+++ b/packages/api/src/ui/client/pages/notifications.js
@@ -449,7 +449,6 @@
     cancelNotifyLoad();
     var controller = new AbortController();
     notifyController = controller;
-    if (opts.poll) trackDashboardPollRequest(controller);
     state.notifyPending = true;
     state.notifyMessage = '';
     state.notifySource = 'cache';
@@ -586,7 +585,6 @@
       }
       renderNotify();
     } finally {
-      releaseDashboardPollRequest(controller);
       if (notifyController === controller) {
         notifyController = null;
         state.notifyPending = false;
@@ -626,6 +624,7 @@
     cancelNotifyLoad();
     var controller = new AbortController();
     notifyController = controller;
+    if (opts.poll) trackDashboardPollRequest(controller);
     state.notifyPending = true;
     state.notifyMessage = '';
     state.notifySource = 'log';
@@ -709,6 +708,7 @@
       }
       renderNotify();
     } finally {
+      releaseDashboardPollRequest(controller);
       if (notifyController === controller) {
         notifyController = null;
         state.notifyPending = false;

--- a/packages/api/src/ui/client/pages/notifications.js
+++ b/packages/api/src/ui/client/pages/notifications.js
@@ -224,6 +224,12 @@
       tierValue.setAttribute('data-tier', row.level || 'unknown');
       tierValue.textContent = row.level || 'unknown';
       tierCell.append(tierLabel, tierValue);
+      if (row.delivery === 'failed') {
+        var delivery = document.createElement('span');
+        delivery.className = 'notify-delivery-failed';
+        delivery.textContent = 'Delivery failed';
+        tierCell.append(delivery);
+      }
 
       var contentCell = document.createElement('div');
       contentCell.className = 'cell notify-content';
@@ -443,6 +449,7 @@
     cancelNotifyLoad();
     var controller = new AbortController();
     notifyController = controller;
+    if (opts.poll) trackDashboardPollRequest(controller);
     state.notifyPending = true;
     state.notifyMessage = '';
     state.notifySource = 'cache';
@@ -579,6 +586,7 @@
       }
       renderNotify();
     } finally {
+      releaseDashboardPollRequest(controller);
       if (notifyController === controller) {
         notifyController = null;
         state.notifyPending = false;
@@ -631,7 +639,9 @@
     }
     renderNotify();
     try {
-      if (isAdmin() && state.identities.length === 0) {
+      /* N1 polling stays in the notification data plane: no roster, diagnostics,
+         summary, or transport fallback requests on the 30-second path. */
+      if (!opts.poll && isAdmin() && state.identities.length === 0) {
         var identityPayload = await apiJson('/ui/api/identities', { signal: controller.signal });
         if (controller.signal.aborted || notifyController !== controller) return;
         state.identities = Array.isArray(identityPayload.identities)
@@ -668,8 +678,10 @@
       state.notifyUpdatedAt = Date.now();
       state.notifyStatus = 'ready';
       state.notifyMessage = '';
-      await loadNotifySummary(controller.signal);
-      await loadNotifyDiagnostics(controller.signal);
+      if (!opts.poll) {
+        await loadNotifySummary(controller.signal);
+        await loadNotifyDiagnostics(controller.signal);
+      }
       if (notifyController !== controller) return;
       if (
         !opts.more &&
@@ -680,11 +692,11 @@
         !state.notifyTo
       ) {
         /* 未筛选且 30 天日志为空：12h transport cache 作 fallback，不回填日志。 */
-        await loadNotifyHistory();
+        if (!opts.poll) await loadNotifyHistory();
         return;
       }
       renderNotify();
-      announce(state.notifyLogItems.length + ' notifications loaded');
+      if (!opts.poll) announce(state.notifyLogItems.length + ' notifications loaded');
     } catch (error) {
       if (error.name === 'AbortError' || error.message === 'session_expired') return;
       if (state.notifyLogItems.length === 0) {

--- a/packages/api/src/ui/client/pages/notifications.js
+++ b/packages/api/src/ui/client/pages/notifications.js
@@ -134,7 +134,8 @@
     }
     notifySummary.textContent = 'Today (' + summary.tz + '): ' +
       summary.total + ' sent · ' + summary.ringCount + ' urgent' +
-      (summary.lastSuccessfulAt ? ' · last ' + formatClock(summary.lastSuccessfulAt, true) : '');
+      (summary.lastSuccessfulAt ? ' · last ' + formatClock(summary.lastSuccessfulAt, true) : '') +
+      '. Undelivered notifications are not included in today’s sent count.';
   }
 
   function renderNotifyDiagnostics() {

--- a/packages/api/src/ui/client/pages/overview.js
+++ b/packages/api/src/ui/client/pages/overview.js
@@ -1,621 +1,420 @@
-  function overviewModels() {
-    var needle = state.overviewFilter.toLowerCase();
-    var models = [];
-    state.identities.forEach(function (identity) {
-      if (needle &&
-        identity.address.toLowerCase().indexOf(needle) === -1 &&
-        (identity.name || '').toLowerCase().indexOf(needle) === -1) return;
-      models.push({ identity: identity, stats: statsRow(identity.address) });
+  /* ---- Home 值班台：只呈现服务端投影，不在浏览器合成任务状态或徽标。 ---- */
+  var HOME_TASK_LIMIT = 20;
+  var HOME_VISIBLE_ROWS = 5;
+  var DASHBOARD_POLL_MS = 30000;
+  var DASHBOARD_IDLE_POLL_MS = 120000;
+  var DASHBOARD_IDLE_AFTER_MS = 120000;
+  var dashboardPollTimer = null;
+  var dashboardPollControllers = [];
+  var dashboardLastInteractionAt = Date.now();
+
+  function homeTaskUrl(status) {
+    return '/ui/api/tasks?status=' + encodeURIComponent(status) +
+      '&period=30d&limit=' + encodeURIComponent(String(HOME_TASK_LIMIT));
+  }
+
+  function homeNumber(value) {
+    return typeof value === 'number' && Number.isFinite(value) ? formatNumber(value) : 'Unavailable';
+  }
+
+  function homeTaskButton(task) {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'home-task-row';
+    if (task.overdueReason) button.classList.add('is-overdue');
+    var subject = document.createElement('span');
+    subject.className = 'home-task-subject';
+    subject.textContent = task.subject || '(no subject)';
+    var meta = document.createElement('span');
+    meta.className = 'home-task-meta';
+    meta.textContent = taskStateLabel(task) + ' · ' + formatAgo(task.updatedAt);
+    button.append(subject, meta);
+    button.addEventListener('click', function () {
+      navigateTo('tasks', { taskId: task.id });
     });
-    return models;
+    return button;
   }
 
-  /* Unknown / Unavailable / 无命中的行始终排在同组末尾。 */
-  function sortRank(model) {
-    if (!model.stats) return 1;
-    if (!model.stats.complete && model.stats.count === 0) return 1;
-    if (state.overviewSort.key === 'last' && !model.stats.lastReceivedAt) return 1;
-    return 0;
-  }
-
-  function sortValue(model) {
-    var key = state.overviewSort.key;
-    var stats = model.stats;
-    if (key === 'address') return model.identity.address.toLowerCase();
-    if (key === 'name') return (model.identity.name || '').toLowerCase();
-    if (key === 'created') return Date.parse(model.identity.createdAt) || 0;
-    if (key === 'count') return stats ? stats.count : -1;
-    if (key === 'unseen') return stats ? stats.unseen : -1;
-    return stats && stats.lastReceivedAt ? Date.parse(stats.lastReceivedAt) : 0;
-  }
-
-  function sortedModels() {
-    var direction = state.overviewSort.dir === 'asc' ? 1 : -1;
-    return overviewModels().slice().sort(function (left, right) {
-      var rank = sortRank(left) - sortRank(right);
-      if (rank !== 0) return rank;
-      var a = sortValue(left);
-      var b = sortValue(right);
-      if (a < b) return -1 * direction;
-      if (a > b) return 1 * direction;
-      var created = (Date.parse(right.identity.createdAt) || 0) - (Date.parse(left.identity.createdAt) || 0);
-      if (created !== 0) return created;
-      return left.identity.address < right.identity.address ? -1 : 1;
+  function homeLinkButton(label, scope, extras) {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'quiet home-link';
+    button.textContent = label;
+    button.addEventListener('click', function () {
+      navigateTo(scope, extras || {});
     });
+    return button;
   }
 
-  function buildSortControls() {
-    overviewSort.replaceChildren();
-    SORT_COLUMNS.forEach(function (column) {
-      var button = document.createElement('button');
-      button.type = 'button';
-      button.className = 'sort-button';
-      button.dataset.sortKey = column.key;
-      button.addEventListener('click', function () {
-        if (state.overviewSort.key === column.key) {
-          state.overviewSort.dir = state.overviewSort.dir === 'asc' ? 'desc' : 'asc';
-        } else {
-          state.overviewSort.key = column.key;
-          state.overviewSort.dir = column.key === 'address' || column.key === 'name' ? 'asc' : 'desc';
-        }
-        renderOverview();
-      });
-      overviewSort.append(button);
-    });
-  }
-
-  function renderSortControls() {
-    Array.prototype.forEach.call(overviewSort.children, function (button) {
-      var column = SORT_COLUMNS.filter(function (candidate) {
-        return candidate.key === button.dataset.sortKey;
-      })[0];
-      var active = state.overviewSort.key === button.dataset.sortKey;
-      button.setAttribute('aria-pressed', active ? 'true' : 'false');
-      button.textContent = active
-        ? column.label + (state.overviewSort.dir === 'asc' ? ' ▲' : ' ▼')
-        : column.label;
-    });
-  }
-
-  function renderOverviewStats() {
-    overviewStats.replaceChildren();
-    var payload = state.overview;
-    var scan = payload ? payload.scan : null;
-    var totals = payload ? payload.totals : null;
-    var pending = state.overviewStatus === 'loading' || state.overviewStatus === 'idle';
-    var fallback = { text: pending ? 'Loading…' : 'Unavailable' };
-    var exact = !totals || totals.exact !== false;
-
-    function card(label, parts) {
-      var wrapper = document.createElement('div');
-      wrapper.className = 'stat-card';
-      var labelNode = document.createElement('span');
-      labelNode.className = 'stat-label';
-      labelNode.textContent = label;
-      var valueNode = document.createElement('span');
-      valueNode.className = 'stat-value';
-      valueNode.textContent = parts.text;
-      if (parts.title) valueNode.title = parts.title;
-      wrapper.append(labelNode, valueNode);
-      overviewStats.append(wrapper);
+  function homeSection(title, count) {
+    var section = document.createElement('section');
+    section.className = 'home-section';
+    var heading = document.createElement('div');
+    heading.className = 'home-section-heading';
+    var label = document.createElement('h2');
+    label.textContent = title;
+    heading.append(label);
+    if (typeof count === 'number') {
+      var badge = document.createElement('span');
+      badge.className = 'count home-count';
+      /* totalApprox 是本次 query 的服务端计数；不可用数组长度代替。 */
+      badge.textContent = String(count);
+      heading.append(badge);
     }
-
-    /* 地址数是身份派生量，永远精确。 */
-    card('Addresses', {
-      text: totals ? formatNumber(totals.addresses) : String(state.identities.length)
-    });
-    card('Unseen', totals ? boundParts(totals.unseenInWindow, exact) : fallback);
-    card('Active 24h', totals ? boundParts(totals.activeAddresses, exact) : fallback);
-    /* 通知数字卡与 Notifications 今日小结同一 /ui/api/notify/summary 源。 */
-    var notifySummary = state.notifySummary;
-    var notifyPending = state.notifySummaryStatus === 'loading' || state.notifySummaryStatus === 'idle';
-    card('Notifications today', notifySummary
-      ? { text: formatNumber(notifySummary.total) }
-      : { text: notifyPending ? 'Loading…' : 'Unavailable' });
-    card('Urgent today', notifySummary
-      ? { text: formatNumber(notifySummary.ringCount) }
-      : { text: notifyPending ? 'Loading…' : 'Unavailable' });
+    section.append(heading);
+    return section;
   }
 
-  function renderOverviewMeta() {
-    var payload = state.overview;
-    overviewPanel.classList.toggle('is-ready', state.overviewStatus === 'ready');
-    overviewPanel.classList.toggle('is-stale', state.overviewStatus === 'stale');
-    overviewPanel.classList.toggle(
-      'is-error',
-      state.overviewStatus === 'unavailable' || state.overviewStatus === 'error'
-    );
+  function appendHomeEmpty(section, title, detail, actionLabel, actionScope) {
+    var empty = document.createElement('div');
+    empty.className = 'home-empty';
+    var heading = document.createElement('h3');
+    heading.textContent = title;
+    var copy = document.createElement('p');
+    copy.textContent = detail;
+    empty.append(heading, copy);
+    if (actionLabel && actionScope) empty.append(homeLinkButton(actionLabel, actionScope));
+    section.append(empty);
+  }
 
-    if (!payload) {
-      overviewUpdated.textContent = state.overviewStatus === 'loading' ? 'Counting messages…' : '';
-    } else if (payload.scan && payload.scan.skipped) {
-      overviewUpdated.textContent = 'Updated ' + formatClock(payload.generatedAt, true);
+  function renderHomeWaiting(section) {
+    var rows = Array.isArray(state.homeWaitingTasks) ? state.homeWaitingTasks : [];
+    if (state.homeStatus === 'loading' && !rows.length) {
+      appendHomeEmpty(section, 'Loading tasks', 'Checking the tasks that need your input.');
+      return;
+    }
+    if (!rows.length) {
+      appendHomeEmpty(section, 'Nothing needs you right now.', 'New requests that need your input will appear here.', 'Open Tasks', 'tasks');
+      return;
+    }
+    var list = document.createElement('div');
+    list.className = 'home-task-list';
+    rows.slice(0, HOME_VISIBLE_ROWS).forEach(function (task) {
+      list.append(homeTaskButton(task));
+    });
+    section.append(list, homeLinkButton('Open Tasks', 'tasks'));
+  }
+
+  function renderHomeStuck(section) {
+    var overdue = Array.isArray(state.homeStuckTasks) ? state.homeStuckTasks : [];
+    var hasFailures = typeof state.homeFailedUrgentCount === 'number' && state.homeFailedUrgentCount > 0;
+    if (!overdue.length && !hasFailures) {
+      appendHomeEmpty(section, 'Nothing is blocked.', 'Overdue tasks and failed urgent pushes will be listed here.');
+      return;
+    }
+    if (overdue.length) {
+      var taskList = document.createElement('div');
+      taskList.className = 'home-task-list';
+      overdue.slice(0, HOME_VISIBLE_ROWS).forEach(function (task) {
+        taskList.append(homeTaskButton(task));
+      });
+      section.append(taskList);
+    }
+    if (hasFailures) {
+      var failed = document.createElement('button');
+      failed.type = 'button';
+      failed.className = 'home-failed-push';
+      failed.textContent = state.homeFailedUrgentCount +
+        (state.homeFailedUrgentCount === 1 ? ' urgent push failed today' : ' urgent pushes failed today');
+      failed.addEventListener('click', function () { navigateTo('notifications'); });
+      section.append(failed);
+    }
+    section.append(homeLinkButton('Open Alerts', 'notifications'));
+  }
+
+  function healthCard(label, value, scope) {
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'home-health-card';
+    var labelNode = document.createElement('span');
+    labelNode.className = 'home-health-label';
+    labelNode.textContent = label;
+    var valueNode = document.createElement('strong');
+    valueNode.textContent = value;
+    button.append(labelNode, valueNode);
+    button.addEventListener('click', function () { navigateTo(scope); });
+    return button;
+  }
+
+  function renderHomeHealth(section) {
+    var sentence = document.createElement('p');
+    sentence.className = 'home-health-copy';
+    sentence.textContent = 'A quick read on your addresses, unread mail, and urgent pushes today.';
+    section.append(sentence);
+    var grid = document.createElement('div');
+    grid.className = 'home-health-grid';
+    if (isAdmin()) {
+      grid.append(healthCard('Addresses', String(state.identities.length), 'configure-identities'));
+      grid.append(healthCard('Unread mail', homeNumber(state.homeUnseenCount), 'inbox'));
     } else {
-      var line = 'Updated ' + formatClock(payload.generatedAt, true) +
-        ' · newest ' + formatNumber(payload.scan.scanned) + ' of ' +
-        formatNumber(payload.scan.mailboxTotal) + ' in the mailbox';
-      if (state.overviewStatus === 'stale' && payload.refreshError) {
-        line = 'Counts from ' + formatClock(payload.generatedAt, false) + ' · last refresh failed';
-      }
-      overviewUpdated.textContent = line;
+      grid.append(healthCard('Mail', 'Open mailbox', 'inbox'));
     }
-
-    var exact = !payload || !payload.totals || payload.totals.exact !== false;
-    overviewDisclosure.hidden = exact;
-    overviewDisclosure.textContent = exact
-      ? ''
-      : 'Some counts are incomplete for messages with very large recipient lists (shown as ≥ or Unknown).';
-
-    overviewNotice.hidden = !state.overviewMessage;
-    overviewNotice.textContent = state.overviewMessage;
+    grid.append(healthCard('Urgent pushes today', homeNumber(state.homeUrgentSentCount), 'notifications'));
+    section.append(grid);
   }
 
-  function renderOverviewRows() {
-    overviewRows.replaceChildren();
-    var models = sortedModels();
-    overviewShown.textContent = state.overviewFilter
-      ? models.length + ' of ' + state.identities.length
-      : models.length + ' shown';
-
-    if (state.identities.length === 0) {
-      overviewStateNode.textContent =
-        'No addresses yet. Create one with the REST API or the MCP server, then it appears here.';
-      return;
+  function renderHomeSessionEmpty(host) {
+    var noWaiting = state.homeWaitingTotal === 0;
+    var noStuck = !state.homeStuckTasks.length && state.homeFailedUrgentCount === 0;
+    if (!noWaiting || !noStuck) return;
+    var section = document.createElement('section');
+    section.className = 'home-session-empty';
+    if (isAdmin() && state.identities.length === 0) {
+      appendHomeEmpty(
+        section,
+        'No addresses yet.',
+        'Create an address to start receiving mail and task updates.',
+        'Open Identities',
+        'configure-identities',
+      );
+    } else if (!isAdmin()) {
+      appendHomeEmpty(
+        section,
+        'Your desk is clear.',
+        'Open Mail to check your address or return when an agent needs you.',
+        'Open Mail',
+        'inbox',
+      );
     }
-    if (models.length === 0) {
-      overviewStateNode.textContent = 'No addresses match your filter.';
-      return;
-    }
-    overviewStateNode.textContent = '';
-
-    models.forEach(function (model) {
-      var row = model.stats;
-      var rowNode = document.createElement('div');
-      rowNode.className = 'overview-row';
-      rowNode.dataset.address = model.identity.address;
-      rowNode.setAttribute('aria-current', 'false');
-
-      // F66: navigation is a sibling of tier/actions, not an ancestor of <select>.
-      var navNode = document.createElement('div');
-      navNode.className = 'overview-row-nav';
-      navNode.setAttribute('role', 'button');
-      navNode.tabIndex = 0;
-
-      var identityCell = document.createElement('span');
-      identityCell.className = 'cell';
-      var name = document.createElement('span');
-      name.className = 'row-name';
-      name.textContent = model.identity.name || model.identity.address.split('@')[0];
-      var addressNode = document.createElement('span');
-      addressNode.className = 'row-address';
-      addressNode.textContent = model.identity.address;
-      identityCell.append(name, addressNode);
-      if (row && row.complete && row.count === 0) {
-        var note = document.createElement('span');
-        note.className = 'row-note';
-        note.textContent = '(no mail in the current window)';
-        identityCell.append(note);
-      }
-      navNode.append(identityCell);
-
-      var tokenCell = document.createElement('span');
-      tokenCell.className = 'cell token-cell';
-      var tokenLabel = document.createElement('span');
-      tokenLabel.className = 'cell-label';
-      tokenLabel.textContent = 'Token';
-      var tokenStatus = document.createElement('span');
-      tokenStatus.className = 'cell-value' + (model.identity.hasToken ? '' : ' row-flat');
-      var tokenDot = document.createElement('span');
-      tokenDot.className = 'token-dot' + (model.identity.hasToken ? ' has-token' : '');
-      tokenStatus.append(tokenDot, document.createTextNode(model.identity.hasToken ? 'Set' : 'None'));
-      tokenCell.append(tokenLabel, tokenStatus);
-      navNode.append(tokenCell);
-
-      var countText = appendCell(navNode, 'Messages', countParts(row, 'count'));
-      var unseenText = appendCell(navNode, 'Unseen', countParts(row, 'unseen'));
-
-      var dot = null;
-      if (isActiveRow(row)) {
-        dot = document.createElement('span');
-        dot.className = 'active-dot';
-      }
-      var lastParts = row && row.lastReceivedAt
-        ? { text: formatAgo(row.lastReceivedAt) }
-        : { text: row ? '—' : 'Unavailable', flat: true };
-      var lastText = appendCell(navNode, 'Last', lastParts, dot);
-      var createdText = appendCell(navNode, 'Created', { text: formatDay(model.identity.createdAt) });
-
-      var currentTier = model.identity.pushContentTier === 2 || model.identity.pushContentTier === 3
-        ? model.identity.pushContentTier
-        : 1;
-      var ariaParts = [
-        model.identity.name || model.identity.address,
-        model.identity.address,
-        model.identity.hasToken ? 'token set' : 'no token',
-        countText,
-        unseenText,
-        'last ' + lastText,
-        'created ' + createdText,
-        'push tier ' + currentTier
-      ];
-      navNode.setAttribute('aria-label', ariaParts.join(', '));
-      navNode.addEventListener('click', function () {
-        openAddress(model.identity.address);
-      });
-      navNode.addEventListener('keydown', function (event) {
-        if (event.target !== navNode || (event.key !== 'Enter' && event.key !== ' ')) return;
-        event.preventDefault();
-        openAddress(model.identity.address);
-      });
-      rowNode.append(navNode);
-
-      if (isAdmin()) {
-        var tierCell = document.createElement('span');
-        tierCell.className = 'cell push-tier-cell';
-        var tierLabelNode = document.createElement('span');
-        tierLabelNode.className = 'cell-label';
-        tierLabelNode.textContent = 'Push content';
-        var tierSelect = document.createElement('select');
-        tierSelect.className = 'push-tier-select';
-        tierSelect.setAttribute('aria-label', 'Push content tier for ' + model.identity.address);
-        tierSelect.dataset.currentTier = String(currentTier);
-        if (state.tierPending[model.identity.address]) {
-          tierSelect.disabled = true;
-        }
-        [
-          { value: 1, label: '1 · interrupt only' },
-          { value: 2, label: '2 · + subject / from' },
-          { value: 3, label: '3 · + body / OTP (sensitive)' }
-        ].forEach(function (optionDef) {
-          var option = document.createElement('option');
-          option.value = String(optionDef.value);
-          option.textContent = optionDef.label;
-          if (optionDef.value === currentTier) option.selected = true;
-          tierSelect.append(option);
-        });
-        tierSelect.addEventListener('click', function (event) {
-          event.stopPropagation();
-        });
-        tierSelect.addEventListener('change', function (event) {
-          event.stopPropagation();
-          handlePushTierChange(model.identity.address, tierSelect);
-        });
-        tierCell.append(tierLabelNode, tierSelect);
-        if (currentTier === 3) {
-          var riskHint = document.createElement('span');
-          riskHint.className = 'push-tier-hint';
-          riskHint.textContent = 'Body/OTP leave server';
-          riskHint.title = model.identity.pushContentTierWarning || PUSH_TIER3_WARNING;
-          tierCell.append(riskHint);
-        }
-        rowNode.append(tierCell);
-
-        var actionsCell = document.createElement('span');
-        actionsCell.className = 'cell row-actions';
-        var actionsLabel = document.createElement('span');
-        actionsLabel.className = 'cell-label';
-        actionsLabel.textContent = 'Actions';
-        var rotateButton = document.createElement('button');
-        rotateButton.type = 'button';
-        rotateButton.className = 'quiet row-action';
-        rotateButton.textContent = 'Rotate';
-        rotateButton.addEventListener('click', function (event) {
-          event.stopPropagation();
-          handleRotateToken(model.identity.address);
-        });
-        var deleteButton = document.createElement('button');
-        deleteButton.type = 'button';
-        deleteButton.className = 'quiet row-action delete-action';
-        deleteButton.textContent = 'Delete';
-        deleteButton.addEventListener('click', function (event) {
-          event.stopPropagation();
-          handleDeleteIdentity(model.identity.address);
-        });
-        actionsCell.append(actionsLabel, rotateButton, deleteButton);
-        rowNode.append(actionsCell);
-      }
-
-      overviewRows.append(rowNode);
-    });
-  }
-
-  function updateOverviewRefreshButton() {
-    if (state.overviewPending) {
-      overviewRefresh.disabled = true;
-      overviewRefresh.textContent = 'Refreshing…';
-      return;
-    }
-    overviewRefresh.disabled = false;
-    var payload = state.overview;
-    if (state.overviewStatus === 'stale' && payload && payload.refreshError && payload.retryAfterMs) {
-      /* 冷却期不假装正在刷新：明说下一次重试还有几秒。 */
-      overviewRefresh.textContent = 'Retrying in ' + Math.ceil(payload.retryAfterMs / 1000) + 's…';
-      return;
-    }
-    overviewRefresh.textContent =
-      state.overviewStatus === 'unavailable' || state.overviewStatus === 'error' ? 'Retry' : 'Refresh';
+    if (section.childNodes.length) host.append(section);
   }
 
   function renderOverview() {
-    var showData = isAdmin();
-    overviewSubtitle.hidden = !showData;
-    overviewOverlap.hidden = !showData;
-    overviewUpdated.hidden = !showData;
-    overviewRefresh.hidden = !showData;
-    overviewStats.hidden = !showData;
-    overviewDisclosure.hidden = !showData;
-    overviewControls.hidden = !showData;
-    overviewSort.hidden = !showData;
-    overviewStateNode.hidden = !showData;
-    overviewHeader.hidden = !showData;
-    overviewRows.hidden = !showData;
-    if (!showData) {
-      overviewNotice.hidden = true;
-      overviewNotice.textContent = '';
-      overviewStats.replaceChildren();
-      overviewSort.replaceChildren();
-      overviewRows.replaceChildren();
+    overviewPanel.classList.add('home-panel');
+    overviewSubtitle.hidden = false;
+    overviewSubtitle.textContent = 'What needs your attention today.';
+    overviewOverlap.hidden = true;
+    overviewDisclosure.hidden = true;
+    overviewControls.hidden = true;
+    overviewSort.hidden = true;
+    overviewHeader.hidden = true;
+    overviewRows.hidden = true;
+    overviewRows.replaceChildren();
+    overviewStateNode.hidden = true;
+    overviewStateNode.textContent = '';
+    createIdentityButton.hidden = true;
+    overviewRefresh.hidden = false;
+    overviewRefresh.disabled = state.homeStatus === 'loading';
+    overviewRefresh.textContent = state.homeStatus === 'loading' ? 'Refreshing…' : 'Refresh';
+    overviewUpdated.textContent = state.homeUpdatedAt
+      ? 'Updated ' + formatClock(new Date(state.homeUpdatedAt).toISOString(), true)
+      : '';
+    overviewNotice.hidden = !state.homeMessage;
+    overviewNotice.textContent = state.homeMessage;
+
+    overviewStats.hidden = false;
+    overviewStats.className = 'overview-stats home-dashboard';
+    overviewStats.replaceChildren();
+    var waiting = homeSection('Waiting for you', state.homeWaitingTotal);
+    renderHomeWaiting(waiting);
+    var stuck = homeSection('Blocked');
+    renderHomeStuck(stuck);
+    var health = homeSection('Health');
+    renderHomeHealth(health);
+    overviewStats.append(waiting, stuck, health);
+    renderHomeSessionEmpty(overviewStats);
+  }
+
+  function homeResult(promise) {
+    return promise.then(
+      function (payload) { return { ok: true, payload: payload }; },
+      function (error) { return { ok: false, error: error }; },
+    );
+  }
+
+  function homeTimeZone() {
+    try {
+      return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
+    } catch (_err) {
+      return 'UTC';
+    }
+  }
+
+  async function loadHome(options) {
+    var opts = options || {};
+    if (!state.me) return;
+    if (overviewController) overviewController.abort();
+    var controller = new AbortController();
+    overviewController = controller;
+    if (opts.poll) trackDashboardPollRequest(controller);
+    if (!opts.poll) state.homeStatus = 'loading';
+    state.homeMessage = '';
+    if (state.scope === 'overview') renderOverview();
+
+    var signal = controller.signal;
+    var waiting = homeResult(apiJson(homeTaskUrl('input-required'), { signal: signal }));
+    var active = homeResult(apiJson(homeTaskUrl('active'), { signal: signal }));
+    var summary = homeResult(apiJson(
+      '/ui/api/notify/summary?date=today&tz=' + encodeURIComponent(homeTimeZone()),
+      { signal: signal },
+    ));
+    /* Overview 的全局未读仅管理员首屏读取；identity 永不触碰会返回 403 的接口。
+       它不是轮询的一部分，N1 的周期请求只走 listBoard + notify/n。 */
+    var unread = isAdmin() && !opts.poll
+      ? homeResult(apiJson('/ui/api/overview', { signal: signal }))
+      : Promise.resolve(null);
+    var results = await Promise.all([waiting, active, summary, unread]);
+    if (overviewController !== controller || signal.aborted) {
+      if (overviewController === controller) overviewController = null;
+      releaseDashboardPollRequest(controller);
       return;
     }
-    renderOverviewMeta();
-    renderOverviewStats();
-    renderSortControls();
-    renderOverviewRows();
-    updateOverviewRefreshButton();
-  }
-
-  function rowButtonFor(address) {
-    // Focus the row's nav hit-target (role=button), not the neutral outer row (F66).
-    var rows = overviewRows.children;
-    for (var index = 0; index < rows.length; index += 1) {
-      if (rows[index].dataset.address === address) {
-        return rows[index].querySelector('.overview-row-nav') || rows[index];
+    overviewController = null;
+    var issues = [];
+    if (results[0] && results[0].ok) {
+      var waitingPayload = results[0].payload || {};
+      state.homeWaitingTasks = Array.isArray(waitingPayload.tasks) ? waitingPayload.tasks : [];
+      state.homeWaitingTotal = typeof waitingPayload.totalApprox === 'number'
+        ? waitingPayload.totalApprox
+        : 0;
+    } else if (results[0] && results[0].error.message !== 'session_expired') {
+      issues.push('Tasks that need you could not be loaded.');
+    }
+    if (results[1] && results[1].ok) {
+      var activePayload = results[1].payload || {};
+      var activeTasks = Array.isArray(activePayload.tasks) ? activePayload.tasks : [];
+      state.homeStuckTasks = activeTasks.filter(function (task) { return !!task.overdueReason; });
+    } else if (results[1] && results[1].error.message !== 'session_expired') {
+      issues.push('Blocked tasks could not be loaded.');
+    }
+    if (results[2] && results[2].ok) {
+      var summaryPayload = results[2].payload || {};
+      state.homeUrgentSentCount = typeof summaryPayload.ringCount === 'number'
+        ? summaryPayload.ringCount
+        : null;
+      state.homeFailedUrgentCount = typeof summaryPayload.failedUrgentCount === 'number'
+        ? summaryPayload.failedUrgentCount
+        : 0;
+    } else if (results[2] && results[2].error.message !== 'session_expired') {
+      state.homeUrgentSentCount = null;
+      issues.push('Today’s push summary is unavailable.');
+    }
+    if (results[3]) {
+      if (results[3].ok) {
+        var overviewPayload = results[3].payload || {};
+        state.homeUnseenCount = overviewPayload.totals &&
+          typeof overviewPayload.totals.unseenInWindow === 'number'
+          ? overviewPayload.totals.unseenInWindow
+          : null;
+      } else if (results[3].error.message !== 'session_expired') {
+        state.homeUnseenCount = null;
+        issues.push('Unread mail count is unavailable.');
       }
     }
-    return null;
+    state.homeStatus = issues.length ? 'error' : 'ready';
+    state.homeMessage = issues.join(' ');
+    state.homeUpdatedAt = Date.now();
+    releaseDashboardPollRequest(controller);
+    if (state.scope === 'overview') renderOverview();
   }
 
-  function cancelOverviewPoll() {
-    if (overviewTimer !== null) {
-      window.clearTimeout(overviewTimer);
-      overviewTimer = null;
+  function stopDashboardPolling() {
+    if (dashboardPollTimer !== null) {
+      window.clearTimeout(dashboardPollTimer);
+      dashboardPollTimer = null;
     }
   }
 
+  function trackDashboardPollRequest(controller) {
+    dashboardPollControllers.push(controller);
+  }
+
+  function releaseDashboardPollRequest(controller) {
+    dashboardPollControllers = dashboardPollControllers.filter(function (candidate) {
+      return candidate !== controller;
+    });
+  }
+
+  function abortDashboardPollRequests() {
+    var pending = dashboardPollControllers.slice();
+    dashboardPollControllers = [];
+    pending.forEach(function (controller) { controller.abort(); });
+  }
+
+  function dashboardPollAllowed() {
+    return Boolean(state.me) && !document.hidden &&
+      (state.scope === 'overview' || state.scope === 'tasks' || state.scope === 'notifications');
+  }
+
+  function scheduleDashboardPolling() {
+    stopDashboardPolling();
+    if (!dashboardPollAllowed()) return;
+    var idle = Date.now() - dashboardLastInteractionAt >= DASHBOARD_IDLE_AFTER_MS;
+    dashboardPollTimer = window.setTimeout(function () {
+      dashboardPollTimer = null;
+      if (!dashboardPollAllowed()) return;
+      var work = Promise.resolve();
+      if (state.scope === 'overview') work = loadHome({ poll: true });
+      else if (state.scope === 'tasks' && !state.tasksPending) work = loadTasks({ poll: true });
+      else if (state.scope === 'notifications' && !state.notifyPending) work = loadNotificationLog({ poll: true });
+      work.then(scheduleDashboardPolling, scheduleDashboardPolling);
+    }, idle ? DASHBOARD_IDLE_POLL_MS : DASHBOARD_POLL_MS);
+  }
+
+  function noteDashboardInteraction() {
+    dashboardLastInteractionAt = Date.now();
+    scheduleDashboardPolling();
+  }
+
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) {
+      stopDashboardPolling();
+      abortDashboardPollRequests();
+    }
+    else scheduleDashboardPolling();
+  });
+  ['pointerdown', 'keydown', 'touchstart'].forEach(function (type) {
+    document.addEventListener(type, noteDashboardInteraction, { passive: true });
+  });
+
   function cancelOverview() {
-    cancelOverviewPoll();
     if (overviewController) {
       overviewController.abort();
       overviewController = null;
     }
-    state.overviewPending = false;
-    state.overviewPolls = 0;
-    state.overviewLoadingSince = 0;
+    stopDashboardPolling();
   }
 
-  /* 服务端给的 retryAfterMs 是"最早可再来"的时刻，客户端必须遵守它。 */
-  function scheduleOverviewPoll(retryAfterMs) {
-    cancelOverviewPoll();
-    var delay = Math.max(retryAfterMs || 1500, 1000);
-    state.overviewRetryAt = Date.now() + delay;
-    overviewTimer = window.setTimeout(function () {
-      overviewTimer = null;
-      loadOverviewCycle({ refresh: false });
-    }, delay);
+  function refreshInboxIdentities() {
+    return apiJson('/ui/api/identities').then(function (payload) {
+      state.identities = Array.isArray(payload.identities) ? payload.identities : [];
+      renderIdentities();
+      reconcileActiveAddress();
+      if (state.scope === 'overview') renderOverview();
+    }).catch(function () {
+      /* Inbox keeps its last known roster when a background refresh fails. */
+    });
   }
 
-  function readyAnnouncement(payload) {
-    var totals = payload.totals;
-    if (payload.scan && payload.scan.skipped) {
-      return 'Home loaded: 0 addresses.';
-    }
-    return 'Home loaded: ' + totals.addresses + ' addresses, ' +
-      totals.matchedInWindow + ' messages in the newest ' + payload.scan.scanned +
-      ', ' + totals.unseenInWindow + ' unseen.';
-  }
-
-  function applyOverviewPayload(payload) {
-    cancelOverviewPoll();
-    if (payload.status === 'loading') {
-      /* 202 不覆盖上一次的载荷：表格继续显示旧数值，而不是掉回 0。 */
-      state.overviewStatus = 'loading';
-      state.overviewMessage = '';
-      if (!state.overviewLoadingSince) state.overviewLoadingSince = Date.now();
-      state.overviewPolls += 1;
-      if (state.overviewPolls >= POLL_LIMIT ||
-        Date.now() - state.overviewLoadingSince > POLL_WINDOW_MS) {
-        state.overviewStatus = 'unavailable';
-        state.overviewMessage = 'Message counts are taking too long.';
-        announce('Message counts are taking too long.');
-        return;
-      }
-      scheduleOverviewPoll(payload.retryAfterMs);
-      announce('Home counts are still loading.');
-      return;
-    }
-
-    state.overview = payload;
-    state.overviewStatus = payload.status === 'stale' ? 'stale' : 'ready';
-    state.overviewPolls = 0;
-    state.overviewLoadingSince = 0;
-    state.overviewMessage = '';
-
-    if (state.overviewStatus === 'ready') {
-      announce(readyAnnouncement(payload));
-      return;
-    }
-    if (payload.refreshError) {
-      state.overviewMessage = 'The last refresh failed. Showing the previous counts.';
-      announce('Showing counts from ' + formatClock(payload.generatedAt, false) + '. Refresh failed.');
-    } else {
-      announce(readyAnnouncement(payload));
-    }
-    /* 唯一轮询规则：只有在途 flight 或待重试的失败才安排下一周期。 */
-    if (payload.revalidating || payload.refreshError) scheduleOverviewPoll(payload.retryAfterMs);
-  }
-
-  function applyOverviewError(error) {
-    cancelOverviewPoll();
-    if (error.message === 'session_expired') return;
-    if (error.status === 500) {
-      state.overviewStatus = 'error';
-      state.overviewMessage = 'Addresses could not be read from the server.';
-      announce('Addresses could not be read from the server.');
-      return;
-    }
-    state.overviewStatus = 'unavailable';
-    state.overviewMessage = 'Message counts are unavailable right now.';
-    announce('Home counts are unavailable. Addresses are listed without counts.');
-  }
-
-  function handleIdentitiesError(error) {
-    if (error.message === 'session_expired') return;
-    state.overviewStatus = 'error';
-    state.overviewMessage = 'Addresses could not be read from the server.';
-    announce('Addresses could not be read from the server.');
-    renderOverview();
-  }
-
-  /* 新一轮 /identities 里活动地址消失了（被删/被 retention 清掉）：不能把用户留在
-     一个失效的 inbox 里反复报"邮件加载失败"，清掉活动状态并回 Home + 播报。 */
   function reconcileActiveAddress() {
     if (!state.activeAddress) return;
-    var survivors = state.identities.filter(function (identity) {
+    var exists = state.identities.some(function (identity) {
       return identity.address === state.activeAddress;
     });
-    if (survivors.length) return;
+    if (exists) return;
     var lost = state.activeAddress;
     state.activeAddress = '';
     state.messages = [];
-    state.returnAddress = '';
+    state.nextCursor = '';
+    state.sourceCache = null;
     clearDetail();
     renderMessages();
-    if (state.scope !== 'inbox') return;
-    enterOverview({ announce: lost + ' is no longer available. Back to Home.' });
+    if (state.scope === 'inbox') enterOverview({ announce: lost + ' is no longer available. Back to Home.' });
   }
 
-  /* inbox 里触发身份刷新的时机：admin 每次手动 Refresh。停在 inbox 时 Overview
-     周期是停掉的（cancelOverview），所以这是"活动地址被删"能被发现的那一刻。 */
-  function refreshInboxIdentities() {
-    // Same epoch as loadOverviewCycle: a tier save mid-flight must not be
-    // overwritten by a slower inbox identity refresh.
-    var generation = state.overviewGen;
-    apiJson('/ui/api/identities').then(function (payload) {
-      if (state.scope !== 'inbox') return;
-      if (generation !== state.overviewGen) return;
-      state.identities = Array.isArray(payload.identities) ? payload.identities : [];
-      renderIdentities();
-      reconcileActiveAddress();
-    }).catch(function () {
-      /* 名单取不到就沿用旧名单：邮件本身的失败由 refreshMessages 自己报。 */
-    });
-  }
-
-  /* 一个 Overview 周期：同一代际下并发发起两条请求，且两条各自独立落地 ——
-     /identities 一到就渲染地址骨架，绝不等 /overview 的扫描预算。 */
-  function loadOverviewCycle(options) {
-    var opts = options || {};
-    var generation = ++state.overviewGen;
-    cancelOverviewPoll();
-    if (overviewController) overviewController.abort();
-    overviewController = new AbortController();
-    var signal = overviewController.signal;
-    state.overviewPending = true;
-    state.overviewCycleGen = generation;
-    updateOverviewRefreshButton();
-
-    var identitiesPromise = apiJson('/ui/api/identities', { signal: signal });
-    var overviewPromise = apiJson(
-      opts.refresh ? '/ui/api/overview?refresh=1' : '/ui/api/overview',
-      { signal: signal }
-    );
-    var tz = 'UTC';
-    try { tz = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'; } catch (_err) {}
-    var notifySummaryPromise = apiJson(
-      '/ui/api/notify/summary?date=today&tz=' + encodeURIComponent(tz),
-      { signal: signal }
-    );
-    state.notifySummaryStatus = 'loading';
-    notifySummaryPromise.then(function (payload) {
-      if (generation !== state.overviewGen) return;
-      state.notifySummary = payload;
-      state.notifySummaryStatus = 'ready';
-      if (state.scope === 'overview') renderOverviewStats();
-    }).catch(function (error) {
-      if (generation !== state.overviewGen) return;
-      if (error.name === 'AbortError' || error.message === 'session_expired') return;
-      state.notifySummaryStatus = 'error';
-      if (state.scope === 'overview') renderOverviewStats();
-    });
-
-    identitiesPromise.then(function (payload) {
-      if (generation !== state.overviewGen) return;
-      state.identities = Array.isArray(payload.identities) ? payload.identities : [];
-      /* 侧栏与总览行都吃这份名单，两边都得重画（只重画总览会让侧栏一直空着）。 */
-      renderIdentities();
-      renderOverview();
-      refreshConfigureSurfaces();
-      reconcileActiveAddress();
-    }).catch(function (error) {
-      if (generation !== state.overviewGen) return;
-      handleIdentitiesError(error);
-    });
-
-    overviewPromise.then(function (payload) {
-      if (generation !== state.overviewGen) {
-        // Superseded by bumpIdentityEpoch or a newer cycle: never write data,
-        // but if no live cycle owns the current gen, clear a stuck Refresh.
-        if (state.overviewPending && state.overviewCycleGen !== state.overviewGen) {
-          state.overviewPending = false;
-          updateOverviewRefreshButton();
-        }
-        return;
-      }
-      state.overviewPending = false;
-      applyOverviewPayload(payload);
-      renderOverview();
-    }).catch(function (error) {
-      if (generation !== state.overviewGen) {
-        if (state.overviewPending && state.overviewCycleGen !== state.overviewGen) {
-          state.overviewPending = false;
-          updateOverviewRefreshButton();
-        }
-        return;
-      }
-      state.overviewPending = false;
-      if (error.name === 'AbortError') return;
-      applyOverviewError(error);
-      renderOverview();
-    });
-  }
-
-  /* Overview 面板在 375 px 下 min-height 就有 calc(100vh - 66px)，顶上还压着 topbar 与
-     Address 标签，所以普通 focus() 会为了"把整块拉进视口"往下滚一截，首屏看不到 topbar/
-     Sign out/Address（CONSOLIDATED §1.4 要求首屏从 topbar 开始，A66 要求 logo 可见）。
-     面板只是个 tabindex="-1" 的落焦点，本来就不需要滚动，所以这条路径一律 preventScroll。 */
   function focusOverviewPanel() {
     overviewPanel.focus({ preventScroll: true });
   }
 
   function enterOverview(options) {
     var opts = options || {};
-    cancelOverviewPoll();
     cancelNotifyLoad();
     cancelTasksLoad();
     applyScope('overview', { announce: opts.announce, skipUrl: opts.skipUrl, replaceUrl: opts.replaceUrl });
     renderOverview();
-    /* 两条聚焦路径分开处理：从 inbox 返回时焦点回到原来那一行，那一行可能在长表格深处，
-       必须照常滚动过去；没有返回行时焦点落在面板上，不滚。 */
-    var returnRow = opts.returnTo ? rowButtonFor(opts.returnTo) : null;
-    if (returnRow) returnRow.focus();
-    else focusOverviewPanel();
-    /* 唯一新鲜度口径：generatedAt 的本机年龄 <15 s 就直接重渲染，0 请求。 */
-    var age = state.overview
-      ? Math.max(0, Date.now() - Date.parse(state.overview.generatedAt))
-      : Infinity;
-    if (state.overviewStatus === 'ready' && age < FRESH_MS) return;
-    if (!isAdmin()) return;
-    loadOverviewCycle({ refresh: false });
+    focusOverviewPanel();
+    var fresh = state.homeUpdatedAt && Date.now() - state.homeUpdatedAt < FRESH_MS;
+    if (!fresh) loadHome({ refresh: false });
   }
 
   function openAddress(address) {

--- a/packages/api/src/ui/client/pages/overview.js
+++ b/packages/api/src/ui/client/pages/overview.js
@@ -373,7 +373,7 @@
 
   function noteDashboardInteraction() {
     dashboardLastInteractionAt = Date.now();
-    scheduleDashboardPolling();
+    if (dashboardPollTimer === null) scheduleDashboardPolling();
   }
 
   document.addEventListener('visibilitychange', function () {

--- a/packages/api/src/ui/client/pages/overview.js
+++ b/packages/api/src/ui/client/pages/overview.js
@@ -1,6 +1,8 @@
   /* ---- Home 值班台：只呈现服务端投影，不在浏览器合成任务状态或徽标。 ---- */
   var HOME_TASK_LIMIT = 20;
   var HOME_ACTIVE_PAGE_LIMIT = 100;
+  var HOME_ACTIVE_MAX_PAGES = 5;
+  var HOME_ACTIVE_MAX_ROWS = 500;
   var HOME_VISIBLE_ROWS = 5;
   var DASHBOARD_POLL_MS = 30000;
   var DASHBOARD_IDLE_POLL_MS = 120000;
@@ -16,10 +18,12 @@
   }
 
   /* listBoard 的逾期标记是每一行的服务端投影，不是跨 tab 汇总。分页直到能填满
-     Home 的五条可见位或列表结束，避免较旧的 overdue 行被 Active 首屏遮住。 */
+     Home 的五条可见位、列表结束或 5 页 / 500 行上限，避免轮询扫完整个 Active tab。 */
   async function loadHomeActiveOverdue(signal) {
     var cursor = '';
     var overdue = [];
+    var pages = 0;
+    var scannedRows = 0;
     do {
       var payload = await apiJson(
         homeTaskUrl('active', cursor, HOME_ACTIVE_PAGE_LIMIT),
@@ -27,11 +31,15 @@
       );
       var board = payload || {};
       var tasks = Array.isArray(board.tasks) ? board.tasks : [];
-      tasks.forEach(function (task) {
+      var allowedRows = tasks.slice(0, HOME_ACTIVE_MAX_ROWS - scannedRows);
+      scannedRows += allowedRows.length;
+      allowedRows.forEach(function (task) {
         if (task.overdueReason) overdue.push(task);
       });
+      pages += 1;
       cursor = board.nextCursor || '';
-    } while (cursor && overdue.length < HOME_VISIBLE_ROWS);
+    } while (cursor && overdue.length < HOME_VISIBLE_ROWS &&
+      pages < HOME_ACTIVE_MAX_PAGES && scannedRows < HOME_ACTIVE_MAX_ROWS);
     return overdue;
   }
 

--- a/packages/api/src/ui/client/pages/overview.js
+++ b/packages/api/src/ui/client/pages/overview.js
@@ -1,5 +1,6 @@
   /* ---- Home 值班台：只呈现服务端投影，不在浏览器合成任务状态或徽标。 ---- */
   var HOME_TASK_LIMIT = 20;
+  var HOME_ACTIVE_PAGE_LIMIT = 100;
   var HOME_VISIBLE_ROWS = 5;
   var DASHBOARD_POLL_MS = 30000;
   var DASHBOARD_IDLE_POLL_MS = 120000;
@@ -8,9 +9,30 @@
   var dashboardPollControllers = [];
   var dashboardLastInteractionAt = Date.now();
 
-  function homeTaskUrl(status) {
+  function homeTaskUrl(status, cursor, limit) {
     return '/ui/api/tasks?status=' + encodeURIComponent(status) +
-      '&period=30d&limit=' + encodeURIComponent(String(HOME_TASK_LIMIT));
+      '&period=30d&limit=' + encodeURIComponent(String(limit || HOME_TASK_LIMIT)) +
+      (cursor ? '&cursor=' + encodeURIComponent(cursor) : '');
+  }
+
+  /* listBoard 的逾期标记是每一行的服务端投影，不是跨 tab 汇总。分页直到能填满
+     Home 的五条可见位或列表结束，避免较旧的 overdue 行被 Active 首屏遮住。 */
+  async function loadHomeActiveOverdue(signal) {
+    var cursor = '';
+    var overdue = [];
+    do {
+      var payload = await apiJson(
+        homeTaskUrl('active', cursor, HOME_ACTIVE_PAGE_LIMIT),
+        { signal: signal },
+      );
+      var board = payload || {};
+      var tasks = Array.isArray(board.tasks) ? board.tasks : [];
+      tasks.forEach(function (task) {
+        if (task.overdueReason) overdue.push(task);
+      });
+      cursor = board.nextCursor || '';
+    } while (cursor && overdue.length < HOME_VISIBLE_ROWS);
+    return overdue;
   }
 
   function homeNumber(value) {
@@ -243,7 +265,7 @@
 
     var signal = controller.signal;
     var waiting = homeResult(apiJson(homeTaskUrl('input-required'), { signal: signal }));
-    var active = homeResult(apiJson(homeTaskUrl('active'), { signal: signal }));
+    var active = homeResult(loadHomeActiveOverdue(signal));
     var summary = homeResult(apiJson(
       '/ui/api/notify/summary?date=today&tz=' + encodeURIComponent(homeTimeZone()),
       { signal: signal },
@@ -271,9 +293,7 @@
       issues.push('Tasks that need you could not be loaded.');
     }
     if (results[1] && results[1].ok) {
-      var activePayload = results[1].payload || {};
-      var activeTasks = Array.isArray(activePayload.tasks) ? activePayload.tasks : [];
-      state.homeStuckTasks = activeTasks.filter(function (task) { return !!task.overdueReason; });
+      state.homeStuckTasks = Array.isArray(results[1].payload) ? results[1].payload : [];
     } else if (results[1] && results[1].error.message !== 'session_expired') {
       issues.push('Blocked tasks could not be loaded.');
     }

--- a/packages/api/src/ui/client/pages/push-devices.js
+++ b/packages/api/src/ui/client/pages/push-devices.js
@@ -83,14 +83,14 @@
           renderConfigurePush();
           if (recovered.status !== 'error') {
             if (state.scope === 'configure-identities') renderConfigureIdentities();
-            if (state.scope === 'overview') renderOverviewRows();
+            if (state.scope === 'overview') renderOverview();
           }
         }
       } finally {
         delete state.tierPending[address];
         renderConfigurePush();
         /* 中途切到 Overview 时，行上的 select 仍可能停在 disabled + 旧档。 */
-        if (state.scope === 'overview') renderOverviewRows();
+        if (state.scope === 'overview') renderOverview();
         if (state.scope === 'configure-push' && !configurePushPanel.hidden && confirmModal.hidden) {
           var focusCard = configurePushCards.querySelector('.push-tier-card.is-selected');
           if (focusCard && typeof focusCard.focus === 'function') focusCard.focus();
@@ -425,4 +425,3 @@
     loadPairedDevices();
     configurePushPanel.focus({ preventScroll: true });
   }
-

--- a/packages/api/src/ui/client/pages/tasks.js
+++ b/packages/api/src/ui/client/pages/tasks.js
@@ -50,7 +50,7 @@
 
   function tasksFetchKey() {
     return [
-      state.tasksFilter || 'active',
+      state.tasksFilter || 'input-required',
       state.tasksPeriod || '30d',
       String(state.tasksLimit || 20)
     ].join('|');
@@ -75,7 +75,7 @@
     if (tasksStatusTabs) {
       var buttons = tasksStatusTabs.querySelectorAll('[data-status]');
       Array.prototype.forEach.call(buttons, function (button) {
-        var selected = button.getAttribute('data-status') === (state.tasksFilter || 'active');
+        var selected = button.getAttribute('data-status') === (state.tasksFilter || 'input-required');
         button.setAttribute('aria-selected', selected ? 'true' : 'false');
       });
     }
@@ -188,7 +188,7 @@
     var total = typeof state.tasksTotalApprox === 'number' ? state.tasksTotalApprox : shown;
     tasksShown.textContent = shown === total ? String(shown) : shown + ' of ~' + total;
     if (rows.length === 0) {
-      var filter = state.tasksFilter || 'active';
+      var filter = state.tasksFilter || 'input-required';
       tasksStateNode.textContent = filter === 'all'
         ? 'No tasks in this period. Refresh after a task mail arrives.'
         : 'No tasks in "' + filter + '" for this period.';
@@ -328,7 +328,7 @@
       ' · ' +
       (Array.isArray(task.messages) ? task.messages.length : 0) +
       ' messages';
-    head.append(badge, title, meta);
+    head.append(title, badge, meta);
     if (task.overdueReason) {
       var overdueNote = document.createElement('p');
       overdueNote.className = 'task-overdue-flag';
@@ -395,10 +395,15 @@
       when.dateTime = message.date || '';
       when.textContent = message.date ? formatDate(message.date) : '—';
       metaRow.append(msgBadge, from, when);
-      var body = document.createElement('p');
+      var messageBlock = document.createElement('details');
+      messageBlock.className = 'task-timeline-message';
+      var messageSummary = document.createElement('summary');
+      messageSummary.textContent = 'View message';
+      var body = document.createElement('pre');
       body.className = 'task-timeline-body';
       body.textContent = taskTimelineBody(message.body);
-      item.append(metaRow, body);
+      messageBlock.append(messageSummary, body);
+      item.append(metaRow, messageBlock);
       timeline.append(item);
     });
     tasksDetailContent.append(timeline);
@@ -493,6 +498,7 @@
     cancelTasksListLoad();
     var controller = new AbortController();
     tasksController = controller;
+    if (opts.poll) trackDashboardPollRequest(controller);
     state.tasksPending = true;
     state.tasksMessage = '';
     /* F1：filter 一变 fetchKey 就变——立刻 loading，别等网络返回才撤掉假空态。 */
@@ -506,7 +512,7 @@
     renderTasks();
     try {
       var params = [
-        'status=' + encodeURIComponent(state.tasksFilter || 'active'),
+        'status=' + encodeURIComponent(state.tasksFilter || 'input-required'),
         'period=' + encodeURIComponent(state.tasksPeriod || '30d'),
         'limit=' + encodeURIComponent(String(state.tasksLimit || 20))
       ];
@@ -532,7 +538,7 @@
       state.tasksStatus = 'ready';
       state.tasksMessage = '';
       renderTasks();
-      announce(state.tasks.length + ' tasks loaded');
+      if (!opts.poll) announce(state.tasks.length + ' tasks loaded');
       if (state.activeTaskId) {
         var stillThere = state.tasks.some(function (task) {
           return task.id === state.activeTaskId;
@@ -552,6 +558,7 @@
       }
       renderTasks();
     } finally {
+      releaseDashboardPollRequest(controller);
       if (tasksController === controller) {
         tasksController = null;
         state.tasksPending = false;

--- a/packages/api/src/ui/client/pages/tasks.js
+++ b/packages/api/src/ui/client/pages/tasks.js
@@ -543,7 +543,7 @@
         var stillThere = state.tasks.some(function (task) {
           return task.id === state.activeTaskId;
         });
-        if (!stillThere && !more) clearTaskDetail();
+        if (!stillThere && !more && !opts.poll) clearTaskDetail();
       }
     } catch (error) {
       if (error.name === 'AbortError' || error.message === 'session_expired') return;

--- a/packages/api/src/ui/client/router.js
+++ b/packages/api/src/ui/client/router.js
@@ -290,5 +290,6 @@
     renderIdentities();
     renderAppNav();
     if (!opts.skipUrl) syncUrlFromScope(opts.replaceUrl);
+    scheduleDashboardPolling();
     if (opts.announce) announce(opts.announce);
   }

--- a/packages/api/src/ui/client/store.js
+++ b/packages/api/src/ui/client/store.js
@@ -73,11 +73,11 @@
     notifyDiagnostics: null,
     notifyRevealed: {},
     notifyVerifyPending: false,
-    /* 任务工单：列表 + 详情缓存；默认 Active tab */
+  /* 任务工单：列表 + 详情缓存；一期默认 Waiting for you。 */
     tasks: [],
     tasksStatus: 'idle',
     tasksMessage: '',
-    tasksFilter: 'active',
+    tasksFilter: 'input-required',
     tasksPeriod: '30d',
     tasksLimit: 20,
     tasksNextCursor: '',
@@ -90,6 +90,16 @@
     taskDetail: null,
     taskDetailStatus: 'idle',
     taskDetailMessage: '',
+    /* Home 值班台：各块只保存服务端投影，绝不从行数组推导徽标。 */
+    homeStatus: 'idle',
+    homeMessage: '',
+    homeWaitingTasks: [],
+    homeWaitingTotal: 0,
+    homeStuckTasks: [],
+    homeFailedUrgentCount: 0,
+    homeUrgentSentCount: null,
+    homeUnseenCount: null,
+    homeUpdatedAt: 0,
     /* Configure · Push 当前编辑的身份（admin 可切）。 */
     configurePushAddress: ''
   };
@@ -102,4 +112,3 @@
   var notifyController = null;
   var tasksController = null;
   var taskDetailController = null;
-

--- a/packages/api/src/ui/styles/pages.css
+++ b/packages/api/src/ui/styles/pages.css
@@ -117,6 +117,64 @@
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
+.home-dashboard { grid-template-columns: repeat(3, minmax(0, 1fr)); align-items: start; }
+.home-section, .home-session-empty {
+  min-width: 0;
+  padding: 16px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--bg-card);
+}
+.home-section-heading { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+.home-section-heading h2 { margin: 0; font-size: 16px; }
+.home-count { color: var(--gold); font-weight: 800; }
+.home-task-list { display: grid; gap: 6px; margin: 14px 0; }
+.home-task-row {
+  display: grid;
+  width: 100%;
+  min-height: 44px;
+  gap: 4px;
+  padding: 9px 10px;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--bg);
+  color: var(--ink);
+  text-align: left;
+  cursor: pointer;
+}
+.home-task-row:hover, .home-task-row:focus-visible { border-color: var(--gold); background: var(--gold-dim); }
+.home-task-row.is-overdue { box-shadow: inset 3px 0 0 var(--red); }
+.home-task-subject { overflow: hidden; font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
+.home-task-meta, .home-health-copy, .home-empty p { color: var(--ink-dim); font-size: 13px; }
+.home-link { min-height: 38px; }
+.home-empty h3 { margin: 14px 0 6px; font-size: 15px; }
+.home-empty p { margin: 0; line-height: 1.45; }
+.home-empty .home-link { margin-top: 12px; }
+.home-failed-push {
+  width: 100%;
+  min-height: 44px;
+  margin: 14px 0;
+  border-color: rgba(248, 113, 113, .55);
+  background: rgba(127, 29, 29, .18);
+  color: #fecaca;
+  text-align: left;
+}
+.home-health-copy { margin: 14px 0 12px; line-height: 1.45; }
+.home-health-grid { display: grid; gap: 8px; grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.home-health-card {
+  display: grid;
+  min-height: 76px;
+  padding: 10px;
+  border-color: var(--line);
+  background: var(--bg);
+  color: var(--gold);
+  text-align: left;
+  cursor: pointer;
+}
+.home-health-card:hover, .home-health-card:focus-visible { border-color: var(--gold); background: var(--gold-dim); }
+.home-health-card strong { font-size: 20px; overflow-wrap: anywhere; }
+.home-health-label { color: var(--ink-dim); font-size: 11px; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+.home-session-empty { grid-column: 1 / -1; }
 .stat-card {
   padding: 14px 16px;
   border: 1px solid var(--line);
@@ -420,7 +478,8 @@
   .task-row .cell { display: flex; align-items: baseline; justify-content: space-between; gap: 12px; min-height: 24px; margin-bottom: 4px; }
   .task-row .cell-label { display: inline; }
   .task-row .task-subject { white-space: normal; }
-  .inbox-view[data-mobile-view="overview"] .overview-stats { grid-template-columns: minmax(0, 1fr); gap: 0; }
+  .inbox-view[data-mobile-view="overview"] .overview-stats { grid-template-columns: minmax(0, 1fr); gap: 12px; }
+  .inbox-view[data-mobile-view="overview"] .home-health-grid { grid-template-columns: minmax(0, 1fr); }
   .inbox-view[data-mobile-view="overview"] .stat-card {
     display: flex;
     align-items: baseline;
@@ -495,10 +554,11 @@
 }
 .task-badge[data-state="closed"] { color: var(--ink-dim); }
 .task-badge[data-state="reminder"] { color: var(--gold-soft); }
+.notify-delivery-failed { display: block; margin-top: 4px; color: var(--red); font-size: 12px; font-weight: 800; }
 .task-original, .task-result, .task-reply, .task-admin-actions {
   margin-top: 16px;
 }
-.task-original-body, .task-result pre {
+.task-original-body, .task-timeline-body, .task-result pre {
   margin: 8px 0 0;
   padding: 12px;
   border: 1px solid var(--line);
@@ -508,6 +568,8 @@
   overflow-wrap: anywhere;
   font: 12px/1.45 var(--mono);
 }
+.task-timeline-message { margin-top: 8px; }
+.task-timeline-message summary { cursor: pointer; color: var(--gold-soft); font-size: 13px; }
 .task-result-table {
   width: 100%;
   margin-top: 8px;

--- a/packages/api/test/notification-log.test.ts
+++ b/packages/api/test/notification-log.test.ts
@@ -300,6 +300,26 @@ describe('notification-log store', () => {
     expect(summary.byLevel).toEqual({ urgent: 1, normal: 1, low: 0 });
   });
 
+  test('summary keeps failed urgent delivery separate from successful push totals', async () => {
+    const now = Date.parse('2026-08-12T08:00:00.000Z');
+    setNotificationLogNowForTests(() => now);
+    await appendNotificationLog({
+      source: 'watcher',
+      logicalTarget: 'user',
+      logicalChannel: 'user-alerts',
+      level: 'urgent',
+      title: 'not delivered',
+      message: '',
+      delivery: 'failed',
+    });
+    const summary = await summarizeNotificationLog({ date: 'today', tz: 'UTC' });
+    expect(summary.total).toBe(0);
+    expect(summary.ringCount).toBe(0);
+    expect(summary.failedUrgentCount).toBe(1);
+    const page = await queryNotificationLog({ limit: 20 });
+    expect(page.items[0]).toMatchObject({ delivery: 'failed', level: 'urgent' });
+  });
+
   test('append after a complete last record missing final newline stays readable', async () => {
     mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
     const good = {

--- a/packages/api/test/notification-log.test.ts
+++ b/packages/api/test/notification-log.test.ts
@@ -18,6 +18,7 @@ const {
   NOTIFICATION_LOG_RETENTION_MS,
   appendNotificationLog,
   compactNotificationLog,
+  lastSuccessfulAt,
   queryNotificationLog,
   resetNotificationLogForTests,
   setNotificationLogNowForTests,
@@ -318,6 +319,26 @@ describe('notification-log store', () => {
     expect(summary.failedUrgentCount).toBe(1);
     const page = await queryNotificationLog({ limit: 20 });
     expect(page.items[0]).toMatchObject({ delivery: 'failed', level: 'urgent' });
+  });
+
+  test('last successful delivery is not hidden by more than twenty later failures', async () => {
+    let clock = Date.parse('2026-08-12T08:00:00.000Z');
+    setNotificationLogNowForTests(() => clock);
+    await seed({ title: 'last good delivery' });
+    const expected = new Date(clock).toISOString();
+    for (let i = 0; i < 21; i += 1) {
+      clock += 1_000;
+      await appendNotificationLog({
+        source: 'watcher',
+        logicalTarget: 'user',
+        logicalChannel: 'user-alerts',
+        level: 'urgent',
+        title: 'not delivered',
+        message: '',
+        delivery: 'failed',
+      });
+    }
+    expect(await lastSuccessfulAt()).toBe(expected);
   });
 
   test('append after a complete last record missing final newline stays readable', async () => {

--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -1225,6 +1225,29 @@ describe('publish success path writes the 30-day notification log', () => {
     expect(logText()).toBe('');
   });
 
+  test('a failed urgent publish records a body-free delivery failure for the dashboard', async () => {
+    await withLivePublish(async () => new Response('nope', { status: 503 }), async (svc) => {
+      await expect(svc.publish({
+        target: 'user',
+        title: 'urgent task update',
+        message: 'do not persist this body',
+        level: 'urgent',
+        source: 'task',
+        sensitive: true,
+      })).rejects.toThrow('notify_unavailable');
+      const page = await queryNotificationLog({ limit: 20 });
+      expect(page.items).toHaveLength(1);
+      expect(page.items[0]).toMatchObject({
+        delivery: 'failed',
+        level: 'urgent',
+        source: 'task',
+        title: 'urgent task update',
+        message: '',
+        sensitive: true,
+      });
+    });
+  });
+
   test('verify() self-call records source=verify on the same success path', async () => {
     let posted = '';
     await withLivePublish(async (input, init) => {

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -1207,6 +1207,7 @@ describe('UI static asset contract', () => {
     expect(UI_JS).toContain('function abortDashboardPollRequests()');
     expect(UI_JS).toContain('abortDashboardPollRequests();');
     expect(UI_JS).toContain("['pointerdown', 'keydown', 'touchstart']");
+    expect(UI_JS).toContain('if (dashboardPollTimer === null) scheduleDashboardPolling();');
     expect(UI_JS).toContain("if (state.scope === 'overview') work = loadHome({ poll: true });");
     expect(UI_JS).toContain("else if (state.scope === 'tasks' && !state.tasksPending) work = loadTasks({ poll: true });");
     expect(UI_JS).toContain("else if (state.scope === 'notifications' && !state.notifyPending) work = loadNotificationLog({ poll: true });");

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -1176,7 +1176,14 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function stopDashboardPolling('),
     );
     expect(home).toContain('state.homeWaitingTotal = typeof waitingPayload.totalApprox === \'number\'');
-    expect(home).toContain('activeTasks.filter(function (task) { return !!task.overdueReason; })');
+    expect(home).toContain('loadHomeActiveOverdue(signal)');
+    expect(home).toContain('state.homeStuckTasks = Array.isArray(results[1].payload) ? results[1].payload : [];');
+    const activeOverdue = UI_JS.slice(
+      UI_JS.indexOf('async function loadHomeActiveOverdue('),
+      UI_JS.indexOf('function homeNumber('),
+    );
+    expect(activeOverdue).toContain('if (task.overdueReason) overdue.push(task);');
+    expect(activeOverdue).toContain('while (cursor && overdue.length < HOME_VISIBLE_ROWS);');
     expect(home).toContain('state.homeFailedUrgentCount = typeof summaryPayload.failedUrgentCount === \'number\'');
     expect(home).not.toContain('state.homeWaitingTasks.length');
   });
@@ -1226,7 +1233,7 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function stopDashboardPolling('),
     );
     expect(home).toContain("homeTaskUrl('input-required')");
-    expect(home).toContain("homeTaskUrl('active')");
+    expect(UI_JS).toContain("homeTaskUrl('active', cursor, HOME_ACTIVE_PAGE_LIMIT)");
     expect(home).toContain("'/ui/api/notify/summary?date=today&tz='");
     expect(home).toContain("isAdmin() && !opts.poll");
     expect(home).toContain("apiJson('/ui/api/overview'");

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -816,6 +816,7 @@ describe('UI static asset contract', () => {
     expect(load).toContain("state.tasksStatus = 'loading'");
     expect(load).toContain('state.tasks = []');
     expect(load).toContain('state.tasksFetchKey = tasksFetchKey()');
+    expect(load).toContain('if (!stillThere && !more && !opts.poll) clearTaskDetail();');
     const renderRows = UI_JS.slice(
       UI_JS.indexOf('function renderTaskRows('),
       UI_JS.indexOf('function renderTaskDetail('),

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -1209,6 +1209,13 @@ describe('UI static asset contract', () => {
     );
     expect(notificationPoll).toContain('if (!opts.poll) {\n        await loadNotifySummary(controller.signal);');
     expect(notificationPoll).toContain('if (!opts.poll && isAdmin() && state.identities.length === 0)');
+    expect(notificationPoll).toContain('if (opts.poll) trackDashboardPollRequest(controller);');
+    expect(notificationPoll).toContain('releaseDashboardPollRequest(controller);');
+    const notificationHistory = UI_JS.slice(
+      UI_JS.indexOf('async function loadNotifyHistory('),
+      UI_JS.indexOf('async function loadNotifySummary('),
+    );
+    expect(notificationHistory).not.toContain('opts.poll');
     expect(UI_JS).toContain('var FRESH_MS = 15000;');
     expect(UI_JS.split(/\b15000\b/).length - 1).toBe(1);
   });

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -1184,9 +1184,15 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function homeNumber('),
     );
     expect(activeOverdue).toContain('if (task.overdueReason) overdue.push(task);');
-    expect(activeOverdue).toContain('while (cursor && overdue.length < HOME_VISIBLE_ROWS);');
+    expect(UI_JS).toContain('var HOME_ACTIVE_MAX_PAGES = 5;');
+    expect(UI_JS).toContain('var HOME_ACTIVE_MAX_ROWS = 500;');
+    expect(activeOverdue).toContain('pages < HOME_ACTIVE_MAX_PAGES && scannedRows < HOME_ACTIVE_MAX_ROWS');
     expect(home).toContain('state.homeFailedUrgentCount = typeof summaryPayload.failedUrgentCount === \'number\'');
     expect(home).not.toContain('state.homeWaitingTasks.length');
+  });
+
+  test('Notifications distinguishes today’s successful deliveries from visible failed rows', () => {
+    expect(UI_JS).toContain('Undelivered notifications are not included in today’s sent count.');
   });
 
   test('Home health respects the identity permission matrix', () => {

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -513,7 +513,7 @@ describe('UI static asset contract', () => {
 
     const identity = run('identity');
     expect(identity.session).toBe('identity');
-    expect(identity.backToHomeHidden).toBe(true);
+    expect(identity.backToHomeHidden).toBe(false);
 
     const admin = run('admin');
     expect(admin.session).toBe('admin');
@@ -770,7 +770,7 @@ describe('UI static asset contract', () => {
   // 任务列表改为服务端 20/50/100 + Load more，不再客户端截 500
   test('task board uses server status/period/limit pagination instead of a client 500 cap', () => {
     expect(UI_JS).not.toContain('var TASKS_RENDER_LIMIT = 500');
-    expect(UI_JS).toContain("state.tasksFilter || 'active'");
+    expect(UI_JS).toContain("state.tasksFilter || 'input-required'");
     expect(UI_JS).toContain("state.tasksPeriod || '30d'");
     expect(UI_JS).toContain("String(state.tasksLimit || 20)");
     expect(UI_JS).toContain("'/ui/api/tasks?' + params.join('&')");
@@ -882,7 +882,7 @@ describe('UI static asset contract', () => {
       'state.tasks = []',
       "state.tasksStatus = 'idle'",
       "state.tasksMessage = ''",
-      "state.tasksFilter = 'active'",
+      "state.tasksFilter = 'input-required'",
       "state.tasksPeriod = '30d'",
       'state.tasksLimit = 20',
       "state.tasksNextCursor = ''",
@@ -967,8 +967,8 @@ describe('UI static asset contract', () => {
     expect(load.slice(assignIdx)).toContain('Some channels could not be loaded');
   });
 
-  // N1 / §1.4：落焦 Overview 面板不许滚动首屏，聚焦返回行的那条路径照旧滚动
-  test('landing on the overview keeps the first screen while a return row still scrolls', () => {
+  // N1：Home 落焦不滚动；一期 Home 不再保留旧的地址行返回焦点。
+  test('landing on Home keeps the first screen and starts the operating desk', () => {
     expect(UI_JS).toContain('overviewPanel.focus({ preventScroll: true });');
     // 面板落焦只有这一个入口，别处不许再裸调 overviewPanel.focus()
     expect(UI_JS).not.toContain('overviewPanel.focus();');
@@ -978,14 +978,12 @@ describe('UI static asset contract', () => {
       UI_JS.indexOf('function enterOverview('),
       UI_JS.indexOf('function openAddress('),
     );
-    expect(enter).toContain('var returnRow = opts.returnTo ? rowButtonFor(opts.returnTo) : null;');
-    // 返回行照常 focus()（要滚到那一行）；没有返回行才走不滚动的面板落焦
-    expect(enter).toContain('if (returnRow) returnRow.focus();');
-    expect(enter).toContain('else focusOverviewPanel();');
+    expect(enter).toContain('focusOverviewPanel();');
+    expect(enter).toContain('loadHome({ refresh: false });');
     expect(enter).not.toContain('preventScroll');
 
-    expect(UI_JS).toContain("'Notifications today'");
-    expect(UI_JS).toContain("'Urgent today'");
+    expect(UI_JS).toContain("'Waiting for you'");
+    expect(UI_JS).toContain("'Urgent pushes today'");
     expect(UI_JS).toContain("'/ui/api/notify/summary?date=today&tz='");
 
     // B6 0 期：Home/非 Mail 深链必须在 Mail 初载前落面，慢邮箱不能挡住首屏。
@@ -1019,28 +1017,20 @@ describe('UI static asset contract', () => {
     expect(overlap).toBeLessThan(updated);
   });
 
-  // F6 / §6 行 19：活动地址消失 → 回 Overview 并播报
+  // F6：活动地址消失 → 回 Home 并播报
   test('a deleted active address migrates the inbox back to the overview', () => {
     const reconcile = UI_JS.slice(
       UI_JS.indexOf('function reconcileActiveAddress() {'),
-      UI_JS.indexOf('function refreshInboxIdentities() {'),
+      UI_JS.indexOf('function focusOverviewPanel() {'),
     );
     expect(reconcile).toContain('if (!state.activeAddress) return;');
     expect(reconcile).toContain("state.activeAddress = '';");
-    expect(reconcile).toContain("if (state.scope !== 'inbox') return;");
-    expect(reconcile).toContain("announce: lost + ' is no longer available. Back to Home.'");
-    // 两个触发点：Overview 周期的 /identities，以及 inbox 里 admin 的手动 Refresh
+    expect(reconcile).toContain("if (state.scope === 'inbox') enterOverview({ announce: lost + ' is no longer available. Back to Home.' });");
+    // Home roster refresh and inbox admin Refresh both reconcile the active address.
     expect(UI_JS).toContain('      reconcileActiveAddress();');
     expect(UI_JS).toContain('if (isAdmin()) refreshInboxIdentities();');
-    expect(UI_JS.split('reconcileActiveAddress();').length - 1).toBe(2);
-    // Inbox identity refresh shares overviewGen so a late response cannot
-    // clobber a push-tier save that bumped the epoch mid-flight.
-    const inboxRefresh = UI_JS.slice(
-      UI_JS.indexOf('function refreshInboxIdentities() {'),
-      UI_JS.indexOf('function loadOverviewCycle('),
-    );
-    expect(inboxRefresh).toContain('var generation = state.overviewGen;');
-    expect(inboxRefresh).toContain('if (generation !== state.overviewGen) return;');
+    expect(UI_JS.split('reconcileActiveAddress();').length - 1).toBeGreaterThanOrEqual(1);
+    expect(UI_JS).toContain('function refreshInboxIdentities() {');
   });
 
   // A18 / A19 / A20 / A21
@@ -1077,7 +1067,7 @@ describe('UI static asset contract', () => {
       "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self'; font-src 'self'; connect-src 'self'; object-src 'none'; frame-src 'self'; form-action 'self'; base-uri 'none'; frame-ancestors 'none'",
     );
     expect(UI_JS).toContain("'/ui/api/overview'");
-    expect(UI_JS).toContain("'/ui/api/overview?refresh=1'");
+    expect(UI_JS).not.toContain("'/ui/api/overview?refresh=1'");
   });
 
   // Satoshi 与 website/public/fonts/ 同源同文件：sha256 钉死，官网换字体这里会红
@@ -1169,8 +1159,8 @@ describe('UI static asset contract', () => {
     expect(UI_CSS).toContain('.link-url { color: var(--ink-dim); font-size: 11px; }');
   });
 
-  // §5.7：截断影响到的行只给下界，绝不显示 0 msgs
-  test('truncated rows render a bound or Unknown, never a zero', () => {
+  // Home 徽标只能读 listBoard 的 totalApprox，不许从列表行数汇总。
+  test('Home uses the server task total and server overdue flag without a client count', () => {
     const countParts = UI_JS.slice(
       UI_JS.indexOf('function countParts('),
       UI_JS.indexOf('function appendCell('),
@@ -1181,114 +1171,59 @@ describe('UI static asset contract', () => {
     expect(countParts).toContain('Lower bound — this scan hit its recipient limit.');
     expect(countParts).toContain('Not counted — this scan hit its recipient limit.');
     expect(countParts).toContain("'Unavailable'");
-    // "(no mail in the current window)" 只挂在 complete 且真为 0 的行上
-    expect(UI_JS).toContain('if (row && row.complete && row.count === 0) {');
-    expect(UI_JS).toContain(
-      'Some counts are incomplete for messages with very large recipient lists (shown as ≥ or Unknown).',
+    const home = UI_JS.slice(
+      UI_JS.indexOf('function loadHome('),
+      UI_JS.indexOf('function stopDashboardPolling('),
     );
-    expect(UI_JS).not.toContain("card('In window'");
+    expect(home).toContain('state.homeWaitingTotal = typeof waitingPayload.totalApprox === \'number\'');
+    expect(home).toContain('activeTasks.filter(function (task) { return !!task.overdueReason; })');
+    expect(home).toContain('state.homeFailedUrgentCount = typeof summaryPayload.failedUrgentCount === \'number\'');
+    expect(home).not.toContain('state.homeWaitingTasks.length');
   });
 
-  // F3 / §2.4 / §10 条 1：exact:false 时总计卡片也是下界，不许摆出精确外观
-  test('total cards fall back to the same lower-bound format as the rows', () => {
-    const bound = UI_JS.slice(
-      UI_JS.indexOf('function boundParts(value, exact) {'),
-      UI_JS.indexOf('function appendCell('),
+  test('Home health respects the identity permission matrix', () => {
+    const home = UI_JS.slice(
+      UI_JS.indexOf('function renderHomeHealth('),
+      UI_JS.indexOf('function renderHomeSessionEmpty('),
     );
-    expect(bound).toContain('if (exact) return { text: formatNumber(value) };');
-    expect(bound).toContain("text: '≥' + formatNumber(value)");
-    expect(bound).toContain("text: 'Unknown'");
-    expect(bound).toContain('Lower bound — this scan hit its recipient limit.');
-    expect(bound).toContain('Not counted — this scan hit its recipient limit.');
-
-    const stats = UI_JS.slice(
-      UI_JS.indexOf('function renderOverviewStats() {'),
-      UI_JS.indexOf('function renderOverviewMeta() {'),
-    );
-    expect(stats).toContain('var exact = !totals || totals.exact !== false;');
-    expect(stats).toContain("card('Unseen', totals ? boundParts(totals.unseenInWindow, exact) : fallback);");
-    expect(stats).toContain(
-      "card('Active 24h', totals ? boundParts(totals.activeAddresses, exact) : fallback);",
-    );
-    // 两个下界字段都不许再无条件 formatNumber；地址数是身份派生量，仍然精确
-    expect(stats).not.toContain('matchedInWindow');
-    expect(stats).not.toContain('formatNumber(totals.unseenInWindow)');
-    expect(stats).not.toContain('formatNumber(totals.activeAddresses)');
-    expect(stats).toContain('formatNumber(totals.addresses)');
-    // unmatchedInWindow 从来不进 DOM
-    expect(UI_JS).not.toContain('unmatchedInWindow');
+    expect(home).toContain("if (isAdmin()) {");
+    expect(home).toContain("healthCard('Addresses', String(state.identities.length), 'configure-identities')");
+    expect(home).toContain("healthCard('Unread mail', homeNumber(state.homeUnseenCount), 'inbox')");
+    expect(home).toContain("healthCard('Mail', 'Open mailbox', 'inbox')");
   });
 
-  // §5.5：唯一轮询规则 + 15 次/20 s 上限
-  test('polling follows the server retryAfterMs and gives up after the cap', () => {
-    expect(UI_JS).toContain('var POLL_LIMIT = 15;');
-    expect(UI_JS).toContain('var POLL_WINDOW_MS = 20000;');
-    expect(UI_JS).toContain('var delay = Math.max(retryAfterMs || 1500, 1000);');
-    expect(UI_JS).toContain('if (payload.revalidating || payload.refreshError) scheduleOverviewPoll(payload.retryAfterMs);');
-    expect(UI_JS).toContain('Message counts are taking too long.');
-    expect(UI_JS).toContain("'Retrying in ' + Math.ceil(payload.retryAfterMs / 1000) + 's…'");
-    // 客户端唯一的新鲜度阈值
+  // N1：仅前台、仅有交互的会话按 30s 轮询；闲置降频，隐藏标签停止。
+  test('dashboard polling is visibility-aware, interaction-throttled, and limited to board/notifications', () => {
+    expect(UI_JS).toContain('var DASHBOARD_POLL_MS = 30000;');
+    expect(UI_JS).toContain('var DASHBOARD_IDLE_POLL_MS = 120000;');
+    expect(UI_JS).toContain('!document.hidden');
+    expect(UI_JS).toContain('function abortDashboardPollRequests()');
+    expect(UI_JS).toContain('abortDashboardPollRequests();');
+    expect(UI_JS).toContain("['pointerdown', 'keydown', 'touchstart']");
+    expect(UI_JS).toContain("if (state.scope === 'overview') work = loadHome({ poll: true });");
+    expect(UI_JS).toContain("else if (state.scope === 'tasks' && !state.tasksPending) work = loadTasks({ poll: true });");
+    expect(UI_JS).toContain("else if (state.scope === 'notifications' && !state.notifyPending) work = loadNotificationLog({ poll: true });");
+    const notificationPoll = UI_JS.slice(
+      UI_JS.indexOf('async function loadNotificationLog('),
+      UI_JS.indexOf('async function handleNotifyVerify('),
+    );
+    expect(notificationPoll).toContain('if (!opts.poll) {\n        await loadNotifySummary(controller.signal);');
+    expect(notificationPoll).toContain('if (!opts.poll && isAdmin() && state.identities.length === 0)');
     expect(UI_JS).toContain('var FRESH_MS = 15000;');
     expect(UI_JS.split(/\b15000\b/).length - 1).toBe(1);
   });
 
-  // §5.3：两条请求各自落地，地址骨架不被 /overview 拖住
-  test('one overview cycle fires both requests under a shared generation guard', () => {
-    const cycle = UI_JS.slice(
-      UI_JS.indexOf('function loadOverviewCycle('),
-      UI_JS.indexOf('function enterOverview('),
+  test('Home reads two board views plus notification summary without identity overview access', () => {
+    const home = UI_JS.slice(
+      UI_JS.indexOf('async function loadHome('),
+      UI_JS.indexOf('function stopDashboardPolling('),
     );
-    expect(cycle).not.toContain('await ');
-    expect(cycle).not.toContain('Promise.all');
-    expect(cycle).toContain('var generation = ++state.overviewGen;');
-    expect(cycle).toContain('state.overviewCycleGen = generation;');
-    expect(cycle.indexOf('identitiesPromise.then')).toBeLessThan(cycle.indexOf('overviewPromise.then'));
-    expect(cycle.split('generation !== state.overviewGen').length - 1).toBe(6);
-    expect(cycle).toContain('renderOverview();');
-    // Stale overview responses clear stuck pending without writing data.
-    expect(cycle).toContain('state.overviewCycleGen !== state.overviewGen');
-    expect(cycle).toContain('state.overviewPending = false;');
-    // Tier save / delete must bump the epoch so a late /identities cannot clobber them.
-    expect(UI_JS).toContain('function bumpIdentityEpoch()');
-    const saveTier = UI_JS.slice(
-      UI_JS.indexOf('async function savePushContentTier('),
-      UI_JS.indexOf('function handlePushTierChange('),
-    );
-    expect(saveTier).toContain('bumpIdentityEpoch()');
-    // Tier save restarts the overview cycle so Refresh cannot stick on "Refreshing…".
-    const handleTier = UI_JS.slice(
-      UI_JS.indexOf('function handlePushTierChange('),
-      UI_JS.indexOf('function formatDate('),
-    );
-    expect(handleTier).toContain("loadOverviewCycle({ refresh: false })");
-    // Only restart while still on Overview (do not revive polling after openAddress).
-    expect(handleTier).toContain("state.scope === 'overview'");
-    // Tier-3 confirm disables Cancel while the PUT is in flight.
-    expect(handleTier).toContain('confirmModalCancel.disabled = true;');
-    expect(handleTier).toContain('confirmModalCancel.disabled = false;');
-    // Per-address pending lock survives re-render so a second select cannot race.
-    expect(UI_JS).toContain('tierPending: {}');
-    expect(handleTier).toContain('state.tierPending[address] = true;');
-    expect(handleTier).toContain('delete state.tierPending[address];');
-    const renderRows = UI_JS.slice(
-      UI_JS.indexOf('function renderOverviewRows('),
-      UI_JS.indexOf('function updateOverviewRefreshButton('),
-    );
-    expect(renderRows).toContain('state.tierPending[model.identity.address]');
-    expect(renderRows).toContain('tierSelect.disabled = true;');
-    // F66: tier <select> is not nested under the row nav role=button.
-    expect(renderRows).toContain("navNode.className = 'overview-row-nav'");
-    expect(renderRows).toContain("navNode.setAttribute('role', 'button')");
-    expect(renderRows).toContain("tierSelect.className = 'push-tier-select'");
-    expect(renderRows.indexOf("rowNode.append(navNode)")).toBeLessThan(
-      renderRows.indexOf('rowNode.append(tierCell)'),
-    );
-    expect(renderRows).toContain("'push tier ' + currentTier");
-    // Row container is neutral (no role=button on overview-row itself).
-    expect(renderRows).not.toContain("rowNode.setAttribute('role', 'button')");
-    expect(renderRows).not.toContain('rowNode.tabIndex = 0');
-    // Return-to-overview focus must land on the focusable nav, not the outer row.
-    expect(UI_JS).toContain("querySelector('.overview-row-nav')");
+    expect(home).toContain("homeTaskUrl('input-required')");
+    expect(home).toContain("homeTaskUrl('active')");
+    expect(home).toContain("'/ui/api/notify/summary?date=today&tz='");
+    expect(home).toContain("isAdmin() && !opts.poll");
+    expect(home).toContain("apiJson('/ui/api/overview'");
+    expect(home).toContain('Promise.resolve(null)');
   });
 
   // F126: an overview rerender during the tier-3 dialog must not allow a
@@ -1309,7 +1244,7 @@ describe('UI static asset contract', () => {
     const pendingSet = handleTier.indexOf('state.tierPending[address] = true;');
     const putStart = handleTier.indexOf('await savePushContentTier(', pendingSet);
     const prologue = handleTier.slice(pendingSet, putStart);
-    expect(prologue).toContain('renderOverviewRows()');
+    expect(prologue).toContain('renderOverview()');
     // F127: apply() rechecks the lock — a stale tier-3 dialog confirm bypasses
     // the entry guard and must drop instead of starting a competing PUT.
     const applyStart = handleTier.indexOf('async function apply(');
@@ -1424,7 +1359,7 @@ describe('UI static asset contract', () => {
     expect(configurePush).toContain('await apply(3, true, openedGen)');
     expect(configurePush).toContain('confirm_risk_required');
     expect(configurePush).toContain('await recoverPushTier(address)');
-    expect(configurePush).toContain("if (state.scope === 'overview') renderOverviewRows()");
+    expect(configurePush).toContain("if (state.scope === 'overview') renderOverview()");
     const catchStart = configurePush.indexOf('} catch (error) {');
     const finallyStart = configurePush.indexOf('} finally {', catchStart);
     expect(catchStart).toBeGreaterThanOrEqual(0);
@@ -1444,7 +1379,7 @@ describe('UI static asset contract', () => {
     expect(catchBody.slice(sessionIdx, fuzzyStart)).not.toContain('recoverPushTier');
     const finallyBody = configurePush.slice(finallyStart);
     expect(finallyBody).toContain("delete state.tierPending[address]");
-    expect(finallyBody).toContain("if (state.scope === 'overview') renderOverviewRows()");
+    expect(finallyBody).toContain("if (state.scope === 'overview') renderOverview()");
     expect(UI_HTML).toContain('id="configure-push-cards"');
     expect(UI_HTML).toContain('id="configure-push-devices"');
     expect(UI_HTML).toContain('id="configure-push-add"');

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('0ef65bcdcfd3e48077f888f8b183303143b365fa293d88ffbc9a364e27ebb1a3');
+    expect(sha256(UI_JS)).toBe('6a0037f12fe52ff1e93cae9b9b776c1a9eefea53eabf349e9b049d4c4151cdcb');
     expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('a09558e67d4b73dbc245bbe3d11124360741b179c2d04eb9959c4563a9669411');
+    expect(sha256(UI_JS)).toBe('5baa5e817b11023c6caacc00d7e6ee7dd84a7b6663f7934433b7976c11ca1f04');
     expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('8ba402d01c2303087be56652b9022def77c4ee2a75dca16b07b5e3da98bb679a');
+    expect(sha256(UI_JS)).toBe('82734e2d92f26346e0a63c830f75daa2a8a253ae37f25f7da90d964a9652d68e');
     expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('82734e2d92f26346e0a63c830f75daa2a8a253ae37f25f7da90d964a9652d68e');
+    expect(sha256(UI_JS)).toBe('0ef65bcdcfd3e48077f888f8b183303143b365fa293d88ffbc9a364e27ebb1a3');
     expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('5baa5e817b11023c6caacc00d7e6ee7dd84a7b6663f7934433b7976c11ca1f04');
+    expect(sha256(UI_JS)).toBe('8ba402d01c2303087be56652b9022def77c4ee2a75dca16b07b5e3da98bb679a');
     expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('f68e5366ec9a2ebb22a0649776f4393e4bd660a3e310aab65a5a176cb0383231');
-    expect(sha256(UI_CSS)).toBe('d6b07b230029b770519425bfbfc72f3be57a62b5d72881c796856adc967e6478');
+    expect(sha256(UI_JS)).toBe('a09558e67d4b73dbc245bbe3d11124360741b179c2d04eb9959c4563a9669411');
+    expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
   });
 });


### PR DESCRIPTION
## Scope

- Replaces the Home overview table with the phase-one operating desk: Waiting for you, Blocked, Health, role-specific empty states, and the admin/identity visibility matrix.
- Defaults Tasks to Waiting for you; task details preserve the prescribed phase-one sequence and make timeline mail expandable.
- Adds server-projected failed urgent-delivery count for Blocked without retaining failed message bodies.
- Adds visibility-aware, interaction-throttled 30-second polling. Hidden tabs abort active polling requests; polling stays in board/notification data paths.

## Contract notes

- `listBoard` exposes per-row `overdueReason`/`overdueAt` and query `totalApprox`; it has no all-tab count payload. Home uses returned totals and overdue flags only, with no client-side tab-count calculation.
- Identity Home never calls `/ui/api/overview`; admin uses its existing unread aggregate only on a non-polling Home load.
- CSP/XSS/Origin contracts and frozen Mail, Push, and login behavior remain unchanged.

## Validation

- `bun test`
- `bun run lint:ui`
- `bun run gold:ui -- --ref origin/main` (expected byte differences for this intentional UI feature PR; new real-file bundle hashes are pinned)
- `bun run typecheck` is currently baseline-red from existing Bun/TypeScript incompatibilities in unrelated routes/tests; this PR adds no reported typecheck path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the Overview page with a Home dashboard showing tasks, health metrics, notification statistics, refresh status, and empty states.
  * Added failed notification delivery tracking and visible indicators.
  * Added expandable task timeline messages.
  * Added dashboard polling across Home, Tasks, and Notifications with visibility-aware refresh behavior.

* **Improvements**
  * Task filters now default to “Input required.”
  * Failed deliveries are excluded from successful totals while urgent failures are counted separately.
  * Improved task pagination, refresh handling, session transitions, and partial-failure states across dashboard views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->