### PR TITLE
feat(tasks): add typed approval decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,8 @@ Or the raw JSON config (Claude Desktop, Cursor, Kimi Code):
 | `notify_agent(name, title, message, level?, tags?)` | Wake a named agent without exposing an ntfy topic or token |
 | `notify_check(since?)` | Read recent notifications for the calling identity only |
 | `notify_verify()` | Publish and poll a harmless server-side notification self-check |
-| `task_create(to, subject, body, wait?)` | Assign an email-backed task to another managed identity |
+| `task_create(to, subject, body, wait?)` | Assign an email-backed task to another managed identity; typed approvals add `kind: "approval"` with `approval:{action,expiresAt}` |
+| `task_decide(id, decision)` | Stored reviewer approves or rejects a pending typed approval |
 | `task_list(state?)` | List task threads visible to the calling identity |
 | `task_get(id, wait?)` | Read a task thread and its stamped state history; optionally wait up to 10 minutes |
 | `task_update(id, state, body?, result?)` | Advance a participating task; structured output goes in `result` |

--- a/docs/security.md
+++ b/docs/security.md
@@ -130,13 +130,13 @@ Catch-all 信箱里，身份之间的读边界是**精确整邮箱**匹配（禁
 
 `/mcp` 审计行按 caller 分清：OAuth → `clientId`+`grantId`+`address`；`oa_` → `address`；admin → `address: "admin"`（仅 attribution；REST 侧 actor 行为另案，不在此改）。
 
-### 十五工具四级分层
+### 16 tools / 十六工具四级分层
 
 | 级别 | 工具 | 策略要点 |
 | --- | --- | --- |
 | read | mail_list_messages, mail_read_message, mail_wait_for, mail_list_identities, notify_check, task_list, task_get | 观测 |
 | minimal | mail_mark_seen, task_create | 轻状态变更 |
-| contained | mail_send, task_update, notify_agent, notify_user | 外发 / 唤醒 |
+| contained | mail_send, task_update, task_decide, notify_agent, notify_user | 外发 / 唤醒 |
 | critical | mail_new_identity, notify_verify | **OAuth 票 deny-by-default（403）**；`oa_` 走 REST scope；admin 全通 |
 
 新工具须在注册处声明 tier；未声明 → 注册即报错，HTTP 对未知工具名 403（default deny）。

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1281,7 +1281,11 @@ export async function processWatchedMessage(
         }
       }
       extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
