### PR TITLE
docs+ci: issue triage standard v1.1 + source labeler + stale needs-info closer

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -27,3 +27,15 @@ body:
     attributes:
       label: Alternatives you considered (optional)
       description: Other tools or workarounds you tried.
+
+  - type: dropdown
+    id: willing_to_pr
+    attributes:
+      label: Would you like to open a PR yourself? (optional)
+      description: External contributors who want to implement their own request are especially welcome — we review AI-assisted and human PRs at the same bar.
+      options:
+        - "No"
+        - "Yes — I can try on my own"
+        - "Yes — with maintainer guidance"
+    validations:
+      required: false

--- a/.github/workflows/issue-source-label.yml
+++ b/.github/workflows/issue-source-label.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply source label
-        uses: actions/github-script@60a0d83039c74a4aee543835d87978cb4c6399e3 # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -38,13 +38,19 @@ jobs:
               } catch (err) {
                 if (err.status !== 404) throw err;
                 const isCurrent = label === name;
-                await github.rest.issues.createLabel({
-                  owner, repo, name: label,
-                  color: isCurrent ? color : (internal ? "0e8a16" : "1f6feb"),
-                  description: isCurrent ? description : (internal
-                    ? "Filed by a community user; first-response clock starts at creation"
-                    : "Filed by a maintainer or team agent"),
-                });
+                try {
+                  await github.rest.issues.createLabel({
+                    owner, repo, name: label,
+                    color: isCurrent ? color : (internal ? "0e8a16" : "1f6feb"),
+                    description: isCurrent ? description : (internal
+                      ? "Filed by a community user; first-response clock starts at creation"
+                      : "Filed by a maintainer or team agent"),
+                  });
+                } catch (createErr) {
+                  // Two issues opened concurrently race on first create: 422 = already exists.
+                  if (createErr.status !== 422) throw createErr;
+                  await github.rest.issues.getLabel({ owner, repo, name: label });
+                }
               }
             }
             // Reclassification on reopen must not leave both mutually exclusive labels.

--- a/.github/workflows/issue-source-label.yml
+++ b/.github/workflows/issue-source-label.yml
@@ -27,14 +27,28 @@ jobs:
             const issue = context.payload.issue;
             const internal = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.author_association);
             const name = internal ? "source: internal" : "source: external";
+            const other = internal ? "source: external" : "source: internal";
             const color = internal ? "1f6feb" : "0e8a16";
             const description = internal
               ? "Filed by a maintainer or team agent"
               : "Filed by a community user; first-response clock starts at creation";
-            try {
-              await github.rest.issues.getLabel({ owner, repo, name });
-            } catch (err) {
-              if (err.status !== 404) throw err;
-              await github.rest.issues.createLabel({ owner, repo, name, color, description });
+            for (const label of [name, other]) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name: label });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+                const isCurrent = label === name;
+                await github.rest.issues.createLabel({
+                  owner, repo, name: label,
+                  color: isCurrent ? color : (internal ? "0e8a16" : "1f6feb"),
+                  description: isCurrent ? description : (internal
+                    ? "Filed by a community user; first-response clock starts at creation"
+                    : "Filed by a maintainer or team agent"),
+                });
+              }
             }
+            // Reclassification on reopen must not leave both mutually exclusive labels.
+            await github.rest.issues.removeLabel({ owner, repo, issue_number: issue.number, name: other }).catch((err) => {
+              if (err.status !== 404) throw err;
+            });
             await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [name] });

--- a/.github/workflows/issue-source-label.yml
+++ b/.github/workflows/issue-source-label.yml
@@ -6,7 +6,7 @@ name: Label issues by author source
 
 on:
   issues:
-    types: [opened, reopened]
+    types: [opened, reopened, transferred]
 
 permissions:
   issues: write

