### PR TITLE
feat(api): add automatic compliance BCC archive

### DIFF
--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -40,6 +40,17 @@ TASK_SIGNING_SECRET=change-me-generate-with-openssl-rand-hex-32
 IMAP_TLS_REJECT_UNAUTHORIZED=true
 SMTP_TLS_REJECT_UNAUTHORIZED=true
 
+# Optional compliance archive mailbox. Default off: leave unset/blank. It is
+# an envelope-only recipient for API/MCP/task sends, never a visible To/Bcc
+# header. An external archive mailbox carries its own privacy and retention
+# obligations and is a trusted archive boundary: it receives exact MIME,
+# including internal-message stamps when present. If only the archive RCPT is
+# rejected after original recipients are accepted, the send succeeds with a
+# server warning. Delivery failures
+# after the provider accepts/queues it appear only in relay logs or DSNs, not
+# synchronously in the API response.
+# ALWAYS_BCC=archive@example.net
+
 # Comma-separated domains that identities may use in From. Leave this as your
 # agent domain unless your mail provider has explicitly authorized another one.
 ALLOWED_SEND_DOMAINS=example.com

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -47,8 +47,10 @@ SMTP_TLS_REJECT_UNAUTHORIZED=true
 # including internal-message stamps when present. If at least one original RCPT
 # is accepted and this configured archive RCPT is rejected, Nodemailer
 # partial-success is preserved with a content-free warning, even if another
-# original RCPT was rejected. Delivery failures
-# after the provider accepts/queues it appear only in relay logs or DSNs, not
+# original RCPT was rejected.
+# If the archive is accepted while no original RCPT is reported accepted, the
+# API fails even when SMTP omitted explicit rejected outcomes.
+# Delivery failures after the provider accepts/queues it appear only in relay logs or DSNs, not
 # synchronously in the API response.
 # ALWAYS_BCC=archive@example.net
 

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -44,8 +44,11 @@ SMTP_TLS_REJECT_UNAUTHORIZED=true
 # an envelope-only recipient for API/MCP/task sends, never a visible To/Bcc
 # header. An external archive mailbox carries its own privacy and retention
 # obligations and is a trusted archive boundary: it receives exact MIME,
-# including internal-message stamps when present. If at least one original RCPT
-# is accepted and this configured archive RCPT is rejected, Nodemailer
+# including internal-message stamps when present.
+# An archive outside DOMAIN requires this file's explicit TASK_SIGNING_SECRET;
+# Compose already requires it. Bare-process SMTP_PASS fallback is allowed only
+# with no archive or an archive on DOMAIN.
+# If at least one original RCPT is accepted and this configured archive RCPT is rejected, Nodemailer
 # partial-success is preserved with a content-free warning, even if another
 # original RCPT was rejected.
 # If the archive is accepted while no original RCPT is reported accepted, the

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -45,9 +45,13 @@ SMTP_TLS_REJECT_UNAUTHORIZED=true
 # header. An external archive mailbox carries its own privacy and retention
 # obligations and is a trusted archive boundary: it receives exact MIME,
 # including internal-message stamps when present.
-# An archive outside DOMAIN requires this file's explicit TASK_SIGNING_SECRET;
-# Compose already requires it. Bare-process SMTP_PASS fallback is allowed only
-# with no archive or an archive on DOMAIN.
+# An archive outside DOMAIN requires an explicit, high-entropy (32+ character)
+# TASK_SIGNING_SECRET. Bare-process SMTP_PASS fallback is allowed only with no
+# archive or an archive on DOMAIN. A same-domain archive may use that fallback
+# only when it is not aliased/forwarded outside the trusted compliance boundary;
+# if it can forward externally, set the same explicit 32+ character secret.
+# The application cannot discover downstream aliases: that routing boundary is
+# an operator/MTA responsibility. Compose already requires this secret.
 # If at least one original RCPT is accepted and this configured archive RCPT is rejected, Nodemailer
 # partial-success is preserved with a content-free warning, even if another
 # original RCPT was rejected.

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -45,15 +45,14 @@ SMTP_TLS_REJECT_UNAUTHORIZED=true
 # header. An external archive mailbox carries its own privacy and retention
 # obligations and is a trusted archive boundary: it receives exact MIME,
 # including internal-message stamps when present.
-# An archive outside DOMAIN requires an explicit 32+ character
-# TASK_SIGNING_SECRET. The app enforces presence and length only, not entropy:
-# generate a high-entropy value (this example uses `openssl rand -hex 32`).
-# Bare-process SMTP_PASS fallback is allowed only with no archive or an archive
-# on DOMAIN. A same-domain archive may use that fallback only when it is not
-# aliased/forwarded outside the trusted compliance boundary; if it can forward
-# externally, set the same explicit 32+ character secret. The application
-# cannot discover downstream aliases: that routing boundary is an operator/MTA
-# responsibility. Compose already requires this secret.
+# ALWAYS_BCC must be an independent archive outside DOMAIN. Same-domain values
+# are rejected: the shared catch-all makes them unsuitable as an independent
+# compliance destination, and duplicate suppression is not that boundary.
+# Every enabled archive requires an explicit 32+ character TASK_SIGNING_SECRET.
+# The app enforces presence and length only, not entropy: generate a
+# high-entropy value (this example uses `openssl rand -hex 32`). Bare-process
+# SMTP_PASS fallback is allowed only with no archive. Compose already requires
+# this secret.
 # If at least one original RCPT is accepted and this configured archive RCPT is rejected, Nodemailer
 # partial-success is preserved with a content-free warning, even if another
 # original RCPT was rejected.

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -44,9 +44,10 @@ SMTP_TLS_REJECT_UNAUTHORIZED=true
 # an envelope-only recipient for API/MCP/task sends, never a visible To/Bcc
 # header. An external archive mailbox carries its own privacy and retention
 # obligations and is a trusted archive boundary: it receives exact MIME,
-# including internal-message stamps when present. If only the archive RCPT is
-# rejected after original recipients are accepted, the send succeeds with a
-# server warning. Delivery failures
+# including internal-message stamps when present. If at least one original RCPT
+# is accepted and this configured archive RCPT is rejected, Nodemailer
+# partial-success is preserved with a content-free warning, even if another
+# original RCPT was rejected. Delivery failures
 # after the provider accepts/queues it appear only in relay logs or DSNs, not
 # synchronously in the API response.
 # ALWAYS_BCC=archive@example.net

--- a/.env.api-only.example
+++ b/.env.api-only.example
@@ -45,13 +45,15 @@ SMTP_TLS_REJECT_UNAUTHORIZED=true
 # header. An external archive mailbox carries its own privacy and retention
 # obligations and is a trusted archive boundary: it receives exact MIME,
 # including internal-message stamps when present.
-# An archive outside DOMAIN requires an explicit, high-entropy (32+ character)
-# TASK_SIGNING_SECRET. Bare-process SMTP_PASS fallback is allowed only with no
-# archive or an archive on DOMAIN. A same-domain archive may use that fallback
-# only when it is not aliased/forwarded outside the trusted compliance boundary;
-# if it can forward externally, set the same explicit 32+ character secret.
-# The application cannot discover downstream aliases: that routing boundary is
-# an operator/MTA responsibility. Compose already requires this secret.
+# An archive outside DOMAIN requires an explicit 32+ character
+# TASK_SIGNING_SECRET. The app enforces presence and length only, not entropy:
+# generate a high-entropy value (this example uses `openssl rand -hex 32`).
+# Bare-process SMTP_PASS fallback is allowed only with no archive or an archive
+# on DOMAIN. A same-domain archive may use that fallback only when it is not
+# aliased/forwarded outside the trusted compliance boundary; if it can forward
+# externally, set the same explicit 32+ character secret. The application
+# cannot discover downstream aliases: that routing boundary is an operator/MTA
+# responsibility. Compose already requires this secret.
 # If at least one original RCPT is accepted and this configured archive RCPT is rejected, Nodemailer
 # partial-success is preserved with a content-free warning, even if another
 # original RCPT was rejected.

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,17 @@ TASK_LEASES_ENABLED=false
 # IMAP_TLS_REJECT_UNAUTHORIZED=false
 # SMTP_TLS_REJECT_UNAUTHORIZED=false
 
+# Optional compliance archive mailbox. Default off: leave unset/blank. When
+# set, every API/MCP/task outbound message adds this one envelope recipient;
+# it is never written to To/Bcc MIME headers. Use an external mailbox only
+# with an approved privacy/retention policy and as a trusted archive boundary:
+# it receives the exact MIME, including internal-message stamps when present.
+# If only its RCPT is rejected after original recipients are accepted, sending
+# succeeds with a server warning.
+# Later relay/Postfix delivery failures after queue acceptance are visible only
+# in relay logs or DSNs, not synchronously through the API.
+# ALWAYS_BCC=archive@example.net
+
 # ── SERVER-SIDE PUSH NOTIFICATIONS (ntfy) ───────────────────────────────────
 
 # The ntfy container stays in the Compose stack even when false (about 20 MB

--- a/.env.example
+++ b/.env.example
@@ -52,9 +52,13 @@ TASK_LEASES_ENABLED=false
 # it is never written to To/Bcc MIME headers. Use an external mailbox only
 # with an approved privacy/retention policy and as a trusted archive boundary:
 # it receives the exact MIME, including internal-message stamps when present.
-# An archive outside DOMAIN requires this file's explicit TASK_SIGNING_SECRET;
-# Compose already requires it. Bare-process SMTP_PASS fallback is allowed only
-# with no archive or an archive on DOMAIN.
+# An archive outside DOMAIN requires an explicit, high-entropy (32+ character)
+# TASK_SIGNING_SECRET. Bare-process SMTP_PASS fallback is allowed only with no
+# archive or an archive on DOMAIN. A same-domain archive may use that fallback
+# only when it is not aliased/forwarded outside the trusted compliance boundary;
+# if it can forward externally, set the same explicit 32+ character secret.
+# The application cannot discover downstream aliases: that routing boundary is
+# an operator/MTA responsibility. Compose already requires this secret.
 # If at least one original RCPT is accepted and this configured archive RCPT is
 # rejected, Nodemailer partial-success is preserved with a content-free warning,
 # even if another original RCPT was rejected.

--- a/.env.example
+++ b/.env.example
@@ -52,15 +52,14 @@ TASK_LEASES_ENABLED=false
 # it is never written to To/Bcc MIME headers. Use an external mailbox only
 # with an approved privacy/retention policy and as a trusted archive boundary:
 # it receives the exact MIME, including internal-message stamps when present.
-# An archive outside DOMAIN requires an explicit 32+ character
-# TASK_SIGNING_SECRET. The app enforces presence and length only, not entropy:
-# generate a high-entropy value (this example uses `openssl rand -hex 32`).
-# Bare-process SMTP_PASS fallback is allowed only with no archive or an archive
-# on DOMAIN. A same-domain archive may use that fallback only when it is not
-# aliased/forwarded outside the trusted compliance boundary; if it can forward
-# externally, set the same explicit 32+ character secret. The application
-# cannot discover downstream aliases: that routing boundary is an operator/MTA
-# responsibility. Compose already requires this secret.
+# ALWAYS_BCC must be an independent archive outside DOMAIN. Same-domain values
+# are rejected: the shared catch-all makes them unsuitable as an independent
+# compliance destination, and duplicate suppression is not that boundary.
+# Every enabled archive requires an explicit 32+ character TASK_SIGNING_SECRET.
+# The app enforces presence and length only, not entropy: generate a
+# high-entropy value (this example uses `openssl rand -hex 32`). Bare-process
+# SMTP_PASS fallback is allowed only with no archive. Compose already requires
+# this secret.
 # If at least one original RCPT is accepted and this configured archive RCPT is
 # rejected, Nodemailer partial-success is preserved with a content-free warning,
 # even if another original RCPT was rejected.

--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ TASK_LEASES_ENABLED=false
 # it is never written to To/Bcc MIME headers. Use an external mailbox only
 # with an approved privacy/retention policy and as a trusted archive boundary:
 # it receives the exact MIME, including internal-message stamps when present.
+# An archive outside DOMAIN requires this file's explicit TASK_SIGNING_SECRET;
+# Compose already requires it. Bare-process SMTP_PASS fallback is allowed only
+# with no archive or an archive on DOMAIN.
 # If at least one original RCPT is accepted and this configured archive RCPT is
 # rejected, Nodemailer partial-success is preserved with a content-free warning,
 # even if another original RCPT was rejected.

--- a/.env.example
+++ b/.env.example
@@ -52,8 +52,9 @@ TASK_LEASES_ENABLED=false
 # it is never written to To/Bcc MIME headers. Use an external mailbox only
 # with an approved privacy/retention policy and as a trusted archive boundary:
 # it receives the exact MIME, including internal-message stamps when present.
