### PR TITLE
fix(test): defuse approval expiry time bomb and cap CI timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/api/test/parent-child-root.test.ts
+++ b/packages/api/test/parent-child-root.test.ts
@@ -581,6 +581,7 @@ test('R2 parent validation fails closed on self, repeated, malformed, missing, a
 });
 
 test('R5f parent validation uses one snapshot under the immediate-parent lock and delivers outside it', async () => {
+  tasks.setTaskNowForTests(() => Date.parse('2026-08-30T00:00:00.000Z'));
   const sent: SendInput[] = [];
   let releaseLookup!: () => void;
   const lookupGate = new Promise<void>((resolve) => { releaseLookup = resolve; });


### PR DESCRIPTION
## Summary

`main` CI has been red since 2026-09-01. The last three `push` runs each burned the full six-hour GitHub Actions limit and were reported as `cancelled`, not `failure`.

**Root cause.** `packages/api/test/parent-child-root.test.ts` declares a module-level `const EXPIRES = '2026-09-01T00:00:00.000Z'`. Every test in that file pins the clock with `tasks.setTaskNowForTests(() => Date.parse('2026-08-30T00:00:00.000Z'))` — except `R5f parent validation uses one snapshot under the immediate-parent lock and delivers outside it`. Unpinned, `assertApprovalExpiryBound` compares `EXPIRES` against the real `Date.now()`:

```
error: invalid_approval_expiry
  at assertApprovalExpiryBound (packages/api/src/lib/tasks-internal.ts:448)
  at createApprovalTask (packages/api/src/lib/tasks-internal.ts:1530)
  at parent-child-root.test.ts:604
```

The test passed by luck until the calendar crossed 2026-09-01 — a time bomb, not a regression.

The throw also explains the six-hour hang: the rejected `createApprovalTask` means the second delivery never happens, so the test spins forever on `while (deliveries < 2) await Bun.sleep(1)` waiting on a `firstDeliveryGate` that is never reached, and the bun process never exits.

## Changes

- `packages/api/test/parent-child-root.test.ts` — pin `now` to `2026-08-30T00:00:00.000Z` in `R5f`, matching the convention already used by the other 10 tests in the file. No assertion is weakened and no production code is touched; `EXPIRES` stays exactly two days ahead of the pinned `now`, well inside `APPROVAL_MAX_LIFETIME_MS`.
- `.github/workflows/ci.yml` — add `timeout-minutes: 30` to the `test` job so a future hang fails fast instead of consuming six hours of runner time.

Two lines changed in total.

## Verification

| Step (as CI runs it) | Result |
| --- | --- |
| `bash deploy/test-mail-security.sh` | 54 passed |
| `bun run check:approval-publication` (packages/api) | pass |
| `bun test test/parent-child-root.test.ts` | **15 pass / 0 fail**, exits in ~140ms (was: R5f fail + hang) |
| `bun test` full suite (packages/api) | 1079 pass / 1 skip / 3 fail — see note below |
| `bun run lint:ui` (packages/api) | pass |
| `bunx tsc --noEmit` (packages/mcp) | pass |
| `bun run build` (packages/mcp) | pass |

**Note on the 3 remaining local failures.** `phone device ACL > corrupt registry with ntfy enabled does not block startup and fail-closes devices`, `UI session persistence > resolveUiSessionTokenByHash`, and `UI is enabled by default` fail when the whole suite runs in one bun process, but all three pass in isolation. They are pre-existing and unrelated to this PR: running the identical full suite on pristine `main` (`9209aee`) yields the same three failures *plus* `R5f` (4 fail). This branch turns 4 fail into 3 fail and changes nothing else. They look like cross-file `process.env` leakage that depends on test-file load order, which differs between bun 1.4.0/macOS locally and bun 1.2.21/ubuntu in CI.

## Test plan

- [ ] CI `test` job is `success` (not `cancelled`) on this PR
- [ ] Job wall-clock is ~1 minute, consistent with the last green run on 2026-08-31, confirming no hang
- [ ] Do not merge until the checks are green — `cancelled` is not green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a 30-minute execution limit to automated test runs.
  * Improved consistency in parent-validation test results by using a fixed task timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->