--- a/.github/workflows/issue-source-label.yml
+++ b/.github/workflows/issue-source-label.yml
@@ -1,0 +1,40 @@
+name: Label issues by author source
+
+# Rule-based first pass of the issue triage standard (no AI):
+# every new issue gets a source label so the external queue is visible.
+# Priority (prio: P0–P3) stays a maintainer decision; see CONTRIBUTING.md.
+
+on:
+  issues:
+    types: [opened, reopened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-source-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  label-source:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply source label
+        uses: actions/github-script@60a0d83039c74a4aee543835d87978cb4c6399e3 # v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const internal = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.author_association);
+            const name = internal ? "source: internal" : "source: external";
+            const color = internal ? "1f6feb" : "0e8a16";
+            const description = internal
+              ? "Filed by a maintainer or team agent"
+              : "Filed by a community user; first-response clock starts at creation";
+            try {
+              await github.rest.issues.getLabel({ owner, repo, name });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              await github.rest.issues.createLabel({ owner, repo, name, color, description });
+            }
+            await github.rest.issues.addLabels({ owner, repo, issue_number: issue.number, labels: [name] });

--- a/.github/workflows/issue-source-label.yml
+++ b/.github/workflows/issue-source-label.yml
@@ -25,7 +25,12 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const issue = context.payload.issue;
-            const internal = ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.author_association);
+            // Team issues are filed through the maintainer account; keep an explicit
+            // allowlist so team-agent filings never fall into the external queue.
+            const teamLogins = ["tizerluo"];
+            const internal =
+              ["OWNER", "MEMBER", "COLLABORATOR"].includes(issue.author_association) ||
+              teamLogins.includes(issue.user.login.toLowerCase());
             const name = internal ? "source: internal" : "source: external";
             const other = internal ? "source: external" : "source: internal";
             const color = internal ? "1f6feb" : "0e8a16";

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -1,0 +1,55 @@
+name: Close stale needs-info issues
+
+# When a maintainer asks for more detail (label `needs-info`) and the reporter
+# stays silent, the issue is marked stale after 14 days and closed 7 days later.
+# Removing the label or any new comment resets the clock (actions/stale default).
+
+on:
+  schedule:
+    - cron: "23 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+concurrency:
+  group: stale-needs-info
+  cancel-in-progress: false
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure labels exist
+        uses: actions/github-script@60a0d83039c74a4aee543835d87978cb4c6399e3 # v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            for (const [name, color, description] of [
+              ["needs-info", "d4c5f9", "Maintainer asked for more detail; waiting on the reporter"],
+              ["stale", "ffffff", "No activity on a needs-info issue; will close soon unless updated"],
+            ]) {
+              try {
+                await github.rest.issues.getLabel({ owner, repo, name });
+              } catch (err) {
+                if (err.status !== 404) throw err;
+                await github.rest.issues.createLabel({ owner, repo, name, color, description });
+              }
+            }
+
+      - name: Mark and close stale needs-info issues
+        uses: actions/stale@28f10391e5e8fe9d3f28795c41b8f36a3b1ad4e8 # v9
+        with:
+          days-before-issue-stale: 14
+          days-before-issue-close: 7
+          only-issue-labels: needs-info
+          stale-issue-label: stale
+          stale-issue-message: |
+            This issue is waiting on reporter-provided detail (`needs-info`) and has seen no
+            activity for 14 days. If we do not hear back within 7 days it will be closed;
+            commenting or updating the issue resets the clock.
+          close-issue-message: |
+            Closed for inactivity while waiting on requested information. You are welcome to
+            reopen (or file a fresh issue) with the details any time.
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -43,7 +43,7 @@ jobs:
           days-before-issue-stale: 14
           days-before-issue-close: 7
           only-issue-labels: needs-info
-          exempt-issue-labels: security,prio: P0,prio: P1
+          exempt-issue-labels: "security,prio: P0,prio: P1"
           stale-issue-label: stale
           stale-issue-message: |
             This issue is waiting on reporter-provided detail (`needs-info`) and has seen no

--- a/.github/workflows/stale-needs-info.yml
+++ b/.github/workflows/stale-needs-info.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Ensure labels exist
-        uses: actions/github-script@60a0d83039c74a4aee543835d87978cb4c6399e3 # v7
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -38,11 +38,12 @@ jobs:
             }
 
       - name: Mark and close stale needs-info issues
-        uses: actions/stale@28f10391e5e8fe9d3f28795c41b8f36a3b1ad4e8 # v9
+        uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           days-before-issue-stale: 14
           days-before-issue-close: 7
           only-issue-labels: needs-info
+          exempt-issue-labels: security,prio: P0,prio: P1
           stale-issue-label: stale
           stale-issue-message: |
             This issue is waiting on reporter-provided detail (`needs-info`) and has seen no

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,9 +104,9 @@ internal and external issues:
 
 External issues additionally follow three rules:
 