-# If only its RCPT is rejected after original recipients are accepted, sending
-# succeeds with a server warning.
+# If at least one original RCPT is accepted and this configured archive RCPT is
+# rejected, Nodemailer partial-success is preserved with a content-free warning,
+# even if another original RCPT was rejected.
 # Later relay/Postfix delivery failures after queue acceptance are visible only
 # in relay logs or DSNs, not synchronously through the API.
 # ALWAYS_BCC=archive@example.net

--- a/.env.example
+++ b/.env.example
@@ -52,13 +52,15 @@ TASK_LEASES_ENABLED=false
 # it is never written to To/Bcc MIME headers. Use an external mailbox only
 # with an approved privacy/retention policy and as a trusted archive boundary:
 # it receives the exact MIME, including internal-message stamps when present.
-# An archive outside DOMAIN requires an explicit, high-entropy (32+ character)
-# TASK_SIGNING_SECRET. Bare-process SMTP_PASS fallback is allowed only with no
-# archive or an archive on DOMAIN. A same-domain archive may use that fallback
-# only when it is not aliased/forwarded outside the trusted compliance boundary;
-# if it can forward externally, set the same explicit 32+ character secret.
-# The application cannot discover downstream aliases: that routing boundary is
-# an operator/MTA responsibility. Compose already requires this secret.
+# An archive outside DOMAIN requires an explicit 32+ character
+# TASK_SIGNING_SECRET. The app enforces presence and length only, not entropy:
+# generate a high-entropy value (this example uses `openssl rand -hex 32`).
+# Bare-process SMTP_PASS fallback is allowed only with no archive or an archive
+# on DOMAIN. A same-domain archive may use that fallback only when it is not
+# aliased/forwarded outside the trusted compliance boundary; if it can forward
+# externally, set the same explicit 32+ character secret. The application
+# cannot discover downstream aliases: that routing boundary is an operator/MTA
+# responsibility. Compose already requires this secret.
 # If at least one original RCPT is accepted and this configured archive RCPT is
 # rejected, Nodemailer partial-success is preserved with a content-free warning,
 # even if another original RCPT was rejected.

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,8 @@ TASK_LEASES_ENABLED=false
 # If at least one original RCPT is accepted and this configured archive RCPT is
 # rejected, Nodemailer partial-success is preserved with a content-free warning,
 # even if another original RCPT was rejected.
+# If the archive is accepted while no original RCPT is reported accepted, the
+# API fails even when SMTP omitted explicit rejected outcomes.
 # Later relay/Postfix delivery failures after queue acceptance are visible only
 # in relay logs or DSNs, not synchronously through the API.
 # ALWAYS_BCC=archive@example.net

--- a/README.md
+++ b/README.md
@@ -344,14 +344,17 @@ The archive is a trust boundary, not an ordinary untrusted external recipient:
 for all-local visible recipients it receives the exact MIME, including the
 `X-OA-Mail-Stamp` that preserves local `internal` classification. Configure it
 only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
-An external archive requires an explicit high-entropy `TASK_SIGNING_SECRET` of
-at least 32 characters. The SMTP-password fallback is allowed only when the
-archive is absent or on the configured `DOMAIN`. A same-domain archive may use
-that fallback only when its mailbox is not aliased or forwarded outside this
-trusted compliance boundary; if it can forward externally, configure the same
-explicit 32+ character secret. The application cannot discover downstream
-alias expansion, so this routing assessment remains an operator/MTA
-responsibility. Both Compose deployments already require the dedicated secret.
+An external archive requires an explicit `TASK_SIGNING_SECRET` of at least 32
+characters. The application enforces only presence and that length minimum; it
+does not prove entropy, so operators must generate a high-entropy secret (the
+Compose examples use `openssl rand -hex 32`). The SMTP-password fallback is
+allowed only when the archive is absent or on the configured `DOMAIN`. A
+same-domain archive may use that fallback only when its mailbox is not aliased
+or forwarded outside this trusted compliance boundary; if it can forward
+externally, configure the same explicit 32+ character secret. The application
+cannot discover downstream alias expansion, so this routing assessment remains
+an operator/MTA responsibility. Both Compose deployments already require the
+dedicated secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs
@@ -360,6 +363,12 @@ the archive is accepted while no original recipient is reported accepted, the
 API fails instead. After an upstream SMTP server accepts or queues the archive
 RCPT, later delivery failures appear in SMTP/Postfix/relay logs or DSNs rather
 than synchronously in the API response.
+
+SMTP result matching deliberately keeps local-part spelling exact. A relay that
+rewrites accepted RCPT local-part case can therefore cause a conservative
+failure/retry; configure relays to preserve RCPT spelling. Case-distinct archive
+and original local-parts are intentionally separate SMTP mailboxes and can
+produce two copies with a case-folding provider, so use consistent spelling.
 
 ## Use it from your agent (MCP)
 

--- a/README.md
+++ b/README.md
@@ -344,9 +344,14 @@ The archive is a trust boundary, not an ordinary untrusted external recipient:
 for all-local visible recipients it receives the exact MIME, including the
 `X-OA-Mail-Stamp` that preserves local `internal` classification. Configure it
 only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
-An external archive also requires an explicit dedicated `TASK_SIGNING_SECRET`:
-the SMTP-password fallback is allowed only when the archive is absent or on the
-configured `DOMAIN`. Both Compose deployments already require this secret.
+An external archive requires an explicit high-entropy `TASK_SIGNING_SECRET` of
+at least 32 characters. The SMTP-password fallback is allowed only when the
+archive is absent or on the configured `DOMAIN`. A same-domain archive may use
+that fallback only when its mailbox is not aliased or forwarded outside this
+trusted compliance boundary; if it can forward externally, configure the same
+explicit 32+ character secret. The application cannot discover downstream
+alias expansion, so this routing assessment remains an operator/MTA
+responsibility. Both Compose deployments already require the dedicated secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs

--- a/README.md
+++ b/README.md
@@ -345,10 +345,13 @@ for all-local visible recipients it receives the exact MIME, including the
 `X-OA-Mail-Stamp` that preserves local `internal` classification. Configure it
 only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
 
-If the original recipients are accepted and only the archive RCPT is rejected,
-the API keeps the send successful and logs a warning. After an upstream SMTP
-server accepts or queues that archive RCPT, later delivery failures appear in
-SMTP/Postfix/relay logs or DSNs rather than synchronously in the API response.
+If at least one original recipient is accepted and the configured archive RCPT
+is rejected, the API preserves Nodemailer's partial-success semantics and logs
+a content-free warning, even when another original recipient was rejected. If
+the archive is accepted while every original recipient is rejected, the API
+fails instead. After an upstream SMTP server accepts or queues the archive RCPT,
+later delivery failures appear in SMTP/Postfix/relay logs or DSNs rather than
+synchronously in the API response.
 
 ## Use it from your agent (MCP)
 

--- a/README.md
+++ b/README.md
@@ -329,6 +329,26 @@ IMAP, matches messages to identities by the `To`/`Delivered-To` header, and send
 via SMTP with the `From` rewritten to the chosen identity. Polling + IMAP IDLE for
 low-latency waits.
 
+### Optional compliance archive
+
+Set `ALWAYS_BCC=archive@example.net` only when your compliance policy permits
+an additional external delivery copy. It is off by default and adds the archive
+once to the SMTP envelope for API, MCP, and task sends—case-insensitively
+deduplicated with visible recipients—without adding a MIME `Bcc` header or
+changing visible `To`, header From, envelope MAIL FROM, SPF, DKIM content, or
+DMARC alignment. Archive mailbox access, privacy, retention, aliases, and
+forwarding are operator/MTA responsibilities.
+
+The archive is a trust boundary, not an ordinary untrusted external recipient:
+for all-local visible recipients it receives the exact MIME, including the
+`X-OA-Mail-Stamp` that preserves local `internal` classification. Configure it
+only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
+
+If the original recipients are accepted and only the archive RCPT is rejected,
+the API keeps the send successful and logs a warning. After an upstream SMTP
+server accepts or queues that archive RCPT, later delivery failures appear in
+SMTP/Postfix/relay logs or DSNs rather than synchronously in the API response.
+
 ## Use it from your agent (MCP)
 
 Requires Node.js 18+ on the machine running the MCP client — no install step,

--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ The archive is a trust boundary, not an ordinary untrusted external recipient:
 for all-local visible recipients it receives the exact MIME, including the
 `X-OA-Mail-Stamp` that preserves local `internal` classification. Configure it
 only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
+An external archive also requires an explicit dedicated `TASK_SIGNING_SECRET`:
+the SMTP-password fallback is allowed only when the archive is absent or on the
+configured `DOMAIN`. Both Compose deployments already require this secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs

--- a/README.md
+++ b/README.md
@@ -340,21 +340,20 @@ changing visible `To`, header From, envelope MAIL FROM, SPF, DKIM content, or
 DMARC alignment. Archive mailbox access, privacy, retention, aliases, and
 forwarding are operator/MTA responsibilities.
 
-The archive is a trust boundary, not an ordinary untrusted external recipient:
-for all-local visible recipients it receives the exact MIME, including the
-`X-OA-Mail-Stamp` that preserves local `internal` classification. Configure it
-only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
-An external archive requires an explicit `TASK_SIGNING_SECRET` of at least 32
-characters. The application enforces only presence and that length minimum; it
-does not prove entropy, so operators must generate a high-entropy secret (the
-Compose examples use `openssl rand -hex 32`). The SMTP-password fallback is
-allowed only when the archive is absent or on the configured `DOMAIN`. A
-same-domain archive may use that fallback only when its mailbox is not aliased
-or forwarded outside this trusted compliance boundary; if it can forward
-externally, configure the same explicit 32+ character secret. The application
-cannot discover downstream alias expansion, so this routing assessment remains
-an operator/MTA responsibility. Both Compose deployments already require the
-dedicated secret.
+The archive is an independent, off-domain compliance destination—not an
+ordinary untrusted recipient. For all-local visible recipients it receives the
+exact MIME, including the `X-OA-Mail-Stamp` that preserves local `internal`
+classification. Same-domain `ALWAYS_BCC` values are rejected at startup: on a
+shared catch-all deployment they are not an independent archive destination,
+and duplicate suppression is not a substitute for that boundary. Configure a
+controlled external compliance mailbox or leave `ALWAYS_BCC` unset.
+
+Every enabled archive requires an explicit `TASK_SIGNING_SECRET` of at least
+32 characters. The application enforces only presence and that length minimum;
+it does not prove entropy, so operators must generate a high-entropy secret
+(the Compose examples use `openssl rand -hex 32`). The historical SMTP-password
+fallback remains only when the archive is absent or blank. Both Compose
+deployments already require the dedicated secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs

--- a/README.md
+++ b/README.md
@@ -348,10 +348,10 @@ only for a controlled compliance mailbox; otherwise leave `ALWAYS_BCC` unset.
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs
 a content-free warning, even when another original recipient was rejected. If
-the archive is accepted while every original recipient is rejected, the API
-fails instead. After an upstream SMTP server accepts or queues the archive RCPT,
-later delivery failures appear in SMTP/Postfix/relay logs or DSNs rather than
-synchronously in the API response.
+the archive is accepted while no original recipient is reported accepted, the
+API fails instead. After an upstream SMTP server accepts or queues the archive
+RCPT, later delivery failures appear in SMTP/Postfix/relay logs or DSNs rather
+than synchronously in the API response.
 
 ## Use it from your agent (MCP)
 

--- a/README.md
+++ b/README.md
@@ -333,8 +333,9 @@ low-latency waits.
 
 Set `ALWAYS_BCC=archive@example.net` only when your compliance policy permits
 an additional external delivery copy. It is off by default and adds the archive
-once to the SMTP envelope for API, MCP, and task sends—case-insensitively
-deduplicated with visible recipients—without adding a MIME `Bcc` header or
+once to the SMTP envelope for API, MCP, and task sends, preserving visible
+recipient order and matching an existing recipient only by exact local-part and
+case-insensitive domain—without adding a MIME `Bcc` header or
 changing visible `To`, header From, envelope MAIL FROM, SPF, DKIM content, or
 DMARC alignment. Archive mailbox access, privacy, retention, aliases, and
 forwarding are operator/MTA responsibilities.

--- a/compose.api-only.yaml
+++ b/compose.api-only.yaml
@@ -33,6 +33,8 @@ services:
       SMTP_TLS_REJECT_UNAUTHORIZED: ${SMTP_TLS_REJECT_UNAUTHORIZED:-false}
       SMTP_USER: ${SMTP_USER:?Set SMTP_USER in .env}
       SMTP_PASS: ${SMTP_PASS:?Set SMTP_PASS in .env}
