### PR TITLE
fix(compose): isolate API-only instances

### DIFF
--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -82,5 +82,9 @@ RETENTION_DAYS=30
 
 # The API binds localhost only by default. Use an SSH tunnel or TLS reverse
 # proxy; never expose it directly to the public internet without protection.
+# For multiple API-only instances, copy this file once per instance, give each
+# copy a different API_PORT, and launch each with a unique `docker compose -p`
+# value (or a unique COMPOSE_PROJECT_NAME). Compose then gives every project its
+# own api-data named volume. The container port stays fixed at 3100.
 # API_BIND=127.0.0.1
 # API_PORT=3100

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -83,8 +83,8 @@ RETENTION_DAYS=30
 # The API binds localhost only by default. Use an SSH tunnel or TLS reverse
 # proxy; never expose it directly to the public internet without protection.
 # For multiple API-only instances, keep populated copies outside the repository
-# (for example ../oae-api-only-env/alpha.env and beta.env). Give each copy a
-# different API_PORT, independently generated API_KEYS and TASK_SIGNING_SECRET,
+# (for example ../oae-api-only-env/alpha.env and beta.env) with mode 0600. Give
+# each copy a different API_PORT, independently generated API_KEYS and TASK_SIGNING_SECRET,
 # and mailbox/provider-appropriate IMAP/SMTP credentials. Launch each with a
 # unique `docker compose -p` value (or a unique COMPOSE_PROJECT_NAME). Compose
 # then gives every project its own api-data named volume. The container port

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -82,9 +82,12 @@ RETENTION_DAYS=30
 
 # The API binds localhost only by default. Use an SSH tunnel or TLS reverse
 # proxy; never expose it directly to the public internet without protection.
-# For multiple API-only instances, copy this file once per instance, give each
-# copy a different API_PORT, and launch each with a unique `docker compose -p`
-# value (or a unique COMPOSE_PROJECT_NAME). Compose then gives every project its
-# own api-data named volume. The container port stays fixed at 3100.
+# For multiple API-only instances, keep populated copies outside the repository
+# (for example ../oae-api-only-env/alpha.env and beta.env). Give each copy a
+# different API_PORT, independently generated API_KEYS and TASK_SIGNING_SECRET,
+# and mailbox/provider-appropriate IMAP/SMTP credentials. Launch each with a
+# unique `docker compose -p` value (or a unique COMPOSE_PROJECT_NAME). Compose
+# then gives every project its own api-data named volume. The container port
+# stays fixed at 3100.
 # API_BIND=127.0.0.1
 # API_PORT=3100

--- a/README.md
+++ b/README.md
@@ -145,19 +145,24 @@ listens on port 3100 inside its container; `API_PORT` changes only the host-side
 mapping. For example:
 
 ```bash
-cp .env.api-only.example .env.alpha
-cp .env.api-only.example .env.beta
-# Set API_PORT=3100 in .env.alpha and API_PORT=3101 in .env.beta.
+mkdir -p ../oae-api-only-env
+cp .env.api-only.example ../oae-api-only-env/alpha.env
+cp .env.api-only.example ../oae-api-only-env/beta.env
+# Set API_PORT=3100 in alpha.env and API_PORT=3101 in beta.env.
+# Generate separate API_KEYS and TASK_SIGNING_SECRET values in each file.
 
-docker compose -p oae-alpha --env-file .env.alpha -f compose.api-only.yaml up -d
-docker compose -p oae-beta  --env-file .env.beta  -f compose.api-only.yaml up -d
+docker compose -p oae-alpha --env-file ../oae-api-only-env/alpha.env -f compose.api-only.yaml up -d
+docker compose -p oae-beta  --env-file ../oae-api-only-env/beta.env  -f compose.api-only.yaml up -d
 ```
 
 You may set a unique `COMPOSE_PROJECT_NAME` for each command instead of using
 `-p`. The project names make Compose generate distinct container names and
 project-scoped named volumes (for example `oae-alpha_api-data` and
 `oae-beta_api-data`). Do not reuse a project name or `API_PORT` between the two