-1. **First response within 24 hours.** Even "got it, looking" counts. A patrol
-   automation watches the external queue and escalates to a maintainer; a human
-   still writes or approves every posted reply.
+1. **First response within 24 hours.** Even "got it, looking" counts. A
+   maintainer-side patrol (run outside this repository) watches the external
+   queue and escalates; a human still writes or approves every posted reply.
 2. **Feature requests pass a roadmap-alignment check.** Aligned → scheduled as
    P1/P2. Valuable but misaligned → parked at P3 with a courteous explanation.
    Declined → closed with thanks and one sentence of reasoning. Silence is not

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,3 +80,41 @@ What to expect when you open a PR from a fork:
 - **AI-authored PRs** are held to the same bar as human ones; our review chain
   (bots + maintainer review) provides the independent review, so you do not
   need to arrange your own.
+
+## Issue triage (v1.1)
+
+Every issue gets classified on two axes:
+
+- **Source**: `source: internal` (maintainers/team agents) or `source: external`
+  (community). Applied automatically on open.
+- **Type**: `bug`, `feature` (label `enhancement`), `follow-up`, `hardening`,
+  `docs`, `security`.
+
+Priority is a maintainer decision made at triage, using one shared ruler for
+internal and external issues:
+
+- **P0 — firefighting**: production outage, security hole, data corruption.
+  Drops everything.
+- **P1 — this week**: defects on a core path users are hitting now, or work
+  blocking the current roadmap milestone.
+- **P2 — this month**: valuable but not urgent; tech-debt batches; roadmap
+  items outside the current milestone.
+- **P3 — recorded**: theoretical corners, nice-to-haves, ideas not aligned
+  with the roadmap right now. Recording it is the completion.
+
+External issues additionally follow three rules:
+
+1. **First response within 24 hours.** Even "got it, looking" counts. A patrol
+   automation watches the external queue and escalates to a maintainer; a human
+   still writes or approves every posted reply.
+2. **Feature requests pass a roadmap-alignment check.** Aligned → scheduled as
+   P1/P2. Valuable but misaligned → parked at P3 with a courteous explanation.
+   Declined → closed with thanks and one sentence of reasoning. Silence is not
+   an answer we give.
+3. **Security reports go private.** We redirect to the channel in
+   [SECURITY.md](SECURITY.md) instead of discussing details in public.
+
+Labels: `source: internal|external`, `prio: P0|P1|P2|P3`, plus the type labels
+above. An issue is triaged when it carries a source label, a type, and a
+priority. Issues labeled `needs-info` are closed automatically after 14 days
+of reporter silence plus a 7-day grace period (see `stale-needs-info.yml`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,4 +117,4 @@ External issues additionally follow three rules:
 Labels: `source: internal|external`, `prio: P0|P1|P2|P3`, plus the type labels
 above. An issue is triaged when it carries a source label, a type, and a
 priority. Issues labeled `needs-info` are closed automatically after 14 days
-of reporter silence plus a 7-day grace period (see `stale-needs-info.yml`).
+of no issue activity plus a 7-day grace period (see `stale-needs-info.yml`).


### PR DESCRIPTION
## What

Lands the issue triage standard (v1.1) approved by the owner, plus the non-AI automation half of it:

- **CONTRIBUTING.md — new "Issue triage" section**: two-axis classification (source × type), the shared P0–P3 ruler, and the three external-issue rules (24h first response, roadmap-alignment check with courteous park/decline, private security channel).
- **feature_request.yml**: new optional field "Would you like to open a PR yourself?" — external users willing to implement their own request are the easiest converts to contributors.
- **issue-source-label.yml** (new workflow, issues opened/reopened): labels every new issue `source: internal` or `source: external` by author association, creating the label if missing. Rule-based, no AI.
- **stale-needs-info.yml** (new workflow, daily 06:23 UTC + manual): issues labeled `needs-info` go stale after 14 days of silence and close after 7 more; any comment or label removal resets the clock. PR processing disabled.

Priority assignment (`prio: P0–P3`) deliberately stays a maintainer decision — no keyword guessing. The external-queue patrol (detect + draft, never auto-post) runs separately on our side.

## Not in this PR

- AI dedup/translate triage (à la opencodex) — deferred until external volume justifies it.
- Backfilling labels onto existing open issues — queued behind the current claim/checkout work.

## Notes

- `.github/workflows/` is a sensitive path per CONTRIBUTING — maintainer final review requested as usual.
- No runtime code touched; no new dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional feature-request question to indicate interest in contributing a pull request.
  - Added automatic classification of newly opened, reopened, or transferred issues by submission source.
  - Added automated reminders and eventual closure for issues awaiting requested information, with exemptions for critical issues.

- **Documentation**
  - Expanded contribution guidance with issue categorization, priority levels, required labels, roadmap expectations, security-report handling, and response timelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->