### PR TITLE
fix(ui): align Home cards and widen mail headers

### DIFF
--- a/packages/api/src/ui/client/app.js
+++ b/packages/api/src/ui/client/app.js
@@ -133,6 +133,13 @@
     list.append(term, value);
   }
 
+  function appendMetadataItem(list, labelText, valueText) {
+    var item = document.createElement('div');
+    item.className = 'metadata-item';
+    appendMeta(item, labelText, valueText);
+    list.append(item);
+  }
+
   function selectForManualCopy(sourceNode) {
     var range = document.createRange();
     range.selectNodeContents(sourceNode);
@@ -340,28 +347,24 @@
     }
   }
 
-  function fillMetadata(drawer, detail) {
+  function fillMetadata(drawer, detail, summary) {
     drawer.replaceChildren();
     var heading = document.createElement('h3');
     heading.textContent = 'Headers';
     var meta = document.createElement('dl');
-    meta.className = 'meta';
-    appendMeta(meta, 'From', detail.from);
-    appendMeta(meta, 'To', detail.to);
-    appendMeta(meta, 'Date', formatDate(detail.date));
-    appendMeta(meta, 'Id', detail.id);
-    appendMeta(meta, 'Source', detail.source === 'internal' ? 'internal' : 'external');
+    meta.className = summary ? 'meta metadata-summary' : 'meta';
+    var append = summary ? appendMetadataItem : appendMeta;
+    append(meta, 'From', detail.from);
+    append(meta, 'To', detail.to);
+    append(meta, 'Date', formatDate(detail.date));
+    append(meta, 'Id', detail.id);
+    append(meta, 'Source', detail.source === 'internal' ? 'internal' : 'external');
     drawer.append(heading, meta);
   }
 
   function renderDetail(detail) {
     detailContent.replaceChildren();
     state.bodyView = detail.hasHtml && !detail.htmlTooLarge ? 'rendered' : 'plain';
-
-    var layout = document.createElement('div');
-    layout.className = 'detail-body-layout';
-    var mainCol = document.createElement('div');
-    mainCol.className = 'detail-main-col';
 
     var header = document.createElement('header');
     header.className = 'detail-header';
@@ -447,7 +450,9 @@
     sourceTab.addEventListener('click', function () { selectBodyView('source'); });
     headersTab.addEventListener('click', function () { selectBodyView('headers'); });
 
-    mainCol.append(header, otpHost, tabs);
+    var mainCol = document.createElement('div');
+    mainCol.className = 'detail-main-col';
+    mainCol.append(otpHost, tabs);
     if (detail.htmlTooLarge) {
       var htmlUnavailable = document.createElement('p');
       htmlUnavailable.className = 'notice warning';
@@ -457,12 +462,14 @@
     }
     mainCol.append(body);
 
-    var drawer = document.createElement('aside');
+    var drawer = document.createElement('section');
     drawer.className = 'metadata-drawer';
     drawer.setAttribute('aria-label', 'Message metadata');
-    fillMetadata(drawer, detail);
+    fillMetadata(drawer, detail, true);
 
-    layout.append(mainCol, drawer);
+    var layout = document.createElement('div');
+    layout.className = 'detail-body-layout';
+    layout.append(header, drawer, mainCol);
     detailContent.append(layout);
     selectBodyView(state.bodyView);
   }

--- a/packages/api/src/ui/styles/pages.css
+++ b/packages/api/src/ui/styles/pages.css
@@ -435,16 +435,14 @@
  * Compact fixed tracks+gaps+row pad ≈542px + 210 sidebar + panel pad ≈800px → stack below 820px
  * so portrait tablets (720–800) do not collapse the identity track.
  * 1280 详情列：220 nav + 240 身份 + 360 列表 ≈820，剩余详情约 460。邮件元数据现置于全文宽顶部，
- * 不再与正文争抢横向空间；1100 仍只管 overview 轨与侧栏收窄。
+ * 不再与正文争抢横向空间；1100 以下摘要改为单列，避免嵌套桌面列把元数据压得过窄。
  */
 @media (max-width: 1440px) { .tab-headers { display: inline-flex; min-height: 44px; } }
-@media (max-width: 520px) {
-  .metadata-drawer .metadata-summary { grid-template-columns: minmax(0, 1fr); gap: 8px; }
-  .metadata-summary .metadata-item { grid-column: auto !important; }
-}
 @media (max-width: 1100px) {
   .inbox-view[data-scope="inbox"] .inbox-layout { grid-template-columns: 210px minmax(0, 1fr); }
   .inbox-main { grid-template-columns: 320px minmax(0, 1fr); }
+  .metadata-drawer .metadata-summary { grid-template-columns: minmax(0, 1fr); gap: 8px; }
+  .metadata-summary .metadata-item { grid-column: auto !important; }
   .overview-header, .overview-row {
     gap: 6px;
     grid-template-columns: minmax(0, 1fr) 58px 60px 58px 80px 66px 100px 58px;

--- a/packages/api/src/ui/styles/pages.css
+++ b/packages/api/src/ui/styles/pages.css
@@ -53,15 +53,27 @@
   font-weight: 700;
 }
 .detail-otp { margin: 12px 0 0; }
-.detail-main-col { min-width: 12em; }
-.detail-body-layout { display: grid; grid-template-columns: minmax(12em, 1fr) minmax(0, 240px); gap: 16px; align-items: start; }
+.detail-main-col { min-width: 0; }
+.detail-body-layout { display: grid; gap: 18px; }
 .metadata-drawer {
   border: 1px solid var(--line);
   border-radius: var(--radius);
   background: var(--bg-card);
-  padding: 14px 14px 18px;
+  padding: 13px 16px;
 }
-.metadata-drawer h3 { margin: 0 0 10px; font-size: 13px; letter-spacing: .04em; text-transform: uppercase; color: var(--ink-dim); }
+.metadata-drawer h3 { margin: 0 0 9px; font-size: 11px; letter-spacing: .08em; text-transform: uppercase; color: var(--ink-dim); }
+.metadata-drawer .metadata-summary {
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 10px 16px;
+  margin: 0;
+}
+.metadata-summary .metadata-item { min-width: 0; }
+.metadata-summary .metadata-item:nth-child(-n + 2) { grid-column: span 3; }
+.metadata-summary .metadata-item:nth-child(n + 3) { grid-column: span 2; }
+.metadata-summary .metadata-item dt { font-size: 11px; }
+.metadata-summary .metadata-item dd { margin: 2px 0 0; font-size: 13px; }
+.metadata-summary .metadata-item:nth-child(n + 4) dt,
+.metadata-summary .metadata-item:nth-child(n + 4) dd { color: var(--ink-dim); font-size: 12px; }
 .tab-headers { display: none; }
 .source-body {
   min-height: 180px;
@@ -117,7 +129,7 @@
   gap: 12px;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
 }
-.home-dashboard { grid-template-columns: repeat(3, minmax(0, 1fr)); align-items: start; }
+.home-dashboard { grid-template-columns: repeat(3, minmax(0, 1fr)); align-items: stretch; }
 .home-section, .home-session-empty {
   min-width: 0;
   padding: 16px;
@@ -422,13 +434,13 @@
  * Desktop overview fixed tracks+gaps ≈724px + 240 sidebar + panel pad ≈1044px → compact to 1100px.
  * Compact fixed tracks+gaps+row pad ≈542px + 210 sidebar + panel pad ≈800px → stack below 820px
  * so portrait tablets (720–800) do not collapse the identity track.
- * 1280 详情列：220 nav + 240 身份 + 360 列表 ≈820，剩余详情约 460；再减 padding 与 240 抽屉后主题列 <100px，中文逐字竖排。
- * 抽屉改在 ≤1440 收起（算术含 app-nav）；1100 仍只管 overview 轨与侧栏收窄。
+ * 1280 详情列：220 nav + 240 身份 + 360 列表 ≈820，剩余详情约 460。邮件元数据现置于全文宽顶部，
+ * 不再与正文争抢横向空间；1100 仍只管 overview 轨与侧栏收窄。
  */
-@media (max-width: 1440px) {
-  .detail-body-layout { display: block; }
-  .metadata-drawer { display: none; }
-  .tab-headers { display: inline-flex; min-height: 44px; }
+@media (max-width: 1440px) { .tab-headers { display: inline-flex; min-height: 44px; } }
+@media (max-width: 520px) {
+  .metadata-drawer .metadata-summary { grid-template-columns: minmax(0, 1fr); gap: 8px; }
+  .metadata-summary .metadata-item { grid-column: auto !important; }
 }
 @media (max-width: 1100px) {
   .inbox-view[data-scope="inbox"] .inbox-layout { grid-template-columns: 210px minmax(0, 1fr); }

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -1717,10 +1717,12 @@ describe('UI static asset contract', () => {
     );
   });
 
-  test('1280 detail subject wraps as a row, not per-character vertical CJK', () => {
+  test('1280 detail keeps the subject and metadata in a full-width header', () => {
     expect(UI_CSS).toContain('@media (max-width: 1440px)');
     expect(UI_CSS).toContain('@media (max-width: 1100px)');
-    expect(UI_CSS).toContain('minmax(12em, 1fr) minmax(0, 240px)');
+    expect(UI_CSS).toContain('.detail-body-layout { display: grid; gap: 18px; }');
+    expect(UI_CSS).toContain('.metadata-drawer .metadata-summary');
+    expect(UI_CSS).not.toContain('minmax(12em, 1fr) minmax(0, 240px)');
     expect(UI_CSS).toContain('.detail-header h2 { margin: 5px 0 18px; font-size: clamp(24px, 4vw, 34px); line-height: 1.18; overflow-wrap: break-word; word-break: normal; min-width: 0; }');
     expect(UI_CSS).toContain('.meta { display: grid; grid-template-columns: 58px minmax(0, 1fr); gap: 5px 14px; margin: 0 0 22px; }');
     expect(UI_CSS).toContain('.folder-nav-title');

--- a/packages/api/test/ui-assets.test.ts
+++ b/packages/api/test/ui-assets.test.ts
@@ -1722,6 +1722,7 @@ describe('UI static asset contract', () => {
     expect(UI_CSS).toContain('@media (max-width: 1100px)');
     expect(UI_CSS).toContain('.detail-body-layout { display: grid; gap: 18px; }');
     expect(UI_CSS).toContain('.metadata-drawer .metadata-summary');
+    expect(UI_CSS).toContain('.metadata-drawer .metadata-summary { grid-template-columns: minmax(0, 1fr); gap: 8px; }');
     expect(UI_CSS).not.toContain('minmax(12em, 1fr) minmax(0, 240px)');
     expect(UI_CSS).toContain('.detail-header h2 { margin: 5px 0 18px; font-size: clamp(24px, 4vw, 34px); line-height: 1.18; overflow-wrap: break-word; word-break: normal; min-width: 0; }');
     expect(UI_CSS).toContain('.meta { display: grid; grid-template-columns: 58px minmax(0, 1fr); gap: 5px 14px; margin: 0 0 22px; }');

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('6a0037f12fe52ff1e93cae9b9b776c1a9eefea53eabf349e9b049d4c4151cdcb');
-    expect(sha256(UI_CSS)).toBe('71e5c8e09e6e3e6867b495e39e31fc32a353b481b02a2f6174cfdee0507bc93e');
+    expect(sha256(UI_JS)).toBe('9cd55720ff17035aa7ed0a6258060f6cea809ac445d42947f085059788b3cf08');
+    expect(sha256(UI_CSS)).toBe('fe11c3fc7869a41e270140603edd2e999244c820b37f701c73419dab254b297c');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -100,6 +100,6 @@ describe('UI real-file manifest (#520-A)', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
     expect(sha256(UI_JS)).toBe('9cd55720ff17035aa7ed0a6258060f6cea809ac445d42947f085059788b3cf08');
-    expect(sha256(UI_CSS)).toBe('fe11c3fc7869a41e270140603edd2e999244c820b37f701c73419dab254b297c');
+    expect(sha256(UI_CSS)).toBe('851ba389069a9ae9a8587d9c228ec79a94c035b88792f3afca89ec1fb4e41f77');
   });
 });


### PR DESCRIPTION
## Summary

- Make the three Home dashboard cards stretch to a shared row height.
- Move Mail message metadata into a full-width header strip, ahead of OTP and message views.
- Retain Rendered, Plain text, Source, and mobile Headers views; update intentional UI asset byte pins.

## Validation

- `bun run lint:ui`
- `bun test test/ui-real-files.test.ts` (4 pass)
- `bun test test/ui-assets.test.ts` (71 pass)
- `bun test`: 892 pass, 1 skip, 3 failures that reproduce unchanged on main baseline: phone device ACL corrupt-registry startup; UI enabled by default; UI session persistence admin-key hash.
- Chromium screenshots: `/home/ops/acceptance/2026-08-22-dash-visual/` (`home-1440.png`, `mail-detail-1440.png`, `home-390.png`, `mail-detail-390.png`)

No merge or deployment performed.