+      # Optional envelope-only compliance archive recipient; blank = disabled.
+      ALWAYS_BCC: ${ALWAYS_BCC:-}
       TASK_SIGNING_SECRET: ${TASK_SIGNING_SECRET:?Set TASK_SIGNING_SECRET in .env (openssl rand -hex 32)}
       # Optional dashboard origin for ntfy click actions on mail-arrival pushes.
       DASHBOARD_PUBLIC_URL: ${DASHBOARD_PUBLIC_URL:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -236,6 +236,8 @@ services:
       SMTP_PORT: 587
       SMTP_USER: ${MAIL_ACCOUNT:-agent}@${DOMAIN}
       SMTP_PASS: ${MAIL_PASSWORD:?Set MAIL_PASSWORD in .env}
+      # Optional envelope-only compliance archive recipient; blank = disabled.
+      ALWAYS_BCC: ${ALWAYS_BCC:-}
       # Safety belt: avoid Bun retaining mailserver's old container IP after a rebuild.
       BUN_CONFIG_DNS_TIME_TO_LIVE_SECONDS: "0"
       TASK_SIGNING_SECRET: ${TASK_SIGNING_SECRET:?Set TASK_SIGNING_SECRET in .env (openssl rand -hex 32)}

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,17 +58,19 @@ mailbox controlled by the same trusted compliance boundary, and leave it unset
 when that premise cannot be made. This preserves source-classification behavior
 rather than silently downgrading original local delivery to `external`.
 
-An external archive requires an explicit high-entropy `TASK_SIGNING_SECRET` of
-at least 32 characters at startup. The historical bare-process `SMTP_PASS`
-fallback remains only when `ALWAYS_BCC` is absent or its mailbox is on
-`DOMAIN`; this prevents a stamped external archive copy from becoming a
-known-message password-guessing surface. A same-domain archive may use that
-fallback only if it is not aliased or forwarded outside the trusted compliance
-boundary. If it can forward externally, it needs the same explicit 32+
-character secret as an external archive. Application code cannot discover
-downstream alias expansion; configuring and enforcing that routing boundary is
-the operator/MTA responsibility. Both Compose configurations already require
-the dedicated secret.
+An external archive requires an explicit `TASK_SIGNING_SECRET` of at least 32
+characters at startup. The application enforces presence and this length
+minimum only; it does not guarantee entropy. Operators must generate a
+high-entropy secret (the Compose examples use `openssl rand -hex 32`). The
+historical bare-process `SMTP_PASS` fallback remains only when `ALWAYS_BCC` is
+absent or its mailbox is on `DOMAIN`; this prevents a stamped external archive
+copy from becoming a known-message password-guessing surface. A same-domain
+archive may use that fallback only if it is not aliased or forwarded outside
+the trusted compliance boundary. If it can forward externally, it needs the
+same explicit 32+ character secret as an external archive. Application code
+cannot discover downstream alias expansion; configuring and enforcing that
+routing boundary is the operator/MTA responsibility. Both Compose
+configurations already require the dedicated secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs
@@ -77,6 +79,15 @@ the archive is accepted while no original recipient is reported accepted, the
 API fails. Once the upstream SMTP server accepts/queues the archive RCPT, any
 later off-domain delivery failure is observable through SMTP/Postfix/relay logs
 or DSNs, not synchronously through this API.
+
+**SMTP relay compatibility:** result matching intentionally preserves exact
+local-part spelling. A relay that rewrites an accepted RCPT local-part's case
+can cause a conservative failure/retry, so operators should configure relays
+to preserve RCPT spelling. Case-distinct archive and original local-parts are
+intentionally separate SMTP mailboxes and can produce two copies on
+case-folding providers; use consistent spelling. There is intentionally no
+case-insensitive result fallback, because it could confuse archive-only
+acceptance with original-recipient acceptance.
 
 ## Inbox identity ACL（#26 PR 2）
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -61,10 +61,10 @@ rather than silently downgrading original local delivery to `external`.
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs
 a content-free warning, even when another original recipient was rejected. If
-the archive is accepted while every original recipient is rejected, the API
-fails. Once the upstream SMTP server accepts/queues the archive RCPT, any later
-off-domain delivery failure is observable through SMTP/Postfix/relay logs or
-DSNs, not synchronously through this API.
+the archive is accepted while no original recipient is reported accepted, the
+API fails. Once the upstream SMTP server accepts/queues the archive RCPT, any
+later off-domain delivery failure is observable through SMTP/Postfix/relay logs
+or DSNs, not synchronously through this API.
 
 ## Inbox identity ACL（#26 PR 2）
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -29,13 +29,39 @@ retention window before reusing one.
 `DATA_DIR/send-log.jsonl` 是 API/MCP `POST /v1/send` 的 30 天发送审计（不是 IMAP Sent 文件夹）。
 
 - **覆盖：** 每次 `/v1/send`（成功 queued + 失败 failed+稳定原因）。字段：time / from / to / subject / message-id / result / source(`api|mcp`)。**不写正文、不写 token。**
-- **不覆盖：** SMTP 直发（docker-mailserver 本机投递、外部客户端）。full 版再议 always_bcc 类方案。
+- **不覆盖：** SMTP 直发（docker-mailserver 本机投递、外部客户端）。`ALWAYS_BCC` 只覆盖 API/MCP/task 经 `sendMail` 的应用出站，不改变其他 Postfix 收件路径。
 - **来源：** 不信任公共 `X-OAE-Send-Source`。MCP→API 用 `taskSigningSecret` 域分离（`send-source-v1`）HMAC 头 `X-OAE-Send-Source-Mac`；验签通过才记 `mcp`，其余一律 `api`。
 - **有界：** 每身份每限流窗口最多 1 条 `rate_limited`；from/to 单项 ≤254；硬上限 **10_000 行或 8MB**（先到先限，append/compact drop-oldest）。追加热路径不全量解析。
 - **UI：** Dashboard Sent 文件夹读本日志，不再用 IMAP From 匹配（那条路径对 API 发送几乎永远为空且误导）。
 - **INBOX：** 本路径不 IMAP-append 副本，不污染 unseen / Overview。
 - **ACL：** admin 可全量或按 from 筛；identity 只能看自己的 from，看他人 403。
 - **纪律：** 单写者、0600、tmp+fsync+rename+目录 fsync（含首次创建）、corrupt fail-closed、30 天 sweeper。
+
+## Optional outbound compliance archive (#72)
+
+`ALWAYS_BCC` is optional and off by default. When set to exactly one valid
+mailbox, the API adds it once to the SMTP envelope RCPT list for each API/MCP/
+task send, case-insensitively deduplicated with the original recipients. It is
+not a Nodemailer `bcc` field: visible `To`, MIME headers, header From, envelope
+MAIL FROM, SPF, DKIM content, and DMARC alignment are unchanged. The added
+recipient does create another delivery copy, so its external mailbox, privacy,
+access, and retention controls are an operator responsibility. Aliases and
+forwarding remain downstream MTA behavior.
+
+**Trust boundary:** this is not an ordinary untrusted external recipient. When
+all visible `To` recipients are local, the exact MIME retains its
+`X-OA-Mail-Stamp` so local recipients continue to classify it as `internal`;
+the archive receives that same signed MIME. Configure `ALWAYS_BCC` only for a
+mailbox controlled by the same trusted compliance boundary, and leave it unset
+when that premise cannot be made. This preserves source-classification behavior
+rather than silently downgrading original local delivery to `external`.
+
+If every original recipient is accepted and only the archive RCPT is rejected,
+the API preserves successful send semantics and logs a content-free warning.
+If original recipients are all rejected while only the archive is accepted, the
+send fails. Once the upstream SMTP server accepts/queues the archive RCPT, any
+later off-domain delivery failure is observable through SMTP/Postfix/relay logs
+or DSNs, not synchronously through this API.
 
 ## Inbox identity ACL（#26 PR 2）
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,12 +58,13 @@ mailbox controlled by the same trusted compliance boundary, and leave it unset
 when that premise cannot be made. This preserves source-classification behavior
 rather than silently downgrading original local delivery to `external`.
 
-If every original recipient is accepted and only the archive RCPT is rejected,
-the API preserves successful send semantics and logs a content-free warning.
-If original recipients are all rejected while only the archive is accepted, the
-send fails. Once the upstream SMTP server accepts/queues the archive RCPT, any
-later off-domain delivery failure is observable through SMTP/Postfix/relay logs
-or DSNs, not synchronously through this API.
+If at least one original recipient is accepted and the configured archive RCPT
+is rejected, the API preserves Nodemailer's partial-success semantics and logs
+a content-free warning, even when another original recipient was rejected. If
+the archive is accepted while every original recipient is rejected, the API
+fails. Once the upstream SMTP server accepts/queues the archive RCPT, any later
+off-domain delivery failure is observable through SMTP/Postfix/relay logs or
+DSNs, not synchronously through this API.
 
 ## Inbox identity ACL（#26 PR 2）
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -41,7 +41,9 @@ retention window before reusing one.
 
 `ALWAYS_BCC` is optional and off by default. When set to exactly one valid
 mailbox, the API adds it once to the SMTP envelope RCPT list for each API/MCP/
-task send, case-insensitively deduplicated with the original recipients. It is
+task send, preserving the original recipient list exactly and appending the
+archive only when no original recipient has the same exact local-part and a
+case-insensitively matching domain. It is
 not a Nodemailer `bcc` field: visible `To`, MIME headers, header From, envelope
 MAIL FROM, SPF, DKIM content, and DMARC alignment are unchanged. The added
 recipient does create another delivery copy, so its external mailbox, privacy,

--- a/docs/security.md
+++ b/docs/security.md
@@ -50,27 +50,21 @@ recipient does create another delivery copy, so its external mailbox, privacy,
 access, and retention controls are an operator responsibility. Aliases and
 forwarding remain downstream MTA behavior.
 
-**Trust boundary:** this is not an ordinary untrusted external recipient. When
-all visible `To` recipients are local, the exact MIME retains its
-`X-OA-Mail-Stamp` so local recipients continue to classify it as `internal`;
-the archive receives that same signed MIME. Configure `ALWAYS_BCC` only for a
-mailbox controlled by the same trusted compliance boundary, and leave it unset
-when that premise cannot be made. This preserves source-classification behavior
-rather than silently downgrading original local delivery to `external`.
+**Trust boundary:** this is an independent, off-domain compliance destination,
+not an ordinary untrusted recipient. When all visible `To` recipients are
+local, the exact MIME retains its `X-OA-Mail-Stamp` so local recipients continue
+to classify it as `internal`; the archive receives that same signed MIME.
+Same-domain `ALWAYS_BCC` values are rejected at startup: a mailbox on the shared
+catch-all domain is not an independent archive destination, and duplicate
+suppression cannot establish that boundary. Configure a controlled external
+compliance mailbox or leave the setting unset.
 
-An external archive requires an explicit `TASK_SIGNING_SECRET` of at least 32
-characters at startup. The application enforces presence and this length
-minimum only; it does not guarantee entropy. Operators must generate a
-high-entropy secret (the Compose examples use `openssl rand -hex 32`). The
-historical bare-process `SMTP_PASS` fallback remains only when `ALWAYS_BCC` is
-absent or its mailbox is on `DOMAIN`; this prevents a stamped external archive
-copy from becoming a known-message password-guessing surface. A same-domain
-archive may use that fallback only if it is not aliased or forwarded outside
-the trusted compliance boundary. If it can forward externally, it needs the
-same explicit 32+ character secret as an external archive. Application code
-cannot discover downstream alias expansion; configuring and enforcing that
-routing boundary is the operator/MTA responsibility. Both Compose
-configurations already require the dedicated secret.
+Every enabled archive requires an explicit `TASK_SIGNING_SECRET` of at least 32
+characters at startup. The application enforces presence and this length minimum
+only; it does not guarantee entropy. Operators must generate a high-entropy
+secret (the Compose examples use `openssl rand -hex 32`). The historical
+bare-process `SMTP_PASS` fallback remains only when `ALWAYS_BCC` is absent or
+blank. Both Compose configurations already require the dedicated secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,6 +58,12 @@ mailbox controlled by the same trusted compliance boundary, and leave it unset
 when that premise cannot be made. This preserves source-classification behavior
 rather than silently downgrading original local delivery to `external`.
 
+An external archive requires an explicit dedicated `TASK_SIGNING_SECRET` at
+startup. The historical bare-process `SMTP_PASS` fallback remains only when
+`ALWAYS_BCC` is absent or its mailbox is on `DOMAIN`; this prevents a stamped
+external archive copy from becoming a known-message password-guessing surface.
+Both Compose configurations already require the dedicated secret.
+
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs
 a content-free warning, even when another original recipient was rejected. If

--- a/docs/security.md
+++ b/docs/security.md
@@ -58,11 +58,17 @@ mailbox controlled by the same trusted compliance boundary, and leave it unset
 when that premise cannot be made. This preserves source-classification behavior
 rather than silently downgrading original local delivery to `external`.
 
-An external archive requires an explicit dedicated `TASK_SIGNING_SECRET` at
-startup. The historical bare-process `SMTP_PASS` fallback remains only when
-`ALWAYS_BCC` is absent or its mailbox is on `DOMAIN`; this prevents a stamped
-external archive copy from becoming a known-message password-guessing surface.
-Both Compose configurations already require the dedicated secret.
+An external archive requires an explicit high-entropy `TASK_SIGNING_SECRET` of
+at least 32 characters at startup. The historical bare-process `SMTP_PASS`
+fallback remains only when `ALWAYS_BCC` is absent or its mailbox is on
+`DOMAIN`; this prevents a stamped external archive copy from becoming a
+known-message password-guessing surface. A same-domain archive may use that
+fallback only if it is not aliased or forwarded outside the trusted compliance
+boundary. If it can forward externally, it needs the same explicit 32+
+character secret as an external archive. Application code cannot discover
+downstream alias expansion; configuring and enforcing that routing boundary is
+the operator/MTA responsibility. Both Compose configurations already require
+the dedicated secret.
 
 If at least one original recipient is accepted and the configured archive RCPT
 is rejected, the API preserves Nodemailer's partial-success semantics and logs

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -19,6 +19,7 @@ function emptyAsUndefined(value: unknown): unknown {
 
 /** RFC 5321 mailbox maximum; matches the API send-route address boundary. */
 const SMTP_MAILBOX_MAX_LENGTH = 254;
+const SMTP_LOCAL_PART_MAX_OCTETS = 64;
 
 /** Only http(s) — these values feed ntfy HTTP calls and push click actions. */
 const httpUrl = z
@@ -117,7 +118,17 @@ const envSchema = z.object({
   // disabled; a nonblank value must be exactly one mailbox, not a list/name.
   ALWAYS_BCC: z.preprocess(
     emptyAsUndefined,
-    z.string().email().max(SMTP_MAILBOX_MAX_LENGTH).optional(),
+    z
+      .string()
+      .email()
+      .max(SMTP_MAILBOX_MAX_LENGTH)
+      .refine(
+        (address) =>
+          Buffer.byteLength(address.slice(0, address.lastIndexOf('@')), 'utf8')
+          <= SMTP_LOCAL_PART_MAX_OCTETS,
+        { message: 'SMTP local part must be at most 64 octets' },
+      )
+      .optional(),
   ),
 
   // Stable private key for task-header stamps. This must outlive SMTP account

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -262,7 +262,9 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
   const archiveDomain = raw.ALWAYS_BCC
     ?.slice(raw.ALWAYS_BCC.lastIndexOf('@') + 1)
     .toLowerCase();
-  if (raw.ALWAYS_BCC && archiveDomain === raw.DOMAIN.toLowerCase()) {
+  const canonicalArchiveDomain = archiveDomain?.replace(/\.+$/, '');
+  const canonicalConfiguredDomain = raw.DOMAIN.toLowerCase().replace(/\.+$/, '');
+  if (raw.ALWAYS_BCC && canonicalArchiveDomain === canonicalConfiguredDomain) {
     throw new Error('ALWAYS_BCC must be an external compliance archive');
   }
   if (raw.ALWAYS_BCC) {

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -110,6 +110,10 @@ const envSchema = z.object({
   // certificate, while external public SMTP servers should normally use true.
   SMTP_TLS_REJECT_UNAUTHORIZED: z.enum(['true', 'false']).default('false'),
 
+  // Optional compliance archive recipient. Empty Compose interpolation stays
+  // disabled; a nonblank value must be exactly one mailbox, not a list/name.
+  ALWAYS_BCC: z.preprocess(emptyAsUndefined, z.string().email().optional()),
+
   // Stable private key for task-header stamps. This must outlive SMTP account
   // password rotations so old task threads remain verifiable.
   TASK_SIGNING_SECRET: z.string().min(16).optional(),
@@ -245,6 +249,7 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
       pass: raw.SMTP_PASS,
       tlsRejectUnauthorized: raw.SMTP_TLS_REJECT_UNAUTHORIZED === 'true',
     },
+    alwaysBcc: raw.ALWAYS_BCC,
     // The fallback supports an upgrade where the new variable has not reached
     // a bare-process config yet. Both Compose variants require the dedicated
     // secret, which is the supported v0.4 deployment path.

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -20,6 +20,7 @@ function emptyAsUndefined(value: unknown): unknown {
 /** RFC 5321 mailbox maximum; matches the API send-route address boundary. */
 const SMTP_MAILBOX_MAX_LENGTH = 254;
 const SMTP_LOCAL_PART_MAX_OCTETS = 64;
+const SMTP_DOMAIN_LABEL_MAX_OCTETS = 63;
 
 /** Only http(s) — these values feed ntfy HTTP calls and push click actions. */
 const httpUrl = z
@@ -127,6 +128,14 @@ const envSchema = z.object({
           Buffer.byteLength(address.slice(0, address.lastIndexOf('@')), 'utf8')
           <= SMTP_LOCAL_PART_MAX_OCTETS,
         { message: 'SMTP local part must be at most 64 octets' },
+      )
+      .refine(
+        (address) =>
+          address
+            .slice(address.lastIndexOf('@') + 1)
+            .split('.')
+            .every((label) => Buffer.byteLength(label, 'utf8') <= SMTP_DOMAIN_LABEL_MAX_OCTETS),
+        { message: 'SMTP domain labels must be at most 63 octets' },
       )
       .optional(),
   ),

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -233,13 +233,16 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
     .toLowerCase();
   const externalArchive =
     raw.ALWAYS_BCC !== undefined && archiveDomain !== raw.DOMAIN.toLowerCase();
-  if (externalArchive && !raw.TASK_SIGNING_SECRET) {
-    throw new Error('TASK_SIGNING_SECRET is required for an external compliance archive');
-  }
-  if (externalArchive && raw.TASK_SIGNING_SECRET.length < 32) {
-    throw new Error(
-      'TASK_SIGNING_SECRET must be at least 32 characters for an external compliance archive',
-    );
+  if (externalArchive) {
+    const externalArchiveSigningSecret = raw.TASK_SIGNING_SECRET;
+    if (!externalArchiveSigningSecret) {
+      throw new Error('TASK_SIGNING_SECRET is required for an external compliance archive');
+    }
+    if (externalArchiveSigningSecret.length < 32) {
+      throw new Error(
+        'TASK_SIGNING_SECRET must be at least 32 characters for an external compliance archive',
+      );
+    }
   }
   const taskSigningSecret = raw.TASK_SIGNING_SECRET ?? raw.SMTP_PASS;
 

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -231,8 +231,15 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
   const archiveDomain = raw.ALWAYS_BCC
     ?.slice(raw.ALWAYS_BCC.lastIndexOf('@') + 1)
     .toLowerCase();
-  if (raw.ALWAYS_BCC && !raw.TASK_SIGNING_SECRET && archiveDomain !== raw.DOMAIN.toLowerCase()) {
+  const externalArchive =
+    raw.ALWAYS_BCC !== undefined && archiveDomain !== raw.DOMAIN.toLowerCase();
+  if (externalArchive && !raw.TASK_SIGNING_SECRET) {
     throw new Error('TASK_SIGNING_SECRET is required for an external compliance archive');
+  }
+  if (externalArchive && raw.TASK_SIGNING_SECRET.length < 32) {
+    throw new Error(
+      'TASK_SIGNING_SECRET must be at least 32 characters for an external compliance archive',
+    );
   }
   const taskSigningSecret = raw.TASK_SIGNING_SECRET ?? raw.SMTP_PASS;
 

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -228,6 +228,12 @@ export function normalizeUrl(value: string): string {
 /** Parse an environment object so TLS defaults and validation stay testable. */
 export function parseConfig(env: NodeJS.ProcessEnv) {
   const raw = envSchema.parse(env);
+  const archiveDomain = raw.ALWAYS_BCC
+    ?.slice(raw.ALWAYS_BCC.lastIndexOf('@') + 1)
+    .toLowerCase();
+  if (raw.ALWAYS_BCC && !raw.TASK_SIGNING_SECRET && archiveDomain !== raw.DOMAIN.toLowerCase()) {
+    throw new Error('TASK_SIGNING_SECRET is required for an external compliance archive');
+  }
   const taskSigningSecret = raw.TASK_SIGNING_SECRET ?? raw.SMTP_PASS;
 
   return {

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -17,6 +17,9 @@ function emptyAsUndefined(value: unknown): unknown {
   return value.trim() === '' ? undefined : value;
 }
 
+/** RFC 5321 mailbox maximum; matches the API send-route address boundary. */
+const SMTP_MAILBOX_MAX_LENGTH = 254;
+
 /** Only http(s) — these values feed ntfy HTTP calls and push click actions. */
 const httpUrl = z
   .string()
@@ -112,7 +115,10 @@ const envSchema = z.object({
 
   // Optional compliance archive recipient. Empty Compose interpolation stays
   // disabled; a nonblank value must be exactly one mailbox, not a list/name.
-  ALWAYS_BCC: z.preprocess(emptyAsUndefined, z.string().email().optional()),
+  ALWAYS_BCC: z.preprocess(
+    emptyAsUndefined,
+    z.string().email().max(SMTP_MAILBOX_MAX_LENGTH).optional(),
+  ),
 
   // Stable private key for task-header stamps. This must outlive SMTP account
   // password rotations so old task threads remain verifiable.

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -262,9 +262,10 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
   const archiveDomain = raw.ALWAYS_BCC
     ?.slice(raw.ALWAYS_BCC.lastIndexOf('@') + 1)
     .toLowerCase();
-  const externalArchive =
-    raw.ALWAYS_BCC !== undefined && archiveDomain !== raw.DOMAIN.toLowerCase();
-  if (externalArchive) {
+  if (raw.ALWAYS_BCC && archiveDomain === raw.DOMAIN.toLowerCase()) {
+    throw new Error('ALWAYS_BCC must be an external compliance archive');
+  }
+  if (raw.ALWAYS_BCC) {
     const externalArchiveSigningSecret = raw.TASK_SIGNING_SECRET;
     if (!externalArchiveSigningSecret) {
       throw new Error('TASK_SIGNING_SECRET is required for an external compliance archive');

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -21,6 +21,7 @@ function emptyAsUndefined(value: unknown): unknown {
 const SMTP_MAILBOX_MAX_LENGTH = 254;
 const SMTP_LOCAL_PART_MAX_OCTETS = 64;
 const SMTP_DOMAIN_LABEL_MAX_OCTETS = 63;
+const SMTP_DOMAIN_LABEL_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/;
 
 /** Only http(s) — these values feed ntfy HTTP calls and push click actions. */
 const httpUrl = z
@@ -134,8 +135,12 @@ const envSchema = z.object({
           address
             .slice(address.lastIndexOf('@') + 1)
             .split('.')
-            .every((label) => Buffer.byteLength(label, 'utf8') <= SMTP_DOMAIN_LABEL_MAX_OCTETS),
-        { message: 'SMTP domain labels must be at most 63 octets' },
+            .every(
+              (label) =>
+                Buffer.byteLength(label, 'utf8') <= SMTP_DOMAIN_LABEL_MAX_OCTETS
+                && SMTP_DOMAIN_LABEL_PATTERN.test(label),
+            ),
+        { message: 'SMTP domain labels must be valid ASCII labels of at most 63 octets' },
       )
       .optional(),
   ),

--- a/packages/api/src/lib/smtp-envelope.ts
+++ b/packages/api/src/lib/smtp-envelope.ts
@@ -90,9 +90,8 @@ export function applyArchiveRecipientPolicy(
   const rejected = new Set((result.rejected ?? []).map(normalizeDeliveryAddress).map(mailboxComparisonKey));
   const archive = mailboxComparisonKey(archiveRecipient);
   const acceptedOriginal = [...original].some((recipient) => accepted.has(recipient));
-  const rejectedOriginal = [...original].some((recipient) => rejected.has(recipient));
 
-  if (accepted.has(archive) && !acceptedOriginal && rejectedOriginal) {
+  if (accepted.has(archive) && !acceptedOriginal) {
     throw new Error('SMTP rejected all original recipients; archive acceptance does not make send successful');
   }
 

--- a/packages/api/src/lib/smtp-envelope.ts
+++ b/packages/api/src/lib/smtp-envelope.ts
@@ -92,7 +92,9 @@ export function applyArchiveRecipientPolicy(
   const acceptedOriginal = [...original].some((recipient) => accepted.has(recipient));
 
   if (accepted.has(archive) && !acceptedOriginal) {
-    throw new Error('SMTP rejected all original recipients; archive acceptance does not make send successful');
+    throw new Error(
+      'SMTP reported archive acceptance without any accepted original recipient; send cannot be considered successful',
+    );
   }
 
   if (rejected.has(archive) && acceptedOriginal) {

--- a/packages/api/src/lib/smtp-envelope.ts
+++ b/packages/api/src/lib/smtp-envelope.ts
@@ -1,0 +1,88 @@
+/**
+ * SMTP envelope and archive-result policy shared by the production send path.
+ * Keep original recipient strings untouched: SMTP local-parts can be
+ * case-sensitive, while domains are case-insensitive.
+ */
+
+export interface RecipientAddress {
+  address: string;
+}
+
+export type RecipientDeliveryAddress = string | RecipientAddress;
+
+export interface RecipientDeliveryResult {
+  accepted?: readonly RecipientDeliveryAddress[];
+  rejected?: readonly RecipientDeliveryAddress[];
+}
+
+function mailboxComparisonKey(address: string): string {
+  const at = address.lastIndexOf('@');
+  if (at < 0) return address;
+  return `${address.slice(0, at)}@${address.slice(at + 1).toLowerCase()}`;
+}
+
+function normalizeDeliveryAddress(address: RecipientDeliveryAddress): string {
+  return typeof address === 'string' ? address : address.address;
+}
+
+/** Returns an archive recipient only when it is not already an original RCPT. */
+export function archiveRecipientToAppend(
+  originalRecipients: readonly string[],
+  archiveRecipient?: string,
+): string | undefined {
+  if (!archiveRecipient) return undefined;
+  const archiveKey = mailboxComparisonKey(archiveRecipient);
+  return originalRecipients.some((recipient) => mailboxComparisonKey(recipient) === archiveKey)
+    ? undefined
+    : archiveRecipient;
+}
+
+/**
+ * SMTP recipients are independent of MIME headers. Original recipients remain
+ * byte-for-byte and in their caller-provided order; only a new archive RCPT is
+ * appended when it is not already represented by an original recipient.
+ */
+export function buildSmtpEnvelope(
+  from: string,
+  originalRecipients: readonly string[],
+  archiveRecipient?: string,
+) {
+  const archive = archiveRecipientToAppend(originalRecipients, archiveRecipient);
+  return { from, to: archive ? [...originalRecipients, archive] : [...originalRecipients] };
+}
+
+/** The API never emits a MIME Bcc header, including from internal callers. */
+export function stripBccHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'bcc'),
+  );
+}
+
+/**
+ * Nodemailer SMTP results contain string or Address values. An archive-only
+ * rejection is fail-open after any primary acceptance; archive-only acceptance
+ * must never turn total primary rejection into success.
+ */
+export function applyArchiveRecipientPolicy(
+  result: RecipientDeliveryResult,
+  originalRecipients: readonly string[],
+  archiveRecipient?: string,
+): void {
+  if (!archiveRecipient) return;
+
+  const original = new Set(originalRecipients.map(mailboxComparisonKey));
+  const accepted = new Set((result.accepted ?? []).map(normalizeDeliveryAddress).map(mailboxComparisonKey));
+  const rejected = new Set((result.rejected ?? []).map(normalizeDeliveryAddress).map(mailboxComparisonKey));
+  const archive = mailboxComparisonKey(archiveRecipient);
+  const acceptedOriginal = [...original].some((recipient) => accepted.has(recipient));
+  const rejectedOriginal = [...original].some((recipient) => rejected.has(recipient));
+
+  if (accepted.has(archive) && !acceptedOriginal && rejectedOriginal) {
+    throw new Error('SMTP rejected all original recipients; archive acceptance does not make send successful');
+  }
+
+  if (rejected.has(archive) && acceptedOriginal) {
+    // Do not include the archive address, message content, or SMTP response.
+    console.warn('[smtp] archive recipient rejected; preserving successful send for original recipients');
+  }
+}

--- a/packages/api/src/lib/smtp-envelope.ts
+++ b/packages/api/src/lib/smtp-envelope.ts
@@ -51,6 +51,21 @@ export function buildSmtpEnvelope(
   return { from, to: archive ? [...originalRecipients, archive] : [...originalRecipients] };
 }
 
+/**
+ * Couples the configured archive identity used for result policy to the
+ * envelope that may omit an already-present archive recipient.
+ */
+export function buildSmtpEnvelopePlan(
+  from: string,
+  originalRecipients: readonly string[],
+  configuredArchive?: string,
+) {
+  return {
+    envelope: buildSmtpEnvelope(from, originalRecipients, configuredArchive),
+    archiveRecipient: configuredArchive,
+  };
+}
+
 /** The API never emits a MIME Bcc header, including from internal callers. */
 export function stripBccHeaders(headers: Record<string, string>): Record<string, string> {
   return Object.fromEntries(
@@ -59,9 +74,9 @@ export function stripBccHeaders(headers: Record<string, string>): Record<string,
 }
 
 /**
- * Nodemailer SMTP results contain string or Address values. An archive-only
- * rejection is fail-open after any primary acceptance; archive-only acceptance
- * must never turn total primary rejection into success.
+ * Nodemailer SMTP results contain string or Address values. Any configured
+ * archive rejection is fail-open after a primary acceptance; archive-only
+ * acceptance must never turn total primary rejection into success.
  */
 export function applyArchiveRecipientPolicy(
   result: RecipientDeliveryResult,

--- a/packages/api/src/lib/smtp.ts
+++ b/packages/api/src/lib/smtp.ts
@@ -34,6 +34,72 @@ export function coerceOutboundText(text: string, html?: string): string {
   return htmlToText(html);
 }
 
+function recipientKey(address: string): string {
+  return address.toLowerCase();
+}
+
+/**
+ * SMTP recipients are independent of MIME headers. Keep the caller's first
+ * spelling/order, while preventing case-only duplicate RCPT commands.
+ */
+export function buildSmtpEnvelope(
+  from: string,
+  originalRecipients: readonly string[],
+  archiveRecipient?: string,
+) {
+  const seen = new Set<string>();
+  const to = [...originalRecipients, ...(archiveRecipient ? [archiveRecipient] : [])].filter(
+    (recipient) => {
+      const key = recipientKey(recipient);
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    },
+  );
+  return { from, to };
+}
+
+/** The API never emits a MIME Bcc header, including from internal callers. */
+export function stripBccHeaders(headers: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'bcc'),
+  );
+}
+
+interface RecipientDeliveryResult {
+  accepted?: readonly string[];
+  rejected?: readonly string[];
+}
+
+/**
+ * Nodemailer exposes per-RCPT outcomes for SMTP transports. An archive-only
+ * rejection is deliberately fail-open after every primary RCPT was accepted;
+ * archive-only acceptance must never turn total primary rejection into success.
+ */
+export function applyArchiveRecipientPolicy(
+  result: RecipientDeliveryResult,
+  originalRecipients: readonly string[],
+  archiveRecipient?: string,
+): void {
+  if (!archiveRecipient) return;
+
+  const original = new Set(originalRecipients.map(recipientKey));
+  const accepted = new Set((result.accepted ?? []).map(recipientKey));
+  const rejected = new Set((result.rejected ?? []).map(recipientKey));
+  const archive = recipientKey(archiveRecipient);
+  const acceptedOriginal = [...original].some((recipient) => accepted.has(recipient));
+  const rejectedOriginal = [...original].some((recipient) => rejected.has(recipient));
+
+  if (accepted.has(archive) && !acceptedOriginal && rejectedOriginal) {
+    throw new Error('SMTP rejected all original recipients; archive acceptance does not make send successful');
+  }
+
+  if (rejected.has(archive) && acceptedOriginal && !rejectedOriginal) {
+    // Do not include the archive address, message content, or SMTP response.
+    console.warn('[smtp] archive recipient rejected; preserving successful send for original recipients');
+  }
+}
+
 function createSmtpTransport(endpoint: MailserverEndpoint) {
   return nodemailer.createTransport({
     host: endpoint.host,
@@ -57,12 +123,10 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
   const text = coerceOutboundText(input.text, input.html);
   const outbound = { ...input, text };
   // 仅当全部 To 均在本域时写 stamp（防 HMAC 预言机随外发信泄漏）。
-  const headers = buildOutboundStampHeaders(
-    outbound,
-    date,
-    config.taskSigningSecret,
-    config.domain,
+  const headers = stripBccHeaders(
+    buildOutboundStampHeaders(outbound, date, config.taskSigningSecret, config.domain),
   );
+  const envelope = buildSmtpEnvelope(input.from, input.to, config.alwaysBcc);
 
   return withMailserverReconnect(config.smtp.host, async (endpoint) => {
     const transporter = createSmtpTransport(endpoint);
@@ -75,7 +139,11 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
         date,
         ...(input.html ? { html: input.html } : {}),
         headers,
+        envelope,
       });
+      // Nodemailer's generic SentMessageInfo type omits SMTP's accepted/rejected
+      // arrays, although SMTP transport supplies them at runtime.
+      applyArchiveRecipientPolicy(info as unknown as RecipientDeliveryResult, input.to, config.alwaysBcc);
       // 服务端真正出站成功才登记。登记失败不得否决这次投递（否则 502 重试会重复外发）。
       recordSentMessageIdAfterSend(info.messageId, input.from);
       return { messageId: info.messageId };

--- a/packages/api/src/lib/smtp.ts
+++ b/packages/api/src/lib/smtp.ts
@@ -11,6 +11,12 @@ import { buildOutboundStampHeaders, stampDate } from './mail-stamp.ts';
 import { htmlToText } from './otp.ts';
 import { recordSentMessageIdAfterSend } from './sent-registry.ts';
 import {
+  applyArchiveRecipientPolicy,
+  archiveRecipientToAppend,
+  buildSmtpEnvelope,
+  stripBccHeaders,
+} from './smtp-envelope.ts';
+import {
   withMailserverReconnect,
   type MailserverEndpoint,
 } from './mailserver-reconnect.ts';
@@ -34,71 +40,13 @@ export function coerceOutboundText(text: string, html?: string): string {
   return htmlToText(html);
 }
 
-function recipientKey(address: string): string {
-  return address.toLowerCase();
-}
-
-/**
- * SMTP recipients are independent of MIME headers. Keep the caller's first
- * spelling/order, while preventing case-only duplicate RCPT commands.
- */
-export function buildSmtpEnvelope(
-  from: string,
-  originalRecipients: readonly string[],
-  archiveRecipient?: string,
-) {
-  const seen = new Set<string>();
-  const to = [...originalRecipients, ...(archiveRecipient ? [archiveRecipient] : [])].filter(
-    (recipient) => {
-      const key = recipientKey(recipient);
-      if (seen.has(key)) return false;
-      seen.add(key);
-      return true;
-    },
-  );
-  return { from, to };
-}
-
-/** The API never emits a MIME Bcc header, including from internal callers. */
-export function stripBccHeaders(headers: Record<string, string>): Record<string, string> {
-  return Object.fromEntries(
-    Object.entries(headers).filter(([name]) => name.toLowerCase() !== 'bcc'),
-  );
-}
-
-interface RecipientDeliveryResult {
-  accepted?: readonly string[];
-  rejected?: readonly string[];
-}
-
-/**
- * Nodemailer exposes per-RCPT outcomes for SMTP transports. An archive-only
- * rejection is deliberately fail-open after every primary RCPT was accepted;
- * archive-only acceptance must never turn total primary rejection into success.
- */
-export function applyArchiveRecipientPolicy(
-  result: RecipientDeliveryResult,
-  originalRecipients: readonly string[],
-  archiveRecipient?: string,
-): void {
-  if (!archiveRecipient) return;
-
-  const original = new Set(originalRecipients.map(recipientKey));
-  const accepted = new Set((result.accepted ?? []).map(recipientKey));
-  const rejected = new Set((result.rejected ?? []).map(recipientKey));
-  const archive = recipientKey(archiveRecipient);
-  const acceptedOriginal = [...original].some((recipient) => accepted.has(recipient));
-  const rejectedOriginal = [...original].some((recipient) => rejected.has(recipient));
-
-  if (accepted.has(archive) && !acceptedOriginal && rejectedOriginal) {
-    throw new Error('SMTP rejected all original recipients; archive acceptance does not make send successful');
-  }
-
-  if (rejected.has(archive) && acceptedOriginal && !rejectedOriginal) {
-    // Do not include the archive address, message content, or SMTP response.
-    console.warn('[smtp] archive recipient rejected; preserving successful send for original recipients');
-  }
-}
+// Retain these module exports for callers that imported the initial #72 seam.
+export {
+  applyArchiveRecipientPolicy,
+  archiveRecipientToAppend,
+  buildSmtpEnvelope,
+  stripBccHeaders,
+} from './smtp-envelope.ts';
 
 function createSmtpTransport(endpoint: MailserverEndpoint) {
   return nodemailer.createTransport({
@@ -126,7 +74,8 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
   const headers = stripBccHeaders(
     buildOutboundStampHeaders(outbound, date, config.taskSigningSecret, config.domain),
   );
-  const envelope = buildSmtpEnvelope(input.from, input.to, config.alwaysBcc);
+  const archiveRecipient = archiveRecipientToAppend(input.to, config.alwaysBcc);
+  const envelope = buildSmtpEnvelope(input.from, input.to, archiveRecipient);
 
   return withMailserverReconnect(config.smtp.host, async (endpoint) => {
     const transporter = createSmtpTransport(endpoint);
@@ -141,9 +90,7 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
         headers,
         envelope,
       });
-      // Nodemailer's generic SentMessageInfo type omits SMTP's accepted/rejected
-      // arrays, although SMTP transport supplies them at runtime.
-      applyArchiveRecipientPolicy(info as unknown as RecipientDeliveryResult, input.to, config.alwaysBcc);
+      applyArchiveRecipientPolicy(info, input.to, archiveRecipient);
       // 服务端真正出站成功才登记。登记失败不得否决这次投递（否则 502 重试会重复外发）。
       recordSentMessageIdAfterSend(info.messageId, input.from);
       return { messageId: info.messageId };

--- a/packages/api/src/lib/smtp.ts
+++ b/packages/api/src/lib/smtp.ts
@@ -12,8 +12,8 @@ import { htmlToText } from './otp.ts';
 import { recordSentMessageIdAfterSend } from './sent-registry.ts';
 import {
   applyArchiveRecipientPolicy,
-  archiveRecipientToAppend,
   buildSmtpEnvelope,
+  buildSmtpEnvelopePlan,
   stripBccHeaders,
 } from './smtp-envelope.ts';
 import {
@@ -43,8 +43,8 @@ export function coerceOutboundText(text: string, html?: string): string {
 // Retain these module exports for callers that imported the initial #72 seam.
 export {
   applyArchiveRecipientPolicy,
-  archiveRecipientToAppend,
   buildSmtpEnvelope,
+  buildSmtpEnvelopePlan,
   stripBccHeaders,
 } from './smtp-envelope.ts';
 
@@ -74,8 +74,11 @@ export async function sendMail(input: SendInput): Promise<{ messageId: string }>
   const headers = stripBccHeaders(
     buildOutboundStampHeaders(outbound, date, config.taskSigningSecret, config.domain),
   );
-  const archiveRecipient = archiveRecipientToAppend(input.to, config.alwaysBcc);
-  const envelope = buildSmtpEnvelope(input.from, input.to, archiveRecipient);
+  const { envelope, archiveRecipient } = buildSmtpEnvelopePlan(
+    input.from,
+    input.to,
+    config.alwaysBcc,
+  );
 
   return withMailserverReconnect(config.smtp.host, async (endpoint) => {
     const transporter = createSmtpTransport(endpoint);

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -73,7 +73,23 @@ describe('ALWAYS_BCC configuration', () => {
       parseConfig({
         ...requiredEnv,
         ALWAYS_BCC: 'archive@external.example',
+        TASK_SIGNING_SECRET: 'a'.repeat(15),
+      }),
+    ).toThrow();
+
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: 'archive@external.example',
         TASK_SIGNING_SECRET: 'a'.repeat(16),
+      }),
+    ).toThrow('TASK_SIGNING_SECRET must be at least 32 characters for an external compliance archive');
+
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: 'archive@external.example',
+        TASK_SIGNING_SECRET: 'a'.repeat(31),
       }),
     ).toThrow('TASK_SIGNING_SECRET must be at least 32 characters for an external compliance archive');
 

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -52,17 +52,26 @@ describe('TLS certificate verification configuration', () => {
 describe('ALWAYS_BCC configuration', () => {
   test('is disabled when unset or blank and exposes the configured mailbox', () => {
     expect(parseConfig(requiredEnv).alwaysBcc).toBeUndefined();
-    expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: '   ' }).alwaysBcc).toBeUndefined();
-    expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: 'archive@example.com' }).alwaysBcc).toBe(
-      'archive@example.com',
+    expect(parseConfig(requiredEnv).taskSigningSecret).toBe('smtp-secret');
+    const blankArchive = parseConfig({ ...requiredEnv, ALWAYS_BCC: '   ' });
+    expect(blankArchive.alwaysBcc).toBeUndefined();
+    expect(blankArchive.taskSigningSecret).toBe('smtp-secret');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: 'archive@external.example',
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }).alwaysBcc,
+    ).toBe(
+      'archive@external.example',
     );
   });
 
   test('limits a nonblank archive mailbox to SMTP local-part and total maximums without disclosing secrets', () => {
     const maximumMailbox = `${'a'.repeat(64)}@${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(61)}`;
     const overlongMailbox = `${'a'.repeat(64)}@${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(62)}`;
-    const maximumLocalPartMailbox = `${'a'.repeat(64)}@example.com`;
-    const overlongLocalPartMailbox = `${'a'.repeat(65)}@example.com`;
+    const maximumLocalPartMailbox = `${'a'.repeat(64)}@example.net`;
+    const overlongLocalPartMailbox = `${'a'.repeat(65)}@example.net`;
     const maximumDomainLabelMailbox = `archive@${'a'.repeat(63)}.com`;
     const overlongDomainLabelMailbox = `archive@${'a'.repeat(64)}.com`;
     const punycodeDomainLabelMailbox = 'archive@xn--bcher-kva.example';
@@ -79,7 +88,11 @@ describe('ALWAYS_BCC configuration', () => {
     ).toBe(maximumMailbox);
     expect(overlongMailbox).toHaveLength(255);
     expect(
-      parseConfig({ ...requiredEnv, ALWAYS_BCC: maximumLocalPartMailbox }).alwaysBcc,
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: maximumLocalPartMailbox,
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }).alwaysBcc,
     ).toBe(maximumLocalPartMailbox);
     expect(() =>
       parseConfig({ ...requiredEnv, ALWAYS_BCC: overlongLocalPartMailbox }),
@@ -175,14 +188,15 @@ describe('ALWAYS_BCC configuration', () => {
     ).toBe('a'.repeat(32));
   });
 
-  test('keeps the SMTP password fallback for a same-domain archive, case-insensitively', () => {
-    expect(
+  test('rejects a same-domain archive, case-insensitively', () => {
+    expect(() =>
       parseConfig({
         ...requiredEnv,
         DOMAIN: 'EXAMPLE.COM',
-        ALWAYS_BCC: 'archive@EXAMPLE.COM',
-      }).taskSigningSecret,
-    ).toBe('smtp-secret');
+        ALWAYS_BCC: 'archive@example.com',
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }),
+    ).toThrow('ALWAYS_BCC must be an external compliance archive');
   });
 });
 

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -64,17 +64,26 @@ describe('ALWAYS_BCC configuration', () => {
     }
   });
 
-  test('requires an explicit signing secret for an external archive', () => {
+  test('requires a 32-character explicit signing secret for an external archive', () => {
     expect(() =>
       parseConfig({ ...requiredEnv, ALWAYS_BCC: 'archive@external.example' }),
     ).toThrow('TASK_SIGNING_SECRET is required for an external compliance archive');
+
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: 'archive@external.example',
+        TASK_SIGNING_SECRET: 'a'.repeat(16),
+      }),
+    ).toThrow('TASK_SIGNING_SECRET must be at least 32 characters for an external compliance archive');
+
     expect(
       parseConfig({
         ...requiredEnv,
         ALWAYS_BCC: 'archive@external.example',
-        TASK_SIGNING_SECRET: 'dedicated-archive-signing-secret',
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
       }).taskSigningSecret,
-    ).toBe('dedicated-archive-signing-secret');
+    ).toBe('a'.repeat(32));
   });
 
   test('keeps the SMTP password fallback for a same-domain archive, case-insensitively', () => {
@@ -82,7 +91,7 @@ describe('ALWAYS_BCC configuration', () => {
       parseConfig({
         ...requiredEnv,
         DOMAIN: 'EXAMPLE.COM',
-        ALWAYS_BCC: 'archive@example.com',
+        ALWAYS_BCC: 'archive@EXAMPLE.COM',
       }).taskSigningSecret,
     ).toBe('smtp-secret');
   });

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -53,8 +53,8 @@ describe('ALWAYS_BCC configuration', () => {
   test('is disabled when unset or blank and exposes the configured mailbox', () => {
     expect(parseConfig(requiredEnv).alwaysBcc).toBeUndefined();
     expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: '   ' }).alwaysBcc).toBeUndefined();
-    expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: 'archive@example.net' }).alwaysBcc).toBe(
-      'archive@example.net',
+    expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: 'archive@example.com' }).alwaysBcc).toBe(
+      'archive@example.com',
     );
   });
 
@@ -62,6 +62,29 @@ describe('ALWAYS_BCC configuration', () => {
     for (const value of ['not-an-address', 'Archive <archive@example.net>', 'a@example.net,b@example.net']) {
       expect(() => parseConfig({ ...requiredEnv, ALWAYS_BCC: value })).toThrow();
     }
+  });
+
+  test('requires an explicit signing secret for an external archive', () => {
+    expect(() =>
+      parseConfig({ ...requiredEnv, ALWAYS_BCC: 'archive@external.example' }),
+    ).toThrow('TASK_SIGNING_SECRET is required for an external compliance archive');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: 'archive@external.example',
+        TASK_SIGNING_SECRET: 'dedicated-archive-signing-secret',
+      }).taskSigningSecret,
+    ).toBe('dedicated-archive-signing-secret');
+  });
+
+  test('keeps the SMTP password fallback for a same-domain archive, case-insensitively', () => {
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        DOMAIN: 'EXAMPLE.COM',
+        ALWAYS_BCC: 'archive@example.com',
+      }).taskSigningSecret,
+    ).toBe('smtp-secret');
   });
 });
 

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -58,6 +58,35 @@ describe('ALWAYS_BCC configuration', () => {
     );
   });
 
+  test('limits a nonblank archive mailbox to the SMTP maximum without disclosing secrets', () => {
+    const maximumMailbox = `${'a'.repeat(242)}@example.com`;
+    const overlongMailbox = `${'a'.repeat(243)}@example.com`;
+    const smtpPassword = 'smtp-password-not-for-validation-errors';
+    const taskSigningSecret = 'task-signing-secret-not-for-validation-errors';
+
+    expect(maximumMailbox).toHaveLength(254);
+    expect(
+      parseConfig({ ...requiredEnv, ALWAYS_BCC: maximumMailbox }).alwaysBcc,
+    ).toBe(maximumMailbox);
+    expect(overlongMailbox).toHaveLength(255);
+
+    const parseOverlongArchive = () =>
+      parseConfig({
+        ...requiredEnv,
+        SMTP_PASS: smtpPassword,
+        TASK_SIGNING_SECRET: taskSigningSecret,
+        ALWAYS_BCC: overlongMailbox,
+      });
+    expect(parseOverlongArchive).toThrow();
+    try {
+      parseOverlongArchive();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '';
+      expect(message).not.toContain(smtpPassword);
+      expect(message).not.toContain(taskSigningSecret);
+    }
+  });
+
   test('rejects a malformed address, display name, or address list at startup', () => {
     for (const value of ['not-an-address', 'Archive <archive@example.net>', 'a@example.net,b@example.net']) {
       expect(() => parseConfig({ ...requiredEnv, ALWAYS_BCC: value })).toThrow();

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -188,15 +188,17 @@ describe('ALWAYS_BCC configuration', () => {
     ).toBe('a'.repeat(32));
   });
 
-  test('rejects a same-domain archive, case-insensitively', () => {
-    expect(() =>
-      parseConfig({
-        ...requiredEnv,
-        DOMAIN: 'EXAMPLE.COM',
-        ALWAYS_BCC: 'archive@example.com',
-        TASK_SIGNING_SECRET: 'a'.repeat(32),
-      }),
-    ).toThrow('ALWAYS_BCC must be an external compliance archive');
+  test('rejects same-domain archives case-insensitively, including DNS root dots', () => {
+    for (const domain of ['EXAMPLE.COM', 'EXAMPLE.COM.', 'EXAMPLE.COM..']) {
+      expect(() =>
+        parseConfig({
+          ...requiredEnv,
+          DOMAIN: domain,
+          ALWAYS_BCC: 'archive@example.com',
+          TASK_SIGNING_SECRET: 'a'.repeat(32),
+        }),
+      ).toThrow('ALWAYS_BCC must be an external compliance archive');
+    }
   });
 });
 

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -58,17 +58,29 @@ describe('ALWAYS_BCC configuration', () => {
     );
   });
 
-  test('limits a nonblank archive mailbox to the SMTP maximum without disclosing secrets', () => {
-    const maximumMailbox = `${'a'.repeat(242)}@example.com`;
-    const overlongMailbox = `${'a'.repeat(243)}@example.com`;
+  test('limits a nonblank archive mailbox to SMTP local-part and total maximums without disclosing secrets', () => {
+    const maximumMailbox = `${'a'.repeat(64)}@${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(61)}`;
+    const overlongMailbox = `${'a'.repeat(64)}@${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(62)}`;
+    const maximumLocalPartMailbox = `${'a'.repeat(64)}@example.com`;
+    const overlongLocalPartMailbox = `${'a'.repeat(65)}@example.com`;
     const smtpPassword = 'smtp-password-not-for-validation-errors';
     const taskSigningSecret = 'task-signing-secret-not-for-validation-errors';
 
     expect(maximumMailbox).toHaveLength(254);
     expect(
-      parseConfig({ ...requiredEnv, ALWAYS_BCC: maximumMailbox }).alwaysBcc,
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: maximumMailbox,
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }).alwaysBcc,
     ).toBe(maximumMailbox);
     expect(overlongMailbox).toHaveLength(255);
+    expect(
+      parseConfig({ ...requiredEnv, ALWAYS_BCC: maximumLocalPartMailbox }).alwaysBcc,
+    ).toBe(maximumLocalPartMailbox);
+    expect(() =>
+      parseConfig({ ...requiredEnv, ALWAYS_BCC: overlongLocalPartMailbox }),
+    ).toThrow('SMTP local part must be at most 64 octets');
 
     const parseOverlongArchive = () =>
       parseConfig({

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -65,6 +65,7 @@ describe('ALWAYS_BCC configuration', () => {
     const overlongLocalPartMailbox = `${'a'.repeat(65)}@example.com`;
     const maximumDomainLabelMailbox = `archive@${'a'.repeat(63)}.com`;
     const overlongDomainLabelMailbox = `archive@${'a'.repeat(64)}.com`;
+    const punycodeDomainLabelMailbox = 'archive@xn--bcher-kva.example';
     const smtpPassword = 'smtp-password-not-for-validation-errors';
     const taskSigningSecret = 'task-signing-secret-not-for-validation-errors';
 
@@ -96,7 +97,22 @@ describe('ALWAYS_BCC configuration', () => {
         ALWAYS_BCC: overlongDomainLabelMailbox,
         TASK_SIGNING_SECRET: 'a'.repeat(32),
       }),
-    ).toThrow('SMTP domain labels must be at most 63 octets');
+    ).toThrow('SMTP domain labels must be valid ASCII labels of at most 63 octets');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: punycodeDomainLabelMailbox,
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }).alwaysBcc,
+    ).toBe(punycodeDomainLabelMailbox);
+    for (const malformedDomainLabelMailbox of [
+      'archive@example-.com',
+      'archive@a.example-.com',
+    ]) {
+      expect(() =>
+        parseConfig({ ...requiredEnv, ALWAYS_BCC: malformedDomainLabelMailbox }),
+      ).toThrow('SMTP domain labels must be valid ASCII labels of at most 63 octets');
+    }
 
     const parseOverlongArchive = () =>
       parseConfig({

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -63,6 +63,8 @@ describe('ALWAYS_BCC configuration', () => {
     const overlongMailbox = `${'a'.repeat(64)}@${'b'.repeat(63)}.${'c'.repeat(63)}.${'d'.repeat(62)}`;
     const maximumLocalPartMailbox = `${'a'.repeat(64)}@example.com`;
     const overlongLocalPartMailbox = `${'a'.repeat(65)}@example.com`;
+    const maximumDomainLabelMailbox = `archive@${'a'.repeat(63)}.com`;
+    const overlongDomainLabelMailbox = `archive@${'a'.repeat(64)}.com`;
     const smtpPassword = 'smtp-password-not-for-validation-errors';
     const taskSigningSecret = 'task-signing-secret-not-for-validation-errors';
 
@@ -81,6 +83,20 @@ describe('ALWAYS_BCC configuration', () => {
     expect(() =>
       parseConfig({ ...requiredEnv, ALWAYS_BCC: overlongLocalPartMailbox }),
     ).toThrow('SMTP local part must be at most 64 octets');
+    expect(
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: maximumDomainLabelMailbox,
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }).alwaysBcc,
+    ).toBe(maximumDomainLabelMailbox);
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        ALWAYS_BCC: overlongDomainLabelMailbox,
+        TASK_SIGNING_SECRET: 'a'.repeat(32),
+      }),
+    ).toThrow('SMTP domain labels must be at most 63 octets');
 
     const parseOverlongArchive = () =>
       parseConfig({

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -9,7 +9,7 @@ process.env.SMTP_PASS = 'smtp-secret';
 
 import { createHmac } from 'node:crypto';
 import { describe, expect, test } from 'bun:test';
-import { normalizeUrl, parseConfig } from '../src/lib/config.ts';
+const { normalizeUrl, parseConfig } = await import('../src/lib/config.ts');
 
 const requiredEnv: NodeJS.ProcessEnv = {
   DOMAIN: 'example.com',
@@ -46,6 +46,22 @@ describe('TLS certificate verification configuration', () => {
     expect(() =>
       parseConfig({ ...requiredEnv, SMTP_TLS_REJECT_UNAUTHORIZED: 'no' }),
     ).toThrow();
+  });
+});
+
+describe('ALWAYS_BCC configuration', () => {
+  test('is disabled when unset or blank and exposes the configured mailbox', () => {
+    expect(parseConfig(requiredEnv).alwaysBcc).toBeUndefined();
+    expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: '   ' }).alwaysBcc).toBeUndefined();
+    expect(parseConfig({ ...requiredEnv, ALWAYS_BCC: 'archive@example.net' }).alwaysBcc).toBe(
+      'archive@example.net',
+    );
+  });
+
+  test('rejects a malformed address, display name, or address list at startup', () => {
+    for (const value of ['not-an-address', 'Archive <archive@example.net>', 'a@example.net,b@example.net']) {
+      expect(() => parseConfig({ ...requiredEnv, ALWAYS_BCC: value })).toThrow();
+    }
   });
 });
 

--- a/packages/api/test/smtp-bcc.test.ts
+++ b/packages/api/test/smtp-bcc.test.ts
@@ -1,0 +1,134 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+
+import { describe, expect, test } from 'bun:test';
+import nodemailer from 'nodemailer';
+import { simpleParser } from 'mailparser';
+import {
+  buildOutboundStampHeaders,
+  classifyMailSource,
+  hashMailBody,
+  normalizeMailbox,
+  normalizeToList,
+  stampDate,
+} from '../src/lib/mail-stamp.ts';
+const {
+  applyArchiveRecipientPolicy,
+  buildSmtpEnvelope,
+  stripBccHeaders,
+} = await import('../src/lib/smtp.ts');
+
+describe('automatic compliance BCC envelope', () => {
+  test('adds one archive RCPT to single and multi-recipient envelopes', () => {
+    expect(buildSmtpEnvelope('sender@test.example', ['one@example.net'], 'archive@example.net')).toEqual({
+      from: 'sender@test.example',
+      to: ['one@example.net', 'archive@example.net'],
+    });
+    expect(
+      buildSmtpEnvelope(
+        'sender@test.example',
+        ['first@example.net', 'second@example.net'],
+        'archive@example.net',
+      ),
+    ).toEqual({
+      from: 'sender@test.example',
+      to: ['first@example.net', 'second@example.net', 'archive@example.net'],
+    });
+  });
+
+  test('deduplicates envelope RCPT case-insensitively while preserving original order', () => {
+    expect(
+      buildSmtpEnvelope(
+        'sender@test.example',
+        ['First@example.net', 'first@EXAMPLE.net', 'alias+legal@example.net'],
+        'FIRST@example.net',
+      ).to,
+    ).toEqual(['First@example.net', 'alias+legal@example.net']);
+  });
+
+  test('keeps alias-shaped visible recipients untouched and serializes no archive/Bcc MIME header', async () => {
+    const visible = ['team+legal@example.net', 'person@example.net'];
+    const archive = 'archive@example.net';
+    const transport = nodemailer.createTransport({ streamTransport: true, buffer: true, newline: 'unix' });
+    const info = await transport.sendMail({
+      from: 'sender@test.example',
+      to: visible,
+      subject: 'compliance check',
+      text: 'body',
+      headers: stripBccHeaders({ Bcc: archive, 'X-Archive-Test': 'present' }),
+      envelope: buildSmtpEnvelope('sender@test.example', visible, archive),
+    });
+    const mime = (info.message as Buffer).toString('utf8');
+    const parsed = await simpleParser(info.message as Buffer);
+
+    expect(info.envelope.to).toEqual(['team+legal@example.net', 'person@example.net', archive]);
+    const parsedTo = parsed.to ? (Array.isArray(parsed.to) ? parsed.to : [parsed.to]) : [];
+    expect(parsedTo.flatMap(({ value }) => value.map(({ address }) => address))).toEqual(visible);
+    expect(mime).not.toMatch(/^bcc:/im);
+    expect(mime).not.toContain(archive);
+  });
+
+  test('warns and stays successful only when the archive alone is rejected', () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      expect(() =>
+        applyArchiveRecipientPolicy(
+          { accepted: ['one@example.net'], rejected: ['archive@example.net'] },
+          ['one@example.net'],
+          'archive@example.net',
+        ),
+      ).not.toThrow();
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings).toEqual([
+      ['[smtp] archive recipient rejected; preserving successful send for original recipients'],
+    ]);
+  });
+
+  test('does not let archive-only acceptance mask total primary rejection', () => {
+    expect(() =>
+      applyArchiveRecipientPolicy(
+        { accepted: ['archive@example.net'], rejected: ['one@example.net'] },
+        ['one@example.net'],
+        'archive@example.net',
+      ),
+    ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+  });
+
+  test('a controlled archive does not change internal stamping for all-local visible recipients', () => {
+    const original = ['recipient@test.example'];
+    const text = 'trusted body';
+    const date = stampDate(new Date('2026-09-01T00:00:00Z'));
+    const headers = buildOutboundStampHeaders(
+      { from: 'sender@test.example', to: original, subject: 'trusted', text },
+      date,
+      'archive-stamp-test-key',
+      'test.example',
+    );
+
+    expect(buildSmtpEnvelope('sender@test.example', original, 'archive@example.net').to).toEqual([
+      'recipient@test.example',
+      'archive@example.net',
+    ]);
+    expect(
+      classifyMailSource(
+        headers['X-OA-Mail-Stamp'],
+        {
+          from: normalizeMailbox('sender@test.example'),
+          to: normalizeToList(original),
+          subject: 'trusted',
+          dateIso: date.toISOString(),
+          bodyHash: hashMailBody(text),
+        },
+        'archive-stamp-test-key',
+      ),
+    ).toBe('internal');
+  });
+});

--- a/packages/api/test/smtp-bcc.test.ts
+++ b/packages/api/test/smtp-bcc.test.ts
@@ -107,7 +107,9 @@ describe('automatic compliance BCC envelope', () => {
         ['one@example.net'],
         'archive@example.net',
       ),
-    ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+    ).toThrow(
+      'SMTP reported archive acceptance without any accepted original recipient; send cannot be considered successful',
+    );
   });
 
   test('rejects archive-only acceptance when rejected outcomes are omitted', () => {
@@ -117,7 +119,9 @@ describe('automatic compliance BCC envelope', () => {
         ['primary@example.net'],
         'archive@example.net',
       ),
-    ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+    ).toThrow(
+      'SMTP reported archive acceptance without any accepted original recipient; send cannot be considered successful',
+    );
   });
 
   test('rejects archive-only acceptance when rejected outcomes are empty', () => {
@@ -127,7 +131,9 @@ describe('automatic compliance BCC envelope', () => {
         ['primary@example.net'],
         'archive@example.net',
       ),
-    ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+    ).toThrow(
+      'SMTP reported archive acceptance without any accepted original recipient; send cannot be considered successful',
+    );
   });
 
   test('warns exactly once when an archive rejection accompanies partial primary rejection', () => {

--- a/packages/api/test/smtp-bcc.test.ts
+++ b/packages/api/test/smtp-bcc.test.ts
@@ -110,6 +110,26 @@ describe('automatic compliance BCC envelope', () => {
     ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
   });
 
+  test('rejects archive-only acceptance when rejected outcomes are omitted', () => {
+    expect(() =>
+      applyArchiveRecipientPolicy(
+        { accepted: ['archive@example.net'] },
+        ['primary@example.net'],
+        'archive@example.net',
+      ),
+    ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+  });
+
+  test('rejects archive-only acceptance when rejected outcomes are empty', () => {
+    expect(() =>
+      applyArchiveRecipientPolicy(
+        { accepted: ['archive@example.net'], rejected: [] },
+        ['primary@example.net'],
+        'archive@example.net',
+      ),
+    ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+  });
+
   test('warns exactly once when an archive rejection accompanies partial primary rejection', () => {
     const originalWarn = console.warn;
     const warnings: unknown[][] = [];
@@ -135,12 +155,12 @@ describe('automatic compliance BCC envelope', () => {
     try {
       expect(() =>
         applyArchiveRecipientPolicy(
-        {
-          accepted: [{ address: 'primary@example.net' }],
-          rejected: [{ address: 'archive@EXAMPLE.net' }],
-        },
-        ['primary@example.net'],
-        'archive@example.net',
+          {
+            accepted: [{ address: 'primary@example.net' }],
+            rejected: [{ address: 'archive@EXAMPLE.net' }],
+          },
+          ['primary@example.net'],
+          'archive@example.net',
         ),
       ).not.toThrow();
     } finally {

--- a/packages/api/test/smtp-bcc.test.ts
+++ b/packages/api/test/smtp-bcc.test.ts
@@ -16,11 +16,11 @@ import {
   normalizeToList,
   stampDate,
 } from '../src/lib/mail-stamp.ts';
-const {
+import {
   applyArchiveRecipientPolicy,
   buildSmtpEnvelope,
   stripBccHeaders,
-} = await import('../src/lib/smtp.ts');
+} from '../src/lib/smtp-envelope.ts';
 
 describe('automatic compliance BCC envelope', () => {
   test('adds one archive RCPT to single and multi-recipient envelopes', () => {
@@ -40,14 +40,21 @@ describe('automatic compliance BCC envelope', () => {
     });
   });
 
-  test('deduplicates envelope RCPT case-insensitively while preserving original order', () => {
+  test('preserves case-distinct primary RCPTs and only compares archive domains case-insensitively', () => {
     expect(
       buildSmtpEnvelope(
         'sender@test.example',
-        ['First@example.net', 'first@EXAMPLE.net', 'alias+legal@example.net'],
-        'FIRST@example.net',
+        ['Case@case-sensitive.example', 'case@case-sensitive.example'],
+        'Case@CASE-SENSITIVE.example',
       ).to,
-    ).toEqual(['First@example.net', 'alias+legal@example.net']);
+    ).toEqual(['Case@case-sensitive.example', 'case@case-sensitive.example']);
+    expect(
+      buildSmtpEnvelope(
+        'sender@test.example',
+        ['Case@case-sensitive.example'],
+        'case@CASE-SENSITIVE.example',
+      ).to,
+    ).toEqual(['Case@case-sensitive.example', 'case@CASE-SENSITIVE.example']);
   });
 
   test('keeps alias-shaped visible recipients untouched and serializes no archive/Bcc MIME header', async () => {
@@ -100,6 +107,37 @@ describe('automatic compliance BCC envelope', () => {
         'archive@example.net',
       ),
     ).toThrow('SMTP rejected all original recipients; archive acceptance does not make send successful');
+  });
+
+  test('warns exactly once when an archive rejection accompanies partial primary rejection', () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      applyArchiveRecipientPolicy(
+        { accepted: ['primary1@example.net'], rejected: ['primary2@example.net', 'archive@example.net'] },
+        ['primary1@example.net', 'primary2@example.net'],
+        'archive@example.net',
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings).toEqual([
+      ['[smtp] archive recipient rejected; preserving successful send for original recipients'],
+    ]);
+  });
+
+  test('normalizes Nodemailer Address result values before applying the policy', () => {
+    expect(() =>
+      applyArchiveRecipientPolicy(
+        {
+          accepted: [{ address: 'primary@example.net' }],
+          rejected: [{ address: 'archive@EXAMPLE.net' }],
+        },
+        ['primary@example.net'],
+        'archive@example.net',
+      ),
+    ).not.toThrow();
   });
 
   test('a controlled archive does not change internal stamping for all-local visible recipients', () => {

--- a/packages/api/test/smtp-bcc.test.ts
+++ b/packages/api/test/smtp-bcc.test.ts
@@ -19,6 +19,7 @@ import {
 import {
   applyArchiveRecipientPolicy,
   buildSmtpEnvelope,
+  buildSmtpEnvelopePlan,
   stripBccHeaders,
 } from '../src/lib/smtp-envelope.ts';
 
@@ -79,7 +80,7 @@ describe('automatic compliance BCC envelope', () => {
     expect(mime).not.toContain(archive);
   });
 
-  test('warns and stays successful only when the archive alone is rejected', () => {
+  test('warns and preserves success when an accepted primary accompanies archive rejection', () => {
     const originalWarn = console.warn;
     const warnings: unknown[][] = [];
     console.warn = (...args: unknown[]) => warnings.push(args);
@@ -127,17 +128,53 @@ describe('automatic compliance BCC envelope', () => {
     ]);
   });
 
-  test('normalizes Nodemailer Address result values before applying the policy', () => {
-    expect(() =>
-      applyArchiveRecipientPolicy(
+  test('normalizes Nodemailer Address result values and emits one static warning', () => {
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      expect(() =>
+        applyArchiveRecipientPolicy(
         {
           accepted: [{ address: 'primary@example.net' }],
           rejected: [{ address: 'archive@EXAMPLE.net' }],
         },
         ['primary@example.net'],
         'archive@example.net',
-      ),
-    ).not.toThrow();
+        ),
+      ).not.toThrow();
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings).toEqual([
+      ['[smtp] archive recipient rejected; preserving successful send for original recipients'],
+    ]);
+  });
+
+  test('production envelope plan keeps configured archive policy after duplicate suppression', () => {
+    const original = ['archive@example.net', 'other@example.net'];
+    const plan = buildSmtpEnvelopePlan(
+      'sender@test.example',
+      original,
+      'archive@EXAMPLE.net',
+    );
+    expect(plan.envelope.to).toEqual(original);
+
+    const originalWarn = console.warn;
+    const warnings: unknown[][] = [];
+    console.warn = (...args: unknown[]) => warnings.push(args);
+    try {
+      applyArchiveRecipientPolicy(
+        { accepted: ['other@example.net'], rejected: ['archive@example.net'] },
+        original,
+        plan.archiveRecipient,
+      );
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(warnings).toEqual([
+      ['[smtp] archive recipient rejected; preserving successful send for original recipients'],
+    ]);
   });
 
   test('a controlled archive does not change internal stamping for all-local visible recipients', () => {


### PR DESCRIPTION
## Summary

- add optional instance-level `ALWAYS_BCC` configuration, disabled by default and startup-validated as exactly one mailbox
- add the configured archive only to the SMTP envelope used by the shared API/MCP/task `sendMail` path; never add a MIME `Bcc` header
- preserve original RCPT strings and order, including case-distinct local-parts; suppress an extra archive RCPT only for the same exact local-part and a case-insensitively matching domain
- document privacy, retention, queueing, failure, and trusted-archive-boundary requirements

Closes #72.

## Design

### Injection layer

The archive is injected at the application's common Nodemailer SMTP-envelope boundary. The visible `To`, header From, envelope MAIL FROM, body, and signed MIME remain unchanged. Any caller-supplied case variant of a `Bcc` header is removed before serialization. This is deliberately narrower than Postfix `always_bcc`, which would copy mail received outside the application send path as well.

REST sends, MCP sends, and task mail converge on this one application path. Direct SMTP submissions and downstream alias/forward expansion remain outside this setting and are documented as MTA responsibilities.

### Configuration and default

`ALWAYS_BCC` is an instance-level environment setting exposed by both Compose variants and env examples. Unset, blank, or whitespace-only means disabled. A nonblank value must be one syntactically valid independent off-domain SMTP mailbox of at most 254 characters, with a local part of at most 64 UTF-8 octets and domain labels of at most 63 UTF-8 octets. Same-domain values are rejected case-insensitively: the shared catch-all domain is not an independent archive destination, and duplicate suppression is not a substitute for that boundary. Malformed, oversized, display-name, and list values fail startup validation.

### Failure semantics

This feature is **fail-open** for the archive copy: when at least one original RCPT is accepted and the configured archive RCPT is rejected, Nodemailer's partial-success result is preserved and the server emits exactly one static, content-free warning. This keeps an unavailable compliance mailbox from blocking customer mail while retaining an immediate operational signal, including mixed primary acceptance/rejection.

The inverse is guarded: if the archive is accepted while no original recipient is reported accepted, the API fails even when SMTP omits explicit rejected outcomes. Once the relay accepts/queues the archive RCPT, later mailbox-delivery failure is asynchronous and must be observed through relay/Postfix logs or DSNs.

### Deliverability and security

Adding an envelope RCPT does not change SPF identity, DKIM-signed MIME, header From, envelope MAIL FROM, or DMARC alignment. It does add a delivery copy and therefore volume, privacy, access-control, and retention obligations.

For all-local visible recipients, the exact MIME retains `X-OA-Mail-Stamp` so original local classification does not change. The independent off-domain archive therefore receives that signed MIME too and must be controlled within the trusted compliance boundary; otherwise `ALWAYS_BCC` must remain unset.

Every enabled archive requires an explicit `TASK_SIGNING_SECRET` of at least 32 characters at startup. The application enforces presence and length, not entropy; operators must generate a high-entropy value. The historical bare-process `SMTP_PASS` fallback remains available only when the archive is absent or blank. Both Compose variants already require the dedicated secret.

## Recipient scenarios

- single or multiple originals: original RCPT strings/order remain unchanged; one archive RCPT is appended
- archive already among originals: no duplicate RCPT is appended, but archive rejection policy still applies
- aliases and forwarding: the input alias remains unchanged; expansion is downstream MTA behavior
- archive rejected with any original accepted: send remains successful and logs one content-free warning
- archive accepted with no original reported accepted: send fails, even if rejected outcomes are omitted
- relays should preserve accepted-RCPT local-part spelling; conservative matching can fail/retry if a relay rewrites it, while case-distinct local-parts remain separate SMTP mailboxes and may produce two copies on case-folding providers

## Validation

- R1m current head `03c8c3ff0fc486f26aa73b9366b35a74ee54723a` — focused config/BCC/stamp/send: 53 pass, 0 fail, 162 assertions; filtered config typecheck: no matching diagnostic; build and diff check: pass; no whole-suite rerun
- `bun test test/smtp-bcc.test.ts test/send.test.ts` — 25 pass, 0 fail
- `bun test test/send.test.ts test/smtp-bcc.test.ts` — 25 pass, 0 fail
- `bun run build` — pass
- `git diff --check` — pass
- R1l full `packages/api` suite — 1078 pass, 1 skip, 4 fail; this includes the known `invalid_approval_expiry`/R5f chain and distinct F50 watcher and #56 lease failures, all recorded without a whole-suite rerun.
- `bun run typecheck 2>&1 | rg 'src/lib/config.ts'` — no R1f/R1g configuration diagnostic; unrelated project-wide type debt remains
- R1m targeted disposition — `notification-watcher.test.ts` file: 120 pass, 0 fail; its immediately following isolated F50 invocation measured 1548.73ms against the <1000ms threshold and failed, so it is recorded rather than represented as green. `task-lease-core.test.ts` file: 27 pass, 0 fail; isolated #56 lease test: 1 pass, 0 fail. R5f at exact base `312a55f547d5021587f532389dc0c09b67a242d5` reproduces the same `invalid_approval_expiry` stack.
- final independent current-head review — CLEAN at `03c8c3ff0fc486f26aa73b9366b35a74ee54723a` (`P0/P1/P2/P3 = 0/0/0/0`); independent canonical-domain matrix 20/20

## Gate status (current head)

- **CI — written baseline-flake disposition:** the workflow remains stuck in the unchanged `parent-child-root` R5f `invalid_approval_expiry` path. The exact base SHA reproduces the same failure/hang, the current-head focused suite is green, and this PR does not touch that path. Maintainer disposition approved this as a pre-existing `#111`-family baseline timing failure; this is not represented as a CI pass.
- **CodeRabbit — written waiver + maintainer review:** repeated current-head attempts were rate-limited, so no formal CodeRabbit review binds `03c8c3ff0fc486f26aa73b9366b35a74ee54723a`. The maintainer reviewed the authoritative GitHub PR-files diff line by line, including startup validation/guards, envelope-only injection, MIME `Bcc` stripping, recipient de-duplication, and partial-delivery policy, and approved a written waiver. This is not represented as a CodeRabbit pass.
- **Codex Local — pass:** current-head review at `03c8c3ff0fc486f26aa73b9366b35a74ee54723a`, `P0/P1/P2/P3 = 0/0/0/0`.
- **ZCode — pass:** current-head review at `03c8c3ff0fc486f26aa73b9366b35a74ee54723a`, `P0 = 0`, `P1 = 0`, `P2 = 3`, `MERGE = yes`; the P2 items are non-blocking hardening/observability notes.
- **Review threads:** 0 unresolved.

## Issue #72 reply draft (do not post before maintainer approval)

> Thanks for the concrete compliance use case. We implemented optional instance-level `ALWAYS_BCC` for API, MCP, and task mail. It is off by default, accepts only an independent off-domain archive mailbox at startup, and adds the archive only to the SMTP envelope—never to visible `To` or `Bcc` MIME headers. Same-domain shared-catch-all destinations are rejected rather than treated as independent archives. Original recipients are preserved, and archive rejection remains fail-open with a content-free server warning whenever any original recipient was accepted. Every enabled archive requires an explicit high-entropy `TASK_SIGNING_SECRET` of at least 32 characters. Please try it with your archive mailbox and let us know whether the documented relay-log/DSN behavior matches your deployment.