-      const approval = await approvalEventForWatcher(message as FetchMessageObject);
+      // Header presence is only a cheap parser gate, never authentication: a
+      // forged approval header still reaches the full signed parser below.
+      const approval = parsed.headers.has('x-oa-task-approval-event')
+        ? await approvalEventForWatcher(message as FetchMessageObject)
+        : null;
       if (approval) {
         hasAuthenticatedApproval = true;
         approvalPreview = approval.type === 'request'

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -38,6 +38,7 @@ import {
   STRONG_OTP_CUES,
 } from './otp.ts';
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
+import { approvalEventForWatcher } from './tasks.ts';
 import { truncateUtf8Bytes } from './utf8-truncate.ts';
 
 const RECONNECT_INITIAL_MS = 2_000;
@@ -1234,6 +1235,7 @@ export async function processWatchedMessage(
   if (matched.length === 0) return;
 
   let hasOtpOrLink = false;
+  let approvalPreview: string | null = null;
   const extras: MailContentExtras = {
     subject: typeof message.envelope?.subject === 'string' ? message.envelope.subject : '',
     from: formatAddressList(message.envelope?.from as Array<{ name?: string | null; address?: string | null }> | undefined),
@@ -1278,6 +1280,20 @@ export async function processWatchedMessage(
         }
       }
       extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
+      const approval = await approvalEventForWatcher(message as FetchMessageObject);
+      if (approval) {
+        approvalPreview = approval.type === 'request'
+          ? 'Approval request recorded. Open the task dashboard to review.'
+          : approval.type === 'decision'
+            ? `Approval decision recorded: ${approval.decision}.`
+            : 'Approval expired.';
+        // A trusted approval push is intentionally metadata-only. Do not let
+        // arbitrary action arguments/body be reintroduced through OTP/links.
+        extras.preview = approvalPreview;
+        extras.codes = [];
+        extras.links = [];
+        hasOtpOrLink = false;
+      }
     } catch {
       // A malformed message is never an OTP match. `all` policy still sends a
       // payload with no message content, which is safe and useful.
@@ -1290,7 +1306,7 @@ export async function processWatchedMessage(
   // — tier 3 would otherwise truncate a long signed subject URL at the
   // metadata cap and publish an unusable partial link, even when the body
   // independently matched.
-  if (extras.subject) {
+  if (extras.subject && !approvalPreview) {
     const subjectOtp = extractOtp(extras.subject);
     hasOtpOrLink =
       hasOtpOrLink || subjectOtp.codes.length > 0 || subjectOtp.links.length > 0;

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1236,6 +1236,7 @@ export async function processWatchedMessage(
 
   let hasOtpOrLink = false;
   let approvalPreview: string | null = null;
+  let hasAuthenticatedApproval = false;
   const extras: MailContentExtras = {
     subject: typeof message.envelope?.subject === 'string' ? message.envelope.subject : '',
     from: formatAddressList(message.envelope?.from as Array<{ name?: string | null; address?: string | null }> | undefined),
@@ -1282,6 +1283,7 @@ export async function processWatchedMessage(
       extras.preview = boundPreviewChars(text, PUSH_BODY_PREVIEW_CHARS);
       const approval = await approvalEventForWatcher(message as FetchMessageObject);
       if (approval) {
+        hasAuthenticatedApproval = true;
         approvalPreview = approval.type === 'request'
           ? 'Approval request recorded. Open the task dashboard to review.'
           : approval.type === 'decision'
@@ -1331,7 +1333,7 @@ export async function processWatchedMessage(
       if (!extras.codes.includes(code)) extras.codes.push(code);
     }
   }
-  if (policy === 'otp' && !hasOtpOrLink) return;
+  if (policy === 'otp' && !hasOtpOrLink && !hasAuthenticatedApproval) return;
 
   const clickUrl = options.clickUrl;
   // Tier-2 metadata mask is message-level; compute at most once per mail.

--- a/packages/api/src/lib/tasks.ts
+++ b/packages/api/src/lib/tasks.ts
@@ -189,6 +189,8 @@ export type TaskService = {
   create(input: CreateTaskInput): Promise<Task>;
   list(state?: TaskState): Promise<Task[]>;
   listBoard(query: TaskBoardQuery, viewer: TaskBoardViewer): Promise<TaskBoardPage>;
+  /** Raw durable/queued view for route authorization; never materializes expiry. */
+  getForAuthorization?(id: string): Promise<Task | null>;
   get(id: string): Promise<Task | null>;
   update(input: UpdateTaskInput): Promise<Task | null>;
   reply(input: { id: string; from: string; body: string }): Promise<Task>;
@@ -540,7 +542,7 @@ async function parseTaskMessage(message: FetchMessageObject, id: string): Promis
       date: new Date(message.internalDate ?? message.envelope.date ?? new Date(0)).toISOString(),
       state: headerState,
       body,
-      ...(result !== undefined ? { result } : {}),
+      ...(approvalPayload.event !== 'request' && result !== undefined ? { result } : {}),
       approval,
     };
   }
@@ -891,8 +893,7 @@ function eventIsIndexed(task: Task, queued: QueuedEvent): boolean {
       const indexed = message.approval;
       if (!indexed || indexed.type !== queuedApproval.type || indexed.digest !== queuedApproval.digest) return false;
       if (indexed.type === 'decision' && (queuedApproval.type !== 'decision' || indexed.decision !== queuedApproval.decision)) return false;
-      const at = Date.parse(message.date);
-      return message.state === queued.message.state && Number.isFinite(at) && at >= queued.sentAt - 1000;
+      return message.state === queued.message.state;
     });
   }
   return (
@@ -1539,6 +1540,7 @@ export const taskService: TaskService = {
   createApproval: createApprovalTask,
   list: listTasks,
   listBoard: listTaskBoard,
+  getForAuthorization: getTaskSnapshot,
   get: getTask,
   update: updateTask,
   reply: replyTask,

--- a/packages/api/src/lib/tasks.ts
+++ b/packages/api/src/lib/tasks.ts
@@ -1286,6 +1286,7 @@ export async function remindTask(input: {
     const existing = await getTaskSnapshot(input.id);
     if (!existing) throw new Error('not_found');
     if (!taskParticipants(existing).has(input.from)) throw new Error('task_participant_required');
+    if (existing.kind === 'approval') throw new Error('approval_decision_required');
     if (!canAdvanceTask(existing.state)) throw new Error('task_already_terminal');
     if (input.idempotencyKey) {
       const replay = existing.messages.find(

--- a/packages/api/src/lib/tasks.ts
+++ b/packages/api/src/lib/tasks.ts
@@ -4,10 +4,11 @@
  * store and the task view can always be rebuilt after an API restart.
  */
 
-import { createHmac, randomUUID } from 'node:crypto';
+import { createHash, createHmac, randomUUID } from 'node:crypto';
 import { simpleParser } from 'mailparser';
 import type { FetchMessageObject } from 'imapflow';
 import { config } from './config.ts';
+import { findIdentity } from './identities.ts';
 import { withInbox, waitForMessage } from './imap.ts';
 import { notifyTrustedAgentDelivery } from './notify.ts';
 import { sendMail, type SendInput } from './smtp.ts';
@@ -57,8 +58,33 @@ const PERIOD_MS: Record<TaskBoardPeriod, number> = {
 /** 催办不是状态转移；IMAP 重建时必须能与 working 区分。 */
 export type TaskEventKind = 'state' | 'reminder';
 
+export type ApprovalAction = {
+  type: string;
+  name: string;
+  arguments: unknown;
+};
+
+export type ApprovalSnapshot = {
+  action: ApprovalAction;
+  reviewer: string;
+  expiresAt: string;
+  digest: string;
+};
+
+export type ApprovalEvent =
+  | { type: 'request'; snapshot: ApprovalSnapshot }
+  | { type: 'decision'; digest: string; decision: 'approved' | 'rejected' }
+  | { type: 'expired'; digest: string };
+
+type ApprovalEventPayload =
+  | { event: 'request'; digest: string; reviewer: string; expiresAt: string }
+  | { event: 'decision'; digest: string; decision: 'approved' | 'rejected'; reviewer: string; decidedAt: string }
+  | { event: 'expired'; digest: string; expiredAt: string };
+
 const TASK_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const RESULT_MARKER = '<!-- openagent.email task result -->';
+const APPROVAL_MARKER = '<!-- openagent.email approval snapshot -->';
+const APPROVAL_DIGEST_RE = /^[a-f0-9]{64}$/;
 const sleep = (milliseconds: number) => new Promise<void>((resolve) => setTimeout(resolve, milliseconds));
 
 export type TaskMessage = {
@@ -73,6 +99,7 @@ export type TaskMessage = {
   /** 缺省为 state 转移；reminder 不改变 task.state。 */
   kind?: TaskEventKind;
   idempotencyKey?: string;
+  approval?: ApprovalEvent;
 };
 
 export type Task = {
@@ -85,7 +112,15 @@ export type Task = {
   updatedAt: string;
   messages: TaskMessage[];
   result?: unknown;
+  kind?: 'approval';
+  approval?: ApprovalSnapshot;
 };
+
+export type ApprovalTask = Task & { kind: 'approval'; approval: ApprovalSnapshot };
+
+function isApprovalTask(task: Task): task is ApprovalTask {
+  return task.kind === 'approval' && !!task.approval;
+}
 
 export type RawTaskMessage = {
   uid: number;
@@ -98,6 +133,7 @@ export type RawTaskMessage = {
   result?: unknown;
   kind?: TaskEventKind;
   idempotencyKey?: string;
+  approval?: ApprovalEvent;
 };
 
 export type CreateTaskInput = {
@@ -105,6 +141,15 @@ export type CreateTaskInput = {
   to: string;
   subject: string;
   body: string;
+};
+
+export type CreateApprovalTaskInput = {
+  from: string;
+  to: string;
+  subject: string;
+  body?: string;
+  action: ApprovalAction;
+  expiresAt: string;
 };
 
 export type UpdateTaskInput = {
@@ -154,6 +199,9 @@ export type TaskService = {
     idempotencyKey?: string;
   }): Promise<Task>;
   close(input: { id: string; from: string; reason: string }): Promise<Task>;
+  /** Additive #55 core. REST decision routing remains a later round. */
+  createApproval?(input: CreateApprovalTaskInput): Promise<ApprovalTask>;
+  decideApproval?(input: { id: string; from: string; decision: 'approved' | 'rejected' }): Promise<ApprovalTask>;
   waitForTerminal(id: string, address: string, timeoutSec?: number): Promise<Task | null>;
 };
 
@@ -170,11 +218,120 @@ export function canAdvanceTask(current: TaskState): boolean {
   return !TERMINAL_TASK_STATES.includes(current);
 }
 
+/** JSON canonicalization used by the approval digest recipe: recursively sort
+ * object keys, preserve array order, and serialize without whitespace. */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('invalid_approval_action');
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(',')}]`;
+  if (!value || typeof value !== 'object' || Object.getPrototypeOf(value) !== Object.prototype) {
+    throw new Error('invalid_approval_action');
+  }
+  const object = value as Record<string, unknown>;
+  return `{${Object.keys(object).sort().map((key) => `${JSON.stringify(key)}:${canonicalJson(object[key])}`).join(',')}}`;
+}
+
+function normalizedApprovalAction(value: unknown): ApprovalAction {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) throw new Error('invalid_approval_action');
+  const input = value as Record<string, unknown>;
+  if (
+    Object.keys(input).length !== 3
+    || typeof input.type !== 'string' || !input.type
+    || typeof input.name !== 'string' || !input.name
+    || !Object.prototype.hasOwnProperty.call(input, 'arguments')
+  ) throw new Error('invalid_approval_action');
+  // Parse the canonical form back so callers cannot mutate the persisted
+  // snapshot after creation and so only JSON values cross the event boundary.
+  return JSON.parse(canonicalJson({ type: input.type, name: input.name, arguments: input.arguments })) as ApprovalAction;
+}
+
+/** Reproducible recipe: SHA-256 of canonical UTF-8 JSON, lower-case hex. */
+export function canonicalApprovalAction(action: unknown): string {
+  return canonicalJson(normalizedApprovalAction(action));
+}
+
+export function approvalActionDigest(action: unknown): string {
+  return createHash('sha256').update(canonicalApprovalAction(action), 'utf8').digest('hex');
+}
+
+function validApprovalExpiry(expiresAt: string, now = nowMs()): boolean {
+  const time = Date.parse(expiresAt);
+  return Number.isFinite(time) && time > now;
+}
+
+export function isApprovalExpired(expiresAt: string, now = nowMs()): boolean {
+  const time = Date.parse(expiresAt);
+  return !Number.isFinite(time) || now >= time;
+}
+
 /** A private signature makes a copied client-side task header non-authoritative. */
 function taskStamp(id: string, state: TaskState, from: string, to: string): string {
   return createHmac('sha256', config.taskSigningSecret)
     .update(`${id}\n${state}\n${from.toLowerCase()}\n${to.toLowerCase()}`)
     .digest('base64url');
+}
+
+function approvalStamp(
+  id: string,
+  state: TaskState,
+  from: string,
+  to: string,
+  payload: string,
+): string {
+  return createHmac('sha256', config.taskSigningSecret)
+    .update(`approval-event-v1\n${id}\n${state}\n${from.toLowerCase()}\n${to.toLowerCase()}\n${payload}`)
+    .digest('base64url');
+}
+
+/** One canonical, domain-separated signed payload for every authoritative
+ * approval event. Headers carry base64url so the RFC field itself is inert. */
+function canonicalApprovalEventPayload(payload: ApprovalEventPayload): string {
+  return canonicalJson(payload);
+}
+
+function approvalPayloadHeader(payload: string): string {
+  return Buffer.from(payload, 'utf8').toString('base64url');
+}
+
+function readApprovalPayloadHeader(value: unknown): { payload: ApprovalEventPayload; canonical: string } | null {
+  if (typeof value !== 'string' || !value) return null;
+  try {
+    const bytes = Buffer.from(value, 'base64url');
+    if (!bytes.length || bytes.toString('base64url') !== value) return null;
+    const decoded = bytes.toString('utf8');
+    const parsed = JSON.parse(decoded) as Record<string, unknown>;
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) || typeof parsed.event !== 'string') return null;
+    let payload: ApprovalEventPayload;
+    if (
+      parsed.event === 'request'
+      && typeof parsed.digest === 'string' && APPROVAL_DIGEST_RE.test(parsed.digest)
+      && typeof parsed.reviewer === 'string' && typeof parsed.expiresAt === 'string'
+      && Number.isFinite(Date.parse(parsed.expiresAt))
+      && Object.keys(parsed).length === 4
+    ) payload = { event: 'request', digest: parsed.digest, reviewer: parsed.reviewer.toLowerCase(), expiresAt: parsed.expiresAt };
+    else if (
+      parsed.event === 'decision'
+      && typeof parsed.digest === 'string' && APPROVAL_DIGEST_RE.test(parsed.digest)
+      && (parsed.decision === 'approved' || parsed.decision === 'rejected')
+      && typeof parsed.reviewer === 'string' && typeof parsed.decidedAt === 'string'
+      && Number.isFinite(Date.parse(parsed.decidedAt))
+      && Object.keys(parsed).length === 5
+    ) payload = { event: 'decision', digest: parsed.digest, decision: parsed.decision, reviewer: parsed.reviewer.toLowerCase(), decidedAt: parsed.decidedAt };
+    else if (
+      parsed.event === 'expired'
+      && typeof parsed.digest === 'string' && APPROVAL_DIGEST_RE.test(parsed.digest)
+      && typeof parsed.expiredAt === 'string' && Number.isFinite(Date.parse(parsed.expiredAt))
+      && Object.keys(parsed).length === 3
+    ) payload = { event: 'expired', digest: parsed.digest, expiredAt: parsed.expiredAt };
+    else return null;
+    const canonical = canonicalApprovalEventPayload(payload);
+    return decoded === canonical ? { payload, canonical } : null;
+  } catch {
+    return null;
+  }
 }
 
 /** 催办 stamp 与状态转移分离，避免伪装成 working。 */
@@ -189,6 +346,25 @@ function taskHeaders(id: string, state: TaskState, from: string, to: string): Re
     'X-OA-Task': id,
     'X-OA-Task-State': state,
     'X-OA-Task-Stamp': taskStamp(id, state, from, to),
+  };
+}
+
+function approvalHeaders(
+  id: string,
+  state: TaskState,
+  from: string,
+  to: string,
+  payload: ApprovalEventPayload,
+): Record<string, string> {
+  const canonical = canonicalApprovalEventPayload(payload);
+  return {
+    'X-OA-Task': id,
+    'X-OA-Task-State': state,
+    'X-OA-Task-Approval-Event': payload.event,
+    'X-OA-Task-Approval-Digest': payload.digest,
+    ...(payload.event === 'decision' ? { 'X-OA-Task-Approval-Decision': payload.decision } : {}),
+    'X-OA-Task-Approval-Payload': approvalPayloadHeader(canonical),
+    'X-OA-Task-Stamp': approvalStamp(id, state, from, to, canonical),
   };
 }
 
@@ -218,6 +394,60 @@ function taskBody(body: string, result: unknown): string {
   return [plain, resultBlock(result)].filter(Boolean).join('\n\n');
 }
 
+function approvalRequestBody(body: string | undefined, snapshot: ApprovalSnapshot): string {
+  const plain = (body ?? '').trim();
+  const block = `${APPROVAL_MARKER}\n\`\`\`json\n${JSON.stringify(snapshot)}\n\`\`\``;
+  return [plain, block].filter(Boolean).join('\n\n');
+}
+
+function readApprovalSnapshot(body: string): ApprovalSnapshot | null {
+  const marker = body.lastIndexOf(APPROVAL_MARKER);
+  if (marker < 0) return null;
+  const match = body.slice(marker + APPROVAL_MARKER.length).match(/^\s*```json\s*\n([\s\S]*?)\n```/);
+  if (!match) return null;
+  try {
+    const parsed = JSON.parse(match[1]) as Record<string, unknown>;
+    if (
+      Object.keys(parsed).length !== 4
+      || !Object.prototype.hasOwnProperty.call(parsed, 'action')
+      || typeof parsed.reviewer !== 'string'
+      || typeof parsed.expiresAt !== 'string'
+      || typeof parsed.digest !== 'string'
+      || !APPROVAL_DIGEST_RE.test(parsed.digest)
+    ) return null;
+    const action = normalizedApprovalAction(parsed.action);
+    if (approvalActionDigest(action) !== parsed.digest || !Number.isFinite(Date.parse(parsed.expiresAt))) return null;
+    return { action, reviewer: parsed.reviewer.toLowerCase(), expiresAt: parsed.expiresAt, digest: parsed.digest };
+  } catch {
+    return null;
+  }
+}
+
+function readApprovalDecision(result: unknown): { decision: 'approved' | 'rejected'; digest: string; reviewer: string; decidedAt: string } | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return null;
+  const value = result as Record<string, unknown>;
+  if (
+    Object.keys(value).length !== 4
+    || (value.decision !== 'approved' && value.decision !== 'rejected')
+    || typeof value.digest !== 'string' || !APPROVAL_DIGEST_RE.test(value.digest)
+    || typeof value.reviewer !== 'string' || typeof value.decidedAt !== 'string'
+    || !Number.isFinite(Date.parse(value.decidedAt))
+  ) return null;
+  return { decision: value.decision, digest: value.digest, reviewer: value.reviewer.toLowerCase(), decidedAt: value.decidedAt };
+}
+
+function readApprovalExpiry(result: unknown): { decision: 'expired'; digest: string; expiredAt: string } | null {
+  if (!result || typeof result !== 'object' || Array.isArray(result)) return null;
+  const value = result as Record<string, unknown>;
+  if (
+    Object.keys(value).length !== 3
+    || value.decision !== 'expired'
+    || typeof value.digest !== 'string' || !APPROVAL_DIGEST_RE.test(value.digest)
+    || typeof value.expiredAt !== 'string' || !Number.isFinite(Date.parse(value.expiredAt))
+  ) return null;
+  return { decision: 'expired', digest: value.digest, expiredAt: value.expiredAt };
+}
+
 function isStampedTaskMessage(
   id: string,
   state: TaskState,
@@ -241,7 +471,78 @@ async function parseTaskMessage(message: FetchMessageObject, id: string): Promis
   const stamp = parsed.headers.get('x-oa-task-stamp');
   const eventRaw = parsed.headers.get('x-oa-task-event');
   const idempotencyRaw = parsed.headers.get('x-oa-task-idempotency-key');
+  const approvalEventRaw = parsed.headers.get('x-oa-task-approval-event');
+  const approvalDigestRaw = parsed.headers.get('x-oa-task-approval-digest');
+  const approvalDecisionRaw = parsed.headers.get('x-oa-task-approval-decision');
+  const approvalPayloadRaw = parsed.headers.get('x-oa-task-approval-payload');
   if (headerId !== id || typeof headerState !== 'string' || !isTaskState(headerState)) return null;
+  const body = (parsed.text ?? '').trim();
+  const result = readResult(body);
+  if (typeof approvalEventRaw === 'string') {
+    if (
+      (approvalEventRaw !== 'request' && approvalEventRaw !== 'decision' && approvalEventRaw !== 'expired')
+      || typeof approvalDigestRaw !== 'string' || !APPROVAL_DIGEST_RE.test(approvalDigestRaw)
+      || typeof stamp !== 'string'
+    ) return null;
+    const payloadHeader = readApprovalPayloadHeader(approvalPayloadRaw);
+    if (!payloadHeader || payloadHeader.payload.event !== approvalEventRaw || payloadHeader.payload.digest !== approvalDigestRaw) return null;
+    const approvalPayload = payloadHeader.payload;
+    const decision = approvalDecisionRaw === 'approved' || approvalDecisionRaw === 'rejected' ? approvalDecisionRaw : undefined;
+    if (
+      (approvalPayload.event === 'decision' && (decision === undefined || approvalPayload.decision !== decision))
+      || (approvalPayload.event !== 'decision' && approvalDecisionRaw !== undefined)
+      || stamp !== approvalStamp(id, headerState, from, to, payloadHeader.canonical)
+    ) return null;
+    let approval: ApprovalEvent;
+    if (approvalPayload.event === 'request') {
+      const snapshot = readApprovalSnapshot(body);
+      if (
+        headerState !== 'input-required'
+        || decision !== undefined
+        || !snapshot
+        || snapshot.digest !== approvalDigestRaw
+        || snapshot.reviewer !== approvalPayload.reviewer
+        || snapshot.expiresAt !== approvalPayload.expiresAt
+        || snapshot.reviewer !== to
+        || snapshot.reviewer === from
+      ) return null;
+      approval = { type: 'request', snapshot };
+    } else if (approvalPayload.event === 'decision') {
+      const resultDecision = readApprovalDecision(result);
+      if (
+        headerState !== 'completed'
+        || !decision
+        || !resultDecision
+        || resultDecision.decision !== decision
+        || resultDecision.digest !== approvalDigestRaw
+        || resultDecision.reviewer !== approvalPayload.reviewer
+        || resultDecision.decidedAt !== approvalPayload.decidedAt
+        || resultDecision.reviewer !== from
+      ) return null;
+      approval = { type: 'decision', digest: approvalDigestRaw, decision };
+    } else {
+      const resultExpiry = readApprovalExpiry(result);
+      if (
+        headerState !== 'failed'
+        || decision !== undefined
+        || !resultExpiry
+        || resultExpiry.digest !== approvalDigestRaw
+        || resultExpiry.expiredAt !== approvalPayload.expiredAt
+      ) return null;
+      approval = { type: 'expired', digest: approvalDigestRaw };
+    }
+    return {
+      uid: message.uid,
+      from,
+      to,
+      subject: parsed.subject ?? message.envelope.subject ?? '',
+      date: new Date(message.internalDate ?? message.envelope.date ?? new Date(0)).toISOString(),
+      state: headerState,
+      body,
+      ...(result !== undefined ? { result } : {}),
+      approval,
+    };
+  }
   const isReminder = eventRaw === 'reminder';
   if (isReminder) {
     if (typeof stamp !== 'string' || stamp !== reminderStamp(id, headerState, from, to)) return null;
@@ -249,7 +550,6 @@ async function parseTaskMessage(message: FetchMessageObject, id: string): Promis
     return null;
   }
 
-  const body = (parsed.text ?? '').trim();
   return {
     uid: message.uid,
     from,
@@ -258,7 +558,7 @@ async function parseTaskMessage(message: FetchMessageObject, id: string): Promis
     date: new Date(message.internalDate ?? message.envelope.date ?? new Date(0)).toISOString(),
     state: headerState,
     body,
-    ...(readResult(body) !== undefined ? { result: readResult(body) } : {}),
+    ...(result !== undefined ? { result } : {}),
     ...(isReminder ? { kind: 'reminder' as const } : {}),
     ...(typeof idempotencyRaw === 'string' && idempotencyRaw ? { idempotencyKey: idempotencyRaw } : {}),
   };
@@ -273,6 +573,46 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
   const participants = new Set([first.from, first.to]);
   if (participants.size !== 2) return null;
   if (ordered.some((message) => !participants.has(message.from) || !participants.has(message.to))) return null;
+  const request = first.approval;
+  if (request?.type === 'request') {
+    const snapshot = request.snapshot;
+    if (
+      first.state !== 'input-required'
+      || snapshot.reviewer !== first.to
+      || snapshot.reviewer === first.from
+      || approvalActionDigest(snapshot.action) !== snapshot.digest
+      || !Number.isFinite(Date.parse(snapshot.expiresAt))
+      || ordered.some((message) => {
+        const event = message.approval;
+        if (!event) return true;
+        if (event.type === 'request') return message !== first;
+        return event.digest !== snapshot.digest;
+      })
+    ) return null;
+    // Only parser-validated approval events reach this point. Select the
+    // mailbox-first terminal decision deterministically even if a duplicate
+    // or a later validly stamped conflicting event exists.
+    const terminal = ordered.find((message) =>
+      message.approval?.type === 'decision' || message.approval?.type === 'expired',
+    ) ?? first;
+    const messages = ordered.map(({ uid, ...message }) => ({ id: String(uid), ...message }));
+    return {
+      id,
+      from: first.from,
+      to: first.to,
+      subject: first.subject,
+      state: terminal.state,
+      createdAt: first.date,
+      updatedAt: boardUpdatedAt(ordered, terminal),
+      messages,
+      ...(terminal.result !== undefined ? { result: terminal.result } : {}),
+      kind: 'approval',
+      approval: snapshot,
+    };
+  }
+  // An approval decision without the authenticated immutable request is never
+  // allowed to masquerade as an ordinary task thread.
+  if (ordered.some((message) => message.approval)) return null;
   // Once an API-stamped terminal event exists it is immutable. A copied old
   // (but validly signed) submitted/working mail can appear again in IMAP, but
   // it cannot reopen the completed/failed task. Before that point normal
@@ -353,7 +693,9 @@ async function findTaskMessages(id: string): Promise<RawTaskMessage[]> {
   });
 }
 
-export async function getTask(id: string): Promise<Task | null> {
+/** Raw durable/queued snapshot. Lock-holding writers must use this rather
+ * than public getTask(), whose approval read path may itself materialize. */
+async function getTaskSnapshot(id: string): Promise<Task | null> {
   if (!isTaskId(id)) return null;
   // 单测注入内存目录，避免并发 reply / IMAP 滞后 reminder 回归打真 IMAP。
   const raw = getTaskForTests
@@ -361,6 +703,21 @@ export async function getTask(id: string): Promise<Task | null> {
     : taskFromMessages(id, await findTaskMessages(id));
   // SMTP 已接受但 Dovecot 尚未索引时，把刚发出的 synthetic 事件并进读路径。
   return raw ? mergeQueuedEvents(raw) : null;
+}
+
+/** Service detail reads lazily make an expired approval terminal. There is no
+ * scheduler or list sweep: only the next detail/wait/decision observes it. */
+async function materializeApprovalExpiry(task: Task | null): Promise<Task | null> {
+  if (!task || !isApprovalTask(task) || task.state !== 'input-required' || !isApprovalExpired(task.approval.expiresAt)) return task;
+  return withTaskLock(task.id, async () => {
+    const current = await getTaskSnapshot(task.id);
+    if (!current || !isApprovalTask(current) || current.state !== 'input-required' || !isApprovalExpired(current.approval.expiresAt)) return current;
+    return materializeApprovalExpiryUnlocked(current);
+  });
+}
+
+export async function getTask(id: string): Promise<Task | null> {
+  return materializeApprovalExpiry(await getTaskSnapshot(id));
 }
 
 export async function listTasks(state?: TaskState): Promise<Task[]> {
@@ -418,6 +775,58 @@ export async function createTask(input: CreateTaskInput): Promise<Task> {
   void notifyTrustedAgentDelivery(input.to);
   invalidateTaskListCache();
   return syntheticTask(input, id, messageId);
+}
+
+function knownManagedIdentity(address: string): boolean {
+  return address.split('@')[1]?.toLowerCase() === config.domain && !!findIdentity(address);
+}
+
+/** Creates the only mutable approval request event. The action is recorded,
+ * never executed; its canonical snapshot is immutable after this point. */
+export async function createApprovalTask(input: CreateApprovalTaskInput): Promise<ApprovalTask> {
+  const from = input.from.toLowerCase();
+  const to = input.to.toLowerCase();
+  if (from === to) throw new Error('approval_participants_must_differ');
+  if (!knownManagedIdentity(from) || !knownManagedIdentity(to)) throw new Error('approval_identity_required');
+  if (!validApprovalExpiry(input.expiresAt)) throw new Error('invalid_approval_expiry');
+  const action = normalizedApprovalAction(input.action);
+  const digest = approvalActionDigest(action);
+  const snapshot: ApprovalSnapshot = { action, reviewer: to, expiresAt: input.expiresAt, digest };
+  const id = randomUUID();
+  const text = approvalRequestBody(input.body, snapshot);
+  const { messageId } = await deliverMail({
+    from,
+    to: [to],
+    subject: input.subject,
+    text,
+    headers: approvalHeaders(id, 'input-required', from, to, {
+      event: 'request', digest, reviewer: to, expiresAt: input.expiresAt,
+    }),
+  });
+  void notifyTrustedAgentDelivery(to);
+  invalidateTaskListCache();
+  const now = new Date(nowMs()).toISOString();
+  return {
+    id,
+    from,
+    to,
+    subject: input.subject,
+    state: 'input-required',
+    createdAt: now,
+    updatedAt: now,
+    messages: [{
+      id: messageId,
+      from,
+      to,
+      subject: input.subject,
+      date: now,
+      state: 'input-required',
+      body: text,
+      approval: { type: 'request', snapshot },
+    }],
+    kind: 'approval',
+    approval: snapshot,
+  };
 }
 
 const taskLocks = new Map<string, Promise<void>>();
@@ -562,8 +971,9 @@ async function withTaskLock<T>(id: string, fn: () => Promise<T>): Promise<T> {
  *（同 id 会自死锁）。调用方负责在锁内完成前置状态断言。
  */
 async function updateTaskUnlocked(input: UpdateTaskInput, existing?: Task): Promise<Task | null> {
-  const current = existing ?? await getTask(input.id);
+  const current = existing ?? await getTaskSnapshot(input.id);
   if (!current) return null;
+  if (isApprovalTask(current)) throw new Error('approval_decision_required');
   if (!taskParticipants(current).has(input.from)) throw new Error('task_participant_required');
   if (!canAdvanceTask(current.state)) throw new Error('task_already_terminal');
 
@@ -591,7 +1001,7 @@ async function updateTaskUnlocked(input: UpdateTaskInput, existing?: Task): Prom
     ...(input.result !== undefined ? { result: input.result } : {}),
   };
   const queued = { message: eventMessage, sentAt: Date.parse(now) || nowMs() };
-  const persisted = await getTask(current.id);
+  const persisted = await getTaskSnapshot(current.id);
   // IMAP 未索引时不得把旧 state 当真；把 synthetic 转移排进 overlay，后续读才能拒冲突。
   if (persisted && eventIsIndexed(persisted, queued)) return persisted;
   queueEventUntilIndexed(current.id, eventMessage);
@@ -606,6 +1016,106 @@ async function updateTaskUnlocked(input: UpdateTaskInput, existing?: Task): Prom
 
 export async function updateTask(input: UpdateTaskInput): Promise<Task | null> {
   return withTaskLock(input.id, async () => updateTaskUnlocked(input));
+}
+
+async function writeApprovalTerminal(
+  current: ApprovalTask,
+  input: { from: string; state: 'completed' | 'failed'; event: 'decision' | 'expired'; decision?: 'approved' | 'rejected'; result: Record<string, unknown> },
+): Promise<ApprovalTask> {
+  const to = input.from === current.from ? current.to : current.from;
+  const payload: ApprovalEventPayload = input.event === 'decision'
+    ? (() => {
+      const result = readApprovalDecision(input.result);
+      if (!result || !input.decision || result.digest !== current.approval.digest || result.decision !== input.decision || result.reviewer !== input.from.toLowerCase()) {
+        throw new Error('invalid_approval_decision_event');
+      }
+      return {
+        event: 'decision', digest: result.digest, decision: result.decision,
+        reviewer: result.reviewer, decidedAt: result.decidedAt,
+      };
+    })()
+    : (() => {
+      const result = readApprovalExpiry(input.result);
+      if (!result || result.digest !== current.approval.digest) throw new Error('invalid_approval_expiry_event');
+      return { event: 'expired', digest: result.digest, expiredAt: result.expiredAt };
+    })();
+  const text = taskBody('', input.result);
+  const { messageId } = await deliverMail({
+    from: input.from,
+    to: [to],
+    subject: current.subject,
+    text,
+    headers: approvalHeaders(current.id, input.state, input.from, to, payload),
+  });
+  void notifyTrustedAgentDelivery(to);
+  invalidateTaskListCache();
+  const date = new Date(nowMs()).toISOString();
+  const eventMessage: TaskMessage = {
+    id: messageId,
+    from: input.from,
+    to,
+    subject: current.subject,
+    date,
+    state: input.state,
+    body: text,
+    result: input.result,
+    approval: input.event === 'decision'
+      ? { type: 'decision', digest: current.approval.digest, decision: input.decision! }
+      : { type: 'expired', digest: current.approval.digest },
+  };
+  const queued = { message: eventMessage, sentAt: Date.parse(date) || nowMs() };
+  const persisted = await getTaskSnapshot(current.id);
+  if (persisted && eventIsIndexed(persisted, queued) && isApprovalTask(persisted)) return persisted;
+  queueEventUntilIndexed(current.id, eventMessage);
+  return {
+    ...current,
+    state: input.state,
+    updatedAt: date,
+    messages: [...current.messages, eventMessage],
+    result: input.result,
+  };
+}
+
+/** Must run under the existing task lock. Public detail reads and decision
+ * both call this path, so an expiry can produce at most one signed event. */
+async function materializeApprovalExpiryUnlocked(current: ApprovalTask): Promise<ApprovalTask> {
+  const expiredAt = new Date(nowMs()).toISOString();
+  return writeApprovalTerminal(current, {
+    from: current.from,
+    state: 'failed',
+    event: 'expired',
+    result: { decision: 'expired', digest: current.approval.digest, expiredAt },
+  });
+}
+
+/** The single approval decision gate. It runs entirely under the existing
+ * per-task lock and re-reads queued overlay state after waiting for the lock. */
+export async function decideApprovalTask(input: {
+  id: string;
+  from: string;
+  decision: 'approved' | 'rejected';
+}): Promise<ApprovalTask> {
+  return withTaskLock(input.id, async () => {
+    const current = await getTaskSnapshot(input.id);
+    if (!current) throw new Error('not_found');
+    if (!isApprovalTask(current)) throw new Error('not_approval_task');
+    if (current.state === 'completed' || current.state === 'failed') throw new Error('task_already_decided');
+    if (isApprovalExpired(current.approval.expiresAt)) {
+      await materializeApprovalExpiryUnlocked(current);
+      throw new Error('task_expired');
+    }
+    if (current.state !== 'input-required') throw new Error('task_already_decided');
+    const actor = input.from.toLowerCase();
+    if (actor !== current.approval.reviewer || actor === current.from) throw new Error('approval_reviewer_required');
+    const decidedAt = new Date(nowMs()).toISOString();
+    return writeApprovalTerminal(current, {
+      from: actor,
+      state: 'completed',
+      event: 'decision',
+      decision: input.decision,
+      result: { decision: input.decision, digest: current.approval.digest, reviewer: actor, decidedAt },
+    });
+  });
 }
 
 export function taskParticipants(task: Task): Set<string> {
@@ -654,6 +1164,7 @@ export function toUiTaskView(task: Task, now = nowMs()): TaskBoardItem {
     updatedAt: task.updatedAt,
     messages: task.messages,
     ...(task.result !== undefined ? { result: task.result } : {}),
+    ...(task.kind === 'approval' && task.approval ? { kind: 'approval' as const, approval: task.approval } : {}),
     ...taskOverdue(task, now),
   };
 }
@@ -751,7 +1262,7 @@ export async function replyTask(input: { id: string; from: string; body: string 
   // 状态检查与 working 写入必须在同一把 per-task 锁内，否则并发双 reply
   // 都能过锁外 input-required 检，随后 updateTask 只拦 terminal，会写出第二条 working。
   return withTaskLock(input.id, async () => {
-    const existing = await getTask(input.id);
+    const existing = await getTaskSnapshot(input.id);
     if (!existing) throw new Error('not_found');
     if (existing.state !== 'input-required') throw new Error('task_not_input_required');
     const updated = await updateTaskUnlocked({
@@ -772,7 +1283,7 @@ export async function remindTask(input: {
   idempotencyKey?: string;
 }): Promise<Task> {
   return withTaskLock(input.id, async () => {
-    const existing = await getTask(input.id);
+    const existing = await getTaskSnapshot(input.id);
     if (!existing) throw new Error('not_found');
     if (!taskParticipants(existing).has(input.from)) throw new Error('task_participant_required');
     if (!canAdvanceTask(existing.state)) throw new Error('task_already_terminal');
@@ -816,7 +1327,7 @@ export async function remindTask(input: {
       ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
     };
     const queued = { message: reminderMessage, sentAt: Date.parse(reminderMessage.date) || nowMs() };
-    const persisted = await getTask(existing.id);
+    const persisted = await getTaskSnapshot(existing.id);
     // 仅当 IMAP 已能看到刚发的这条 reminder 才当真持久化；否则回 synthetic，
     // 并把它并进读路径，避免同 key 重试/15s 冷却窗口读到催办前的旧 task。
     if (persisted && eventIsIndexed(persisted, queued)) return persisted;
@@ -832,7 +1343,7 @@ export async function remindTask(input: {
 export async function closeTask(input: { id: string; from: string; reason: string }): Promise<Task> {
   // terminal 预检与 failed 写入同一把锁，避免与并发 reply 交叉各写一封。
   return withTaskLock(input.id, async () => {
-    const existing = await getTask(input.id);
+    const existing = await getTaskSnapshot(input.id);
     if (!existing) throw new Error('not_found');
     if (!canAdvanceTask(existing.state)) throw new Error('task_already_terminal');
     const updated = await updateTaskUnlocked({
@@ -899,8 +1410,117 @@ export async function waitForTaskTerminal(
   return waitForTaskTerminalWith(id, address, timeoutSec);
 }
 
+function stampedApprovalSource(input: {
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+  headers: Record<string, string>;
+}): string {
+  return [
+    `From: ${input.from}`,
+    `To: ${input.to}`,
+    `Subject: ${input.subject}`,
+    ...Object.entries(input.headers).map(([name, value]) => `${name}: ${value}`),
+    '',
+    input.text,
+  ].join('\r\n');
+}
+
+/** @internal Test-only access to the production parser. No alternate parser. */
+export async function parseStampedTaskMessageForTests(input: {
+  id: string;
+  uid: number;
+  source: string;
+  internalDate: string;
+}): Promise<RawTaskMessage | null> {
+  const parsed = await simpleParser(input.source);
+  const addresses = (value: unknown) => {
+    const values = Array.isArray(value) ? value : [value];
+    return values.flatMap((row) => {
+      const entries = (row as { value?: Array<{ address?: string }> } | undefined)?.value ?? [];
+      return entries.map((entry) => ({ address: entry.address ?? undefined }));
+    });
+  };
+  return parseTaskMessage({
+    uid: input.uid,
+    source: Buffer.from(input.source),
+    envelope: {
+      from: addresses(parsed.from),
+      to: addresses(parsed.to),
+      subject: parsed.subject ?? undefined,
+    },
+    internalDate: new Date(input.internalDate),
+  } as FetchMessageObject, input.id);
+}
+
+/** Narrow watcher bridge: it deliberately returns only parser-authenticated
+ * approval event kind, never an action/body snapshot. */
+export async function approvalEventForWatcher(message: FetchMessageObject): Promise<ApprovalEvent | null> {
+  if (!message.source || !message.envelope) return null;
+  try {
+    const parsed = await simpleParser(message.source);
+    const id = parsed.headers.get('x-oa-task');
+    if (typeof id !== 'string' || !isTaskId(id)) return null;
+    return (await parseTaskMessage(message, id))?.approval ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** @internal Test-only encoder which delegates to the production request body
+ * and approval HMAC header construction. */
+export function encodeStampedApprovalRequestForTests(input: {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  body: string;
+  action: ApprovalAction;
+  expiresAt: string;
+}): string {
+  const action = normalizedApprovalAction(input.action);
+  const digest = approvalActionDigest(action);
+  const snapshot: ApprovalSnapshot = { action, reviewer: input.to.toLowerCase(), expiresAt: input.expiresAt, digest };
+  return stampedApprovalSource({
+    from: input.from,
+    to: input.to,
+    subject: input.subject,
+    text: approvalRequestBody(input.body, snapshot),
+    headers: approvalHeaders(input.id, 'input-required', input.from, input.to, {
+      event: 'request', digest, reviewer: input.to.toLowerCase(), expiresAt: input.expiresAt,
+    }),
+  });
+}
+
+/** @internal Test-only encoder which delegates to the production decision
+ * result and approval HMAC header construction. */
+export function encodeStampedApprovalDecisionForTests(input: {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  digest: string;
+  decision: 'approved' | 'rejected';
+  decidedAt: string;
+}): string {
+  if (!APPROVAL_DIGEST_RE.test(input.digest)) throw new Error('invalid_approval_digest');
+  const result = { decision: input.decision, digest: input.digest, reviewer: input.from.toLowerCase(), decidedAt: input.decidedAt };
+  return stampedApprovalSource({
+    from: input.from,
+    to: input.to,
+    subject: input.subject,
+    text: taskBody('', result),
+    headers: approvalHeaders(input.id, 'completed', input.from, input.to, {
+      event: 'decision', digest: input.digest, decision: input.decision,
+      reviewer: input.from.toLowerCase(), decidedAt: input.decidedAt,
+    }),
+  });
+}
+
 export const taskService: TaskService = {
   create: createTask,
+  createApproval: createApprovalTask,
   list: listTasks,
   listBoard: listTaskBoard,
   get: getTask,
@@ -908,5 +1528,6 @@ export const taskService: TaskService = {
   reply: replyTask,
   remind: remindTask,
   close: closeTask,
+  decideApproval: decideApprovalTask,
   waitForTerminal: waitForTaskTerminal,
 };

--- a/packages/api/src/lib/tasks.ts
+++ b/packages/api/src/lib/tasks.ts
@@ -401,9 +401,10 @@ function approvalRequestBody(body: string | undefined, snapshot: ApprovalSnapsho
 }
 
 function readApprovalSnapshot(body: string): ApprovalSnapshot | null {
-  const marker = body.lastIndexOf(APPROVAL_MARKER);
-  if (marker < 0) return null;
-  const match = body.slice(marker + APPROVAL_MARKER.length).match(/^\s*```json\s*\n([\s\S]*?)\n```/);
+  // The marker is a generated frame delimiter, not an arbitrary payload
+  // token: action JSON may safely contain its literal spelling.
+  const matches = [...body.matchAll(/(?:^|\n)<!-- openagent\.email approval snapshot -->\n```json\s*\n([\s\S]*?)\n```/g)];
+  const match = matches.at(-1);
   if (!match) return null;
   try {
     const parsed = JSON.parse(match[1]) as Record<string, unknown>;
@@ -884,6 +885,16 @@ function eventIsIndexed(task: Task, queued: QueuedEvent): boolean {
       );
     });
   }
+  const queuedApproval = queued.message.approval;
+  if (queuedApproval?.type === 'decision' || queuedApproval?.type === 'expired') {
+    return task.messages.some((message) => {
+      const indexed = message.approval;
+      if (!indexed || indexed.type !== queuedApproval.type || indexed.digest !== queuedApproval.digest) return false;
+      if (indexed.type === 'decision' && (queuedApproval.type !== 'decision' || indexed.decision !== queuedApproval.decision)) return false;
+      const at = Date.parse(message.date);
+      return message.state === queued.message.state && Number.isFinite(at) && at >= queued.sentAt - 1000;
+    });
+  }
   return (
     task.messages.some((message) => {
       if (message.kind === 'reminder' || message.state !== queued.message.state) return false;
@@ -920,7 +931,8 @@ function mergeQueuedEvents(task: Task): Task {
   if (!pending || pending.length === 0) return task;
   const now = nowMs();
   const stillLagging = pending.filter((row) => {
-    if (now - row.sentAt > QUEUED_EVENT_TTL_MS) return false;
+    const approvalTerminal = row.message.approval?.type === 'decision' || row.message.approval?.type === 'expired';
+    if (!approvalTerminal && now - row.sentAt > QUEUED_EVENT_TTL_MS) return false;
     return !eventIsIndexed(task, row);
   });
   if (stillLagging.length === 0) {
@@ -1099,6 +1111,9 @@ export async function decideApprovalTask(input: {
     const current = await getTaskSnapshot(input.id);
     if (!current) throw new Error('not_found');
     if (!isApprovalTask(current)) throw new Error('not_approval_task');
+    if (current.state === 'failed' && readApprovalExpiry(current.result)?.digest === current.approval.digest) {
+      throw new Error('task_expired');
+    }
     if (current.state === 'completed' || current.state === 'failed') throw new Error('task_already_decided');
     if (isApprovalExpired(current.approval.expiresAt)) {
       await materializeApprovalExpiryUnlocked(current);

--- a/packages/api/src/lib/tool-tiers.ts
+++ b/packages/api/src/lib/tool-tiers.ts
@@ -40,6 +40,7 @@ export const TOOL_TIER_SPEC = {
   // contained
   mail_send: 'contained',
   task_update: 'contained',
+  task_decide: 'contained',
   notify_agent: 'contained',
   notify_user: 'contained',
   // critical：OAuth deny-by-default

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -78,6 +78,24 @@ export interface NotificationMessage {
 
 export type TaskState = "submitted" | "working" | "input-required" | "completed" | "failed";
 
+export interface ApprovalAction {
+  type: string;
+  name: string;
+  arguments: unknown;
+}
+
+export interface ApprovalSnapshot {
+  action: ApprovalAction;
+  reviewer: string;
+  expiresAt: string;
+  digest: string;
+}
+
+export type ApprovalEvent =
+  | { type: 'request'; snapshot: ApprovalSnapshot }
+  | { type: 'decision'; digest: string; decision: 'approved' | 'rejected' }
+  | { type: 'expired'; digest: string };
+
 export interface TaskMessage {
   id: string;
   from: string;
@@ -87,6 +105,9 @@ export interface TaskMessage {
   state: TaskState;
   body: string;
   result?: unknown;
+  kind?: 'state' | 'reminder';
+  idempotencyKey?: string;
+  approval?: ApprovalEvent;
 }
 
 export interface Task {
@@ -99,6 +120,8 @@ export interface Task {
   updatedAt: string;
   messages: TaskMessage[];
   result?: unknown;
+  kind?: 'approval';
+  approval?: ApprovalSnapshot;
 }
 
 /**
@@ -362,6 +385,25 @@ export class OpenAgentEmailClient {
     return this.request("POST", "/v1/tasks", { to, subject, body, wait });
   }
 
+  /** Additive approval creation. Ordinary createTask bytes remain unchanged. */
+  createApprovalTask(
+    to: string,
+    subject: string,
+    action: ApprovalAction,
+    expiresAt: string,
+    body?: string,
+    wait = false,
+  ): Promise<Task> {
+    return this.request("POST", "/v1/tasks", {
+      to,
+      subject,
+      ...(body === undefined ? {} : { body }),
+      kind: 'approval',
+      approval: { action, expiresAt },
+      wait,
+    });
+  }
+
   async listTasks(state?: TaskState): Promise<Task[]> {
     const params = new URLSearchParams();
     if (state) params.set("state", state);
@@ -385,5 +427,9 @@ export class OpenAgentEmailClient {
       ...(body === undefined ? {} : { body }),
       ...(result === undefined ? {} : { result }),
     });
+  }
+
+  decideTask(id: string, decision: 'approved' | 'rejected'): Promise<Task> {
+    return this.request("POST", `/v1/tasks/${encodeURIComponent(id)}/decision`, { decision });
   }
 }

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -1,5 +1,5 @@
 /**
- * 15 个 MCP 工具的注册逻辑（stdio 与 HTTP /mcp 共用唯一实现）。
+ * 16 个 MCP 工具的注册逻辑（stdio 与 HTTP /mcp 共用唯一实现）。
  * 每个工具在注册处声明 WriteGuard tier（见 lib/tool-tiers.ts）；
  * 未声明 → HTTP default deny；注册与规格表不一致 → throw。
  * stdio 不执行 tier 策略（operator 本地；REST ACL 兜底）。
@@ -177,6 +177,14 @@ export function registerOpenAgentEmailTools(
     result: z.unknown().optional(),
     kind: z.enum(["state", "reminder"]).optional(),
     idempotencyKey: z.string().optional(),
+    approval: z.union([
+      z.object({ type: z.literal('request'), snapshot: z.object({
+        action: z.object({ type: z.string(), name: z.string(), arguments: z.unknown() }),
+        reviewer: z.email(), expiresAt: z.string(), digest: z.string(),
+      }) }),
+      z.object({ type: z.literal('decision'), digest: z.string(), decision: z.enum(['approved', 'rejected']) }),
+      z.object({ type: z.literal('expired'), digest: z.string() }),
+    ]).optional(),
   });
 
   const taskOutputSchema = {
@@ -189,6 +197,11 @@ export function registerOpenAgentEmailTools(
     updatedAt: z.string(),
     messages: z.array(taskMessageSchema),
     result: z.unknown().optional(),
+    kind: z.literal('approval').optional(),
+    approval: z.object({
+      action: z.object({ type: z.string(), name: z.string(), arguments: z.unknown() }),
+      reviewer: z.email(), expiresAt: z.string(), digest: z.string(),
+    }).optional(),
   };
 
   const taskListOutputSchema = {
@@ -499,7 +512,12 @@ export function registerOpenAgentEmailTools(
       inputSchema: {
         to: z.email().describe("Managed recipient identity address"),
         subject: z.string().min(1).max(998).describe("Task subject"),
-        body: z.string().max(1_000_000).describe("Task instructions in plain text"),
+        body: z.string().max(1_000_000).optional().describe("Task instructions in plain text"),
+        kind: z.literal('approval').optional().describe('Use approval with the typed action and expiry below.'),
+        approval: z.object({
+          action: z.object({ type: z.string().min(1).max(200), name: z.string().min(1).max(200), arguments: z.unknown() }).strict(),
+          expiresAt: z.string().datetime({ offset: true }),
+        }).strict().optional(),
         wait: z
           .boolean()
           .optional()
@@ -511,7 +529,13 @@ export function registerOpenAgentEmailTools(
       outputSchema: taskOutputSchema,
       annotations: mutatingAnnotations,
     },
-    ({ to, subject, body, wait }) => callApi(() => client.createTask(to, subject, body, wait ?? false)),
+    ({ to, subject, body, kind, approval, wait }) => callApi(() => {
+      if (kind === 'approval' && approval) {
+        return client.createApprovalTask(to, subject, approval.action, approval.expiresAt, body, wait ?? false);
+      }
+      if (kind === 'approval' || approval || body === undefined) throw new Error('approval task_create requires approval; ordinary task_create requires body');
+      return client.createTask(to, subject, body, wait ?? false);
+    }),
   );
 
   tier("task_list", "read");
@@ -569,6 +593,22 @@ export function registerOpenAgentEmailTools(
     ({ id, state, body, result }) => callApi(() => client.updateTask(id, state, body, result)),
   );
 
-  // 收尾：规格表 15 工具均须已在本次注册中 declare（declared 不预填，漏 tier() 即炸）
+  tier("task_decide", "contained");
+  server.registerTool(
+    "task_decide",
+    {
+      title: 'Decide Approval Task',
+      description: 'Approve or reject an approval task as the identity bound to this MCP token. This records a decision only; it never executes the action.',
+      inputSchema: {
+        id: z.string().uuid().describe('Approval task UUID'),
+        decision: z.enum(['approved', 'rejected']),
+      },
+      outputSchema: taskOutputSchema,
+      annotations: mutatingAnnotations,
+    },
+    ({ id, decision }) => callApi(() => client.decideTask(id, decision)),
+  );
+
+  // 收尾：规格表 16 工具均须已在本次注册中 declare（declared 不预填，漏 tier() 即炸）
   assertAllSpecTiersDeclared();
 }

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -22,7 +22,17 @@ const createSchema = z.object({
   from: z.string().email().optional(),
   to: z.string().email(),
   subject: z.string().min(1).max(998),
-  body: z.string().max(1_000_000),
+  body: z.string().max(1_000_000).optional(),
+  /** Additive #55 request creation; decision route stays frozen for R3. */
+  kind: z.literal('approval').optional(),
+  approval: z.object({
+    action: z.object({
+      type: z.string().min(1).max(200),
+      name: z.string().min(1).max(200),
+      arguments: z.unknown(),
+    }).strict(),
+    expiresAt: z.string().datetime({ offset: true }),
+  }).strict().optional(),
   wait: z.boolean().optional(),
 }).strict();
 
@@ -33,6 +43,11 @@ const updateSchema = z.object({
   // A task result is serialized by the API into a JSON block in the reply
   // body. It replaces attachments until v0.5 blob storage exists.
   result: z.unknown().optional(),
+}).strict();
+
+const decisionSchema = z.object({
+  from: z.string().email().optional(),
+  decision: z.enum(['approved', 'rejected']),
 }).strict();
 
 const listSchema = z.object({ state: taskStateSchema.optional() });
@@ -103,6 +118,12 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       }
       const parsed = createSchema.safeParse(body);
       if (!parsed.success) return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+      if (parsed.data.kind === 'approval' && !parsed.data.approval) {
+        return c.json({ error: 'invalid_request: approval is required for approval tasks' }, 400);
+      }
+      if (parsed.data.kind !== 'approval' && (parsed.data.approval || parsed.data.body === undefined)) {
+        return c.json({ error: 'invalid_request' }, 400);
+      }
       const from = actorAddress(c, parsed.data.from);
       if (from instanceof Response) return from;
       const sender = known(c, from);
@@ -114,12 +135,21 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       }
 
       try {
-        const task = await service.create({
-          from,
-          to: parsed.data.to.toLowerCase(),
-          subject: parsed.data.subject,
-          body: parsed.data.body,
-        });
+        const task = parsed.data.kind === 'approval'
+          ? await (service.createApproval ?? taskService.createApproval!)({
+            from,
+            to: parsed.data.to.toLowerCase(),
+            subject: parsed.data.subject,
+            ...(parsed.data.body !== undefined ? { body: parsed.data.body } : {}),
+            action: parsed.data.approval!.action,
+            expiresAt: parsed.data.approval!.expiresAt,
+          })
+          : await service.create({
+            from,
+            to: parsed.data.to.toLowerCase(),
+            subject: parsed.data.subject,
+            body: parsed.data.body!,
+          });
         if (!parsed.data.wait) return c.json(task, 201);
         // `wait` deliberately has one capped server turn. Long tasks are
         // resumed by asking task_get or calling task_create(wait) again.
@@ -127,7 +157,11 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
         if (waited instanceof Response) return waited;
         return c.json(waited ?? task, 201);
       } catch (err) {
-        console.warn('[task] create failed:', (err as Error).message);
+        const code = (err as Error).message;
+        if (code === 'invalid_approval_expiry') {
+          return c.json({ error: 'invalid_request' }, 400);
+        }
+        console.warn('[task] create failed:', code);
         return c.json({ error: 'smtp_error' }, 502);
       }
     })
@@ -156,6 +190,45 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       const waited = await waitWithSlot(c, service, task, address);
       if (waited instanceof Response) return waited;
       return c.json(waited ?? task);
+    })
+    .post('/:id/decision', async (c) => {
+      const id = taskIdSchema.safeParse(c.req.param('id'));
+      if (!id.success) return c.json({ error: 'invalid_request' }, 400);
+      let body: unknown;
+      try {
+        body = await c.req.json();
+      } catch {
+        return c.json({ error: 'invalid_json' }, 400);
+      }
+      const parsed = decisionSchema.safeParse(body);
+      if (!parsed.success) return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+      const from = actorAddress(c, parsed.data.from);
+      if (from instanceof Response) return from;
+      const task = await service.get(id.data);
+      if (!task) return c.json({ error: 'not_found' }, 404);
+      if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
+      // Check the stored reviewer before calling the core; the core repeats
+      // this ACL under its task lock, so neither REST nor a forged body gains
+      // authority during a concurrent transition.
+      if (from !== task.approval.reviewer) {
+        return c.json({ error: 'forbidden: approval reviewer required' }, 403);
+      }
+      try {
+        return c.json(await (service.decideApproval ?? taskService.decideApproval!)({
+          id: id.data,
+          from,
+          decision: parsed.data.decision,
+        }));
+      } catch (err) {
+        const code = (err as Error).message;
+        if (code === 'not_found') return c.json({ error: 'not_found' }, 404);
+        if (code === 'approval_reviewer_required') return c.json({ error: 'forbidden: approval reviewer required' }, 403);
+        if (code === 'task_expired' || code === 'task_already_decided' || code === 'not_approval_task') {
+          return c.json({ error: code }, 409);
+        }
+        console.warn('[task] decision failed:', code);
+        return c.json({ error: 'smtp_error' }, 502);
+      }
     })
     .post('/:id/state', async (c) => {
       const id = taskIdSchema.safeParse(c.req.param('id'));
@@ -188,8 +261,8 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
         if (!updated) return c.json({ error: 'not_found' }, 404);
         return c.json(updated);
       } catch (err) {
-        if ((err as Error).message === 'task_already_terminal') {
-          return c.json({ error: 'task_already_terminal' }, 409);
+        if ((err as Error).message === 'task_already_terminal' || (err as Error).message === 'approval_decision_required') {
+          return c.json({ error: (err as Error).message }, 409);
         }
         if ((err as Error).message === 'task_participant_required') {
           return c.json({ error: 'forbidden: task participant required' }, 403);

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -70,6 +70,13 @@ function canReadTask(c: Context, task: Task): boolean {
   return auth.kind === 'admin' || taskParticipants(task).has(auth.address);
 }
 
+function authorizationTask(service: TaskService, id: string): Promise<Task | null> {
+  const read = service === taskService || service.getForAuthorization !== taskService.getForAuthorization
+    ? service.getForAuthorization
+    : undefined;
+  return (read ?? service.get)(id);
+}
+
 async function waitWithSlot(
   c: Context,
   service: TaskService,
@@ -183,9 +190,13 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
       const query = getSchema.safeParse(c.req.query());
       if (!query.success) return c.json({ error: 'invalid_request', details: query.error.issues }, 400);
-      const task = await service.get(parsed.data);
+      const authorization = await authorizationTask(service, parsed.data);
+      if (!authorization) return c.json({ error: 'not_found' }, 404);
+      if (!canReadTask(c, authorization)) return c.json({ error: 'forbidden: task participant required' }, 403);
+      const task = service.getForAuthorization && (service === taskService || service.getForAuthorization !== taskService.getForAuthorization)
+        ? await service.get(parsed.data)
+        : authorization;
       if (!task) return c.json({ error: 'not_found' }, 404);
-      if (!canReadTask(c, task)) return c.json({ error: 'forbidden: task participant required' }, 403);
       if (query.data.wait !== 'true') return c.json(task);
       const auth = getAuth(c);
       const address = auth.kind === 'identity' ? auth.address : task.from;
@@ -206,7 +217,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!parsed.success) return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
       const from = actorAddress(c, parsed.data.from);
       if (from instanceof Response) return from;
-      const task = await service.get(id.data);
+      const task = await authorizationTask(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       if (!canReadTask(c, task)) return c.json({ error: 'not_found' }, 404);
       if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
@@ -248,7 +259,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!parsed.success) return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
       const from = actorAddress(c, parsed.data.from);
       if (from instanceof Response) return from;
-      const task = await service.get(id.data);
+      const task = await authorizationTask(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       // This is a hard server-side ACL boundary. A guessed task UUID alone
       // never gives another identity authority to advance its state.

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -135,8 +135,10 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       }
 
       try {
+        const createApproval = service.createApproval;
+        if (parsed.data.kind === 'approval' && !createApproval) throw new Error('approval_service_unavailable');
         const task = parsed.data.kind === 'approval'
-          ? await (service.createApproval ?? taskService.createApproval!)({
+          ? await createApproval!({
             from,
             to: parsed.data.to.toLowerCase(),
             subject: parsed.data.subject,
@@ -215,7 +217,9 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
         return c.json({ error: 'forbidden: approval reviewer required' }, 403);
       }
       try {
-        return c.json(await (service.decideApproval ?? taskService.decideApproval!)({
+        const decideApproval = service.decideApproval;
+        if (!decideApproval) throw new Error('approval_service_unavailable');
+        return c.json(await decideApproval({
           id: id.data,
           from,
           decision: parsed.data.decision,

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -206,6 +206,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (from instanceof Response) return from;
       const task = await service.get(id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
+      if (!canReadTask(c, task)) return c.json({ error: 'not_found' }, 404);
       if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
       // Check the stored reviewer before calling the core; the core repeats
       // this ACL under its task lock, so neither REST nor a forged body gains

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -257,7 +257,7 @@ function taskMutationError(c: Context, err: unknown): Response {
   const code = (err as Error).message;
   if (code === 'not_found') return c.json({ error: 'not_found' }, 404);
   if (code === 'task_already_terminal') return c.json({ error: 'task_already_terminal' }, 409);
-  if (code === 'task_expired' || code === 'task_already_decided' || code === 'not_approval_task') {
+  if (code === 'task_expired' || code === 'task_already_decided' || code === 'not_approval_task' || code === 'approval_decision_required') {
     return c.json({ error: code }, 409);
   }
   if (code === 'task_not_input_required') return c.json({ error: 'task_not_input_required' }, 409);
@@ -877,6 +877,7 @@ export function createUiApiRoutes(
     const service = dependencies.taskService ?? taskService;
     const task = await service.get(parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
+    if (!canReadUiTask(c, task)) return c.json({ error: 'not_found' }, 404);
     if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
     const auth = getAuth(c);
     const from = auth.kind === 'identity'
@@ -943,6 +944,7 @@ export function createUiApiRoutes(
     const service = dependencies.taskService ?? taskService;
     const task = await service.get(parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
+    if (task.kind === 'approval') return c.json({ error: 'approval_decision_required' }, 409);
     const from = taskActionFrom(c, task, body.data.from);
     if (from instanceof Response) return from;
     try {

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -152,7 +152,7 @@ export type UiApiDependencies = {
    */
   taskService?: Pick<
     TaskService,
-    'list' | 'listBoard' | 'get' | 'reply' | 'remind' | 'close' | 'decideApproval'
+    'list' | 'listBoard' | 'get' | 'getForAuthorization' | 'reply' | 'remind' | 'close' | 'decideApproval'
   >;
 };
 
@@ -222,6 +222,13 @@ function canReadUiTask(c: Context, task: Task): boolean {
   const auth = getAuth(c);
   // 参与者集合按小写存；identity 会话地址比较前归一化，避免大小写漂移。
   return auth.kind === 'admin' || taskParticipants(task).has(auth.address.toLowerCase());
+}
+
+function authorizationUiTask(service: Pick<TaskService, 'get' | 'getForAuthorization'>, id: string): Promise<Task | null> {
+  const read = service === taskService || service.getForAuthorization !== taskService.getForAuthorization
+    ? service.getForAuthorization
+    : undefined;
+  return (read ?? service.get)(id);
 }
 
 /** GET :id 与 reply/remind/close 成功体同一套 viewer 投影，不扩权限。 */
@@ -855,7 +862,12 @@ export function createUiApiRoutes(
     const parsed = taskIdParamSchema.safeParse(c.req.param('id'));
     if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
     const service = dependencies.taskService ?? taskService;
-    const task = await service.get(parsed.data);
+    const authorization = await authorizationUiTask(service, parsed.data);
+    if (!authorization) return c.json({ error: 'not_found' }, 404);
+    if (!canReadUiTask(c, authorization)) return c.json({ error: 'forbidden: task participant required' }, 403);
+    const task = service.getForAuthorization && (service === taskService || service.getForAuthorization !== taskService.getForAuthorization)
+      ? await service.get(parsed.data)
+      : authorization;
     if (!task) return c.json({ error: 'not_found' }, 404);
     // overdue 由服务端按 queryNow 同类时钟计算，避免各浏览器口径漂移。
     return presentUiTask(c, task);
@@ -875,7 +887,7 @@ export function createUiApiRoutes(
     const body = taskDecisionSchema.safeParse(raw);
     if (!body.success) return c.json({ error: 'invalid_request', details: body.error.issues }, 400);
     const service = dependencies.taskService ?? taskService;
-    const task = await service.get(parsed.data);
+    const task = await authorizationUiTask(service, parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
     if (!canReadUiTask(c, task)) return c.json({ error: 'not_found' }, 404);
     if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
@@ -912,7 +924,7 @@ export function createUiApiRoutes(
       return c.json({ error: 'invalid_request', details: body.error.issues }, 400);
     }
     const service = dependencies.taskService ?? taskService;
-    const task = await service.get(parsed.data);
+    const task = await authorizationUiTask(service, parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
     if (!canReadUiTask(c, task)) {
       return c.json({ error: 'forbidden: task participant required' }, 403);

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -889,8 +889,9 @@ export function createUiApiRoutes(
       return c.json({ error: 'forbidden: approval reviewer required' }, 403);
     }
     try {
-      const decide = service.decideApproval ?? taskService.decideApproval;
-      return presentUiTask(c, await decide!({ id: parsed.data, from, decision: body.data.decision }));
+      const decide = service.decideApproval;
+      if (!decide) throw new Error('approval_service_unavailable');
+      return presentUiTask(c, await decide({ id: parsed.data, from, decision: body.data.decision }));
     } catch (err) {
       return taskMutationError(c, err);
     }

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -152,7 +152,7 @@ export type UiApiDependencies = {
    */
   taskService?: Pick<
     TaskService,
-    'list' | 'listBoard' | 'get' | 'reply' | 'remind' | 'close'
+    'list' | 'listBoard' | 'get' | 'reply' | 'remind' | 'close' | 'decideApproval'
   >;
 };
 
@@ -212,6 +212,10 @@ const taskCloseSchema = z
     from: z.string().email().optional(),
   })
   .strict();
+const taskDecisionSchema = z.object({
+  from: z.string().email().optional(),
+  decision: z.enum(['approved', 'rejected']),
+}).strict();
 
 /** 与 routes/tasks.ts#canReadTask 保持同一口径（Dashboard cookie 入口的镜像）。 */
 function canReadUiTask(c: Context, task: Task): boolean {
@@ -253,11 +257,15 @@ function taskMutationError(c: Context, err: unknown): Response {
   const code = (err as Error).message;
   if (code === 'not_found') return c.json({ error: 'not_found' }, 404);
   if (code === 'task_already_terminal') return c.json({ error: 'task_already_terminal' }, 409);
+  if (code === 'task_expired' || code === 'task_already_decided' || code === 'not_approval_task') {
+    return c.json({ error: code }, 409);
+  }
   if (code === 'task_not_input_required') return c.json({ error: 'task_not_input_required' }, 409);
   if (code === 'task_remind_cooldown') return c.json({ error: 'task_remind_cooldown' }, 429);
   if (code === 'task_participant_required') {
     return c.json({ error: 'forbidden: task participant required' }, 403);
   }
+  if (code === 'approval_reviewer_required') return c.json({ error: 'forbidden: approval reviewer required' }, 403);
   if (err instanceof InvalidTaskCursorError) return c.json({ error: 'invalid_cursor' }, 400);
   console.warn('[task] ui mutation failed:', (err as Error).message);
   return c.json({ error: 'smtp_error' }, 502);
@@ -851,6 +859,40 @@ export function createUiApiRoutes(
     if (!task) return c.json({ error: 'not_found' }, 404);
     // overdue 由服务端按 queryNow 同类时钟计算，避免各浏览器口径漂移。
     return presentUiTask(c, task);
+  });
+
+  /** Approval decisions share the core service gate; this route merely maps
+   * cookie identity/admin context to its stored reviewer. */
+  routes.post('/tasks/:id/decision', async (c) => {
+    const parsed = taskIdParamSchema.safeParse(c.req.param('id'));
+    if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
+    let raw: unknown;
+    try {
+      raw = await c.req.json();
+    } catch {
+      raw = null;
+    }
+    const body = taskDecisionSchema.safeParse(raw);
+    if (!body.success) return c.json({ error: 'invalid_request', details: body.error.issues }, 400);
+    const service = dependencies.taskService ?? taskService;
+    const task = await service.get(parsed.data);
+    if (!task) return c.json({ error: 'not_found' }, 404);
+    if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
+    const auth = getAuth(c);
+    const from = auth.kind === 'identity'
+      ? (body.data.from && body.data.from.toLowerCase() !== auth.address.toLowerCase()
+        ? null
+        : auth.address.toLowerCase())
+      : body.data.from?.toLowerCase();
+    if (!from || from !== task.approval.reviewer) {
+      return c.json({ error: 'forbidden: approval reviewer required' }, 403);
+    }
+    try {
+      const decide = service.decideApproval ?? taskService.decideApproval;
+      return presentUiTask(c, await decide!({ id: parsed.data, from, decision: body.data.decision }));
+    } catch (err) {
+      return taskMutationError(c, err);
+    }
   });
 
   /** 人在 input-required 时补料；写 working 事件。identity=自身，admin 必须显式选本方 from。 */

--- a/packages/api/src/ui/client/pages/tasks.js
+++ b/packages/api/src/ui/client/pages/tasks.js
@@ -174,8 +174,12 @@
       String(state.me.address || '').toLowerCase() === String(task.approval.reviewer || '').toLowerCase();
   }
 
-  async function submitApprovalDecision(task, decision, button) {
-    button.disabled = true;
+  var approvalDecisionInFlight = {};
+
+  async function submitApprovalDecision(task, decision, buttons) {
+    if (approvalDecisionInFlight[task.id]) return;
+    approvalDecisionInFlight[task.id] = true;
+    buttons.forEach(function (button) { button.disabled = true; });
     try {
       var updated = await apiJson('/ui/api/tasks/' + encodeURIComponent(task.id) + '/decision', {
         method: 'POST',
@@ -192,7 +196,8 @@
         announce(error.status === 409 ? 'This approval is no longer pending.' : 'Approval decision could not be recorded.');
       }
     } finally {
-      button.disabled = false;
+      delete approvalDecisionInFlight[task.id];
+      buttons.forEach(function (button) { button.disabled = false; });
     }
   }
 
@@ -202,7 +207,7 @@
     var section = document.createElement('section');
     section.className = 'task-approval';
     var title = document.createElement('h4');
-    title.textContent = 'Approval required';
+    title.textContent = task.state === 'input-required' ? 'Approval required' : 'Approval details';
     var type = document.createElement('p');
     type.textContent = 'Type: ' + String(approval.action.type || '—');
     var name = document.createElement('p');
@@ -217,13 +222,13 @@
       approve.className = 'primary';
       approve.setAttribute('aria-label', 'Approve action');
       approve.textContent = 'Approve';
-      approve.addEventListener('click', function () { submitApprovalDecision(task, 'approved', approve); });
+      approve.addEventListener('click', function () { submitApprovalDecision(task, 'approved', [approve, reject]); });
       var reject = document.createElement('button');
       reject.type = 'button';
       reject.className = 'quiet delete-action';
       reject.setAttribute('aria-label', 'Reject action');
       reject.textContent = 'Reject';
-      reject.addEventListener('click', function () { submitApprovalDecision(task, 'rejected', reject); });
+      reject.addEventListener('click', function () { submitApprovalDecision(task, 'rejected', [approve, reject]); });
       section.append(approve, reject);
     }
     return section;

--- a/packages/api/src/ui/client/pages/tasks.js
+++ b/packages/api/src/ui/client/pages/tasks.js
@@ -170,7 +170,6 @@
 
   function approvalCanDecide(task) {
     if (!task || task.kind !== 'approval' || !task.approval || task.state !== 'input-required') return false;
-    if (!task.approval.expiresAt || Date.now() >= Date.parse(task.approval.expiresAt)) return false;
     return !isAdmin() && !!state.me &&
       String(state.me.address || '').toLowerCase() === String(task.approval.reviewer || '').toLowerCase();
   }

--- a/packages/api/src/ui/client/pages/tasks.js
+++ b/packages/api/src/ui/client/pages/tasks.js
@@ -517,7 +517,7 @@
       tasksDetailContent.append(reply);
     }
 
-    if (isAdmin() && task.state !== 'completed' && task.state !== 'failed') {
+    if (isAdmin() && task.kind !== 'approval' && task.state !== 'completed' && task.state !== 'failed') {
       var admin = document.createElement('div');
       admin.className = 'task-admin-actions';
       var fromSelect = document.createElement('select');

--- a/packages/api/src/ui/client/pages/tasks.js
+++ b/packages/api/src/ui/client/pages/tasks.js
@@ -168,6 +168,68 @@
     return pre;
   }
 
+  function approvalCanDecide(task) {
+    if (!task || task.kind !== 'approval' || !task.approval || task.state !== 'input-required') return false;
+    if (!task.approval.expiresAt || Date.now() >= Date.parse(task.approval.expiresAt)) return false;
+    return !isAdmin() && !!state.me &&
+      String(state.me.address || '').toLowerCase() === String(task.approval.reviewer || '').toLowerCase();
+  }
+
+  async function submitApprovalDecision(task, decision, button) {
+    button.disabled = true;
+    try {
+      var updated = await apiJson('/ui/api/tasks/' + encodeURIComponent(task.id) + '/decision', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ decision: decision })
+      });
+      state.taskDetail = updated;
+      state.taskDetailStatus = 'ready';
+      renderTasks();
+      loadTasks();
+      announce(decision === 'approved' ? 'Approval recorded.' : 'Rejection recorded.');
+    } catch (error) {
+      if (error.message !== 'session_expired') {
+        announce(error.status === 409 ? 'This approval is no longer pending.' : 'Approval decision could not be recorded.');
+      }
+    } finally {
+      button.disabled = false;
+    }
+  }
+
+  function renderApprovalAction(task) {
+    var approval = task.approval;
+    if (!approval || !approval.action) return null;
+    var section = document.createElement('section');
+    section.className = 'task-approval';
+    var title = document.createElement('h4');
+    title.textContent = 'Approval required';
+    var type = document.createElement('p');
+    type.textContent = 'Type: ' + String(approval.action.type || '—');
+    var name = document.createElement('p');
+    name.textContent = 'Name: ' + String(approval.action.name || '—');
+    var args = document.createElement('pre');
+    args.className = 'task-approval-arguments';
+    try { args.textContent = JSON.stringify(approval.action.arguments); } catch (_err) { args.textContent = String(approval.action.arguments); }
+    section.append(title, type, name, args);
+    if (approvalCanDecide(task)) {
+      var approve = document.createElement('button');
+      approve.type = 'button';
+      approve.className = 'primary';
+      approve.setAttribute('aria-label', 'Approve action');
+      approve.textContent = 'Approve';
+      approve.addEventListener('click', function () { submitApprovalDecision(task, 'approved', approve); });
+      var reject = document.createElement('button');
+      reject.type = 'button';
+      reject.className = 'quiet delete-action';
+      reject.setAttribute('aria-label', 'Reject action');
+      reject.textContent = 'Reject';
+      reject.addEventListener('click', function () { submitApprovalDecision(task, 'rejected', reject); });
+      section.append(approve, reject);
+    }
+    return section;
+  }
+
   function renderTaskRows() {
     tasksRows.replaceChildren();
     /* fetchKey 不匹配时旧缓存不可见，避免切筛选闪错位行。 */
@@ -418,7 +480,10 @@
       tasksDetailContent.append(resultBlock);
     }
 
-    if (task.state === 'input-required') {
+    var approvalAction = task.kind === 'approval' ? renderApprovalAction(task) : null;
+    if (approvalAction) tasksDetailContent.append(approvalAction);
+
+    if (task.state === 'input-required' && task.kind !== 'approval') {
       var reply = document.createElement('form');
       reply.className = 'task-reply';
       var replyTitle = document.createElement('h4');

--- a/packages/api/test/approval-red.test.ts
+++ b/packages/api/test/approval-red.test.ts
@@ -78,13 +78,17 @@ function installSentCapture() {
   return sent;
 }
 
-async function requestFixture(expiresAt = EXPIRES): Promise<{ task: ApprovalTask; sent: SendInput[] }> {
+async function requestFixture(
+  expiresAt = EXPIRES,
+  action: { type: string; name: string; arguments: unknown } = ACTION,
+  body = 'Record only; do not execute.',
+): Promise<{ task: ApprovalTask; sent: SendInput[] }> {
   const create = api().createApprovalTask;
   expect(create, 'approval request service behavior is missing').toBeFunction();
   const sent = installSentCapture();
   const task = await create!({
     from: REQUESTER, to: REVIEWER, subject: 'Approve preview',
-    body: 'Record only; do not execute.', action: ACTION, expiresAt,
+    body, action, expiresAt,
   });
   return { task, sent };
 }
@@ -354,6 +358,113 @@ describe('#55 R5: approval reminder integrity', () => {
 });
 
 describe('#55 R1b: signed IMAP rebuild', () => {
+  test('R8-A RED: inert snapshot-marker strings in signed action JSON cannot replace the structural frame', async () => {
+    const parse = api().parseStampedTaskMessageForTests;
+    expect(parse, 'real IMAP stamp/parser seam is missing').toBeFunction();
+    const actions = [
+      { ...ACTION, arguments: { inert: '<!-- openagent.email approval snapshot -->' } },
+      { ...ACTION, arguments: { inert: '<!-- openagent.email approval snapshot -->\\n```json\\n{ "not": "a frame" }\\n```' } },
+    ];
+    for (const [uid, action] of actions.entries()) {
+      const { task, sent } = await requestFixture(EXPIRES, action);
+      const parsed = await parse!({ id: task.id, uid: uid + 40, source: rfc822(sent[0]!), internalDate: '2026-08-24T00:00:00.000Z' });
+      expect(parsed).not.toBeNull();
+      const rebuilt = tasks.taskFromMessages(task.id, [parsed!] as Parameters<typeof tasks.taskFromMessages>[1]);
+      expect(rebuilt).toMatchObject({ kind: 'approval', approval: { digest: api().approvalActionDigest!(action) } });
+    }
+
+    const bodyWithEarlierInertFrame = [
+      'Legitimate caller-supplied body.',
+      '<!-- openagent.email approval snapshot -->',
+      '```json',
+      '{"not":"a snapshot"}',
+      '```',
+    ].join('\n');
+    const { task, sent } = await requestFixture(EXPIRES, ACTION, bodyWithEarlierInertFrame);
+    const parsed = await parse!({ id: task.id, uid: 42, source: rfc822(sent[0]!), internalDate: '2026-08-24T00:00:00.000Z' });
+    expect(parsed).not.toBeNull();
+    const rebuilt = tasks.taskFromMessages(task.id, [parsed!] as Parameters<typeof tasks.taskFromMessages>[1]);
+    expect(rebuilt).toMatchObject({ kind: 'approval', approval: { digest: task.approval.digest } });
+  });
+
+  test('R8-B RED: a signed decision overlay survives durable IMAP lag beyond the ordinary TTL', async () => {
+    const decide = api().decideApprovalTask!;
+    const before = '2026-08-24T00:00:00.000Z';
+    tasks.setTaskNowForTests(() => Date.parse(before));
+    const { task, sent } = await requestFixture();
+    tasks.setTaskGetForTests(async () => task); // durable store deliberately remains request-only
+    await decide({ id: task.id, from: REVIEWER, decision: 'approved' });
+    tasks.setTaskNowForTests(() => Date.parse(before) + 60_001);
+    const opposite = await decide({ id: task.id, from: REVIEWER, decision: 'rejected' }).then(
+      () => 'resolved', (error: Error) => error.message,
+    );
+    expect({ opposite, delivered: sent.length }).toEqual({ opposite: 'task_already_decided', delivered: 2 });
+    const parse = api().parseStampedTaskMessageForTests!;
+    const request = await parse({ id: task.id, uid: 51, source: rfc822(sent[0]!), internalDate: before });
+    const terminal = await parse({ id: task.id, uid: 52, source: rfc822(sent[1]!), internalDate: before });
+    expect(request).not.toBeNull();
+    expect(terminal).not.toBeNull();
+    const indexed = tasks.taskFromMessages(task.id, [request!, terminal!] as Parameters<typeof tasks.taskFromMessages>[1])!;
+    tasks.setTaskGetForTests(async () => indexed);
+    const stable = await tasks.getTask(task.id);
+    expect(stable).toMatchObject({ state: 'completed', result: { decision: 'approved', digest: task.approval.digest } });
+    expect(stable?.messages).toHaveLength(indexed.messages.length);
+    expect(sent).toHaveLength(2);
+  });
+
+  test('R8-B RED: a signed expiry overlay survives durable IMAP lag beyond the ordinary TTL', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const { task, sent } = await requestFixture(boundary);
+    tasks.setTaskGetForTests(async () => task); // durable store deliberately remains request-only
+    tasks.setTaskNowForTests(() => Date.parse(boundary));
+    await tasks.getTask(task.id); // lazy materializer writes the first signed expiry
+    tasks.setTaskNowForTests(() => Date.parse(boundary) + 60_001);
+    const repeated = await api().decideApprovalTask!({ id: task.id, from: REVIEWER, decision: 'approved' }).then(
+      () => 'resolved', (error: Error) => error.message,
+    );
+    expect({ repeated, delivered: sent.length }).toEqual({ repeated: 'task_expired', delivered: 2 });
+  });
+
+  test('R8-D RED: REST preserves task_expired after a detail read materializes the signed failure', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const { task, sent } = await requestFixture(boundary);
+    tasks.setTaskGetForTests(async () => task);
+    tasks.setTaskNowForTests(() => Date.parse(boundary));
+    const app = appFor({ kind: 'identity', address: REVIEWER });
+    expect((await app.request(`/v1/tasks/${task.id}`)).status).toBe(200);
+    const calls = await Promise.all([0, 1].map(async () => {
+      const response = await app.request(`/v1/tasks/${task.id}/decision`, {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      });
+      return { status: response.status, body: await response.json() };
+    }));
+    expect({ calls, delivered: sent.length }).toEqual({
+      calls: [{ status: 409, body: { error: 'task_expired' } }, { status: 409, body: { error: 'task_expired' } }], delivered: 2,
+    });
+  });
+
+  test('R8-E RED: an injected REST service never falls back to global approval create/decision', async () => {
+    const pending: ApprovalTask = {
+      id: ID, from: REQUESTER, to: REVIEWER, subject: 'Injected approval', state: 'input-required',
+      createdAt: '2026-08-24T00:00:00.000Z', updatedAt: '2026-08-24T00:00:00.000Z', messages: [], kind: 'approval',
+      approval: { action: ACTION, reviewer: REVIEWER, expiresAt: EXPIRES, digest: api().approvalActionDigest!(ACTION) },
+    };
+    const ordinary: Task = { id: '4bb0f08f-f90c-4862-a7af-a0db890d76fd', from: REQUESTER, to: REVIEWER, subject: 'Injected ordinary', state: 'submitted', createdAt: pending.createdAt, updatedAt: pending.updatedAt, messages: [] };
+    const injected = {
+      create: async () => ordinary,
+      get: async () => pending,
+    } as unknown as typeof tasks.taskService;
+    const sent = installSentCapture();
+    tasks.setTaskGetForTests(async () => pending);
+    const [create, decision] = await Promise.all([
+      appFor({ kind: 'identity', address: REQUESTER }, injected).request('/v1/tasks', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ to: REVIEWER, subject: 'Injected approval', body: 'record only', kind: 'approval', approval: { action: ACTION, expiresAt: EXPIRES } }) }),
+      appFor({ kind: 'identity', address: REVIEWER }, injected).request(`/v1/tasks/${pending.id}/decision`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }) }),
+    ]);
+    expect({ statuses: [create.status, decision.status], delivered: sent.length }).toEqual({ statuses: [502, 502], delivered: 0 });
+  });
+
   test('the real stamp/parser rejects RFC timestamp tampering; first valid terminal wins', async () => {
     const parse = api().parseStampedTaskMessageForTests;
     expect(parse, 'real IMAP stamp/parser seam is missing').toBeFunction();
@@ -400,6 +511,55 @@ describe('#55 R1b: signed IMAP rebuild', () => {
 });
 
 describe('#55 R1b: actual UI/watcher seams and compatibility controls', () => {
+  test('R8-C RED: parser-authenticated request, decision, and expiry previews pass default otp policy without content escalation', async () => {
+    const request = api().encodeStampedApprovalRequestForTests!({ id: ID, from: REQUESTER, to: REVIEWER, subject: 'Approval no OTP', body: 'inert body', action: ACTION, expiresAt: EXPIRES });
+    const decision = api().encodeStampedApprovalDecisionForTests!({ id: ID, from: REVIEWER, to: REQUESTER, subject: 'Approval no OTP', digest: api().approvalActionDigest!(ACTION), decision: 'approved', decidedAt: '2026-08-24T00:01:00.000Z' });
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const expiryFixture = await requestFixture('2026-08-24T00:00:00.000Z');
+    tasks.setTaskGetForTests(async () => expiryFixture.task);
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-24T00:00:00.000Z'));
+    await expect(api().decideApprovalTask!({ id: expiryFixture.task.id, from: REVIEWER, decision: 'approved' })).rejects.toThrow('task_expired');
+    const deliveries: Array<Array<{ level: string; message: string }>> = [];
+    const cases = [
+      { source: request, from: REQUESTER, to: REVIEWER, subject: 'Approval no OTP', recipient: REVIEWER },
+      { source: decision, from: REVIEWER, to: REQUESTER, subject: 'Approval no OTP', recipient: REQUESTER },
+      { source: rfc822(expiryFixture.sent[1]!), from: REQUESTER, to: REVIEWER, subject: 'Approval no OTP', recipient: REVIEWER },
+    ];
+    for (const item of cases) {
+      const perEvent: Array<{ level: string; message: string }> = [];
+      await processWatchedMessage({
+        envelope: { from: [{ address: item.from }], to: [{ address: item.to }], subject: item.subject },
+        headers: Buffer.from(`Delivered-To: ${item.recipient}\\r\\n`), source: Buffer.from(item.source),
+      } as never, [{ address: item.recipient, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'otp', {
+        publish: async (input) => { perEvent.push({ level: input.level, message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+      });
+      deliveries.push(perEvent);
+    }
+    const forged: Array<{ message: string }> = [];
+    await processWatchedMessage({
+      envelope: { from: [{ address: REQUESTER }], to: [{ address: REVIEWER }], subject: 'Approval no OTP' },
+      headers: Buffer.from(`Delivered-To: ${REVIEWER}\\r\\n`), source: Buffer.from(request.replace(/X-OA-Task-Stamp: [^\\r\\n]+/, 'X-OA-Task-Stamp: forged')),
+    } as never, [{ address: REVIEWER, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'otp', {
+      publish: async (input) => { forged.push({ message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+    });
+    const none: Array<{ message: string }> = [];
+    await processWatchedMessage({
+      envelope: { from: [{ address: REQUESTER }], to: [{ address: REVIEWER }], subject: 'Approval no OTP' },
+      headers: Buffer.from(`Delivered-To: ${REVIEWER}\\r\\n`), source: Buffer.from(request),
+    } as never, [{ address: REVIEWER, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'none', {
+      publish: async (input) => { none.push({ message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+    });
+    expect({ deliveries, forged: forged.length, none: none.length }).toEqual({
+      deliveries: [
+        [{ level: 'normal', message: expect.stringContaining('Approval request recorded.') }],
+        [{ level: 'normal', message: expect.stringContaining('Approval decision recorded: approved.') }],
+        [{ level: 'normal', message: expect.stringContaining('Approval expired.') }],
+      ],
+      forged: 0, none: 0,
+    });
+    expect(deliveries.flat().map(({ message }) => message).join('\n')).not.toContain('<img src=x onerror=alert(1)>');
+  });
+
   test('the real watcher queues an approval preview without action arguments', async () => {
     const encodeRequest = api().encodeStampedApprovalRequestForTests;
     expect(encodeRequest, 'real server-stamped approval request encoder is missing').toBeFunction();

--- a/packages/api/test/approval-red.test.ts
+++ b/packages/api/test/approval-red.test.ts
@@ -1,7 +1,7 @@
 // #55 R1b behavioral RED. This file intentionally changes no production
 // source. Every fixture is inert; no credential-like value appears in action
 // arguments or in an RFC-822 payload.
-import { afterEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { Hono } from 'hono';
 import type { SendInput } from '../src/lib/smtp.ts';
 import type { ApprovalTask, Task } from '../src/lib/tasks.ts';
@@ -107,6 +107,10 @@ function appFor(
   }));
   return app;
 }
+
+beforeEach(() => {
+  tasks.setTaskNowForTests(() => Date.parse('2026-08-24T00:00:00.000Z'));
+});
 
 afterEach(() => {
   tasks.setTaskGetForTests(null);
@@ -358,6 +362,85 @@ describe('#55 R5: approval reminder integrity', () => {
 });
 
 describe('#55 R1b: signed IMAP rebuild', () => {
+  test('R9 RED: REST authorizes outsider detail and mutations before lazy expiry materialization', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    const expiredApproval = async () => {
+      tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+      const fixture = await requestFixture(boundary);
+      tasks.setTaskGetForTests(async () => fixture.task);
+      tasks.setTaskNowForTests(() => Date.parse(boundary));
+      return fixture;
+    };
+    const outsider = appFor({ kind: 'identity', address: OUTSIDER });
+    const inspect = async (request: (id: string) => Response | Promise<Response>) => {
+      const { task, sent } = await expiredApproval();
+      const response = await request(task.id);
+      return {
+        status: response.status,
+        body: await response.json(),
+        deliveries: sent.length,
+        durable: { state: task.state, messages: task.messages.length, result: task.result ?? null },
+      };
+    };
+
+    const matrix = {
+      detail: await inspect((id) => outsider.request(`/v1/tasks/${id}`)),
+      decision: await inspect((id) => outsider.request(`/v1/tasks/${id}/decision`, {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      })),
+      state: await inspect((id) => outsider.request(`/v1/tasks/${id}/state`, {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ state: 'working' }),
+      })),
+    };
+    expect(matrix).toEqual({
+      detail: { status: 403, body: { error: 'forbidden: task participant required' }, deliveries: 1, durable: { state: 'input-required', messages: 1, result: null } },
+      decision: { status: 404, body: { error: 'not_found' }, deliveries: 1, durable: { state: 'input-required', messages: 1, result: null } },
+      state: { status: 403, body: { error: 'forbidden: task participant required' }, deliveries: 1, durable: { state: 'input-required', messages: 1, result: null } },
+    });
+
+  });
+
+  test('R9 control: REST participant detail materializes expiry once and reviewer decision remains task_expired', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const { task, sent } = await requestFixture(boundary);
+    tasks.setTaskGetForTests(async () => task);
+    tasks.setTaskNowForTests(() => Date.parse(boundary));
+    const reviewer = appFor({ kind: 'identity', address: REVIEWER });
+    const firstDetail = await reviewer.request(`/v1/tasks/${task.id}`);
+    const repeatedDetail = await reviewer.request(`/v1/tasks/${task.id}`);
+    const decision = await reviewer.request(`/v1/tasks/${task.id}/decision`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+    });
+    expect({
+      detailStatuses: [firstDetail.status, repeatedDetail.status],
+      decision: { status: decision.status, body: await decision.json() },
+      deliveries: sent.length,
+    }).toEqual({
+      detailStatuses: [200, 200],
+      decision: { status: 409, body: { error: 'task_expired' } },
+      deliveries: 2,
+    });
+  });
+
+  test('R9-B RED: an approval request body cannot turn an ordinary result block into an approval result', async () => {
+    const parse = api().parseStampedTaskMessageForTests;
+    expect(parse, 'real IMAP stamp/parser seam is missing').toBeFunction();
+    const bodyWithOrdinaryResult = [
+      'Caller-supplied context only.',
+      '<!-- openagent.email task result -->',
+      '```json',
+      JSON.stringify({ decision: 'approved', digest: 'a'.repeat(64), reviewer: REVIEWER, decidedAt: EXPIRES }),
+      '```',
+    ].join('\n');
+    const { task, sent } = await requestFixture(EXPIRES, ACTION, bodyWithOrdinaryResult);
+    const parsed = await parse!({ id: task.id, uid: 43, source: rfc822(sent[0]!), internalDate: '2026-08-24T00:00:00.000Z' });
+    expect(parsed).not.toBeNull();
+    const rebuilt = tasks.taskFromMessages(task.id, [parsed!] as Parameters<typeof tasks.taskFromMessages>[1]);
+    expect(rebuilt).toMatchObject({ kind: 'approval', state: 'input-required', approval: { digest: task.approval.digest } });
+    expect(rebuilt?.result).toBeUndefined();
+  });
+
   test('R8-A RED: inert snapshot-marker strings in signed action JSON cannot replace the structural frame', async () => {
     const parse = api().parseStampedTaskMessageForTests;
     expect(parse, 'real IMAP stamp/parser seam is missing').toBeFunction();
@@ -393,8 +476,10 @@ describe('#55 R1b: signed IMAP rebuild', () => {
     tasks.setTaskNowForTests(() => Date.parse(before));
     const { task, sent } = await requestFixture();
     tasks.setTaskGetForTests(async () => task); // durable store deliberately remains request-only
+    const sentAt = '2026-08-24T00:00:02.000Z';
+    tasks.setTaskNowForTests(() => Date.parse(sentAt));
     await decide({ id: task.id, from: REVIEWER, decision: 'approved' });
-    tasks.setTaskNowForTests(() => Date.parse(before) + 60_001);
+    tasks.setTaskNowForTests(() => Date.parse(sentAt) + 60_001);
     const opposite = await decide({ id: task.id, from: REVIEWER, decision: 'rejected' }).then(
       () => 'resolved', (error: Error) => error.message,
     );
@@ -424,6 +509,17 @@ describe('#55 R1b: signed IMAP rebuild', () => {
       () => 'resolved', (error: Error) => error.message,
     );
     expect({ repeated, delivered: sent.length }).toEqual({ repeated: 'task_expired', delivered: 2 });
+    const parse = api().parseStampedTaskMessageForTests!;
+    const request = await parse({ id: task.id, uid: 53, source: rfc822(sent[0]!), internalDate: '2026-08-23T23:59:59.999Z' });
+    const terminal = await parse({ id: task.id, uid: 54, source: rfc822(sent[1]!), internalDate: '2026-08-23T23:59:58.000Z' });
+    expect(request).not.toBeNull();
+    expect(terminal).not.toBeNull();
+    const indexed = tasks.taskFromMessages(task.id, [request!, terminal!] as Parameters<typeof tasks.taskFromMessages>[1])!;
+    tasks.setTaskGetForTests(async () => indexed);
+    const stable = await tasks.getTask(task.id);
+    expect(stable).toMatchObject({ state: 'failed', result: { decision: 'expired', digest: task.approval.digest } });
+    expect(stable?.messages).toHaveLength(indexed.messages.length);
+    expect(sent).toHaveLength(2);
   });
 
   test('R8-D RED: REST preserves task_expired after a detail read materializes the signed failure', async () => {

--- a/packages/api/test/approval-red.test.ts
+++ b/packages/api/test/approval-red.test.ts
@@ -1,0 +1,439 @@
+// #55 R1b behavioral RED. This file intentionally changes no production
+// source. Every fixture is inert; no credential-like value appears in action
+// arguments or in an RFC-822 payload.
+import { afterEach, describe, expect, test } from 'bun:test';
+import { Hono } from 'hono';
+import type { SendInput } from '../src/lib/smtp.ts';
+import type { ApprovalTask, Task } from '../src/lib/tasks.ts';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+process.env.DATA_DIR = '/tmp/oae-approval-red';
+
+const tasks = await import('../src/lib/tasks.ts');
+const { createTaskRoutes } = await import('../src/routes/tasks.ts');
+const { processWatchedMessage } = await import('../src/lib/notification-watcher.ts');
+const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
+const { createIdentity, findIdentity } = await import('../src/lib/identities.ts');
+
+const REQUESTER = 'requester@test.example';
+const REVIEWER = 'reviewer@test.example';
+const OUTSIDER = 'outsider@test.example';
+const ID = '2c3d77bc-6e13-48bb-b470-f394cd73a60f';
+const EXPIRES = '2030-08-25T00:00:00.000Z';
+const ACTION = {
+  type: 'deployment',
+  name: 'publish-preview',
+  arguments: { html: '<img src=x onerror=alert(1)>', flags: ['safe', 'dry-run'], retries: 2 },
+};
+
+for (const localpart of ['requester', 'reviewer', 'outsider']) {
+  if (!findIdentity(`${localpart}@test.example`)) createIdentity({ localpart, issueToken: false });
+}
+
+type ApprovalModule = typeof tasks & {
+  canonicalApprovalAction?: (action: unknown) => string;
+  approvalActionDigest?: (action: unknown) => string;
+  createApprovalTask?: (input: {
+    from: string; to: string; subject: string; body?: string; action: unknown; expiresAt: string;
+  }) => Promise<ApprovalTask>;
+  decideApprovalTask?: (input: {
+    id: string; from: string; decision: 'approved' | 'rejected';
+  }) => Promise<ApprovalTask>;
+  /** R1b test seam: invokes the private production IMAP parser on this source. */
+  parseStampedTaskMessageForTests?: (input: {
+    id: string; uid: number; source: string; internalDate: string;
+  }) => Promise<unknown | null>;
+  /** R1b test seam: produces a normal server-stamped approval decision event. */
+  encodeStampedApprovalDecisionForTests?: (input: {
+    id: string; from: string; to: string; subject: string; digest: string;
+    decision: 'approved' | 'rejected'; decidedAt: string;
+  }) => string;
+  /** R1b test seam: produces the same source sent for a server request. */
+  encodeStampedApprovalRequestForTests?: (input: {
+    id: string; from: string; to: string; subject: string; body: string;
+    action: unknown; expiresAt: string;
+  }) => string;
+};
+
+function api(): ApprovalModule {
+  return tasks as ApprovalModule;
+}
+
+function rfc822(sent: SendInput): string {
+  const headers = Object.entries(sent.headers ?? {}).map(([name, value]) => `${name}: ${value}`).join('\r\n');
+  return [`From: ${sent.from}`, `To: ${sent.to.join(', ')}`, `Subject: ${sent.subject}`, headers, '', sent.text].join('\r\n');
+}
+
+function installSentCapture() {
+  const sent: SendInput[] = [];
+  tasks.setTaskSendMailForTests(async (input) => {
+    sent.push(input);
+    return { messageId: `<approval-red-${sent.length}@test.example>` };
+  });
+  return sent;
+}
+
+async function requestFixture(expiresAt = EXPIRES): Promise<{ task: ApprovalTask; sent: SendInput[] }> {
+  const create = api().createApprovalTask;
+  expect(create, 'approval request service behavior is missing').toBeFunction();
+  const sent = installSentCapture();
+  const task = await create!({
+    from: REQUESTER, to: REVIEWER, subject: 'Approve preview',
+    body: 'Record only; do not execute.', action: ACTION, expiresAt,
+  });
+  return { task, sent };
+}
+
+function appFor(
+  auth: { kind: 'admin' } | { kind: 'identity'; address: string },
+  service = tasks.taskService,
+) {
+  const app = new Hono();
+  app.use('*', async (c, next) => { c.set('auth', auth); await next(); });
+  app.route('/v1/tasks', createTaskRoutes({
+    service,
+    findIdentity: (address) => [REQUESTER, REVIEWER, OUTSIDER].includes(address.toLowerCase())
+      ? { address, createdAt: '2026-08-24T00:00:00.000Z' }
+      : undefined,
+  }));
+  return app;
+}
+
+afterEach(() => {
+  tasks.setTaskGetForTests(null);
+  tasks.setTaskSendMailForTests(null);
+  tasks.clearQueuedEventsForTests();
+  tasks.setTaskNowForTests(null);
+});
+
+describe('#55 R1b: canonical request behavior', () => {
+  test('canonical-equivalent requests receive one digest while changed content and array order diverge', () => {
+    const { canonicalApprovalAction, approvalActionDigest } = api();
+    expect(canonicalApprovalAction, 'canonical JSON behavior is missing').toBeFunction();
+    expect(approvalActionDigest, 'SHA-256 digest behavior is missing').toBeFunction();
+    const reordered = {
+      arguments: { retries: 2, flags: ['safe', 'dry-run'], html: '<img src=x onerror=alert(1)>' },
+      name: 'publish-preview', type: 'deployment',
+    };
+    const changed = { ...ACTION, arguments: { ...ACTION.arguments, retries: 3 } };
+    const reorderedArray = { ...ACTION, arguments: { ...ACTION.arguments, flags: ['dry-run', 'safe'] } };
+    expect(canonicalApprovalAction!(ACTION)).toBe(
+      '{"arguments":{"flags":["safe","dry-run"],"html":"<img src=x onerror=alert(1)>","retries":2},"name":"publish-preview","type":"deployment"}',
+    );
+    expect(approvalActionDigest!(reordered)).toBe(approvalActionDigest!(ACTION));
+    expect(approvalActionDigest!(changed)).not.toBe(approvalActionDigest!(ACTION));
+    expect(approvalActionDigest!(reorderedArray)).not.toBe(approvalActionDigest!(ACTION));
+  });
+
+  test('approval creation rejects self at the service boundary and an unknown reviewer at the route boundary before mail writes', async () => {
+    const create = api().createApprovalTask;
+    expect(create, 'approval creation service behavior is missing').toBeFunction();
+    const sent = installSentCapture();
+    await expect(create!({
+      from: REQUESTER, to: REQUESTER, subject: 'Self approval',
+      body: 'Record only; do not execute.', action: ACTION, expiresAt: EXPIRES,
+    })).rejects.toThrow('approval_participants_must_differ');
+    expect(sent).toHaveLength(0);
+
+    const unknown = await appFor({ kind: 'identity', address: REQUESTER }).request('/v1/tasks', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        to: 'unknown@test.example', subject: 'Unknown reviewer', body: 'Record only; do not execute.',
+        kind: 'approval', approval: { action: ACTION, expiresAt: EXPIRES },
+      }),
+    });
+    expect(unknown.status).toBe(403);
+    expect(sent).toHaveLength(0);
+  });
+
+  test('an already-expired approval create is a stable client error through REST and MCP client', async () => {
+    const sent = installSentCapture();
+    const app = appFor({ kind: 'identity', address: REQUESTER });
+    const expiredBody = {
+      to: REVIEWER, subject: 'Expired approval', body: 'Record only; do not execute.',
+      kind: 'approval', approval: { action: ACTION, expiresAt: '2020-01-01T00:00:00.000Z' },
+    };
+    const rest = await app.request('/v1/tasks', {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(expiredBody),
+    });
+    expect(rest.status).toBe(400);
+    expect(await rest.json()).toEqual({ error: 'invalid_request' });
+    expect(sent).toHaveLength(0);
+
+    const client = new OpenAgentEmailClient('http://test.invalid', 'token', (url, init) =>
+      app.request(new Request(String(url), init)),
+    );
+    const clientError = await client.createApprovalTask(
+      REVIEWER, 'Expired approval', ACTION, '2020-01-01T00:00:00.000Z', 'Record only; do not execute.',
+    ).catch((error: unknown) => error);
+    expect(clientError).toMatchObject({ status: 400 });
+    expect(String(clientError)).toContain('invalid_request');
+    expect(String(clientError)).not.toMatch(/smtp|upstream/i);
+    expect(sent).toHaveLength(0);
+  });
+});
+
+describe('#55 R1b: one decision, terminal result, and ACL', () => {
+  test('two concurrent decisions emit one terminal event; repeat and expiry are conflicts', async () => {
+    const decide = api().decideApprovalTask;
+    expect(decide, 'lock-protected decision behavior is missing').toBeFunction();
+    const { task, sent } = await requestFixture();
+    tasks.setTaskGetForTests(async () => task);
+    await expect(tasks.updateTask({
+      id: task.id, from: REVIEWER, state: 'completed', result: { decision: 'approved' },
+    })).rejects.toThrow('approval_decision_required');
+    expect(sent).toHaveLength(1);
+    const settled = await Promise.allSettled([
+      decide!({ id: task.id, from: REVIEWER, decision: 'approved' }),
+      decide!({ id: task.id, from: REVIEWER, decision: 'rejected' }),
+    ]);
+    expect(settled.filter((row) => row.status === 'fulfilled')).toHaveLength(1);
+    expect(settled.filter((row) => row.status === 'rejected')).toHaveLength(1);
+    expect(sent).toHaveLength(2); // request + exactly one terminal decision
+    await expect(decide!({ id: task.id, from: REVIEWER, decision: 'approved' })).rejects.toThrow('task_already_decided');
+
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const expired = await requestFixture('2026-08-24T00:00:00.000Z');
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-24T00:00:00.000Z'));
+    tasks.setTaskGetForTests(async () => expired.task);
+    await expect(decide!({ id: expired.task.id, from: REVIEWER, decision: 'approved' })).rejects.toThrow('task_expired');
+  });
+
+  test('lazy expiry materializes for no-click detail/wait reads and races exactly once at the boundary', async () => {
+    const decide = api().decideApprovalTask;
+    expect(decide, 'lock-protected expiry materializer is missing').toBeFunction();
+    const boundary = '2026-08-24T00:00:00.000Z';
+
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const before = await requestFixture(boundary);
+    tasks.setTaskGetForTests(async () => before.task);
+    await expect(decide!({ id: before.task.id, from: REVIEWER, decision: 'approved' })).resolves.toMatchObject({ state: 'completed' });
+    expect(before.sent).toHaveLength(2);
+    tasks.clearQueuedEventsForTests();
+
+    const noClick = await requestFixture(boundary);
+    tasks.setTaskNowForTests(() => Date.parse(boundary));
+    tasks.setTaskGetForTests(async () => noClick.task);
+    let noClickTicks = 0;
+    const [detail, waited] = await Promise.all([
+      tasks.getTask(noClick.task.id),
+      tasks.waitForTaskTerminalWith(noClick.task.id, REQUESTER, 1, {
+        waitForMessage: async () => null,
+        now: () => (++noClickTicks < 4 ? 0 : 2_000),
+      }),
+    ]);
+    expect(detail).toMatchObject({ state: 'failed', result: { decision: 'expired', digest: noClick.task.approval.digest, expiredAt: boundary } });
+    expect(waited).toMatchObject({ state: 'failed', result: { decision: 'expired', digest: noClick.task.approval.digest, expiredAt: boundary } });
+    expect(noClick.sent).toHaveLength(2); // request + one lazy signed expiry
+    tasks.clearQueuedEventsForTests();
+
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    const raced = await requestFixture(boundary);
+    tasks.setTaskNowForTests(() => Date.parse(boundary));
+    tasks.setTaskGetForTests(async () => raced.task);
+    let raceTicks = 0;
+    const [racedDetail, racedWaited, racedDecision] = await Promise.all([
+      tasks.getTask(raced.task.id),
+      tasks.waitForTaskTerminalWith(raced.task.id, REQUESTER, 1, {
+        waitForMessage: async () => null,
+        now: () => (++raceTicks < 4 ? 0 : 2_000),
+      }),
+      decide!({ id: raced.task.id, from: REVIEWER, decision: 'approved' }).catch((error: unknown) => error),
+    ]);
+    expect(racedDetail).toMatchObject({ state: 'failed', result: { decision: 'expired', digest: raced.task.approval.digest, expiredAt: boundary } });
+    expect(racedWaited).toMatchObject({ state: 'failed', result: { decision: 'expired', digest: raced.task.approval.digest, expiredAt: boundary } });
+    expect(racedDecision).toBeInstanceOf(Error);
+    expect(raced.sent).toHaveLength(2); // request + exactly one terminal expiry
+    await expect(decide!({ id: raced.task.id, from: REVIEWER, decision: 'approved' })).rejects.toThrow();
+    expect(raced.sent).toHaveLength(2);
+  });
+
+  test('approve and reject return the waiting requester the persisted structured decision', async () => {
+    const decide = api().decideApprovalTask;
+    expect(decide, 'decision result behavior is missing').toBeFunction();
+    for (const decision of ['approved', 'rejected'] as const) {
+      const { task } = await requestFixture();
+      tasks.setTaskGetForTests(async () => task);
+      const completed = await decide!({ id: task.id, from: REVIEWER, decision });
+      const waited = await tasks.waitForTaskTerminal(task.id, REQUESTER, 1);
+      expect(completed).toMatchObject({ state: 'completed', result: { decision, digest: task.approval.digest, reviewer: REVIEWER } });
+      expect(waited).toMatchObject({ state: 'completed', result: { decision, digest: task.approval.digest, reviewer: REVIEWER } });
+      tasks.clearQueuedEventsForTests();
+    }
+  });
+
+  test('stored reviewer ACL is enforced through the route/service seam and generic state cannot bypass it', async () => {
+    const stored: ApprovalTask = {
+      id: ID, from: REQUESTER, to: REVIEWER, subject: 'Approve preview', state: 'input-required',
+      createdAt: '2026-08-24T00:00:00.000Z', updatedAt: '2026-08-24T00:00:00.000Z',
+      messages: [{ id: '1', from: REQUESTER, to: REVIEWER, subject: 'Approve preview', date: '2026-08-24T00:00:00.000Z', state: 'input-required', body: 'request' }],
+      kind: 'approval', approval: { action: ACTION, reviewer: REVIEWER, expiresAt: EXPIRES, digest: 'a'.repeat(64) },
+    };
+    const service = {
+      ...tasks.taskService,
+      get: async () => stored,
+      update: async () => { throw new Error('approval_decision_required'); },
+      decideApproval: async (input: { from: string; decision: 'approved' | 'rejected' }) => {
+        if (input.from !== REVIEWER) throw new Error('approval_reviewer_required');
+        return { ...stored, state: 'completed' as const, result: { decision: input.decision, digest: stored.approval.digest, reviewer: REVIEWER } };
+      },
+    };
+    const reviewer = await appFor({ kind: 'identity', address: REVIEWER }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/decision`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+    });
+    expect(reviewer.status).toBe(200);
+    for (const address of [REQUESTER, OUTSIDER]) {
+      const denied = await appFor({ kind: 'identity', address }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/decision`, {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      });
+      expect(denied.status).toBe(403);
+    }
+    const admin = await appFor({ kind: 'admin' }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/decision`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ from: REVIEWER, decision: 'rejected' }),
+    });
+    expect(admin.status).toBe(200);
+    const bypass = await appFor({ kind: 'identity', address: REVIEWER }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/state`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ state: 'completed', result: { decision: 'approved' } }),
+    });
+    expect(bypass.status).toBe(409);
+  });
+});
+
+describe('#55 R1b: signed IMAP rebuild', () => {
+  test('the real stamp/parser rejects RFC timestamp tampering; first valid terminal wins', async () => {
+    const parse = api().parseStampedTaskMessageForTests;
+    expect(parse, 'real IMAP stamp/parser seam is missing').toBeFunction();
+    const encodeDecision = api().encodeStampedApprovalDecisionForTests;
+    expect(encodeDecision, 'real server-stamped decision encoder is missing').toBeFunction();
+    const decide = api().decideApprovalTask;
+    expect(decide, 'real approval decision service is missing').toBeFunction();
+    const { task, sent } = await requestFixture();
+    const requestSource = rfc822(sent[0]!);
+    const request = await parse!({ id: task.id, uid: 1, source: requestSource, internalDate: '2026-08-24T00:00:00.000Z' });
+    expect(request).not.toBeNull();
+    expect(await parse!({ id: task.id, uid: 2, source: requestSource.replace(task.approval.digest, 'b'.repeat(64)), internalDate: '2026-08-24T00:00:01.000Z' })).toBeNull();
+    expect(await parse!({ id: task.id, uid: 3, source: requestSource.replace('"retries":2', '"retries":3'), internalDate: '2026-08-24T00:00:02.000Z' })).toBeNull();
+    expect(await parse!({ id: task.id, uid: 4, source: requestSource.replace(EXPIRES, '2030-08-25T00:00:01.000Z'), internalDate: '2026-08-24T00:00:03.000Z' })).toBeNull();
+    tasks.setTaskNowForTests(() => Date.parse('2026-08-24T00:01:00.000Z'));
+    tasks.setTaskGetForTests(async () => task);
+    await decide!({ id: task.id, from: REVIEWER, decision: 'approved' });
+    const approvedSource = rfc822(sent[1]!);
+    const approved = await parse!({
+      id: task.id, uid: 5, source: approvedSource,
+      internalDate: '2026-08-24T00:01:00.000Z',
+    });
+    expect(await parse!({ id: task.id, uid: 6, source: approvedSource.replace('2026-08-24T00:01:00.000Z', '2026-08-24T00:01:01.000Z'), internalDate: '2026-08-24T00:01:01.000Z' })).toBeNull();
+    const expired = await requestFixture();
+    tasks.setTaskNowForTests(() => Date.parse(EXPIRES));
+    tasks.setTaskGetForTests(async () => expired.task);
+    await expect(decide!({ id: expired.task.id, from: REVIEWER, decision: 'approved' })).rejects.toThrow('task_expired');
+    const expiredSource = rfc822(expired.sent[1]!);
+    const expiryRequest = await parse!({ id: expired.task.id, uid: 7, source: rfc822(expired.sent[0]!), internalDate: '2026-08-24T00:00:00.000Z' });
+    const expiryTerminal = await parse!({ id: expired.task.id, uid: 8, source: expiredSource, internalDate: EXPIRES });
+    expect(expiryTerminal).not.toBeNull();
+    expect(tasks.taskFromMessages(expired.task.id, [expiryRequest!, expiryTerminal!] as Parameters<typeof tasks.taskFromMessages>[1])).toMatchObject({
+      kind: 'approval', state: 'failed', result: { decision: 'expired', digest: expired.task.approval.digest, expiredAt: EXPIRES },
+    });
+    expect(await parse!({ id: expired.task.id, uid: 9, source: expiredSource.replace(EXPIRES, '2030-08-25T00:00:01.000Z'), internalDate: '2030-08-25T00:00:01.000Z' })).toBeNull();
+    const rejected = await parse!({
+      id: task.id, uid: 10,
+      source: encodeDecision!({ id: task.id, from: REVIEWER, to: REQUESTER, subject: task.subject, digest: task.approval.digest, decision: 'rejected', decidedAt: '2026-08-24T00:02:00.000Z' }),
+      internalDate: '2026-08-24T00:02:00.000Z',
+    });
+    const rebuilt = tasks.taskFromMessages(task.id, [request!, approved!, rejected!] as Parameters<typeof tasks.taskFromMessages>[1]);
+    expect(rebuilt).toMatchObject({ kind: 'approval', state: 'completed', result: { decision: 'approved', digest: task.approval.digest } });
+  });
+});
+
+describe('#55 R1b: actual UI/watcher seams and compatibility controls', () => {
+  test('the real watcher queues an approval preview without action arguments', async () => {
+    const encodeRequest = api().encodeStampedApprovalRequestForTests;
+    expect(encodeRequest, 'real server-stamped approval request encoder is missing').toBeFunction();
+    const source = encodeRequest!({
+      id: ID, from: REQUESTER, to: REVIEWER, subject: 'Approve preview', body: 'Record only; do not execute.',
+      action: ACTION, expiresAt: EXPIRES,
+    });
+    const calls: Array<{ message: string }> = [];
+    await processWatchedMessage({
+      envelope: { from: [{ address: REQUESTER }], to: [{ address: REVIEWER }], subject: 'Approve preview' },
+      headers: Buffer.from(`Delivered-To: ${REVIEWER}\r\n`), source: Buffer.from(source),
+    } as never, [{ address: REVIEWER, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'all', {
+      publish: async (input) => { calls.push({ message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.message).not.toContain('<img src=x onerror=alert(1)>');
+    expect(calls[0]!.message).not.toContain('dry-run');
+    expect(calls[0]!.message).not.toContain('retries');
+    expect(calls[0]!.message).toContain('Preview: Approval request recorded. Open the task dashboard to review.');
+
+    const encodeDecision = api().encodeStampedApprovalDecisionForTests;
+    expect(encodeDecision).toBeFunction();
+    const decisionCalls: Array<{ message: string }> = [];
+    await processWatchedMessage({
+      envelope: { from: [{ address: REVIEWER }], to: [{ address: REQUESTER }], subject: 'Approve preview' },
+      headers: Buffer.from(`Delivered-To: ${REQUESTER}\r\n`),
+      source: Buffer.from(encodeDecision!({ id: ID, from: REVIEWER, to: REQUESTER, subject: 'Approve preview', digest: api().approvalActionDigest!(ACTION), decision: 'approved', decidedAt: '2030-08-24T00:01:00.000Z' })),
+    } as never, [{ address: REQUESTER, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'all', {
+      publish: async (input) => { decisionCalls.push({ message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+    });
+    expect(decisionCalls[0]!.message).toContain('Preview: Approval decision recorded: approved.');
+
+    tasks.setTaskNowForTests(() => Date.parse('2030-08-24T23:59:59.999Z'));
+    const expired = await requestFixture(EXPIRES);
+    tasks.setTaskNowForTests(() => Date.parse(EXPIRES));
+    tasks.setTaskGetForTests(async () => expired.task);
+    await expect(api().decideApprovalTask!({ id: expired.task.id, from: REVIEWER, decision: 'approved' })).rejects.toThrow('task_expired');
+    const expiryCalls: Array<{ message: string }> = [];
+    await processWatchedMessage({
+      envelope: { from: [{ address: REQUESTER }], to: [{ address: REVIEWER }], subject: 'Approve preview' },
+      headers: Buffer.from(`Delivered-To: ${REVIEWER}\r\n`), source: Buffer.from(rfc822(expired.sent[1]!)),
+    } as never, [{ address: REVIEWER, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'all', {
+      publish: async (input) => { expiryCalls.push({ message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+    });
+    expect(expiryCalls[0]!.message).toContain('Preview: Approval expired.');
+
+    const invalidCalls: Array<{ message: string }> = [];
+    await processWatchedMessage({
+      envelope: { from: [{ address: REQUESTER }], to: [{ address: REVIEWER }], subject: 'Approve preview' },
+      headers: Buffer.from(`Delivered-To: ${REVIEWER}\r\n`),
+      source: Buffer.from(source.replace(/X-OA-Task-Stamp: [^\r\n]+/, 'X-OA-Task-Stamp: forged')),
+    } as never, [{ address: REVIEWER, createdAt: '2026-08-24T00:00:00.000Z', pushContentTier: 3 }], 'all', {
+      publish: async (input) => { invalidCalls.push({ message: input.message }); return { target: input.target, title: input.title, level: input.level }; },
+    });
+    expect(invalidCalls[0]!.message).not.toContain('Approval request recorded.');
+    expect(invalidCalls[0]!.message).toContain('<img src=x onerror=alert(1)>');
+  });
+
+  test('ordinary REST/MCP/rebuild callers retain their existing task contract', async () => {
+    const ordinary = {
+      id: ID, from: REQUESTER, to: REVIEWER, subject: 'Ordinary', state: 'submitted' as const,
+      createdAt: '2026-08-24T00:00:00.000Z', updatedAt: '2026-08-24T00:00:00.000Z',
+      messages: [{ id: '1', from: REQUESTER, to: REVIEWER, subject: 'Ordinary', date: '2026-08-24T00:00:00.000Z', state: 'submitted' as const, body: 'ordinary body' }],
+    };
+    expect(tasks.taskFromMessages(ID, [{ uid: 1, ...ordinary.messages[0] }])).toMatchObject({ state: 'submitted', subject: 'Ordinary' });
+    let requestBody = '';
+    const client = new OpenAgentEmailClient('http://test.invalid', 'token', async (_url, init) => {
+      requestBody = String(init?.body); return new Response(JSON.stringify(ordinary), { status: 201 });
+    });
+    await client.createTask(REVIEWER, 'Ordinary', 'ordinary body');
+    expect(JSON.parse(requestBody)).toEqual({ to: REVIEWER, subject: 'Ordinary', body: 'ordinary body', wait: false });
+
+    const calls: Array<{ path: string; body: unknown }> = [];
+    const approvalClient = new OpenAgentEmailClient('http://test.invalid', 'token', async (url, init) => {
+      calls.push({ path: String(url), body: JSON.parse(String(init?.body)) });
+      return new Response(JSON.stringify({ ...ordinary, kind: 'approval', approval: { action: ACTION, reviewer: REVIEWER, expiresAt: EXPIRES, digest: 'a'.repeat(64) } }), { status: 200 });
+    });
+    await approvalClient.createApprovalTask(REVIEWER, 'Approve preview', ACTION, EXPIRES, 'Record only; do not execute.');
+    await approvalClient.decideTask(ID, 'approved');
+    expect(calls).toEqual([
+      { path: 'http://test.invalid/v1/tasks', body: { to: REVIEWER, subject: 'Approve preview', body: 'Record only; do not execute.', kind: 'approval', approval: { action: ACTION, expiresAt: EXPIRES }, wait: false } },
+      { path: `http://test.invalid/v1/tasks/${ID}/decision`, body: { decision: 'approved' } },
+    ]);
+  });
+});

--- a/packages/api/test/approval-red.test.ts
+++ b/packages/api/test/approval-red.test.ts
@@ -275,9 +275,13 @@ describe('#55 R1b: one decision, terminal result, and ACL', () => {
       messages: [{ id: '1', from: REQUESTER, to: REVIEWER, subject: 'Approve preview', date: '2026-08-24T00:00:00.000Z', state: 'input-required', body: 'request' }],
       kind: 'approval', approval: { action: ACTION, reviewer: REVIEWER, expiresAt: EXPIRES, digest: 'a'.repeat(64) },
     };
+    const ordinary: Task = {
+      id: '9ab7d4ad-4051-4b33-a4f0-4c5267ea8800', from: REQUESTER, to: REVIEWER, subject: 'Ordinary task', state: 'input-required',
+      createdAt: stored.createdAt, updatedAt: stored.updatedAt, messages: [],
+    };
     const service = {
       ...tasks.taskService,
-      get: async () => stored,
+      get: async (id: string) => id === ordinary.id ? ordinary : stored,
       update: async () => { throw new Error('approval_decision_required'); },
       decideApproval: async (input: { from: string; decision: 'approved' | 'rejected' }) => {
         if (input.from !== REVIEWER) throw new Error('approval_reviewer_required');
@@ -288,20 +292,64 @@ describe('#55 R1b: one decision, terminal result, and ACL', () => {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
     });
     expect(reviewer.status).toBe(200);
-    for (const address of [REQUESTER, OUTSIDER]) {
+    // A task participant can still discover the approval, but cannot make a
+    // decision unless they are its stored reviewer.
+    for (const address of [REQUESTER]) {
       const denied = await appFor({ kind: 'identity', address }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/decision`, {
         method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
       });
       expect(denied.status).toBe(403);
     }
+    // R6 RED: an outsider must not learn either ordinary-vs-approval kind or
+    // the stored reviewer from a guessed decision URL.
+    for (const id of [ordinary.id, stored.id]) {
+      const hidden = await appFor({ kind: 'identity', address: OUTSIDER }, service as typeof tasks.taskService).request(`/v1/tasks/${id}/decision`, {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      });
+      expect(hidden.status).toBe(404);
+      expect(await hidden.json()).toEqual({ error: 'not_found' });
+    }
     const admin = await appFor({ kind: 'admin' }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/decision`, {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ from: REVIEWER, decision: 'rejected' }),
     });
     expect(admin.status).toBe(200);
+    const adminOrdinary = await appFor({ kind: 'admin' }, service as typeof tasks.taskService).request(`/v1/tasks/${ordinary.id}/decision`, {
+      method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ from: REVIEWER, decision: 'rejected' }),
+    });
+    expect(adminOrdinary.status).toBe(409);
+    expect(await adminOrdinary.json()).toEqual({ error: 'not_approval_task' });
     const bypass = await appFor({ kind: 'identity', address: REVIEWER }, service as typeof tasks.taskService).request(`/v1/tasks/${stored.id}/state`, {
       method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ state: 'completed', result: { decision: 'approved' } }),
     });
     expect(bypass.status).toBe(409);
+  });
+});
+
+describe('#55 R5: approval reminder integrity', () => {
+  test('regression: an approval reminder cannot emit the ordinary event that corrupts reconstruction', async () => {
+    const { task, sent } = await requestFixture();
+    const parse = api().parseStampedTaskMessageForTests;
+    expect(parse, 'production parser seam is missing').toBeFunction();
+    tasks.setTaskGetForTests(async () => task);
+    await expect(tasks.remindTask({ id: task.id, from: REQUESTER, body: 'This must not become an approval reminder.' }))
+      .rejects.toThrow('approval_decision_required');
+    expect(sent).toHaveLength(1);
+    const request = await parse!({ id: task.id, uid: 1, source: rfc822(sent[0]!), internalDate: '2026-08-24T00:00:00.000Z' });
+    expect(tasks.taskFromMessages(task.id, [request!] as Parameters<typeof tasks.taskFromMessages>[1]))
+      .toMatchObject({ kind: 'approval', state: 'input-required', approval: { digest: task.approval.digest } });
+  });
+
+  test('approval reminder is rejected before delivery and leaves the authenticated request reconstructable', async () => {
+    const { task, sent } = await requestFixture();
+    const parse = api().parseStampedTaskMessageForTests;
+    expect(parse, 'production parser seam is missing').toBeFunction();
+    tasks.setTaskGetForTests(async () => task);
+    await expect(tasks.remindTask({ id: task.id, from: REQUESTER, body: 'Do not send this.' }))
+      .rejects.toThrow('approval_decision_required');
+    expect(sent).toHaveLength(1);
+    const request = await parse!({ id: task.id, uid: 1, source: rfc822(sent[0]!), internalDate: '2026-08-24T00:00:00.000Z' });
+    expect(tasks.taskFromMessages(task.id, [request!] as Parameters<typeof tasks.taskFromMessages>[1]))
+      .toMatchObject({ kind: 'approval', state: 'input-required', approval: { digest: task.approval.digest } });
   });
 });
 

--- a/packages/api/test/audit-tiering.test.ts
+++ b/packages/api/test/audit-tiering.test.ts
@@ -245,8 +245,8 @@ describe('attribution：三种 caller 落三种行', () => {
 });
 
 describe('工具分层', () => {
-  test('规格表 15 工具均有 tier；注册冲突会 throw', () => {
-    expect(Object.keys(TOOL_TIER_SPEC).length).toBe(15);
+  test('规格表 16 工具均有 tier；注册冲突会 throw', () => {
+    expect(Object.keys(TOOL_TIER_SPEC).length).toBe(16);
     // SPEC 回落：即使 declared 空也能预检
     resetToolTiersForTests();
     expect(isToolTierDeclared('mail_new_identity')).toBe(false);

--- a/packages/api/test/mcp-http.test.ts
+++ b/packages/api/test/mcp-http.test.ts
@@ -158,7 +158,7 @@ describe('MCP 元数据 origin / insecure issuer', () => {
 });
 
 describe('MCP HTTP 工具', () => {
-  test('admin key：tools/list 返回全部 15 工具', async () => {
+  test('admin key：tools/list 返回全部 16 工具', async () => {
     const res = await mcpRequest(adminKey, 'tools/list');
     expect(res.status).toBe(200);
     const body = (await readMcpJson(res)) as {
@@ -178,20 +178,21 @@ describe('MCP HTTP 工具', () => {
       'notify_user',
       'notify_verify',
       'task_create',
+      'task_decide',
       'task_get',
       'task_list',
       'task_update',
     ].sort());
   });
 
-  test('identity token：tools/list 同样返回 15 工具', async () => {
+  test('identity token：tools/list 同样返回 16 工具', async () => {
     const { token } = createIdentity({ localpart: 'mcp-list-id' })!;
     const res = await mcpRequest(token, 'tools/list');
     expect(res.status).toBe(200);
     const body = (await readMcpJson(res)) as {
       result?: { tools?: unknown[] };
     };
-    expect(body.result?.tools?.length).toBe(15);
+    expect(body.result?.tools?.length).toBe(16);
   });
 
   test('mail_list_identities 无状态直连：连续两请求无 session 头各自成功', async () => {
@@ -274,6 +275,20 @@ describe('MCP task_list/task_get 广播 outputSchema 契约', () => {
       expect(item.properties).toHaveProperty('kind');
       expect(item.properties).toHaveProperty('idempotencyKey');
     }
+  });
+
+  test('approval create/decide and task output schemas are broadcast with typed approval fields', async () => {
+    const res = await mcpRequest(adminKey, 'tools/list');
+    const body = (await readMcpJson(res)) as { result?: { tools?: Array<{ name: string; inputSchema?: JsonSchema; outputSchema?: JsonSchema }> } };
+    const tools = body.result?.tools ?? [];
+    const create = tools.find((tool) => tool.name === 'task_create');
+    const decide = tools.find((tool) => tool.name === 'task_decide');
+    const get = tools.find((tool) => tool.name === 'task_get');
+    expect(create?.inputSchema?.properties).toHaveProperty('kind');
+    expect(create?.inputSchema?.properties).toHaveProperty('approval');
+    expect(decide?.inputSchema?.properties).toHaveProperty('decision');
+    expect(get?.outputSchema?.properties).toHaveProperty('kind');
+    expect(get?.outputSchema?.properties).toHaveProperty('approval');
   });
 });
 
@@ -435,5 +450,71 @@ describe('MCP task_list/task_get outputSchema 覆盖催办字段', () => {
     expect(body.result?.isError).toBeFalsy();
     const reminder = body.result?.structuredContent?.messages?.find((m) => m.kind === 'reminder');
     expect(reminder?.idempotencyKey).toBe('nudge-1');
+  });
+});
+
+describe('MCP registered task handlers execute through the production HTTP transport', () => {
+  test('ordinary/approval create and contained decide preserve their distinct REST contracts', async () => {
+    const requester = createIdentity({ localpart: `r3b-requester-${crypto.randomUUID().slice(0, 8)}` })!;
+    const reviewer = createIdentity({ localpart: `r3b-reviewer-${crypto.randomUUID().slice(0, 8)}` })!;
+    const ordinary = {
+      id: 'ac1b2c3d-e5f6-4780-8bcd-ef1234567890', from: requester.identity.address, to: reviewer.identity.address,
+      subject: 'Ordinary handler task', state: 'submitted' as const,
+      createdAt: '2026-08-24T00:00:00.000Z', updatedAt: '2026-08-24T00:00:00.000Z', messages: [],
+    };
+    const action = { type: 'deployment', name: 'publish-preview', arguments: { dryRun: true } };
+    const approval = {
+      id: 'bc1b2c3d-e5f6-4780-8bcd-ef1234567890', from: requester.identity.address, to: reviewer.identity.address,
+      subject: 'Approval handler task', state: 'input-required' as const,
+      createdAt: '2026-08-24T00:00:00.000Z', updatedAt: '2026-08-24T00:00:00.000Z', messages: [],
+      kind: 'approval' as const,
+      approval: { action, reviewer: reviewer.identity.address, expiresAt: '2030-08-25T00:00:00.000Z', digest: 'a'.repeat(64) },
+    };
+    const calls: { ordinary?: unknown; approval?: unknown; decide?: unknown } = {};
+    const unused = async () => { throw new Error('unused in MCP handler fixture'); };
+    const handlerApp = createApp({
+      uiEnabled: false,
+      taskService: {
+        create: async (input) => { calls.ordinary = input; return ordinary; },
+        createApproval: async (input) => { calls.approval = input; return approval; },
+        decideApproval: async (input) => {
+          calls.decide = input;
+          return { ...approval, state: 'completed' as const, result: { decision: input.decision } };
+        },
+        list: unused, listBoard: unused, get: async (id) => id === approval.id ? approval : null,
+        update: unused, reply: unused, remind: unused, close: unused, waitForTerminal: unused,
+      },
+    });
+    const call = (token: string, name: string, args: Record<string, unknown>, id: number) =>
+      handlerApp.request('/mcp', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json', accept: MCP_ACCEPT },
+        body: JSON.stringify({ jsonrpc: '2.0', id, method: 'tools/call', params: { name, arguments: args } }),
+      });
+
+    const ordinaryResponse = await call(requester.token, 'task_create', {
+      to: reviewer.identity.address, subject: ordinary.subject, body: 'ordinary body',
+    }, 801);
+    const approvalResponse = await call(requester.token, 'task_create', {
+      to: reviewer.identity.address, subject: approval.subject, body: 'record only', kind: 'approval',
+      approval: { action, expiresAt: approval.approval.expiresAt },
+    }, 802);
+    const decideResponse = await call(reviewer.token, 'task_decide', {
+      id: approval.id, decision: 'approved',
+    }, 803);
+    for (const response of [ordinaryResponse, approvalResponse, decideResponse]) {
+      expect(response.status).toBe(200);
+      const body = (await readMcpJson(response)) as { result?: { isError?: boolean } };
+      expect(body.result?.isError, JSON.stringify(body)).toBeFalsy();
+    }
+    expect(calls).toEqual({
+      ordinary: { from: requester.identity.address, to: reviewer.identity.address, subject: ordinary.subject, body: 'ordinary body' },
+      approval: {
+        from: requester.identity.address, to: reviewer.identity.address, subject: approval.subject, body: 'record only',
+        action, expiresAt: '2030-08-25T00:00:00.000Z',
+      },
+      // The handler received no `from`; the REST identity binding supplied it.
+      decide: { id: approval.id, from: reviewer.identity.address, decision: 'approved' },
+    });
   });
 });

--- a/packages/api/test/mcp-http.test.ts
+++ b/packages/api/test/mcp-http.test.ts
@@ -158,6 +158,28 @@ describe('MCP 元数据 origin / insecure issuer', () => {
 });
 
 describe('MCP HTTP 工具', () => {
+  test('R9-F RED: shipped public docs describe typed approval creation, decision, and the 16-tool contained inventory', async () => {
+    const [rootReadme, packageReadme, security] = await Promise.all([
+      Bun.file(new URL('../../../README.md', import.meta.url)).text(),
+      Bun.file(new URL('../../mcp/README.md', import.meta.url)).text(),
+      Bun.file(new URL('../../../docs/security.md', import.meta.url)).text(),
+    ]);
+    const docs = `${rootReadme}\n${packageReadme}`;
+    expect({
+      existingCreate: docs.includes('task_create(to, subject, body, wait?)'),
+      typedApproval: /approval.*action.*expiresAt|kind.*approval/s.test(docs),
+      decide: docs.includes('task_decide'),
+      securityToolCount: /16\s+tools/i.test(security),
+      containedDecision: /contained[^\n]*task_decide|task_decide[^\n]*contained/i.test(security),
+    }).toEqual({
+      existingCreate: true,
+      typedApproval: true,
+      decide: true,
+      securityToolCount: true,
+      containedDecision: true,
+    });
+  });
+
   test('admin key：tools/list 返回全部 16 工具', async () => {
     const res = await mcpRequest(adminKey, 'tools/list');
     expect(res.status).toBe(200);

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('abf73069d6731b8a34c402090265ef96f62df555897dbc23dec026207baf3456');
+    expect(sha256(UI_JS)).toBe('7b4e773e0df1d77cf3f7631825799d6d39d84a4a3cf5194a665cd07340aef28f');
     expect(sha256(UI_CSS)).toBe('851ba389069a9ae9a8587d9c228ec79a94c035b88792f3afca89ec1fb4e41f77');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('2387e299fff8264a5a7cf15ce23c63a86257754656f25ff7103fb1f76d21a1b5');
+    expect(sha256(UI_JS)).toBe('fcdd85a2cb6c850c7a70798d4883b7a60b7b97a534647e21de5fc293d0b3dd0c');
     expect(sha256(UI_CSS)).toBe('851ba389069a9ae9a8587d9c228ec79a94c035b88792f3afca89ec1fb4e41f77');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('7b4e773e0df1d77cf3f7631825799d6d39d84a4a3cf5194a665cd07340aef28f');
+    expect(sha256(UI_JS)).toBe('2387e299fff8264a5a7cf15ce23c63a86257754656f25ff7103fb1f76d21a1b5');
     expect(sha256(UI_CSS)).toBe('851ba389069a9ae9a8587d9c228ec79a94c035b88792f3afca89ec1fb4e41f77');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('9cd55720ff17035aa7ed0a6258060f6cea809ac445d42947f085059788b3cf08');
+    expect(sha256(UI_JS)).toBe('abf73069d6731b8a34c402090265ef96f62df555897dbc23dec026207baf3456');
     expect(sha256(UI_CSS)).toBe('851ba389069a9ae9a8587d9c228ec79a94c035b88792f3afca89ec1fb4e41f77');
   });
 });

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -636,6 +636,7 @@ type FakeNode = {
   textContent: string;
   type: string;
   dateTime: string;
+  disabled: boolean;
   attributes: Record<string, string>;
   childNodes: FakeNode[];
   classList: { add: (name: string) => void; contains: (name: string) => boolean };
@@ -654,6 +655,7 @@ function fakeEl(tag: string): FakeNode {
     textContent: '',
     type: '',
     dateTime: '',
+    disabled: false,
     attributes: {},
     childNodes: [],
     classList: {
@@ -683,7 +685,7 @@ function fakeEl(tag: string): FakeNode {
   return node;
 }
 
-function makeApprovalActionHarness() {
+function makeApprovalActionHarness(apiJsonImpl?: (path: string, init: RequestInit) => Promise<Task>) {
   const state = { me: { address: 'owl@test.example' }, taskDetail: null as unknown, taskDetailStatus: '' };
   const calls: Array<{ path: string; init: RequestInit }> = [];
   const announced: string[] = [];
@@ -697,7 +699,10 @@ function makeApprovalActionHarness() {
   );
   const renderer = fn(
     { createElement: fakeEl }, state, () => false,
-    async (path: string, init: RequestInit) => { calls.push({ path, init }); return updated; },
+    async (path: string, init: RequestInit) => {
+      calls.push({ path, init });
+      return apiJsonImpl ? apiJsonImpl(path, init) : updated;
+    },
     () => { renderCount += 1; }, () => { loadCount += 1; }, (message: string) => { announced.push(message); },
   ) as {
     approvalCanDecide: (task: Task) => boolean;
@@ -788,6 +793,77 @@ function makeTaskRowHarness() {
 }
 
 describe('UI approval decision endpoint', () => {
+  test('R9 RED: dashboard authorizes outsider detail and task mutations before lazy expiry materialization', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    const expiredApproval = async () => {
+      const sent: unknown[] = [];
+      setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+      setTaskSendMailForTests(async (input) => { sent.push(input); return { messageId: `<r9-ui-${sent.length}@test.example>` }; });
+      const task = await taskService.createApproval!({
+        from: 'fox@test.example', to: 'owl@test.example', subject: 'R9 dashboard auth before expiry', body: 'record only',
+        action: { type: 'deployment', name: 'preview', arguments: {} }, expiresAt: boundary,
+      });
+      setTaskGetForTests(async () => task);
+      const session = makeApp({ kind: 'identity', address: 'cat@test.example' }, { taskService }, [task]);
+      setTaskNowForTests(() => Date.parse(boundary));
+      return { ...session, task, sent };
+    };
+    const inspect = async (request: (fixture: Awaited<ReturnType<typeof expiredApproval>>) => Response | Promise<Response>) => {
+      const fixture = await expiredApproval();
+      const response = await request(fixture);
+      return {
+        status: response.status,
+        body: await response.json(),
+        deliveries: fixture.sent.length,
+        durable: { state: fixture.task.state, messages: fixture.task.messages.length, result: fixture.task.result ?? null },
+      };
+    };
+
+    const matrix = {
+      detail: await inspect(({ app, cookie, task }) => app.request(`/ui/api/tasks/${task.id}`, { headers: { cookie } })),
+      decision: await inspect(({ app, cookie, task }) => app.request(`/ui/api/tasks/${task.id}/decision`, {
+        method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      })),
+      reply: await inspect(({ app, cookie, task }) => app.request(`/ui/api/tasks/${task.id}/reply`, {
+        method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ body: 'outsider write' }),
+      })),
+    };
+    expect(matrix).toEqual({
+      detail: { status: 403, body: { error: 'forbidden: task participant required' }, deliveries: 1, durable: { state: 'input-required', messages: 1, result: null } },
+      decision: { status: 404, body: { error: 'not_found' }, deliveries: 1, durable: { state: 'input-required', messages: 1, result: null } },
+      reply: { status: 403, body: { error: 'forbidden: task participant required' }, deliveries: 1, durable: { state: 'input-required', messages: 1, result: null } },
+    });
+
+  });
+
+  test('R9 control: dashboard participant detail materializes expiry once and reviewer decision remains task_expired', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    const sent: unknown[] = [];
+    setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    setTaskSendMailForTests(async (input) => { sent.push(input); return { messageId: `<r9-ui-control-${sent.length}@test.example>` }; });
+    const task = await taskService.createApproval!({
+      from: 'fox@test.example', to: 'owl@test.example', subject: 'R9 dashboard auth control', body: 'record only',
+      action: { type: 'deployment', name: 'preview', arguments: {} }, expiresAt: boundary,
+    });
+    setTaskGetForTests(async () => task);
+    const reviewer = makeApp({ kind: 'identity', address: 'owl@test.example' }, { taskService }, [task]);
+    setTaskNowForTests(() => Date.parse(boundary));
+    const firstDetail = await reviewer.app.request(`/ui/api/tasks/${task.id}`, { headers: { cookie: reviewer.cookie } });
+    const repeatedDetail = await reviewer.app.request(`/ui/api/tasks/${task.id}`, { headers: { cookie: reviewer.cookie } });
+    const decision = await reviewer.app.request(`/ui/api/tasks/${task.id}/decision`, {
+      method: 'POST', headers: { cookie: reviewer.cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+    });
+    expect({
+      detailStatuses: [firstDetail.status, repeatedDetail.status],
+      decision: { status: decision.status, body: await decision.json() },
+      deliveries: sent.length,
+    }).toEqual({
+      detailStatuses: [200, 200],
+      decision: { status: 409, body: { error: 'task_expired' } },
+      deliveries: 2,
+    });
+  });
+
   test('R8-D RED: dashboard preserves task_expired after production detail read materializes expiry', async () => {
     const boundary = '2026-08-24T00:00:00.000Z';
     const sent: unknown[] = [];
@@ -838,6 +914,49 @@ describe('UI approval decision endpoint', () => {
     } finally {
       Date.now = originalNow;
     }
+  });
+
+  test('R9-D RED: exact served approval controls allow only one in-flight decision', async () => {
+    let settle: (task: Task) => void = () => {};
+    const blocked = new Promise<Task>((resolve) => { settle = resolve; });
+    const { calls, renderer } = makeApprovalActionHarness(async () => blocked);
+    const section = renderer.renderApprovalAction(APPROVAL_TASK)!;
+    const buttons = section.childNodes.filter((node) => node.tagName === 'BUTTON');
+    buttons[0]!.click();
+    await Promise.resolve();
+    buttons[1]!.click();
+    expect({ calls: calls.length, disabled: buttons.map((button) => button.disabled) }).toEqual({ calls: 1, disabled: [true, true] });
+    settle({ ...APPROVAL_TASK, state: 'completed', result: { decision: 'approved' } });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(buttons.map((button) => button.disabled)).toEqual([false, false]);
+  });
+
+  test('R9-E RED: exact served approval heading is neutral after terminal state', () => {
+    const { renderer } = makeApprovalActionHarness();
+    const pending = renderer.renderApprovalAction(APPROVAL_TASK)!;
+    const terminalHeadings = [
+      { state: 'completed' as const, result: { decision: 'approved' } },
+      { state: 'completed' as const, result: { decision: 'rejected' } },
+      { state: 'failed' as const, result: { decision: 'expired' } },
+    ].map((terminal) => leafTexts(renderer.renderApprovalAction({ ...APPROVAL_TASK, ...terminal })!));
+    expect(leafTexts(pending)).toContain('Approval required');
+    expect(terminalHeadings).toEqual([
+      expect.arrayContaining(['Approval details']),
+      expect.arrayContaining(['Approval details']),
+      expect.arrayContaining(['Approval details']),
+    ]);
+    expect(terminalHeadings.flat()).not.toContain('Approval required');
+  });
+
+  test('R9-D control: one settled served decision reloads normal terminal state', async () => {
+    const { calls, state, renderer, counts } = makeApprovalActionHarness();
+    const button = renderer.renderApprovalAction(APPROVAL_TASK)!.childNodes.find((node) => node.tagName === 'BUTTON')!;
+    button.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect({ calls: calls.length, state: (state.taskDetail as Task).state, counts: counts() }).toEqual({
+      calls: 1, state: 'completed', counts: { renderCount: 1, loadCount: 1 },
+    });
   });
 
   test('dashboard actor matrix keeps approval authority at the stored reviewer and core service', async () => {

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -12,16 +12,28 @@ process.env.SMTP_PASS = 'smtp-secret';
 
 const { UiSessionStore } = await import('../src/lib/ui-session.ts');
 const { createUiApiRoutes } = await import('../src/routes/ui.ts');
+const { createIdentity, findIdentity } = await import('../src/lib/identities.ts');
 const {
   listTaskBoard,
+  clearQueuedEventsForTests,
+  setTaskGetForTests,
   setTaskListAllForTests,
+  setTaskSendMailForTests,
   setTaskNowForTests,
+  taskService,
   toUiTaskView,
 } = await import('../src/lib/tasks.ts');
+
+for (const localpart of ['fox', 'owl']) {
+  if (!findIdentity(`${localpart}@test.example`)) createIdentity({ localpart, issueToken: false });
+}
 
 afterEach(() => {
   setTaskNowForTests(null);
   setTaskListAllForTests(null);
+  setTaskGetForTests(null);
+  setTaskSendMailForTests(null);
+  clearQueuedEventsForTests();
 });
 
 const NOW = '2026-08-12T12:00:00.000Z';
@@ -776,6 +788,58 @@ function makeTaskRowHarness() {
 }
 
 describe('UI approval decision endpoint', () => {
+  test('R8-D RED: dashboard preserves task_expired after production detail read materializes expiry', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    const sent: unknown[] = [];
+    setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    setTaskSendMailForTests(async (input) => { sent.push(input); return { messageId: `<r8-expiry-${sent.length}@test.example>` }; });
+    const pending = await taskService.createApproval!({
+      from: 'fox@test.example', to: 'owl@test.example', subject: 'R8 dashboard expiry', body: 'record only',
+      action: { type: 'deployment', name: 'preview', arguments: {} }, expiresAt: boundary,
+    });
+    setTaskGetForTests(async () => pending);
+    const { app, cookie } = makeApp({ kind: 'identity', address: 'owl@test.example' }, { taskService }, [pending]);
+    setTaskNowForTests(() => Date.parse(boundary));
+    expect((await app.request(`/ui/api/tasks/${pending.id}`, { headers: { cookie } })).status).toBe(200);
+    const responses = await Promise.all([0, 1].map(async () => {
+      const response = await app.request(`/ui/api/tasks/${pending.id}/decision`, {
+        method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      });
+      return { status: response.status, body: await response.json() };
+    }));
+    expect({ responses, delivered: sent.length }).toEqual({
+      responses: [{ status: 409, body: { error: 'task_expired' } }, { status: 409, body: { error: 'task_expired' } }], delivered: 2,
+    });
+  });
+
+  test('R8-E RED: an injected dashboard service never falls back to global approval decisions', async () => {
+    const sent: unknown[] = [];
+    setTaskGetForTests(async () => APPROVAL_TASK);
+    setTaskSendMailForTests(async (input) => { sent.push(input); return { messageId: '<global-fallback@test.example>' }; });
+    const injected = {
+      ...taskService,
+      get: async () => APPROVAL_TASK,
+      decideApproval: undefined,
+    } as typeof taskService;
+    const { app, cookie } = makeApp({ kind: 'identity', address: 'owl@test.example' }, { taskService: injected }, [APPROVAL_TASK]);
+    const response = await app.request(`/ui/api/tasks/${APPROVAL_TASK.id}/decision`, {
+      method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+    });
+    expect({ status: response.status, sent: sent.length }).toEqual({ status: 502, sent: 0 });
+  });
+
+  test('R8-F RED: exact served approval controls follow server state, not an ahead browser clock', () => {
+    const originalNow = Date.now;
+    try {
+      Date.now = () => Date.parse(APPROVAL_EXPIRES_AT) + 1;
+      const { renderer } = makeApprovalActionHarness();
+      const failed: Task = { ...APPROVAL_TASK, state: 'failed', result: { decision: 'expired' } };
+      expect([renderer.approvalCanDecide(APPROVAL_TASK), renderer.approvalCanDecide(failed)]).toEqual([true, false]);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
   test('dashboard actor matrix keeps approval authority at the stored reviewer and core service', async () => {
     const decided: unknown[] = [];
     const { app, cookie, deps } = makeApp(

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -108,6 +108,17 @@ const TASK_INPUT: Task = {
   ],
 };
 
+const APPROVAL_TASK: Task = {
+  id: '55555555-5555-4555-8555-555555555555',
+  from: 'fox@test.example', to: 'owl@test.example', subject: 'Approve preview', state: 'input-required',
+  createdAt: '2026-08-12T08:00:00.000Z', updatedAt: '2026-08-12T08:00:00.000Z',
+  messages: [], kind: 'approval',
+  approval: {
+    action: { type: 'deployment', name: 'publish-preview', arguments: { dryRun: true } },
+    reviewer: 'owl@test.example', expiresAt: '2030-08-25T00:00:00.000Z', digest: 'a'.repeat(64),
+  },
+};
+
 type AuthKind = { kind: 'admin' } | { kind: 'identity'; address: string };
 
 const ORIGIN = { origin: 'http://localhost' };
@@ -600,11 +611,13 @@ type FakeNode = {
   textContent: string;
   type: string;
   dateTime: string;
+  attributes: Record<string, string>;
   childNodes: FakeNode[];
   classList: { add: (name: string) => void; contains: (name: string) => boolean };
   setAttribute: (key: string, value: string) => void;
   append: (...nodes: FakeNode[]) => void;
-  addEventListener: () => void;
+  addEventListener: (event: string, listener: () => void) => void;
+  click: () => void;
 };
 
 /** 无 jsdom：够 renderTaskRows 建行、加 class、写 Overdue 文案。 */
@@ -615,6 +628,7 @@ function fakeEl(tag: string): FakeNode {
     textContent: '',
     type: '',
     dateTime: '',
+    attributes: {},
     childNodes: [],
     classList: {
       add(name: string) {
@@ -626,13 +640,41 @@ function fakeEl(tag: string): FakeNode {
         return node.className.split(/\s+/).includes(name);
       },
     },
-    setAttribute() {},
+    setAttribute(key: string, value: string) {
+      node.attributes[key] = value;
+    },
     append(...nodes: FakeNode[]) {
       node.childNodes.push(...nodes);
     },
-    addEventListener() {},
+    addEventListener(event: string, listener: () => void) {
+      if (event === 'click') node.click = listener;
+    },
+    click() {},
   };
   return node;
+}
+
+function makeApprovalActionHarness() {
+  const state = { me: { address: 'owl@test.example' }, taskDetail: null as unknown, taskDetailStatus: '' };
+  const calls: Array<{ path: string; init: RequestInit }> = [];
+  const announced: string[] = [];
+  let renderCount = 0;
+  let loadCount = 0;
+  const updated = { ...APPROVAL_TASK, state: 'completed' as const, result: { decision: 'approved' } };
+  const source = sliceTasksFn('function approvalCanDecide(', 'function renderTaskRows(');
+  const fn = new Function(
+    'document', 'state', 'isAdmin', 'apiJson', 'renderTasks', 'loadTasks', 'announce',
+    `${source}\nreturn { approvalCanDecide: approvalCanDecide, renderApprovalAction: renderApprovalAction };`,
+  );
+  const renderer = fn(
+    { createElement: fakeEl }, state, () => false,
+    async (path: string, init: RequestInit) => { calls.push({ path, init }); return updated; },
+    () => { renderCount += 1; }, () => { loadCount += 1; }, (message: string) => { announced.push(message); },
+  ) as {
+    approvalCanDecide: (task: Task) => boolean;
+    renderApprovalAction: (task: Task) => FakeNode | null;
+  };
+  return { state, calls, announced, renderer, counts: () => ({ renderCount, loadCount }) };
 }
 
 /** 收集叶子 textContent，用来断言 Overdue 文字通道。 */
@@ -690,6 +732,110 @@ function makeTaskRowHarness() {
   ) as () => void;
   return { state, tasksRows, renderTaskRows };
 }
+
+describe('UI approval decision endpoint', () => {
+  test('dashboard actor matrix keeps approval authority at the stored reviewer and core service', async () => {
+    const decided: unknown[] = [];
+    const { app, cookie, deps } = makeApp(
+      { kind: 'identity', address: 'owl@test.example' },
+      {},
+      [APPROVAL_TASK],
+    );
+    (deps.taskService as any).decideApproval = mock(async (input: unknown) => {
+      decided.push(input);
+      return { ...APPROVAL_TASK, state: 'completed' as const, result: { decision: 'approved', digest: APPROVAL_TASK.approval!.digest } };
+    });
+    const ok = await app.request(`/ui/api/tasks/${APPROVAL_TASK.id}/decision`, {
+      method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' },
+      body: JSON.stringify({ decision: 'approved' }),
+    });
+    expect(ok.status).toBe(200);
+    expect(await ok.json()).toMatchObject({ kind: 'approval', state: 'completed', approval: { reviewer: 'owl@test.example' } });
+    expect(decided).toEqual([{ id: APPROVAL_TASK.id, from: 'owl@test.example', decision: 'approved' }]);
+
+    async function decide(app: Hono, cookie: string, body: unknown) {
+      return app.request(`/ui/api/tasks/${APPROVAL_TASK.id}/decision`, {
+        method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify(body),
+      });
+    }
+
+    for (const address of ['fox@test.example', 'stranger@test.example']) {
+      const denied = makeApp({ kind: 'identity', address }, {}, [APPROVAL_TASK]);
+      const response = await decide(denied.app, denied.cookie, { decision: 'approved' });
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: 'forbidden: approval reviewer required' });
+    }
+
+    const admin = makeApp({ kind: 'admin' }, {}, [APPROVAL_TASK]);
+    expect((await decide(admin.app, admin.cookie, { decision: 'approved' })).status).toBe(403);
+    expect((await decide(admin.app, admin.cookie, { from: 'fox@test.example', decision: 'approved' })).status).toBe(403);
+    (admin.deps.taskService as any).decideApproval = mock(async (input: unknown) => {
+      decided.push(input);
+      return { ...APPROVAL_TASK, state: 'completed' as const, result: { decision: 'rejected' } };
+    });
+    const adminOk = await decide(admin.app, admin.cookie, { from: 'owl@test.example', decision: 'rejected' });
+    expect(adminOk.status).toBe(200);
+    expect(decided.at(-1)).toEqual({ id: APPROVAL_TASK.id, from: 'owl@test.example', decision: 'rejected' });
+
+    const missing = makeApp({ kind: 'identity', address: 'owl@test.example' }, {}, []);
+    expect((await decide(missing.app, missing.cookie, { decision: 'approved' })).status).toBe(404);
+    const ordinary = makeApp({ kind: 'identity', address: 'owl@test.example' }, {}, [TASK_A]);
+    const ordinaryResponse = await ordinary.app.request(`/ui/api/tasks/${TASK_A.id}/decision`, {
+      method: 'POST', headers: { cookie: ordinary.cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+    });
+    expect(ordinaryResponse.status).toBe(409);
+    expect(await ordinaryResponse.json()).toEqual({ error: 'not_approval_task' });
+
+    const terminalTask: Task = { ...APPROVAL_TASK, state: 'completed', result: { decision: 'approved' } };
+    const terminal = makeApp({ kind: 'identity', address: 'owl@test.example' }, {}, [terminalTask]);
+    (terminal.deps.taskService as any).decideApproval = mock(async () => { throw new Error('task_already_decided'); });
+    expect((await decide(terminal.app, terminal.cookie, { decision: 'approved' })).status).toBe(409);
+
+    const coreRecheck = makeApp({ kind: 'identity', address: 'owl@test.example' }, {}, [APPROVAL_TASK]);
+    (coreRecheck.deps.taskService as any).decideApproval = mock(async () => { throw new Error('approval_reviewer_required'); });
+    const rechecked = await decide(coreRecheck.app, coreRecheck.cookie, { decision: 'approved' });
+    expect(rechecked.status).toBe(403);
+    expect(await rechecked.json()).toEqual({ error: 'forbidden: approval reviewer required' });
+  });
+
+  test('the exact served renderer keeps action text inert and posts an approval decision', async () => {
+    const { state, calls, announced, renderer, counts } = makeApprovalActionHarness();
+    const malicious: Task = {
+      ...APPROVAL_TASK,
+      approval: {
+        ...APPROVAL_TASK.approval!,
+        action: {
+          type: 'deployment', name: '<img src=x onerror=alert(1)>',
+          arguments: { html: '<img src=x onerror=alert(1)>', flags: ['safe', 'dry-run'] },
+        },
+      },
+    };
+    const section = renderer.renderApprovalAction(malicious)!;
+    expect(renderer.approvalCanDecide(malicious)).toBe(true);
+    expect(leafTexts(section)).toContain('Name: <img src=x onerror=alert(1)>');
+    expect(leafTexts(section)).toContain(JSON.stringify(malicious.approval!.action.arguments));
+    expect(Object.hasOwn(section, 'innerHTML')).toBe(false);
+    const buttons = section.childNodes.filter((node) => node.tagName === 'BUTTON');
+    expect(buttons.map((button) => ({ type: button.type, label: button.attributes['aria-label'], text: button.textContent }))).toEqual([
+      { type: 'button', label: 'Approve action', text: 'Approve' },
+      { type: 'button', label: 'Reject action', text: 'Reject' },
+    ]);
+    buttons[0]!.click();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual({
+      path: `/ui/api/tasks/${APPROVAL_TASK.id}/decision`,
+      init: {
+        method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      },
+    });
+    expect(state.taskDetail).toEqual({ ...APPROVAL_TASK, state: 'completed', result: { decision: 'approved' } });
+    expect(state.taskDetailStatus).toBe('ready');
+    expect(counts()).toEqual({ renderCount: 1, loadCount: 1 });
+    expect(announced).toEqual(['Approval recorded.']);
+  });
+});
 
 describe('UI task overdue presentation (PR4 dual channel)', () => {
   test('overdue row has is-overdue class and Overdue text; on-time row has neither', () => {
@@ -750,4 +896,3 @@ describe('UI task overdue presentation (PR4 dual channel)', () => {
     expect(PAGES_CSS).toContain('.task-overdue-flag {\n  display: inline-block;\n  margin-top: 4px;\n  color: var(--red);');
   });
 });
-

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -108,6 +108,8 @@ const TASK_INPUT: Task = {
   ],
 };
 
+const APPROVAL_EXPIRES_AT = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
 const APPROVAL_TASK: Task = {
   id: '55555555-5555-4555-8555-555555555555',
   from: 'fox@test.example', to: 'owl@test.example', subject: 'Approve preview', state: 'input-required',
@@ -115,7 +117,7 @@ const APPROVAL_TASK: Task = {
   messages: [], kind: 'approval',
   approval: {
     action: { type: 'deployment', name: 'publish-preview', arguments: { dryRun: true } },
-    reviewer: 'owl@test.example', expiresAt: '2030-08-25T00:00:00.000Z', digest: 'a'.repeat(64),
+    reviewer: 'owl@test.example', expiresAt: APPROVAL_EXPIRES_AT, digest: 'a'.repeat(64),
   },
 };
 
@@ -540,6 +542,17 @@ describe('UI task reply / remind / close', () => {
     expect(await terminal.json()).toEqual({ error: 'task_already_terminal' });
   });
 
+  test('admin reminder rejects an approval before the service can deliver it', async () => {
+    const { app, cookie, remindCalls } = makeApp({ kind: 'admin' }, {}, [APPROVAL_TASK]);
+    const response = await app.request(`/ui/api/tasks/${APPROVAL_TASK.id}/remind`, {
+      method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' },
+      body: JSON.stringify({ from: 'fox@test.example', body: 'Do not remind approval.' }),
+    });
+    expect(response.status).toBe(409);
+    expect(await response.json()).toEqual({ error: 'approval_decision_required' });
+    expect(remindCalls).toEqual([]);
+  });
+
   test('admin close writes structured closed_by_admin; repeat terminal is 409', async () => {
     const { app, cookie, closeCalls } = makeApp({ kind: 'admin' });
     const ok = await app.request(`/ui/api/tasks/${TASK_A.id}/close`, {
@@ -616,6 +629,7 @@ type FakeNode = {
   classList: { add: (name: string) => void; contains: (name: string) => boolean };
   setAttribute: (key: string, value: string) => void;
   append: (...nodes: FakeNode[]) => void;
+  replaceChildren: (...nodes: FakeNode[]) => void;
   addEventListener: (event: string, listener: () => void) => void;
   click: () => void;
 };
@@ -646,6 +660,9 @@ function fakeEl(tag: string): FakeNode {
     append(...nodes: FakeNode[]) {
       node.childNodes.push(...nodes);
     },
+    replaceChildren(...nodes: FakeNode[]) {
+      node.childNodes = [...nodes];
+    },
     addEventListener(event: string, listener: () => void) {
       if (event === 'click') node.click = listener;
     },
@@ -675,6 +692,31 @@ function makeApprovalActionHarness() {
     renderApprovalAction: (task: Task) => FakeNode | null;
   };
   return { state, calls, announced, renderer, counts: () => ({ renderCount, loadCount }) };
+}
+
+function makeAdminTaskDetailHarness(task: Task) {
+  const tasksDetailContent = fakeEl('div');
+  const state = { activeTaskId: task.id, taskDetailStatus: 'ready', taskDetailMessage: '', taskDetail: task };
+  const source = sliceTasksFn('function renderTaskDetail(', 'function renderTasks(');
+  const fn = new Function(
+    'document', 'state', 'tasksDetailContent', 'isAdmin', 'clearTaskDetail', 'taskStateToken', 'taskStateLabel',
+    'formatAgo', 'taskTimelineBody', 'formatDate', 'taskIsClosed', 'renderTaskResultNode', 'renderApprovalAction',
+    'fillTaskFromSelect', 'submitTaskReply', 'submitTaskRemind', 'confirmCloseTask', 'TASK_TIMELINE_RENDER_LIMIT',
+    `${source}\nreturn renderTaskDetail;`,
+  );
+  const renderTaskDetail = fn(
+    { createElement: fakeEl }, state, tasksDetailContent, () => true, () => {}, () => 'input-required', () => 'Input required',
+    () => 'just now', (value: string) => value, () => '2026-08-12', () => false, () => fakeEl('pre'),
+    () => {
+      const actions = fakeEl('section');
+      const approve = fakeEl('button'); approve.type = 'button'; approve.textContent = 'Approve';
+      const reject = fakeEl('button'); reject.type = 'button'; reject.textContent = 'Reject';
+      actions.append(approve, reject);
+      return actions;
+    },
+    () => {}, () => {}, () => {}, () => {}, 100,
+  ) as () => void;
+  return { tasksDetailContent, renderTaskDetail };
 }
 
 /** 收集叶子 textContent，用来断言 Overdue 文字通道。 */
@@ -759,11 +801,22 @@ describe('UI approval decision endpoint', () => {
       });
     }
 
-    for (const address of ['fox@test.example', 'stranger@test.example']) {
+    for (const address of ['fox@test.example']) {
       const denied = makeApp({ kind: 'identity', address }, {}, [APPROVAL_TASK]);
       const response = await decide(denied.app, denied.cookie, { decision: 'approved' });
       expect(response.status).toBe(403);
       expect(await response.json()).toEqual({ error: 'forbidden: approval reviewer required' });
+    }
+
+    // R6 RED: a dashboard outsider guessing an ordinary or approval decision
+    // URL sees neither the task kind nor the stored reviewer ACL outcome.
+    for (const task of [TASK_A, APPROVAL_TASK]) {
+      const outsider = makeApp({ kind: 'identity', address: 'stranger@test.example' }, {}, [task]);
+      const response = await outsider.app.request(`/ui/api/tasks/${task.id}/decision`, {
+        method: 'POST', headers: { cookie: outsider.cookie, ...ORIGIN, 'content-type': 'application/json' }, body: JSON.stringify({ decision: 'approved' }),
+      });
+      expect(response.status).toBe(404);
+      expect(await response.json()).toEqual({ error: 'not_found' });
     }
 
     const admin = makeApp({ kind: 'admin' }, {}, [APPROVAL_TASK]);
@@ -834,6 +887,19 @@ describe('UI approval decision endpoint', () => {
     expect(state.taskDetailStatus).toBe('ready');
     expect(counts()).toEqual({ renderCount: 1, loadCount: 1 });
     expect(announced).toEqual(['Approval recorded.']);
+  });
+
+  test('the exact served admin detail hides generic actions for approval but retains them for ordinary tasks', () => {
+    const approval = makeAdminTaskDetailHarness(APPROVAL_TASK);
+    approval.renderTaskDetail();
+    expect(leafTexts(approval.tasksDetailContent)).toContain('Approve');
+    expect(leafTexts(approval.tasksDetailContent)).toContain('Reject');
+    expect(approval.tasksDetailContent.childNodes.some((node) => node.className === 'task-admin-actions')).toBe(false);
+
+    const ordinary = makeAdminTaskDetailHarness(TASK_A);
+    ordinary.renderTaskDetail();
+    expect(ordinary.tasksDetailContent.childNodes.some((node) => node.className === 'task-admin-actions')).toBe(true);
+    expect(leafTexts(ordinary.tasksDetailContent)).toEqual(expect.arrayContaining(['Remind', 'Close']));
   });
 });
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -39,7 +39,8 @@ If `OPENAGENTEMAIL_API_KEY` is missing the server exits immediately with a clear
 | `notify_agent(name, title, message, level?, tags?)` | Wake a named agent without exposing a topic or ntfy credential |
 | `notify_check(since?)` | Read recent notifications for the calling identity only |
 | `notify_verify()` | Send and poll a harmless server-side notification self-check |
-| `task_create(to, subject, body, wait?)` | Assign an email-backed task to another managed identity; `wait:true` waits up to 10 minutes for a terminal state |
+| `task_create(to, subject, body, wait?)` | Assign an email-backed task to another managed identity; typed approvals add `kind: "approval"` with `approval:{action,expiresAt}`; `wait:true` waits up to 10 minutes for a terminal state |
+| `task_decide(id, decision)` | Stored reviewer approves or rejects a pending typed approval |
 | `task_list(state?)` | List this identity's task threads, optionally by current state |
 | `task_get(id, wait?)` | Read one task thread and its stamped state history; `wait:true` waits up to 10 minutes |
 | `task_update(id, state, body?, result?)` | Advance a participating task; `result` is written as a JSON block in the reply body |

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -42,7 +42,7 @@ mock.module("@modelcontextprotocol/server/stdio", () => ({
 process.env.OPENAGENTEMAIL_API_KEY = "test-key";
 await import("../src/main.ts");
 
-test("15 个工具都公布新 SDK 支持的元数据", () => {
+test("16 个工具都公布新 SDK 支持的元数据", () => {
   expect([...toolConfigs.keys()]).toEqual([
     "mail_new_identity",
     "mail_list_identities",
@@ -59,6 +59,7 @@ test("15 个工具都公布新 SDK 支持的元数据", () => {
     "task_list",
     "task_get",
     "task_update",
+    "task_decide",
   ]);
 
   for (const config of toolConfigs.values()) {
@@ -79,6 +80,7 @@ test("15 个工具都公布新 SDK 支持的元数据", () => {
   expect(toolConfigs.get("task_get")?.annotations?.readOnlyHint).toBe(true);
   expect(toolConfigs.get("task_create")?.annotations?.readOnlyHint).toBe(false);
   expect(toolConfigs.get("task_update")?.annotations?.readOnlyHint).toBe(false);
+  expect(toolConfigs.get("task_decide")?.annotations?.readOnlyHint).toBe(false);
   expect(toolConfigs.get("mail_read_message")?.outputSchema).toBe(
     toolConfigs.get("mail_wait_for")?.outputSchema,
   );
@@ -188,6 +190,11 @@ test("工具入参约束要和 REST API 对齐，别把服务端必拒的值放�
   expect(ok(taskUpdate, "state", "input-required")).toBe(true);
   expect(ok(taskUpdate, "state", "reopened")).toBe(false);
   expect(ok(taskUpdate, "body", "x".repeat(1_000_001))).toBe(false);
+
+  const taskDecide = toolSchemas.get("task_decide")!;
+  expect(ok(taskDecide, "id", "0fdc3207-056e-47c1-a65c-b29d39f66b83")).toBe(true);
+  expect(ok(taskDecide, "decision", "approved")).toBe(true);
+  expect(ok(taskDecide, "decision", "execute")).toBe(false);
 });
 
 test("identity 输出 schema 覆盖 REST 的 token / pushContentTier", () => {

--- a/state/task-55-typed-approvals-r1.md
+++ b/state/task-55-typed-approvals-r1.md
@@ -1,0 +1,224 @@
+# #55 typed approval tasks — R1 architecture map and RED contract
+
+Task: `b3f3b030-b5f4-4545-b5de-02f3b3290bf1`
+Scope: #55 only. This is a design/RED checkpoint; it makes no production change.
+
+## Current architecture map
+
+| Concern | Current owner | Relevant boundary |
+|---|---|---|
+| Durable task model / state machine | `packages/api/src/lib/tasks.ts` | `Task`, `TaskMessage`, `RawTaskMessage`; messages are IMAP-backed and `taskFromMessages()` rebuilds the thread. |
+| Server event provenance | `packages/api/src/lib/tasks.ts` | `taskStamp()` / `parseTaskMessage()` validate `X-OA-Task*`; result JSON is carried in the textual message body. |
+| Atomic task mutations | `packages/api/src/lib/tasks.ts` | `withTaskLock()` wraps `updateTask`, `replyTask`, `remindTask`, and `closeTask`; queued overlays prevent an IMAP-indexing race from reopening a just-written state. |
+| REST task API / ACL | `packages/api/src/routes/tasks.ts` | `/v1/tasks`, `/:id`, `/:id/state`; `actorAddress`, `known`, and `taskParticipants` enforce existing managed-identity and participant rules. |
+| REST client + MCP | `packages/api/src/mcp/client.ts`, `packages/api/src/mcp/tools.ts` | Client mirrors task routes; MCP exposes `task_create`, `task_list`, `task_get`, and `task_update` with independently broadcast output schemas. |
+| Dashboard | `packages/api/src/routes/ui.ts`, `packages/api/src/ui/client/pages/tasks.js` | Cookie ACL mirrors task participants. The client builds nodes with `textContent`, so it has a safe rendering primitive already; current actions are reply/remind/close only. |
+| Push previews | `packages/api/src/lib/notify.ts`, `packages/api/src/lib/notification-watcher.ts` | Server-originated task mail invokes `notifyTrustedAgentDelivery()` (address-only). Generic IMAP arrival preview is constructed in `processWatchedMessage()`. |
+| Fixtures / seams | `packages/api/test/tasks.test.ts`, `task-board.test.ts`, `ui-tasks.test.ts`, `notification-watcher.test.ts`, `mcp-http.test.ts`, `packages/mcp/test/tools.test.ts` | Task get/send/clock/list seams and route-local mock services exist; tests are the correct place to extend them, not a new store. |
+
+## Smallest additive persisted event model
+
+Ordinary tasks remain byte-for-byte compatible: `kind` is absent and their existing stamp/parser path is unchanged.
+
+An approval request is an optional generic task creation shape:
+
+```ts
+{
+  kind: 'approval',
+  to: reviewer,                 // requester is the authenticated `from`
+  subject,
+  body?,
+  approval: {
+    action: { type, name, arguments },
+    expiresAt: ISO_8601_UTC
+  },
+  wait?
+}
+```
+
+The server rejects equal requester/reviewer and unknown managed identities before it writes. It canonicalizes `action` as UTF-8 JSON with recursively lexicographically sorted object keys, preserved array order, and no whitespace; SHA-256 over those UTF-8 bytes is the lower-case hex `digest`. It stores the canonical action plus `{ reviewer, expiresAt, digest }` in a marked, parseable initial task-message body. The initial approval event carries a versioned approval header containing the digest and an approval-specific HMAC stamp. On rebuild, the parser recomputes the digest from the action and discards the event if it differs or its approval stamp is invalid. This prevents a body-only tamper from changing the displayed/executed snapshot.
+
+The only approval mutation is:
+
+```ts
+POST /v1/tasks/:id/decision
+{ from?: reviewer, decision: 'approved' | 'rejected' }
+```
+
+Identity tokens derive `from`; admin requests must explicitly name the reviewer. The service, not the route, acquires the existing per-task lock and then re-reads the task/queued overlay. Inside that one critical section it verifies all of: approval kind, requester != reviewer, caller == stored reviewer, task is `input-required`, and `now < expiresAt`. It writes exactly one terminal, approval-specific signed event referencing the original digest:
+
+```ts
+{ decision: 'approved' | 'rejected', digest, reviewer, decidedAt }
+```
+
+`approved` and `rejected` are `completed`; expiry is a server-written `failed` event with `{ decision: 'expired', digest, expiredAt }`. A decision after expiry first records/observes expiry, then returns a conflict; any second/concurrent terminal decision returns `409 task_already_decided`. A generic `/:id/state` update must reject approval tasks, so it cannot bypass this decision gate. `waitForTerminal()` stays unchanged and returns the terminal structured result to the requester once the signed event is visible or in its queue overlay. OpenAgentEmail records this decision only; it never invokes `action`.
+
+### IMAP/stamp detail
+
+Keep the current task headers for ordinary threads. For approval messages add an explicitly versioned metadata header (containing only `kind`, `event`, and `digest`) and calculate a distinct HMAC domain over `id`, state, participants, event, and digest. The large canonical action remains in the signed-by-digest marked body, not an RFC header. Rebuild accepts only:
+
+1. one valid immutable request snapshot whose recomputed digest matches its stamped digest; then
+2. its first valid decision/expiry event whose digest equals that snapshot digest.
+
+All later decision events are retained as non-authoritative evidence only if they are validly stamped; the reconstructed task always uses the first valid terminal event. The live per-task lock prevents the server from emitting more than one in the normal case, while this replay rule is fail-safe for mailbox duplication.
+
+## REST, MCP, dashboard, and notification surface
+
+- Extend `task_create` / `OpenAgentEmailClient.createTask` additively with optional `kind: 'approval'` and the typed `approval` object; ordinary callers retain the current `{to, subject, body, wait}` contract.
+- Add `task_decide` / `OpenAgentEmailClient.decideTask(id, decision)` instead of overloading `task_update`. Its output is the existing task shape extended additively with `kind?: 'approval'` and `approval?: { action, reviewer, expiresAt, digest }` plus the structured terminal result.
+- Dashboard UI API gets `POST /ui/api/tasks/:id/decision`. It uses the authenticated reviewer (or an admin-selected reviewer), delegates to the same service method, and maps already-decided/expired to 409.
+- For approval detail, render action type/name and a `<pre>`/table built exclusively with `textContent`; never use `innerHTML`. Native `<button type="button">Approve</button>` and `<button type="button">Reject</button>` provide Enter/Space keyboard operation, must have explicit accessible labels, and use the same decision route.
+- Trusted task notification remains address-only. The generic watcher must recognize valid approval task mail and use a fixed approval preview (subject/status/digest is acceptable), never any serialized action `arguments` or body snapshot.
+- MCP output schemas must include all new optional approval fields, and its tools/list count/contract test must be updated deliberately. No #56 claim, lease, or ownership fields are introduced.
+
+## RED test contract and acceptance mapping
+
+`packages/api/test/approval-red.test.ts` is intentionally RED until the above production work exists. It specifies these focused groups:
+
+1. canonical-equivalent action digest stability; changed content divergence; array order sensitivity;
+2. managed requester/reviewer distinction and reviewer-only/admin-on-behalf ACL;
+3. one lock-protected decision, repeat/concurrent conflict, and expiry conflict;
+4. approved/rejected terminal result and waiter payload;
+5. inert escaped action arguments, native keyboard controls, and preview redaction;
+6. IMAP rebuild of request plus decision, including digest linkage; and
+7. ordinary-task reconstruction compatibility.
+
+The first RED round may report missing proposed helpers/routes rather than assertion mismatches. That is intentional: the test names and expected payloads are the implementation checklist, and no production shim is added merely to make RED look cleaner.
+
+## Design choices / non-goals
+
+- Digest reference, not a reviewer nonce/challenge, is the v1 decision binding.
+- SHA-256 is a reproducibility/integrity identifier; the server HMAC stamp is the authorization provenance. Neither causes action execution.
+- The existing IMAP event log remains the only durable storage; no database, attachment, policy engine, quorum, remote reviewer, framework adapter, or #56 lease behavior is introduced.
+- Expected remaining rounds: R2 GREEN service+IMAP stamps; R3 REST/MCP/UI/preview and focused GREEN; R4 full regression, security review, and FC review. This R1 does not start them.
+
+## R1 self-review
+
+| Severity | Result |
+|---|---|
+| P0 | No credentials or realistic secrets added; action fixtures are inert. |
+| P1 | Snapshot immutability and one-decision atomicity are both server-side, not UI/client assertions. |
+| P2 | Ordinary task REST/MCP/rebuild paths are explicitly additive and have a compatibility RED case. |
+| P3 | No unrelated cleanup or #56 behavior is proposed. |
+
+## R1b — FC behavioral RED correction
+
+This revision replaces the earlier symbol-presence and static-only RED checks.
+It keeps the same two-file scope and adds no production source. The exact
+behavioral test plan now uses these production-facing seams:
+
+1. Canonical JSON and digest call their own helpers, with no shared guard.
+2. The decision test calls the proposed service concurrently against the
+   existing per-task lock, captures actual mail writes, retries, and crosses
+   the expiry boundary.
+3. Approve and reject each use `waitForTaskTerminal()` and assert the returned
+   persisted structured result, rather than comparing a literal object.
+4. Route tests authenticate reviewer/requester/outsider/admin independently
+   and assert generic `/:id/state` is rejected for approval tasks.
+5. IMAP reconstruction builds RFC-822 request/decision messages from captured
+   server sends and passes them through an explicit test-only wrapper around
+   the real private stamp/parser; tampered body, wrong digest, and competing
+   valid terminal events are all exercised. The watcher separately receives a
+   request encoded by the real request stamper.
+6. The watcher is invoked with the actual captured approval message and an
+   inert metacharacter action. The final dashboard behavior test executes the
+   exact served `TASKS_PAGE_JS` renderer through its fake-DOM harness and
+   observes the actual nodes (text, tag, type, and accessible label);
+   substring inspection is retained only as a negative guard against
+   `innerHTML`, not as proof of presentation behavior.
+7. Ordinary IMAP reconstruction and the current MCP client's ordinary
+   `task_create` request are positive controls.
+
+The three proposed test-only wrappers (`parseStampedTaskMessageForTests`,
+`encodeStampedApprovalRequestForTests`, and
+`encodeStampedApprovalDecisionForTests`) must delegate to the real production
+parser/stamper. They are not alternative implementations or durable APIs. Each
+RED group asserts its own missing behavior before it can pass; this prevents a
+single multi-symbol guard from masking coverage.
+
+## R2 — service and IMAP core implemented
+
+R2 implements only the durable core in `lib/tasks.ts` plus additive approval
+creation validation in the existing task-create route. The request action is
+canonicalized into a detached JSON snapshot, SHA-256 digested, persisted in a
+marked body block, and bound to a domain-separated HMAC event stamp. Approval
+request, decision, and expiry events have distinct authenticated metadata;
+the parser recomputes the snapshot digest and rejects body tampering, digest
+substitution, or mismatched terminal results before rebuild.
+
+The existing per-task lock now guards a re-read of the queued overlay before
+one reviewer decision. Generic state mutations reject approval tasks. Expiry
+writes a `failed` event then rejects the late decision; approve/reject write a
+single `completed` result. Rebuild chooses the first parser-valid terminal
+approval event and ordinary task handling remains on its original path.
+
+R2 deliberately leaves three R3 behaviors red: `POST /v1/tasks/:id/decision`
+and its client/MCP surface, dashboard approval rendering/controls, and the
+watcher preview redaction. OpenAgentEmail still records decisions only and
+does not invoke an action.
+
+## R2b — timestamp-bound authoritative event payload
+
+Every approval RFC now carries exactly one canonical JSON payload in the
+base64url `X-OA-Task-Approval-Payload` header and the domain-separated HMAC
+signs that payload together with task id, state, and RFC participants. Its
+fixed shapes are:
+
+- request: `event`, `digest`, `reviewer`, `expiresAt`;
+- decision: `event`, `digest`, `decision`, `reviewer`, `decidedAt`;
+- expiry: `event`, `digest`, `expiredAt`.
+
+The parser accepts only a canonical, finite-timestamp payload, recomputes the
+same production HMAC, then cross-checks its fields against both headers and
+the structured RFC body. This binds `expiresAt`, `decidedAt`, and `expiredAt`:
+changing only any one of those body values in an otherwise captured RFC makes
+the event invalid. Expiry results have their own strict three-key shape.
+
+The parser/rebuild tests deliberately use the same production event encoder
+and parser, cover all three single-timestamp mutations, and retain the
+first-valid-terminal replay assertion. The three R3 RED cases remain unchanged.
+
+## R2c — lazy expiry materialization
+
+Expiry is now materialized only on the next approval detail read, waiter
+lookup, or decision attempt; there is no background scheduler, cron, store,
+or list sweep. Public `getTask()` obtains an immutable raw/queued snapshot and,
+when an approval is still `input-required` at `now >= expiresAt`, enters the
+existing per-task lock, re-reads that raw snapshot, and writes the one signed
+failed expiry event. Lock-holding writers use the raw snapshot helper so this
+read path cannot self-deadlock.
+
+The decision-after-expiry branch delegates to that same locked materializer.
+Thus a pre-boundary reviewer decision can win, but boundary-time concurrent
+detail/wait/decision activity emits exactly one terminal event; queued overlay
+state makes later calls observe it rather than writing another. Captured
+request+expiry RFC reconstruction remains a failed approval task. The three
+R3 RED cases remain unchanged.
+
+## R3 — REST, MCP, dashboard, and watcher surface
+
+R3 exposes the existing approval service without creating a second decision
+state machine. REST and dashboard decision endpoints accept only a strict
+`{ from?, decision }` body, derive identity callers from their session/token,
+require an admin to name the stored reviewer, and map not-found, reviewer ACL,
+expiry, terminal, and non-approval cases to stable public responses. Generic
+state mutation remains unable to decide an approval.
+
+The MCP client keeps ordinary `task_create` bytes unchanged, adds typed
+approval creation plus `task_decide(id, decision)`, and broadcasts optional
+approval task/message fields in task create/list/get/decide schemas. The new
+decision tool is contained and does not accept a caller-controlled `from`.
+
+Dashboard task projection carries the optional approval snapshot. Its real
+page asset uses only DOM nodes and `textContent` for action type/name/arguments
+and presents native labelled approve/reject buttons only to an unexpired stored
+reviewer; the button posts to the dashboard endpoint and presents the returned
+task. The watcher asks the production signed-message parser for a narrow
+authenticated approval event, then emits a fixed bounded request/decision/
+expiry preview. Forged lookalike headers retain ordinary preview behavior.
+
+Independent read-only R3 audit confirmed these four boundaries and P0–P3:
+no action execution/HTML injection or watcher body leakage (P0); reviewer ACL
+and terminal mapping remain server-side (P1); ordinary client/watcher/task
+behavior stays covered (P2); only #55 surface files changed, with no #56 work
+(P3).


### PR DESCRIPTION
## Summary
- add immutable typed approval tasks with reviewer-only approve/reject decisions
- expose typed approval create/decide through REST, MCP, dashboard, and authenticated watcher previews
- preserve ordinary task contracts and add end-to-end behavior coverage

## Verification
- `bun test test/approval-red.test.ts test/tasks.test.ts test/task-board.test.ts test/ui-tasks.test.ts test/ui-real-files.test.ts test/notification-watcher.test.ts test/mcp-http.test.ts test/audit-tiering.test.ts` — 224 pass, 0 fail, 1,579 assertions
- changed-file scoped typecheck: clean
- `git diff --check` (including untracked no-index checks): clean

Package-wide `tsc --noEmit` retains pre-existing repository baseline diagnostics and is not represented as green here.

Scope: #55 only; no #56 changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added typed approval tasks with defined actions, reviewers, expiration, and secure approve/reject decisions.
  * Added approval-task support through REST APIs, MCP tools, and the dashboard.
  * Added a dedicated MCP tool for recording approval decisions.
* **Notifications**
  * Approval notifications show metadata-only previews without exposing one-time codes or links.
* **User Experience**
  * Dashboard controls are limited to authorized reviewers and prevent duplicate submissions.
  * Approval tasks do not allow generic replies, reminders, or administrator actions.
* **Documentation**
  * Updated tool and security documentation for approval workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->