### PR TITLE
docs: link Cloudflare Zero Trust deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,6 +453,7 @@ through a [relay](https://openagent.email/docs/guides/deliverability/) and you d
 - [docs/api.md](https://openagent.email/docs/reference/api/) — REST API reference with curl examples
 - [docs/security.md](https://openagent.email/docs/guides/security/) — tokens, exposure, rate limits, retention
 - [docs/mcp-clients.md](https://openagent.email/docs/reference/mcp-clients/) — MCP setup for every major client
+- [docs/cloudflare-zero-trust.md](https://openagent.email/docs/guides/cloudflare-zero-trust/) — Cloudflare Tunnel and Access for the Dashboard without blocking MCP
 - [docs/agent-signup.md](https://openagent.email/docs/guides/agent-signup/) — let agents finish sign-ups that email a code, with a verified OKX wallet example
 - [docs/dns-setup.md](https://openagent.email/docs/guides/dns-setup/) — DNS records, explained one by one
 - [docs/deliverability.md](https://openagent.email/docs/guides/deliverability/) — the field guide to actually


### PR DESCRIPTION
## Summary

- add the main README pointer for the Cloudflare Zero Trust deployment guide
- keep this repository change to one docs link; the full guide is in openagentemail/website#30

## Validation

- `git diff --check`
- canonical docs URL verified
- independent fresh review: CLEAN (P0/P1/P2/P3 = 0/0/0/0)
- workflow-version focused proxy/public-edge tests: Bun 1.2.21, 14 pass, 0 fail, 61 assertions

## CI baseline-flaky disposition

This PR changes only `README.md`. Run
[`33511186261`](https://github.com/openagentemail/openagentemail/actions/runs/33511186261)
and its one bounded rerun both stopped advancing in the unchanged `Test
packages/api` step (jobs `99866953442` and `99871783998`). The PR branch and
base `fa2c495fe88d52d38d3fd8587a98c4c68cb76f0c` have byte-identical
`packages/api/test/parent-child-root.test.ts` and
`packages/api/src/lib/tasks-internal.ts` files. This is the tracked baseline
timing failure where R5f can raise `invalid_approval_expiry` and Bun 1.2.21
does not exit; see #111 (related follow-up #103).

Per the written maintainer ruling, the CI gate is satisfied by the focused
green result, exact-base identical-path proof, same-step bounded rerun, and
#111. The cancelled Actions check is retained as evidence and is **not**
represented as a successful run. Full local evidence:
`/home/ops/materials/62-cloudflare-guide/ci-ruling-evidence.md`.

Refs #62.

This PR is intentionally docs-only and must remain open pending maintainer review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a link to the Cloudflare Zero Trust guide for using Cloudflare Tunnel and Access with the Dashboard without blocking MCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->