### PR TITLE
fix(api): keep newly created tasks readable during IMAP indexing lag

### DIFF
--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -1374,10 +1374,15 @@ export function currentTaskMessage<T extends { uid: number; state: TaskState; ki
   return firstTerminal ?? pool[pool.length - 1]!;
 }
 
-async function findTaskMessages(id: string): Promise<ParsedTaskMessage[]> {
+type TaskLookupResult = {
+  messages: ParsedTaskMessage[];
+  hadMatchingRows: boolean;
+};
+
+async function findTaskMessages(id: string): Promise<TaskLookupResult> {
   return withInbox(async (client) => {
     const uids = await client.search({ header: { 'x-oa-task': id } }, { uid: true });
-    if (!uids || uids.length === 0) return [];
+    if (!uids || uids.length === 0) return { messages: [], hadMatchingRows: false };
     const messages: ParsedTaskMessage[] = [];
     for await (const message of client.fetch(
       uids,
@@ -1387,7 +1392,7 @@ async function findTaskMessages(id: string): Promise<ParsedTaskMessage[]> {
       const parsed = await parseTaskMessageWithIntegrity(message, id);
       if (parsed) messages.push(parsed);
     }
-    return messages;
+    return { messages, hadMatchingRows: true };
   });
 }
 
@@ -1395,12 +1400,34 @@ async function findTaskMessages(id: string): Promise<ParsedTaskMessage[]> {
  * than public getTask(), whose approval read path may itself materialize. */
 async function getTaskSnapshot(id: string): Promise<Task | null> {
   if (!isTaskId(id)) return null;
-  // 单测注入内存目录，避免并发 reply / IMAP 滞后 reminder 回归打真 IMAP。
-  const raw = getTaskForTests
-    ? await getTaskForTests(id)
-    : taskFromParsedMessages(id, await findTaskMessages(id));
-  // SMTP 已接受但 Dovecot 尚未索引时，把刚发出的 synthetic 事件并进读路径。
-  return raw ? mergeQueuedEvents(raw) : null;
+  let raw: Task | null;
+  let hadMatchingRows: boolean;
+
+  if (getTaskForTests) {
+    raw = await getTaskForTests(id);
+    hadMatchingRows = raw !== null;
+  } else {
+    const lookup = await findTaskMessages(id);
+    hadMatchingRows = lookup.hadMatchingRows;
+    raw = lookup.messages.length > 0 ? taskFromParsedMessages(id, lookup.messages) : null;
+  }
+
+  if (raw) {
+    return mergeQueuedEvents(raw);
+  }
+
+  // Matching rows existed in IMAP but reconstruction failed (e.g. integrity failure).
+  // Fail closed: suppress/retire synthetic base and return null.
+  if (hadMatchingRows) {
+    if (syntheticTaskBases.has(id)) {
+      syntheticTaskBases.delete(id);
+      invalidateTaskListCache();
+    }
+    return null;
+  }
+
+  const synthetic = getSyntheticTaskBase(id);
+  return synthetic ? mergeQueuedEvents(synthetic) : null;
 }
 
 const PARENT_CHAIN_MAX = 64;
@@ -1454,10 +1481,16 @@ export async function getTask(id: string): Promise<Task | null> {
   return materializeApprovalExpiry(await getTaskSnapshot(id));
 }
 
-export async function listTasks(state?: TaskState): Promise<Task[]> {
+type TaskListSnapshot = {
+  tasks: Task[];
+  hadMatchingRowsIds: Set<string>;
+};
+
+async function scanDurableTasks(): Promise<TaskListSnapshot> {
   return withInbox(async (client) => {
     const uids = await client.search({ header: { 'x-oa-task': true } }, { uid: true });
-    if (!uids || uids.length === 0) return [];
+    if (!uids || uids.length === 0) return { tasks: [], hadMatchingRowsIds: new Set() };
+    const hadMatchingRowsIds = new Set<string>();
     const grouped = new Map<string, ParsedTaskMessage[]>();
     for await (const message of client.fetch(
       uids,
@@ -1468,21 +1501,28 @@ export async function listTasks(state?: TaskState): Promise<Task[]> {
       const parsed = await simpleParser(message.source);
       const id = parsed.headers.get('x-oa-task');
       if (typeof id !== 'string' || !isTaskId(id)) continue;
+      hadMatchingRowsIds.add(id);
       const taskMessage = await parseTaskMessageWithIntegrity(message, id);
       if (!taskMessage) continue;
       const entries = grouped.get(id) ?? [];
       entries.push(taskMessage);
       grouped.set(id, entries);
     }
-    return [...grouped.entries()]
+    const tasks = [...grouped.entries()]
       .map(([id, messages]) => taskFromParsedMessages(id, messages))
-      .filter((task): task is Task => !!task && (!state || task.state === state))
+      .filter((task): task is Task => !!task)
       .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt));
+    return { tasks, hadMatchingRowsIds };
   });
 }
 
+export async function listTasks(state?: TaskState): Promise<Task[]> {
+  const { tasks } = await scanDurableTasks();
+  return state ? tasks.filter((task) => task.state === state) : tasks;
+}
+
 function syntheticTask(input: CreateTaskInput, id: string, messageId: string): Task {
-  const now = new Date().toISOString();
+  const now = new Date(nowMs()).toISOString();
   return {
     id,
     from: input.from,
@@ -1512,7 +1552,9 @@ export async function createTask(input: CreateTaskInput): Promise<Task> {
   // agent route. The generic IMAP watcher never has that authority.
   notifyTrustedTaskDelivery(input.to);
   invalidateTaskListCache();
-  return syntheticTask(normalized, id, messageId);
+  const task = syntheticTask(normalized, id, messageId);
+  recordSyntheticTaskBase(task);
+  return task;
 }
 
 function knownManagedIdentity(address: string): boolean {
@@ -1548,7 +1590,7 @@ export async function createApprovalTask(input: CreateApprovalTaskInput): Promis
   notifyTrustedTaskDelivery(to);
   invalidateTaskListCache();
   const now = new Date(nowMs()).toISOString();
-  return {
+  const task: ApprovalTask = {
     id,
     from,
     to,
@@ -1570,11 +1612,13 @@ export async function createApprovalTask(input: CreateApprovalTaskInput): Promis
     kind: 'approval',
     approval: snapshot,
   };
+  recordSyntheticTaskBase(task);
+  return task;
 }
 
 const taskLocks = new Map<string, Promise<void>>();
 let nowFn: () => number = () => Date.now();
-let listCache: { at: number; tasks: Task[] } | null = null;
+let listCache: { at: number; snapshot: TaskListSnapshot } | null = null;
 let listAllForTests: (() => Promise<Task[]>) | null = null;
 let getTaskForTests: ((id: string) => Promise<Task | null>) | null = null;
 let sendMailForTests: ((input: SendInput) => Promise<{ messageId: string }>) | null = null;
@@ -1595,6 +1639,81 @@ type QueuedEvent = {
   sentAt: number;
   lease?: LeaseEvent;
 };
+
+type SyntheticTaskBase = {
+  task: Task;
+  createdAtMs: number;
+};
+
+/** Bounded in-memory synthetic task base retained after SMTP acceptance during the IMAP indexing lag window. */
+const syntheticTaskBases = new Map<string, SyntheticTaskBase>();
+const SYNTHETIC_TASK_TTL_MS = QUEUED_EVENT_TTL_MS;
+const SYNTHETIC_TASK_BASE_CAPACITY = 100;
+
+function evictExpiredSyntheticTaskBases(now: number): void {
+  for (const [id, entry] of syntheticTaskBases.entries()) {
+    if (now - entry.createdAtMs > SYNTHETIC_TASK_TTL_MS) {
+      syntheticTaskBases.delete(id);
+    }
+  }
+}
+
+function recordSyntheticTaskBase(task: Task): void {
+  const now = nowMs();
+  syntheticTaskBases.delete(task.id);
+
+  if (syntheticTaskBases.size >= SYNTHETIC_TASK_BASE_CAPACITY) {
+    evictExpiredSyntheticTaskBases(now);
+  }
+
+  while (syntheticTaskBases.size >= SYNTHETIC_TASK_BASE_CAPACITY) {
+    const oldestId = syntheticTaskBases.keys().next().value;
+    if (oldestId === undefined) break;
+    syntheticTaskBases.delete(oldestId);
+  }
+
+  syntheticTaskBases.set(task.id, {
+    task: structuredClone(task),
+    createdAtMs: now,
+  });
+}
+
+function getSyntheticTaskBase(id: string): Task | null {
+  const entry = syntheticTaskBases.get(id);
+  if (!entry) return null;
+  if (nowMs() - entry.createdAtMs > SYNTHETIC_TASK_TTL_MS) {
+    syntheticTaskBases.delete(id);
+    return null;
+  }
+  return structuredClone(entry.task);
+}
+
+function getUnindexedSyntheticTaskBases(
+  indexed: Task[],
+  hadMatchingRowsIds: ReadonlySet<string> = new Set(indexed.map((task) => task.id)),
+): Task[] {
+  const indexedIds = new Set(indexed.map((task) => task.id));
+  const now = nowMs();
+  const unindexed: Task[] = [];
+  for (const [id, entry] of syntheticTaskBases.entries()) {
+    if (indexedIds.has(id)) {
+      syntheticTaskBases.delete(id);
+      continue;
+    }
+    if (hadMatchingRowsIds.has(id)) {
+      // Matching row(s) exist in IMAP but reconstruction failed (e.g. integrity failure).
+      // Fail closed: suppress and delete synthetic base so board reads do not expose it.
+      syntheticTaskBases.delete(id);
+      continue;
+    }
+    if (now - entry.createdAtMs > SYNTHETIC_TASK_TTL_MS) {
+      syntheticTaskBases.delete(id);
+      continue;
+    }
+    unindexed.push(structuredClone(entry.task));
+  }
+  return unindexed;
+}
 
 export function setTaskNowForTests(fn: (() => number) | null): void {
   nowFn = fn ?? (() => Date.now());
@@ -1629,10 +1748,9 @@ export function clearTaskSideEffectObserverForTests(): void {
   taskSideEffectObserverForTests = null;
 }
 
-
-
 export function clearQueuedEventsForTests(): void {
   queuedEvents.clear();
+  syntheticTaskBases.clear();
 }
 
 function indexedLeaseGenerationDominates(
@@ -2543,19 +2661,29 @@ function olderThanCursor(task: Task, cursor: { t: number; id: string }): boolean
   return task.id < cursor.id;
 }
 
-async function loadAllTasksCached(): Promise<Task[]> {
-  const snapshot = await loadImapTaskSnapshot();
-  // 列表与详情同一套 overlay：IMAP 滞后窗口内扫描也要看到刚接受的转移/催办。
-  return snapshot.map(mergeQueuedEvents);
+async function loadImapTaskSnapshotWithMatching(): Promise<TaskListSnapshot> {
+  if (listAllForTests) {
+    const tasks = await listAllForTests();
+    return { tasks, hadMatchingRowsIds: new Set(tasks.map((t) => t.id)) };
+  }
+  const now = nowMs();
+  if (listCache && now - listCache.at < TASK_LIST_CACHE_MS) return listCache.snapshot;
+  const snapshot = await scanDurableTasks();
+  listCache = { at: now, snapshot };
+  return snapshot;
 }
 
 async function loadImapTaskSnapshot(): Promise<Task[]> {
-  if (listAllForTests) return listAllForTests();
-  const now = nowMs();
-  if (listCache && now - listCache.at < TASK_LIST_CACHE_MS) return listCache.tasks;
-  const tasks = await listTasks();
-  listCache = { at: now, tasks };
+  const { tasks } = await loadImapTaskSnapshotWithMatching();
   return tasks;
+}
+
+async function loadAllTasksCached(): Promise<Task[]> {
+  const { tasks: snapshot, hadMatchingRowsIds } = await loadImapTaskSnapshotWithMatching();
+  const unindexed = getUnindexedSyntheticTaskBases(snapshot, hadMatchingRowsIds);
+  const combined = unindexed.length === 0 ? snapshot : [...snapshot, ...unindexed];
+  // 列表与详情同一套 overlay：IMAP 滞后窗口内扫描也要看到刚接受的转移/催办。
+  return combined.map(mergeQueuedEvents);
 }
 
 /**

--- a/packages/api/test/parent-child-root.test.ts
+++ b/packages/api/test/parent-child-root.test.ts
@@ -242,6 +242,8 @@ test('root pointer survives later v1 state events, conflicting second roots fail
   expect(tasks.taskFromMessages(approval.id, [approvalRoot!, decisionRaw!])).toMatchObject({ parentTaskId: PARENT, state: 'completed' });
 
   tasks.setTaskGetForTests(async () => null);
+  expect(await tasks.getTask(created.id)).toMatchObject({ id: created.id, state: 'submitted' });
+  tasks.clearQueuedEventsForTests();
   expect(await tasks.getTask(created.id)).toBeNull();
 });
 

--- a/packages/api/test/task-board.test.ts
+++ b/packages/api/test/task-board.test.ts
@@ -1,11 +1,9 @@
-/**
- * 工单板：status/period/limit/cursor、4h/24h 超时、terminal 30 天窗、
- * reminder 不改 state、IMAP 重建。权威存储仍是 stamped 邮件线程。
- */
+import { createHmac } from 'node:crypto';
+import { EventEmitter } from 'node:events';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { RawTaskMessage, Task, TaskState } from '../src/lib/tasks.ts';
+import type { RawTaskMessage, Task, TaskState, SendInput } from '../src/lib/tasks.ts';
 
 process.env.DOMAIN = 'test.example';
 process.env.API_KEYS = 'admin-key';
@@ -15,14 +13,59 @@ process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-task-board-'));
 
-const { afterEach, beforeEach, describe, expect, test } = await import('bun:test');
+const { afterEach, beforeEach, describe, expect, mock, test } = await import('bun:test');
+
+type FakeMailMessage = {
+  uid: number;
+  envelope: {
+    from: { address: string }[];
+    to: { address: string }[];
+    subject?: string;
+    date: Date;
+  };
+  internalDate: Date;
+  source: Buffer;
+};
+
+let fakeInboxMessages: FakeMailMessage[] = [];
+
+class FakeImapFlow extends EventEmitter {
+  async connect() {}
+  async getMailboxLock() {
+    return { release() {} };
+  }
+  async search(query: { header?: Record<string, string | boolean> }) {
+    const taskHeader = query?.header?.['x-oa-task'];
+    if (typeof taskHeader === 'string') {
+      const match = taskHeader.toLowerCase();
+      return fakeInboxMessages
+        .filter((msg) => msg.source.toString('utf8').toLowerCase().includes(`x-oa-task: ${match}`))
+        .map((msg) => msg.uid);
+    }
+    return fakeInboxMessages.map((msg) => msg.uid);
+  }
+  async *fetch(uids: number[]) {
+    for (const msg of fakeInboxMessages) {
+      if (uids.includes(msg.uid)) {
+        yield msg;
+      }
+    }
+  }
+  close() {}
+}
+
+mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
+
 const {
   TASK_BOARD_LIMITS,
   TASK_BOARD_PERIODS,
   TASK_REMIND_COOLDOWN_MS,
   clearQueuedEventsForTests,
+  createApprovalTask,
+  createTask,
   currentTaskMessage,
   getTask,
+  invalidateTaskListCache,
   isClosedByAdmin,
   listTaskBoard,
   closeTask,
@@ -34,8 +77,13 @@ const {
   setTaskSendMailForTests,
   taskFromMessages,
   taskOverdue,
+  taskService,
 } = await import('../src/lib/tasks.ts');
 const { encodeTaskBoardCursor, InvalidTaskCursorError } = await import('../src/lib/task-cursor.ts');
+const { createIdentity, findIdentity } = await import('../src/lib/identities.ts');
+const { config } = await import('../src/lib/config.ts');
+
+const SYNTHETIC_TASK_TTL_MS = 60 * 1000;
 
 const NOW = Date.parse('2026-08-12T12:00:00.000Z');
 const HOUR = 60 * 60 * 1000;
@@ -104,6 +152,7 @@ afterEach(() => {
   setTaskGetForTests(null);
   setTaskSendMailForTests(null);
   clearQueuedEventsForTests();
+  fakeInboxMessages = [];
 });
 
 describe('task overdue clock', () => {
@@ -769,5 +818,518 @@ describe('IMAP lag overlay for state transitions and list', () => {
       { kind: 'admin' },
     );
     expect(page.tasks[0]?.state).toBe('input-required');
+  });
+});
+
+describe('issue #95: newly created tasks readable during IMAP indexing lag', () => {
+  function installEmptyMailbox() {
+    const store = new Map<string, Task>();
+    const sent: SendInput[] = [];
+    setTaskGetForTests(async (id) => {
+      const current = store.get(id);
+      return current ? structuredClone(current) : null;
+    });
+    setTaskListAllForTests(async () => [...store.values()].map((row) => structuredClone(row)));
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<test-msg-${sent.length}@test.example>` };
+    });
+    return { store, sent };
+  }
+
+  test('1. ordinary create followed immediately by detail read while IMAP returns no rows returns the created task', async () => {
+    installEmptyMailbox();
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Ordinary unindexed task',
+      body: 'initial body',
+    });
+
+    const detail = await getTask(created.id);
+    expect(detail).not.toBeNull();
+    expect(detail?.id).toBe(created.id);
+    expect(detail?.from).toBe('fox@test.example');
+    expect(detail?.to).toBe('owl@test.example');
+    expect(detail?.subject).toBe('Ordinary unindexed task');
+    expect(detail?.state).toBe('submitted');
+    expect(detail?.createdAt).toBe(iso(NOW));
+    expect(detail?.updatedAt).toBe(iso(NOW));
+    expect(detail?.messages).toHaveLength(1);
+    expect(detail?.messages[0]?.body).toBe('initial body');
+  });
+
+  test('2. approval create followed immediately by detail read while IMAP returns no rows returns the created approval task with its approval snapshot intact', async () => {
+    installEmptyMailbox();
+    for (const localpart of ['fox', 'owl']) {
+      if (!findIdentity(`${localpart}@test.example`)) {
+        createIdentity({ localpart, issueToken: false });
+      }
+    }
+    const expiresAt = iso(NOW + 2 * DAY);
+    const action = { type: 'deploy', name: 'publish', arguments: { version: '1.0.0' } };
+    const created = await createApprovalTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Approval unindexed task',
+      body: 'please review',
+      action,
+      expiresAt,
+    });
+
+    const detail = await getTask(created.id);
+    expect(detail).not.toBeNull();
+    expect(detail?.id).toBe(created.id);
+    expect(detail?.kind).toBe('approval');
+    expect(detail?.state).toBe('input-required');
+    expect(detail?.approval).toBeDefined();
+    expect(detail?.approval?.action).toEqual(action);
+    expect(detail?.approval?.reviewer).toBe('owl@test.example');
+    expect(detail?.approval?.expiresAt).toBe(expiresAt);
+    expect(detail?.approval?.digest).toBe(created.approval.digest);
+    expect(detail?.messages).toHaveLength(1);
+    expect(detail?.messages[0]?.approval?.type).toBe('request');
+    expect(detail?.messages[0]?.approval?.snapshot).toEqual(created.approval);
+  });
+
+  test('3. create followed immediately by board read while IMAP returns no rows includes the task exactly once', async () => {
+    installEmptyMailbox();
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Board unindexed task',
+      body: 'immediate board read',
+    });
+
+    // Admin view
+    const adminPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    const adminMatches = adminPage.tasks.filter((t) => t.id === created.id);
+    expect(adminMatches).toHaveLength(1);
+    expect(adminMatches[0]?.state).toBe('submitted');
+    expect(adminMatches[0]?.subject).toBe('Board unindexed task');
+
+    // Participant user view
+    const userPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'user', address: 'fox@test.example' },
+    );
+    const userMatches = userPage.tasks.filter((t) => t.id === created.id);
+    expect(userMatches).toHaveLength(1);
+
+    // Outsider user view (should not see it)
+    const outsiderPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'user', address: 'outsider@test.example' },
+    );
+    expect(outsiderPage.tasks.filter((t) => t.id === created.id)).toHaveLength(0);
+  });
+
+  test('4. when IMAP later returns the durable initial message/task, detail and board converge without duplicate messages or rows', async () => {
+    const { store } = installEmptyMailbox();
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Convergence task',
+      body: 'will be indexed',
+    });
+
+    // Lag window: detail and board see synthetic task once
+    expect(await getTask(created.id)).not.toBeNull();
+    const lagPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(lagPage.tasks.filter((t) => t.id === created.id)).toHaveLength(1);
+
+    // IMAP indexes the task as a durable record
+    const durableTask: Task = {
+      ...created,
+      messages: [
+        {
+          id: '<durable-msg-1@test.example>',
+          from: 'fox@test.example',
+          to: 'owl@test.example',
+          subject: 'Convergence task',
+          date: created.createdAt,
+          state: 'submitted',
+          body: 'will be indexed',
+        },
+      ],
+    };
+    store.set(created.id, durableTask);
+
+    // Detail read converges to durable task without duplicating messages
+    const durableDetail = await getTask(created.id);
+    expect(durableDetail).not.toBeNull();
+    expect(durableDetail?.messages).toHaveLength(1);
+    expect(durableDetail?.messages[0]?.id).toBe('<durable-msg-1@test.example>');
+
+    // Board read converges without duplicating board row
+    const postIndexPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    const matches = postIndexPage.tasks.filter((t) => t.id === created.id);
+    expect(matches).toHaveLength(1);
+    expect(matches[0]?.messages).toHaveLength(1);
+    expect(matches[0]?.messages[0]?.id).toBe('<durable-msg-1@test.example>');
+  });
+
+  test('5. prove bounded lifetime with an injected clock (approval expiry derived from injected clock)', async () => {
+    let currentClock = NOW;
+    setTaskNowForTests(() => currentClock);
+    installEmptyMailbox();
+
+    for (const localpart of ['fox', 'owl']) {
+      if (!findIdentity(`${localpart}@test.example`)) {
+        createIdentity({ localpart, issueToken: false });
+      }
+    }
+
+    // Follow #115: approval expiry derived safely from current injected clock
+    const expiresAt = iso(currentClock + 2 * DAY);
+    const action = { type: 'deploy', name: 'publish', arguments: { version: '1.0.0' } };
+
+    const ordinary = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Expiring ordinary task',
+      body: 'bounded test',
+    });
+    const approval = await createApprovalTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Expiring approval task',
+      body: 'bounded approval test',
+      action,
+      expiresAt,
+    });
+
+    // Initially within lag window: both are readable and present on board
+    expect(await getTask(ordinary.id)).not.toBeNull();
+    expect(await getTask(approval.id)).not.toBeNull();
+    const initialPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(initialPage.tasks.filter((t) => t.id === ordinary.id)).toHaveLength(1);
+    expect(initialPage.tasks.filter((t) => t.id === approval.id)).toHaveLength(1);
+
+    // Advance clock past SYNTHETIC_TASK_TTL_MS (60s), while approval expiry (2 days) is safely in bounds
+    currentClock = NOW + SYNTHETIC_TASK_TTL_MS + 1000;
+
+    // Detail reads expire and return null
+    expect(await getTask(ordinary.id)).toBeNull();
+    expect(await getTask(approval.id)).toBeNull();
+
+    // Board read excludes expired synthetic tasks
+    const expiredPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(expiredPage.tasks.filter((t) => t.id === ordinary.id)).toHaveLength(0);
+    expect(expiredPage.tasks.filter((t) => t.id === approval.id)).toHaveLength(0);
+  });
+
+  test('6. synthetic task base adheres to explicit capacity limit with deterministic FIFO eviction', async () => {
+    installEmptyMailbox();
+    const first = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'First burst task',
+      body: 'first',
+    });
+    expect(await getTask(first.id)).not.toBeNull();
+
+    // Create 100 burst tasks to exceed capacity (100)
+    let lastId = '';
+    for (let i = 0; i < 100; i++) {
+      const burst = await createTask({
+        from: 'fox@test.example',
+        to: 'owl@test.example',
+        subject: `Burst task ${i}`,
+        body: `burst ${i}`,
+      });
+      lastId = burst.id;
+    }
+
+    // First task should have been evicted deterministically by capacity overflow
+    expect(await getTask(first.id)).toBeNull();
+    // Latest task should still be present
+    expect(await getTask(lastId)).not.toBeNull();
+  });
+
+  test('7. detail and authorization reads fail closed when IMAP search yields matching rows that fail parser integrity', async () => {
+    setTaskGetForTests(null);
+    setTaskSendMailForTests(async () => ({ messageId: '<sent-msg-1@test.example>' }));
+    fakeInboxMessages = [];
+
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Tampered durable task',
+      body: 'initial body',
+    });
+
+    // Zero matching rows in IMAP: synthetic fallback works
+    const lagDetail = await getTask(created.id);
+    expect(lagDetail).not.toBeNull();
+    expect(lagDetail?.id).toBe(created.id);
+    expect(await taskService.getForAuthorization?.(created.id)).not.toBeNull();
+
+    // Matching row appears in IMAP search, but fails parser integrity
+    const tamperedSource = Buffer.from(
+      [
+        'From: fox@test.example',
+        'To: owl@test.example',
+        'Subject: Tampered durable task',
+        `X-OA-Task: ${created.id}`,
+        'X-OA-Task-State: submitted',
+        'X-OA-Task-Stamp: invalid-tampered-stamp',
+        '',
+        'corrupted body',
+      ].join('\r\n'),
+    );
+
+    fakeInboxMessages = [
+      {
+        uid: 101,
+        envelope: {
+          from: [{ address: 'fox@test.example' }],
+          to: [{ address: 'owl@test.example' }],
+          subject: 'Tampered durable task',
+          date: new Date('2026-08-12T12:00:00Z'),
+        },
+        internalDate: new Date('2026-08-12T12:00:00Z'),
+        source: tamperedSource,
+      },
+    ];
+
+    // Detail read and authorization read must fail closed and return null rather than the synthetic task
+    const tamperedDetail = await getTask(created.id);
+    expect(tamperedDetail).toBeNull();
+    expect(await taskService.getForAuthorization?.(created.id)).toBeNull();
+
+    // Repeated read also returns null (synthetic base was suppressed/retired)
+    expect(await getTask(created.id)).toBeNull();
+  });
+
+  test('8. concurrent detail read during suspended empty board scan does not evict synthetic base or lose board row', async () => {
+    let detailDurable: Task | null = null;
+    setTaskGetForTests(async (id) => detailDurable ? structuredClone(detailDurable) : null);
+    setTaskSendMailForTests(async () => ({ messageId: '<sent-concurrency@test.example>' }));
+
+    // 1. Create task and retain synthetic base
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Race resistance task',
+      body: 'concurrency test',
+    });
+
+    // 2. Start board read whose list snapshot captures empty then pauses
+    let scanStartedResolve: () => void;
+    const scanStartedPromise = new Promise<void>((resolve) => {
+      scanStartedResolve = resolve;
+    });
+
+    let scanResumeResolve: () => void;
+    const scanResumePromise = new Promise<void>((resolve) => {
+      scanResumeResolve = resolve;
+    });
+
+    let scanCount = 0;
+    setTaskListAllForTests(async () => {
+      scanCount++;
+      if (scanCount === 1) {
+        scanStartedResolve();
+        await scanResumePromise;
+        return [];
+      }
+      return detailDurable ? [structuredClone(detailDurable)] : [];
+    });
+
+    const pendingBoardRead = listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+
+    await scanStartedPromise;
+
+    // 3. Make detail source expose durable task and perform detail read
+    const durableTask: Task = {
+      ...created,
+      messages: [
+        {
+          id: '<durable-msg-1@test.example>',
+          from: 'fox@test.example',
+          to: 'owl@test.example',
+          subject: 'Race resistance task',
+          date: created.createdAt,
+          state: 'submitted',
+          body: 'concurrency test',
+        },
+      ],
+    };
+    detailDurable = durableTask;
+
+    const detail = await getTask(created.id);
+    expect(detail).not.toBeNull();
+    expect(detail?.messages[0]?.id).toBe('<durable-msg-1@test.example>');
+
+    // 4. Resume earlier empty board snapshot
+    scanResumeResolve!();
+
+    // 5. Verify board still includes exactly one synthetic row rather than caching empty result
+    const boardPage = await pendingBoardRead;
+    const matchingTasks = boardPage.tasks.filter((t) => t.id === created.id);
+    expect(matchingTasks).toHaveLength(1);
+
+    // Later board snapshot contains durable task; verify convergence without duplication
+    const nextBoardPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    const convergedTasks = nextBoardPage.tasks.filter((t) => t.id === created.id);
+    expect(convergedTasks).toHaveLength(1);
+    expect(convergedTasks[0]?.messages[0]?.id).toBe('<durable-msg-1@test.example>');
+  });
+
+  test('9. board read fails closed when IMAP search yields matching rows that fail parser integrity (without prior detail read)', async () => {
+    setTaskGetForTests(null);
+    setTaskListAllForTests(null);
+    setTaskSendMailForTests(async () => ({ messageId: '<sent-msg-board-fail-closed@test.example>' }));
+    fakeInboxMessages = [];
+
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Board tampered task',
+      body: 'initial body',
+    });
+
+    // Zero matching rows in IMAP: board includes synthetic task
+    const lagPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(lagPage.tasks.filter((t) => t.id === created.id)).toHaveLength(1);
+
+    // Invalidate list cache so subsequent board read scans IMAP
+    invalidateTaskListCache();
+
+    // Matching row appears in IMAP search, but fails parser integrity
+    const tamperedSource = Buffer.from(
+      [
+        'From: fox@test.example',
+        'To: owl@test.example',
+        'Subject: Board tampered task',
+        `X-OA-Task: ${created.id}`,
+        'X-OA-Task-State: submitted',
+        'X-OA-Task-Stamp: invalid-tampered-stamp',
+        '',
+        'corrupted body',
+      ].join('\r\n'),
+    );
+
+    fakeInboxMessages = [
+      {
+        uid: 202,
+        envelope: {
+          from: [{ address: 'fox@test.example' }],
+          to: [{ address: 'owl@test.example' }],
+          subject: 'Board tampered task',
+          date: new Date('2026-08-12T12:00:00Z'),
+        },
+        internalDate: new Date('2026-08-12T12:00:00Z'),
+        source: tamperedSource,
+      },
+    ];
+
+    // Board read WITHOUT prior detail read must fail closed: do NOT display the synthetic task
+    const postTamperPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(postTamperPage.tasks.filter((t) => t.id === created.id)).toHaveLength(0);
+
+    // Synthetic base has been suppressed/retired
+    expect(await getTask(created.id)).toBeNull();
+  });
+
+  test('10. board and detail reads fail closed when matching durable row contains poisoned relationship-integrity root', async () => {
+    setTaskGetForTests(null);
+    setTaskListAllForTests(null);
+    setTaskSendMailForTests(async () => ({ messageId: '<sent-msg-poison-fail-closed@test.example>' }));
+    fakeInboxMessages = [];
+
+    const created = await createTask({
+      from: 'fox@test.example',
+      to: 'owl@test.example',
+      subject: 'Poison root task',
+      body: 'initial body',
+    });
+
+    // Zero matching rows in IMAP: board includes synthetic task
+    const lagPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(lagPage.tasks.filter((t) => t.id === created.id)).toHaveLength(1);
+
+    // Invalidate list cache so subsequent board read scans IMAP
+    invalidateTaskListCache();
+
+    // Matching row appears with valid v2 witness but invalid root signature (relationship integrity poison)
+    const witness = createHmac('sha256', config.taskSigningSecret)
+      .update(`openagentemail-task-root-v2-witness\n${created.id}\nsubmitted\nfox@test.example\nowl@test.example`)
+      .digest('base64url');
+    const poisonedStamp = `v2.${witness}.tampered-root-mac`;
+    const poisonedRootHeader = Buffer.from(
+      JSON.stringify({ version: 2, parentTaskId: '00000000-0000-4000-8000-000000000001' }),
+      'utf8',
+    ).toString('base64url');
+
+    const poisonedSource = Buffer.from(
+      [
+        'From: fox@test.example',
+        'To: owl@test.example',
+        'Subject: Poison root task',
+        `X-OA-Task: ${created.id}`,
+        'X-OA-Task-State: submitted',
+        `X-OA-Task-Root: ${poisonedRootHeader}`,
+        `X-OA-Task-Stamp: ${poisonedStamp}`,
+        '',
+        'corrupted body',
+      ].join('\r\n'),
+    );
+
+    fakeInboxMessages = [
+      {
+        uid: 303,
+        envelope: {
+          from: [{ address: 'fox@test.example' }],
+          to: [{ address: 'owl@test.example' }],
+          subject: 'Poison root task',
+          date: new Date('2026-08-12T12:00:00Z'),
+        },
+        internalDate: new Date('2026-08-12T12:00:00Z'),
+        source: poisonedSource,
+      },
+    ];
+
+    // Board read WITHOUT prior detail read must fail closed and suppress synthetic base
+    const postPoisonPage = await listTaskBoard(
+      { status: 'all', period: '30d', limit: 20 },
+      { kind: 'admin' },
+    );
+    expect(postPoisonPage.tasks.filter((t) => t.id === created.id)).toHaveLength(0);
+
+    // Detail and authorization reads also fail closed
+    expect(await getTask(created.id)).toBeNull();
+    expect(await taskService.getForAuthorization?.(created.id)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Fixes #95

### Problem
After `createTask` or `createApprovalTask` accepted SMTP delivery, the service returned a synthetic task to the caller but did not retain that synthetic base for subsequent reads. While IMAP/Dovecot had not yet indexed the initial message, `getTaskSnapshot` received no raw messages and returned `null`; `loadAllTasksCached` likewise started only from indexed tasks, leaving immediate detail and board reads reporting the new task as missing. Furthermore:
1. Production `findTaskMessages(id)` previously collapsed "truly zero matching rows in IMAP" with "matching rows found in IMAP that all failed parser or relationship integrity", which could cause a damaged or tampered thread to improperly expose the synthetic fallback for 60s instead of failing closed.
2. The durable list scan similarly omitted poisoned/failed IDs from the reconstructed task list, causing `getUnindexedSyntheticTaskBases` to mistakenly treat them as unindexed and restore the synthetic base on the board.
3. An in-flight board scan capturing an empty snapshot before indexing could suffer a race if a concurrent detail read observed the durable task and deleted `syntheticTaskBases[id]`, resulting in the board temporarily losing the task for up to `TASK_LIST_CACHE_MS` (30s).

### Solution
- Refactored private production read path in `tasks-internal.ts` to preserve an explicit `hadMatchingRows` signal from IMAP search alongside parsed messages in `findTaskMessages`.
- Refactored the durable list scan (`scanDurableTasks`) to preserve a set of all task IDs encountered in `X-OA-Task` headers (`hadMatchingRowsIds`).
- In `getTaskSnapshot`, consult the synthetic task base ONLY when IMAP search truly returned zero matching rows. If matching rows exist in IMAP but reconstruction fails (e.g. invalid stamp or corrupted relationship root), fail closed: suppress/retire any synthetic base and return `null` for detail and authorization reads.
- In `getUnindexedSyntheticTaskBases`, check `hadMatchingRowsIds`. If matching rows exist in IMAP but reconstruction failed, fail closed: suppress and delete the synthetic base so board reads do not expose it.
- Removed synthetic-base retirement from the successful detail-read branch in `getTaskSnapshot`. Instead, driven exclusively by `getUnindexedSyntheticTaskBases(indexedSnapshot)`: only when a board/list snapshot contains the durable task is the synthetic base retired, eliminating the in-flight board scan race.
- Retain a bounded, short-lived synthetic task base in `tasks-internal.ts` (`syntheticTaskBases` map with `SYNTHETIC_TASK_TTL_MS = 60s` and explicit `SYNTHETIC_TASK_BASE_CAPACITY = 100` with deterministic FIFO eviction) following successful SMTP delivery of ordinary and approval tasks.
- In `loadAllTasksCached`, gather unindexed synthetic task bases from `syntheticTaskBases` that have not yet appeared in the durable IMAP snapshot, retiring any that have appeared or expired, and include them before applying queued overlays.
- Kept all internal test seams private to `tasks-internal.ts` and preserved clean production facade in `tasks.ts`. Reverted incidental type annotations in `validateParentChain` to minimize scope.
- Derived timestamps in `syntheticTask` from `nowMs()` to respect the injected test clock without wall-clock sleeps, adhering to the #115 time-bomb doctrine.
- Added deterministic regression tests in `packages/api/test/task-board.test.ts` covering the complete fail-closed matrix:
  1. Ordinary create followed immediately by detail read while IMAP returns no rows returns the created task (detail zero rows).
  2. Approval create followed immediately by detail read while IMAP returns no rows returns the created approval task with snapshot intact.
  3. Create followed immediately by board read while IMAP returns no rows includes the task once and enforces ACL (board zero rows).
  4. Once IMAP indexes the initial message, detail and board converge to the durable task without duplicate messages or board rows (board matching valid durable root).
  5. Bounded lifetime proved with injected clock; approval expiry safely derived from injected clock.
  6. Explicit capacity limit (100) enforced with deterministic FIFO eviction under high-concurrency burst.
  7. Detail and authorization reads fail closed when IMAP search yields matching rows that fail parser integrity (detail matching invalid row).
  8. Concurrent detail read during a suspended in-flight empty board scan does not evict synthetic base or lose the board row (concurrent stale-empty board snapshot vs durable detail read).
  9. Board-first read fails closed when IMAP search yields matching rows that fail parser integrity without prior detail read (board matching invalid row).
  10. Board and detail reads fail closed when matching durable row contains poisoned relationship-integrity root (reconstruction null).

### Test Evidence
- `bun test test/task-board.test.ts` (30/30 pass)
- `bun test test/parent-child-root.test.ts` (15/15 pass)
- `bun test` (540/540 pass across 57 files)
- `bun run check:approval-publication` (passed)
- `git diff origin/main --check` (clean, 0 whitespace/newline issues)