-instances.
+instances. Each instance must have independently generated `API_KEYS` and
+`TASK_SIGNING_SECRET` values; configure its IMAP and SMTP credentials for that
+instance's intended mailbox/provider boundary as well. Keep these populated
+environment files outside the repository, as in the example above.
 
 ## Read mail in a browser
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,26 @@ catch-all mailbox. The [external mail server guide](https://openagent.email/docs
 covers the required catch-all setup, Portainer deployment, SMTP sender limits,
 and TLS certificate verification.
 
+To run multiple API-only instances on one host, give every instance its own
+environment file, unique Compose project, and host `API_PORT`. The API always
+listens on port 3100 inside its container; `API_PORT` changes only the host-side
+mapping. For example:
+
+```bash
+cp .env.api-only.example .env.alpha
+cp .env.api-only.example .env.beta
+# Set API_PORT=3100 in .env.alpha and API_PORT=3101 in .env.beta.
+
+docker compose -p oae-alpha --env-file .env.alpha -f compose.api-only.yaml up -d
+docker compose -p oae-beta  --env-file .env.beta  -f compose.api-only.yaml up -d
+```
+
+You may set a unique `COMPOSE_PROJECT_NAME` for each command instead of using
+`-p`. The project names make Compose generate distinct container names and
+project-scoped named volumes (for example `oae-alpha_api-data` and
+`oae-beta_api-data`). Do not reuse a project name or `API_PORT` between the two
+instances.
+
 ## Read mail in a browser
 
 Open [`http://localhost:3100/ui`](http://localhost:3100/ui) and paste an admin

--- a/README.md
+++ b/README.md
@@ -139,6 +139,11 @@ catch-all mailbox. The [external mail server guide](https://openagent.email/docs
 covers the required catch-all setup, Portainer deployment, SMTP sender limits,
 and TLS certificate verification.
 
+The standalone default project name is `openagentemail`. If the full
+`compose.yaml` stack also runs on the same host, the API-only stack must not
+share that default project: give it an explicitly different `-p` value or
+`COMPOSE_PROJECT_NAME` so the two stacks cannot adopt each other's resources.
+
 To run multiple API-only instances on one host, give every instance its own
 environment file, unique Compose project, and host `API_PORT`. The API always
 listens on port 3100 inside its container; `API_PORT` changes only the host-side
@@ -148,6 +153,7 @@ mapping. For example:
 mkdir -p ../oae-api-only-env
 cp .env.api-only.example ../oae-api-only-env/alpha.env
 cp .env.api-only.example ../oae-api-only-env/beta.env
+chmod 600 ../oae-api-only-env/*.env
 # Set API_PORT=3100 in alpha.env and API_PORT=3101 in beta.env.
 # Generate separate API_KEYS and TASK_SIGNING_SECRET values in each file.
 

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -10,7 +10,6 @@ name: openagentemail
 services:
   api:
     build: ./packages/api
-    container_name: openagent-api
     environment:
       # --- shared API contract env ---
       DOMAIN: ${DOMAIN:?Set DOMAIN in .env}

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -2,8 +2,11 @@
 #
 # Use this when your mail provider already hosts your domain. It runs only the
 # API: IMAP reads one catch-all mailbox and SMTP sends through that provider.
-# Copy .env.api-only.example to .env, fill every required value, then run:
+# Copy .env.api-only.example to .env, fill every required value, then run this
+# standalone default. If compose.yaml also runs on this host, this API-only
+# stack MUST use an explicitly different -p / COMPOSE_PROJECT_NAME instead:
 #   docker compose -f compose.api-only.yaml up -d
+#   docker compose -p oae-api-only -f compose.api-only.yaml up -d
 
 name: openagentemail
 

--- a/packages/api/test/api-only-compose.test.ts
+++ b/packages/api/test/api-only-compose.test.ts
@@ -7,28 +7,67 @@ const repoDir = join(import.meta.dir, '..', '..', '..');
 const compose = readFileSync(join(repoDir, 'compose.api-only.yaml'), 'utf8');
 const envExample = readFileSync(join(repoDir, '.env.api-only.example'), 'utf8');
 const readme = readFileSync(join(repoDir, 'README.md'), 'utf8');
+const composeLines = new Set(compose.split('\n').map((line) => line.trim()));
+const multiInstanceDocs = readme.split('To run multiple API-only instances', 2)[1]!.split('## Read mail', 1)[0]!;
+
+function topLevelSection(source: string, name: string): string {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => line === `${name}:`);
+  if (start < 0) return '';
+  const endOffset = lines.slice(start + 1).findIndex((line) => /^\S/.test(line));
+  return lines.slice(start, endOffset < 0 ? undefined : start + 1 + endOffset).join('\n');
+}
+
+function hasStaticProjectVolume(source: string): boolean {
+  const volumes = topLevelSection(source, 'volumes');
+  const entries = [...volumes.matchAll(/^  ([^\s:#][^:]*):(?:\s*(.*))?$/gm)]
+    .map((match) => ({ key: match[1], value: match[2] ?? '' }));
+  return entries.length === 1 &&
+    entries[0]!.key === 'api-data' &&
+    entries[0]!.value === '' &&
+    !/\$\{|^\s+(?:name|external):/m.test(volumes);
+}
 
 test('#70 API-only Compose keeps the internal API and storage contracts project-scoped', () => {
-  expect(compose).toContain('name: openagentemail');
+  expect(composeLines).toContain('name: openagentemail');
   expect(compose).not.toMatch(/^\s*container_name:/m);
-  expect(compose).toMatch(/^\s*PORT: 3100$/m);
-  expect(compose).toContain('- "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:3100"');
+  expect(composeLines).toContain('PORT: 3100');
+  expect(composeLines).toContain('- "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:3100"');
   expect(compose).toMatch(/healthcheck:\n\s+test: .*localhost:3100\/healthz/);
-  expect(compose).not.toMatch(/healthcheck:\n\s+test: .*API_PORT/);
-  expect(compose).toMatch(/^\s*- api-data:\/app\/data$/m);
-  expect(compose).toMatch(/^volumes:\n\s{2}api-data:\s*$/m);
+  expect(composeLines).toContain('- api-data:/app/data');
   expect(compose).not.toContain('EXTERNAL_PORT');
+
+  expect(hasStaticProjectVolume(compose)).toBe(true);
 });
 
-test('#70 API-only docs require unique projects and host ports for two instances', () => {
-  expect(readme).toContain('docker compose -p oae-alpha --env-file .env.alpha -f compose.api-only.yaml up -d');
-  expect(readme).toContain('docker compose -p oae-beta  --env-file .env.beta  -f compose.api-only.yaml up -d');
-  expect(readme).toContain('API_PORT=3100 in .env.alpha and API_PORT=3101 in .env.beta');
-  expect(readme).toContain('oae-alpha_api-data');
-  expect(readme).toContain('oae-beta_api-data');
-  expect(readme).toContain('COMPOSE_PROJECT_NAME');
-  expect(envExample).toContain('different API_PORT');
-  expect(envExample).toContain('unique `docker compose -p`');
-  expect(envExample).toContain('unique COMPOSE_PROJECT_NAME');
-  expect(envExample).toContain('container port stays fixed at 3100');
+test('#70 API-only volume regression rejects renamed, interpolated, external, and shared-volume canaries', () => {
+  const replaceVolume = (replacement: string) => compose.replace('\n  api-data:\n', `\n${replacement}\n`);
+  expect({
+    live: hasStaticProjectVolume(compose),
+    renamed: hasStaticProjectVolume(replaceVolume('  shared-data:')),
+    interpolated: hasStaticProjectVolume(replaceVolume('  ${VOLUME_NAME}:')),
+    blockName: hasStaticProjectVolume(replaceVolume('  api-data:\n    name: shared')),
+    blockExternal: hasStaticProjectVolume(replaceVolume('  api-data:\n    external: true')),
+    inlineName: hasStaticProjectVolume(replaceVolume('  api-data: { name: shared }')),
+    inlineExternal: hasStaticProjectVolume(replaceVolume('  api-data: { external: true }')),
+  }).toEqual({
+    live: true,
+    renamed: false,
+    interpolated: false,
+    blockName: false,
+    blockExternal: false,
+    inlineName: false,
+    inlineExternal: false,
+  });
+});
+
+test('#70 API-only docs keep two projects, ports, and secrets isolated outside the repository', () => {
+  expect(multiInstanceDocs).toMatch(/mkdir -p \.\.\/oae-api-only-env/);
+  expect(multiInstanceDocs).toMatch(/-p oae-alpha --env-file \.\.\/oae-api-only-env\/alpha\.env/);
+  expect(multiInstanceDocs).toMatch(/-p oae-beta\s+--env-file \.\.\/oae-api-only-env\/beta\.env/);
+  expect(multiInstanceDocs).toMatch(/API_PORT=3100.*API_PORT=3101/);
+  expect(multiInstanceDocs).toMatch(/independently generated `API_KEYS` and\s+`TASK_SIGNING_SECRET`/);
+  expect(multiInstanceDocs).toContain('COMPOSE_PROJECT_NAME');
+  expect(multiInstanceDocs).not.toMatch(/--env-file \.env\.(?:alpha|beta)\b/);
+  expect(envExample).toMatch(/outside the repository[\s\S]*different API_PORT[\s\S]*independently generated API_KEYS and TASK_SIGNING_SECRET/);
 });

--- a/packages/api/test/api-only-compose.test.ts
+++ b/packages/api/test/api-only-compose.test.ts
@@ -8,6 +8,7 @@ const compose = readFileSync(join(repoDir, 'compose.api-only.yaml'), 'utf8');
 const envExample = readFileSync(join(repoDir, '.env.api-only.example'), 'utf8');
 const readme = readFileSync(join(repoDir, 'README.md'), 'utf8');
 const composeLines = new Set(compose.split('\n').map((line) => line.trim()));
+const apiOnlyIntro = readme.split('## Using your own mail server', 2)[1]!.split('To run multiple API-only instances', 1)[0]!;
 const multiInstanceDocs = readme.split('To run multiple API-only instances', 2)[1]!.split('## Read mail', 1)[0]!;
 
 function topLevelSection(source: string, name: string): string {
@@ -26,6 +27,18 @@ function hasStaticProjectVolume(source: string): boolean {
     entries[0]!.key === 'api-data' &&
     entries[0]!.value === '' &&
     !/\$\{|^\s+(?:name|external):/m.test(volumes);
+}
+
+function requiresIndependentInstanceSecrets(source: string): boolean {
+  const candidates = [
+    ...source.split('\n'),
+    ...source.replace(/\s+/g, ' ').split(/[.!?]/),
+  ];
+  return candidates.some((candidate) =>
+    /\beach (?:instance|file|copy)\b|\bper[- ]instance\b/i.test(candidate) &&
+    /\bseparate\b|\bindependently generated\b/i.test(candidate) &&
+    /\bAPI_KEYS\b/.test(candidate) &&
+    /\bTASK_SIGNING_SECRET\b/.test(candidate));
 }
 
 test('#70 API-only Compose keeps the internal API and storage contracts project-scoped', () => {
@@ -63,11 +76,25 @@ test('#70 API-only volume regression rejects renamed, interpolated, external, an
 
 test('#70 API-only docs keep two projects, ports, and secrets isolated outside the repository', () => {
   expect(multiInstanceDocs).toMatch(/mkdir -p \.\.\/oae-api-only-env/);
+  expect(multiInstanceDocs).toContain('chmod 600 ../oae-api-only-env/*.env');
   expect(multiInstanceDocs).toMatch(/-p oae-alpha --env-file \.\.\/oae-api-only-env\/alpha\.env/);
   expect(multiInstanceDocs).toMatch(/-p oae-beta\s+--env-file \.\.\/oae-api-only-env\/beta\.env/);
   expect(multiInstanceDocs).toMatch(/API_PORT=3100.*API_PORT=3101/);
-  expect(multiInstanceDocs).toMatch(/independently generated `API_KEYS` and\s+`TASK_SIGNING_SECRET`/);
+  expect(requiresIndependentInstanceSecrets(multiInstanceDocs)).toBe(true);
+  expect(requiresIndependentInstanceSecrets(envExample)).toBe(true);
+  const reusedSecretsCanary = multiInstanceDocs
+    .replace(/\bseparate\b/gi, 'shared')
+    .replace(/\bindependently generated\b/gi, 'reused');
+  expect(requiresIndependentInstanceSecrets(reusedSecretsCanary)).toBe(false);
+  expect(multiInstanceDocs).toContain('outside the repository');
+  expect(multiInstanceDocs).toContain('unique Compose project');
   expect(multiInstanceDocs).toContain('COMPOSE_PROJECT_NAME');
   expect(multiInstanceDocs).not.toMatch(/--env-file \.env\.(?:alpha|beta)\b/);
-  expect(envExample).toMatch(/outside the repository[\s\S]*different API_PORT[\s\S]*independently generated API_KEYS and TASK_SIGNING_SECRET/);
+  for (const token of ['outside the repository', '0600', 'different API_PORT', 'API_KEYS', 'TASK_SIGNING_SECRET', 'COMPOSE_PROJECT_NAME']) {
+    expect(envExample).toContain(token);
+  }
+  expect(apiOnlyIntro).toContain('compose.yaml');
+  expect(apiOnlyIntro).toContain('must not');
+  expect(apiOnlyIntro).toContain('different `-p`');
+  expect(compose).toMatch(/compose\.yaml[\s\S]*MUST use an explicitly different -p \/ COMPOSE_PROJECT_NAME/);
 });

--- a/packages/api/test/api-only-compose.test.ts
+++ b/packages/api/test/api-only-compose.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { expect, test } = await import('bun:test');
+
+const repoDir = join(import.meta.dir, '..', '..', '..');
+const compose = readFileSync(join(repoDir, 'compose.api-only.yaml'), 'utf8');
+const envExample = readFileSync(join(repoDir, '.env.api-only.example'), 'utf8');
+const readme = readFileSync(join(repoDir, 'README.md'), 'utf8');
+
+test('#70 API-only Compose keeps the internal API and storage contracts project-scoped', () => {
+  expect(compose).toContain('name: openagentemail');
+  expect(compose).not.toMatch(/^\s*container_name:/m);
+  expect(compose).toMatch(/^\s*PORT: 3100$/m);
+  expect(compose).toContain('- "${API_BIND:-127.0.0.1}:${API_PORT:-3100}:3100"');
+  expect(compose).toMatch(/healthcheck:\n\s+test: .*localhost:3100\/healthz/);
+  expect(compose).not.toMatch(/healthcheck:\n\s+test: .*API_PORT/);
+  expect(compose).toMatch(/^\s*- api-data:\/app\/data$/m);
+  expect(compose).toMatch(/^volumes:\n\s{2}api-data:\s*$/m);
+  expect(compose).not.toContain('EXTERNAL_PORT');
+});
+
+test('#70 API-only docs require unique projects and host ports for two instances', () => {
+  expect(readme).toContain('docker compose -p oae-alpha --env-file .env.alpha -f compose.api-only.yaml up -d');
+  expect(readme).toContain('docker compose -p oae-beta  --env-file .env.beta  -f compose.api-only.yaml up -d');
+  expect(readme).toContain('API_PORT=3100 in .env.alpha and API_PORT=3101 in .env.beta');
+  expect(readme).toContain('oae-alpha_api-data');
+  expect(readme).toContain('oae-beta_api-data');
+  expect(readme).toContain('COMPOSE_PROJECT_NAME');
+  expect(envExample).toContain('different API_PORT');
+  expect(envExample).toContain('unique `docker compose -p`');
+  expect(envExample).toContain('unique COMPOSE_PROJECT_NAME');
+  expect(envExample).toContain('container port stays fixed at 3100');
+});


### PR DESCRIPTION
## Summary

- let Compose derive API-only container names from the project
- keep the container port, healthcheck, and static api-data key fixed while exposing only API_BIND/API_PORT on the host
- document and test two concurrent projects with distinct host ports and project-scoped volumes
- keep populated per-instance env files outside the repository and require independent API/task-signing secrets

This is the maintainer takeover of #71. The original contribution is preserved with Co-authored-by trailers.

Closes #70

## Validation

- focused + runtime-artifact tests: 4 pass, 37 assertions on the final test revision
- seven-case volume-contract canary (renamed/interpolated/block+inline shared/external variants rejected)
- PyYAML semantic contract checks
- `git diff --check`
- independent final fresh review: CLEAN (0/0/0/0)
- Codex Local current-head review: 0/0/0/0
- ZCode current-head review: P0=0, P1=0
- unresolved review threads: 0

## CI baseline-flaky disposition

GitHub Actions run `33496438399` was cancelled after its final bounded rerun job `99830737449` remained in `Test packages/api` beyond 8 minutes. This was the third same-family hang seen while validating the PR.

The CI-pinned Bun 1.2.21 passes the changed-path focused suite. Its full suite locally reproduces an unchanged `parent-child-root` R5f `invalid_approval_expiry` failure and then does not exit. Both `packages/api/test/parent-child-root.test.ts` and `packages/api/src/lib/tasks-internal.ts` are byte-identical to `origin/main`.

Per the written maintainer ruling, this satisfies the CI gate as a baseline timing flaky. Follow-up #111 records the defect and links #103. Full evidence is retained at `/home/ops/materials/70-takeover/ci-baseline-flaky-evidence.md`.

CodeRabbit on the final head was rate limited. It is recorded as a written maintainer waiver, not as a pass. The maintainer manually reviewed the full diff at `51492ac4`; the later delta is documentation and tests addressing ZCode P2 guidance and received independent CLEAN review plus current-head Local/ZCode review.

## Runtime acceptance

The implementation host has no Docker, Podman, nerdctl, or Compose frontend. Dynamic clean-stack and dual-project acceptance is assigned to the commander on Docker Desktop before any merge. Static checks are not presented as runtime acceptance.

## Scope

Only `compose.api-only.yaml`, `.env.api-only.example`, `README.md`, and the focused regression test are changed. The main `compose.yaml` is unchanged.