### PR TITLE
Update compose.api-only.yaml

### DIFF
--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -63,7 +63,7 @@ services:
       - "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:3100"
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "bun -e 'fetch(\"http://localhost:3100/healthz\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]
+      test: ["CMD-SHELL", "bun -e 'fetch(\"http://localhost:${API_PORT:-3100}/healthz\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]
       interval: 30s
       timeout: 5s
       retries: 5

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -16,6 +16,7 @@ services:
       DOMAIN: ${DOMAIN:?Set DOMAIN in .env}
       API_KEYS: ${API_KEYS:?Set API_KEYS in .env (openssl rand -hex 32)}
       PORT: ${PORT:-3100}
+      EXTERNAL_PORT: ${EXTERNAL_PORT:-3100?Set EXTERNAL_PORT in .env}
       UI_ENABLED: ${UI_ENABLED:-true}
       ALLOWED_SEND_DOMAINS: ${ALLOWED_SEND_DOMAINS:-}
       # --- external catch-all mailbox access ---
@@ -60,7 +61,7 @@ services:
       # SSH tunnel (ssh -L 3100:127.0.0.1:3100 user@server) or put a TLS
       # reverse proxy in front (see docs/security.md). Set API_BIND=0.0.0.0
       # in .env only if you know exactly why you need it.
-      - "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:${API_PORT:-3100}"
+      - "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:${EXTERNAL_PORT:-3100}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "bun -e 'fetch(\"http://localhost:${API_PORT:-3100}/healthz\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -10,12 +10,12 @@ name: openagentemail
 services:
   api:
     build: ./packages/api
-    container_name: openagent-api
+    container_name: ${CONTAINER_NAME:-openagent-api}
     environment:
       # --- shared API contract env ---
       DOMAIN: ${DOMAIN:?Set DOMAIN in .env}
       API_KEYS: ${API_KEYS:?Set API_KEYS in .env (openssl rand -hex 32)}
-      PORT: 3100
+      PORT: ${PORT:-3100}
       UI_ENABLED: ${UI_ENABLED:-true}
       ALLOWED_SEND_DOMAINS: ${ALLOWED_SEND_DOMAINS:-}
       # --- external catch-all mailbox access ---

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -60,7 +60,7 @@ services:
       # SSH tunnel (ssh -L 3100:127.0.0.1:3100 user@server) or put a TLS
       # reverse proxy in front (see docs/security.md). Set API_BIND=0.0.0.0
       # in .env only if you know exactly why you need it.
-      - "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:3100"
+      - "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:${API_PORT:-3100}"
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "bun -e 'fetch(\"http://localhost:${API_PORT:-3100}/healthz\").then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))'"]

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -55,7 +55,7 @@ services:
       # Auto-delete mail older than this many days (0 = keep forever):
       RETENTION_DAYS: ${RETENTION_DAYS:-30}
     volumes:
-      - api-data:/app/data
+      - ${CONTAINER_NAME:-api-data}:/app/data
     ports:
       # SAFETY DEFAULT: localhost only. Reach it from your agent host over an
       # SSH tunnel (ssh -L 3100:127.0.0.1:3100 user@server) or put a TLS
@@ -71,4 +71,4 @@ services:
       start_period: 10s
 
 volumes:
-  api-data:
+  ${CONTAINER_NAME:-api-data}:


### PR DESCRIPTION
updating to allow multiple instances on one docker container

## Summary

- Updated PORT and container-name to allow to be modifiable when deploying.

## Verification

- List the commands or checks you ran (e.g. `npx -y bun@1.2.21 test` in `packages/api`).

## Checklist

- [ ] Scope stays focused and avoids unrelated cleanup.
- [ ] Tests were added or updated for behavior changes.
- [ ] Docs (README / website docs) were updated in the same PR when behavior changed.
- [ ] Security-sensitive changes were reviewed for secrets, auth, and unsafe defaults.
