### PR TITLE
fix(api): make lease-expiry retries idempotent across SMTP acceptance

### DIFF
--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -586,6 +586,19 @@ function leaseVerifiersEqual(candidate: unknown, persisted: unknown): boolean {
   return left.length === right.length && timingSafeEqual(left, right);
 }
 
+/**
+ * Equivalence predicate for server lease-expiry idempotency: same lease
+ * generation and exact canonical claimedUntil timestamp.
+ */
+function isSameLeaseExpiryIdentity(
+  a: { leaseGeneration?: number; generation?: number; claimedUntil: string },
+  b: { leaseGeneration?: number; generation?: number; claimedUntil: string },
+): boolean {
+  const genA = a.leaseGeneration ?? a.generation;
+  const genB = b.leaseGeneration ?? b.generation;
+  return genA !== undefined && genA === genB && a.claimedUntil === b.claimedUntil;
+}
+
 function leaseEventStamp(
   id: string,
   state: TaskState,
@@ -1155,26 +1168,29 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
   let expiredLease: ExpiredLeaseReceipt | undefined;
   let firstClaimedAt: string | undefined;
   const appliedExpiryReceipts = new Map<number, ExpiredLeaseReceipt>();
-  const exactDuplicateExpiryMessages = new Set<RawTaskMessage>();
+  const duplicateExpiryMessages = new Set<RawTaskMessage>();
   for (const message of leaseEvents) {
     const lease = message.lease;
     if (lease.event === 'expired') {
-      const priorReceipt = appliedExpiryReceipts.get(lease.generation);
-      if (
-        priorReceipt?.leaseGeneration === lease.generation
-        && priorReceipt.claimedUntil === lease.claimedUntil
-        && priorReceipt.expiredAt === lease.expiredAt
-      ) {
-        exactDuplicateExpiryMessages.add(message);
-        continue;
-      }
       if (
         lease.actor !== 'server'
-        || !leaseAuthority?.claimedUntil
+        || lease.at !== lease.expiredAt
+        || !Number.isFinite(Date.parse(lease.expiredAt))
+        || !Number.isFinite(Date.parse(lease.claimedUntil))
+        || Date.parse(lease.expiredAt) < Date.parse(lease.claimedUntil)
+      ) return null;
+      const priorReceipt = appliedExpiryReceipts.get(lease.generation);
+      if (priorReceipt) {
+        if (isSameLeaseExpiryIdentity(priorReceipt, lease)) {
+          duplicateExpiryMessages.add(message);
+          continue;
+        }
+        return null;
+      }
+      if (
+        !leaseAuthority?.claimedUntil
         || lease.generation !== leaseAuthority.leaseGeneration
         || lease.claimedUntil !== leaseAuthority.claimedUntil
-        || lease.at !== lease.expiredAt
-        || Date.parse(lease.expiredAt) < Date.parse(lease.claimedUntil)
       ) return null;
       leaseAuthority = undefined;
       releasedLease = undefined;
@@ -1300,7 +1316,7 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
   // (but validly signed) submitted/working mail can appear again in IMAP, but
   // it cannot reopen the completed/failed task. Before that point normal
   // concurrent writes retain mailbox-order last-writer-wins semantics.
-  const durableOrdered = ordered.filter((message) => !exactDuplicateExpiryMessages.has(message)).map((message) => message.lease
+  const durableOrdered = ordered.filter((message) => !duplicateExpiryMessages.has(message)).map((message) => message.lease
     ? { ...message, date: message.lease.at }
     : message);
   const current = currentTaskMessage(durableOrdered);
@@ -1784,11 +1800,7 @@ function eventIsIndexed(task: Task, queued: QueuedEvent): boolean {
     const authority = task.lease;
     if (queued.lease.event === 'expired') {
       const receipt = task.expiredLease;
-      if (
-        receipt?.leaseGeneration === queued.lease.generation
-        && receipt.claimedUntil === queued.lease.claimedUntil
-        && receipt.expiredAt === queued.lease.expiredAt
-      ) return true;
+      if (receipt && isSameLeaseExpiryIdentity(receipt, queued.lease)) return true;
       return indexedLeaseGenerationDominates(task, queued.lease.generation, 'strict');
     }
     if (queued.lease.event === 'release') {

--- a/packages/api/test/task-lease-reaper-red.test.ts
+++ b/packages/api/test/task-lease-reaper-red.test.ts
@@ -28,6 +28,7 @@ const {
   taskFromMessages,
   taskService,
   toTaskView,
+  getTask,
 } = await import('../src/lib/tasks.ts');
 const { claimLeaseHeadersForTests, parseTaskMessageForTests, withTaskLeasesEnabledForTests } = await import('./support/task-lease-seams.ts');
 const test = (name: string, work: () => void | Promise<void>) => bunTest(name, () => withTaskLeasesEnabledForTests(true, work));
@@ -95,7 +96,7 @@ function expiryEvent(input: { claimedUntil: string; at?: string; actor?: string 
   };
 }
 
-function expiryDelivery(input: { claimedUntil: string; actor?: string }): SendInput {
+function expiryDelivery(input: { claimedUntil: string; actor?: string; at?: string }): SendInput {
   const event = expiryEvent(input);
   return {
     from: REQUESTER,
@@ -398,7 +399,7 @@ describe('#56 R8b explicit server lease expiry reaper RED', () => {
     expect({ afterClose: await reapExpiredTaskLeasesOnce(), expiryDeliveries: sent.filter((mail) => mail.headers?.['X-OA-Task-Lease-Event'] === 'expired').length }).toEqual({ afterClose: 0, expiryDeliveries: 0 });
   });
 
-  test('a signed same-generation expiry with different timing is fail-closed rather than an exact duplicate', async () => {
+  test('a signed same-generation expiry with different claimedUntil is fail-closed rather than an exact duplicate', async () => {
     const sent: SendInput[] = [];
     setTaskNowForTests(() => START);
     setTaskGetForTests(async () => submittedTask());
@@ -808,5 +809,385 @@ describe('#56 R8b explicit server lease expiry reaper RED', () => {
       exitCode: 0,
       elapsedUnderFiveSeconds: true,
     });
+  });
+
+  test('issue #97: reproduce full acceptance-loss-retry path: expiry retry with later timestamp reconstructs as single logical expiry', async () => {
+    let now = START;
+    let durable = submittedTask();
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => durable);
+    setTaskListAllForTests(async () => [durable]);
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<retry-test-${sent.length}>` };
+    });
+
+    if (!taskService.claim) throw new Error('shipped claim service is unavailable');
+    const first = await taskService.claim({ id: ID, from: RECIPIENT, leaseSec: 300 });
+    const claim1 = await parseCaptured(sent[0]!, 2);
+    expect(claim1).not.toBeNull();
+    durable = taskFromMessages(ID, [submittedRaw(), claim1!])!;
+
+    // Move to equality boundary: attempt A
+    now = Date.parse(first.claimedUntil);
+    setTaskGetForTests(async () => durable);
+    setTaskListAllForTests(async () => [durable]);
+    await reapExpiredTaskLeasesOnce();
+    const expiryA = await parseCaptured(sent[1]!, 3);
+    expect(expiryA).not.toBeNull();
+    expect(expiryA?.lease?.event).toBe('expired');
+    const expiryALease = expiryA!.lease as { generation: number; claimedUntil: string; expiredAt: string };
+    expect(expiryALease.generation).toBe(1);
+    expect(expiryALease.claimedUntil).toBe(first.claimedUntil);
+    expect(expiryALease.expiredAt).toBe(first.claimedUntil);
+
+    // Simulate process restart / loss of queued overlays before IMAP indexes attempt A
+    clearQueuedEventsForTests();
+    // Advance injected clock: attempt B (retry)
+    now = Date.parse(first.claimedUntil) + 30_000;
+    setTaskGetForTests(async () => durable); // durable still only has claim1
+    setTaskListAllForTests(async () => [durable]);
+    await reapExpiredTaskLeasesOnce();
+    const expiryB = await parseCaptured(sent[2]!, 4);
+    expect(expiryB).not.toBeNull();
+    expect(expiryB?.lease?.event).toBe('expired');
+    const expiryBLease = expiryB!.lease as { generation: number; claimedUntil: string; expiredAt: string };
+    expect(expiryBLease.generation).toBe(1);
+    expect(expiryBLease.claimedUntil).toBe(first.claimedUntil);
+    expect(expiryBLease.expiredAt).not.toBe(expiryALease.expiredAt);
+    expect(expiryBLease.expiredAt).toBe(new Date(now).toISOString());
+
+    // Durable mailbox now contains both A and B: reconstruction succeeds idempotently
+    const rebuilt = taskFromMessages(ID, [submittedRaw(), claim1!, expiryA!, expiryB!]);
+    expect(rebuilt).not.toBeNull();
+    expect(rebuilt?.lease).toBeUndefined();
+    expect(rebuilt?.expiredLease).toEqual({
+      leaseGeneration: 1,
+      claimedUntil: first.claimedUntil,
+      expiredAt: expiryALease.expiredAt, // Preserves the first applied receipt
+      firstClaimedAt: '2026-08-24T00:00:00.000Z',
+    });
+    // Public messages omit duplicate expiry audit noise (only 1 expiry message, total 3 messages)
+    const publicMessages = rebuilt!.messages;
+    expect(publicMessages).toHaveLength(3);
+    expect(publicMessages.filter((m) => m.body === 'Lease expired.')).toHaveLength(1);
+  });
+
+  test('issue #97: queued indexed detection: queued retry B is recognized as indexed by durable expiry A and retired', async () => {
+    let now = START;
+    let durable = submittedTask();
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => durable);
+    setTaskListAllForTests(async () => [durable]);
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<queued-retry-${sent.length}>` };
+    });
+
+    if (!taskService.claim) throw new Error('shipped claim service is unavailable');
+    const first = await taskService.claim({ id: ID, from: RECIPIENT, leaseSec: 300 });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+    durable = taskFromMessages(ID, [submittedRaw(), claim1])!;
+
+    // Materialize expiry A
+    now = Date.parse(first.claimedUntil);
+    setTaskGetForTests(async () => durable);
+    setTaskListAllForTests(async () => [durable]);
+    await reapExpiredTaskLeasesOnce();
+    const expiryA = (await parseCaptured(sent[1]!, 3))!;
+    const expiryALease = expiryA.lease as { generation: number; claimedUntil: string; expiredAt: string };
+
+    // Clear queued events, simulate durable IMAP now having claim1 + expiryA
+    clearQueuedEventsForTests();
+    const durableWithA = taskFromMessages(ID, [submittedRaw(), claim1, expiryA])!;
+    expect(durableWithA.expiredLease?.expiredAt).toBe(expiryALease.expiredAt);
+
+    // Now suppose in a separate process retry B was materialized and queued:
+    now = Date.parse(first.claimedUntil) + 60_000;
+    setTaskGetForTests(async () => durable);
+    setTaskListAllForTests(async () => [durable]);
+    await reapExpiredTaskLeasesOnce();
+    // B is now queued in queuedEvents!
+    const expiryB = (await parseCaptured(sent[2]!, 4))!;
+    const expiryBLease = expiryB.lease as { generation: number; claimedUntil: string; expiredAt: string };
+    expect(expiryBLease.expiredAt).not.toBe(expiryALease.expiredAt);
+
+    // Detail read durableWithA: mergeQueuedEvents must recognize B as already indexed
+    setTaskGetForTests(async () => durableWithA);
+    const readTask = await getTask(ID);
+    expect(readTask).not.toBeNull();
+    // It must NOT append retry B as duplicate message
+    expect(readTask!.messages).toHaveLength(3);
+    // It must NOT overwrite A's expiredAt
+    expect(readTask!.expiredLease?.expiredAt).toBe(expiryALease.expiredAt);
+  });
+
+  test('issue #97: direct reconstruction of two valid authenticated expiry events with same generation and claimedUntil but different timestamps is idempotent', async () => {
+    let now = START;
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => submittedTask());
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<direct-reconstruct-${sent.length}>` };
+    });
+
+    if (!taskService.claim) throw new Error('shipped claim service is unavailable');
+    const first = await taskService.claim({ id: ID, from: RECIPIENT, leaseSec: 300 });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+
+    const at1 = first.claimedUntil;
+    const at2 = new Date(Date.parse(first.claimedUntil) + 15_000).toISOString();
+    const expiry1 = (await parseCaptured(expiryDelivery({ claimedUntil: first.claimedUntil, at: at1 }), 3))!;
+    const expiry2 = (await parseCaptured(expiryDelivery({ claimedUntil: first.claimedUntil, at: at2 }), 4))!;
+
+    const rebuilt = taskFromMessages(ID, [submittedRaw(), claim1, expiry1, expiry2]);
+    expect(rebuilt).not.toBeNull();
+    expect(rebuilt?.expiredLease).toEqual({
+      leaseGeneration: 1,
+      claimedUntil: first.claimedUntil,
+      expiredAt: at1,
+      firstClaimedAt: '2026-08-24T00:00:00.000Z',
+    });
+    expect(rebuilt?.messages).toHaveLength(3);
+    expect(toTaskView(rebuilt!).messages).toHaveLength(3);
+  });
+
+  test('issue #97: fail-closed controls: mismatched claimedUntil, forged actor, malformed time, expiredAt before claimedUntil, and unexpired stale expiry', async () => {
+    let now = START;
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => submittedTask());
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<controls-${sent.length}>` };
+    });
+
+    if (!taskService.claim) throw new Error('shipped claim service is unavailable');
+    const first = await taskService.claim({ id: ID, from: RECIPIENT, leaseSec: 300 });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+
+    // 1. Same generation with different claimedUntil
+    const diffUntil = new Date(Date.parse(first.claimedUntil) + 10_000).toISOString();
+    const expiryDiffUntil = await parseCaptured(expiryDelivery({ claimedUntil: diffUntil }), 3);
+    expect(expiryDiffUntil).not.toBeNull();
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, expiryDiffUntil!])).toBeNull();
+
+    // 2. Forged actor (not 'server')
+    const forgedActorDelivery: SendInput = {
+      from: REQUESTER,
+      to: [RECIPIENT],
+      subject: 'Lease this task',
+      text: 'Lease expired.',
+      headers: claimLeaseHeadersForTests({
+        id: ID,
+        state: 'working',
+        from: REQUESTER,
+        to: RECIPIENT,
+        event: {
+          version: 1,
+          event: 'expired',
+          actor: 'attacker@test.example' as unknown as 'server',
+          at: first.claimedUntil,
+          generation: 1,
+          claimedUntil: first.claimedUntil,
+          expiredAt: first.claimedUntil,
+        },
+      }),
+    };
+    const expiryForgedActor = await parseCaptured(forgedActorDelivery, 4);
+    // Intentionally rejected at parser layer (readLeaseEventPayload enforces actor === 'server')
+    expect(expiryForgedActor).toBeNull();
+    expect(expiryForgedActor === null || taskFromMessages(ID, [submittedRaw(), claim1, expiryForgedActor]) === null).toBe(true);
+    // Defense-in-depth in taskFromMessages: durable reconstruction rejects forged actor
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, {
+      uid: 4,
+      from: REQUESTER,
+      to: RECIPIENT,
+      subject: 'Lease this task',
+      date: first.claimedUntil,
+      state: 'working',
+      body: 'Lease expired.',
+      lease: {
+        version: 1,
+        event: 'expired',
+        actor: 'attacker@test.example' as unknown as 'server',
+        at: first.claimedUntil,
+        generation: 1,
+        claimedUntil: first.claimedUntil,
+        expiredAt: first.claimedUntil,
+      },
+    }])).toBeNull();
+
+    // 3. Malformed time
+    const malformedTimeDelivery: SendInput = {
+      from: REQUESTER,
+      to: [RECIPIENT],
+      subject: 'Lease this task',
+      text: 'Lease expired.',
+      headers: claimLeaseHeadersForTests({
+        id: ID,
+        state: 'working',
+        from: REQUESTER,
+        to: RECIPIENT,
+        event: {
+          version: 1,
+          event: 'expired',
+          actor: 'server',
+          at: 'not-a-valid-date',
+          generation: 1,
+          claimedUntil: first.claimedUntil,
+          expiredAt: 'not-a-valid-date',
+        },
+      }),
+    };
+    const expiryMalformedTime = await parseCaptured(malformedTimeDelivery, 5);
+    // Intentionally rejected at parser layer (readLeaseEventPayload requires finite date parsing)
+    expect(expiryMalformedTime).toBeNull();
+    expect(expiryMalformedTime === null || taskFromMessages(ID, [submittedRaw(), claim1, expiryMalformedTime]) === null).toBe(true);
+    // Defense-in-depth in taskFromMessages: durable reconstruction rejects malformed timestamps
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, {
+      uid: 5,
+      from: REQUESTER,
+      to: RECIPIENT,
+      subject: 'Lease this task',
+      date: first.claimedUntil,
+      state: 'working',
+      body: 'Lease expired.',
+      lease: {
+        version: 1,
+        event: 'expired',
+        actor: 'server',
+        at: 'not-a-valid-date',
+        generation: 1,
+        claimedUntil: first.claimedUntil,
+        expiredAt: 'not-a-valid-date',
+      },
+    }])).toBeNull();
+
+    // 4. expiredAt < claimedUntil
+    const earlyTime = new Date(Date.parse(first.claimedUntil) - 5_000).toISOString();
+    const earlyDelivery: SendInput = {
+      from: REQUESTER,
+      to: [RECIPIENT],
+      subject: 'Lease this task',
+      text: 'Lease expired.',
+      headers: claimLeaseHeadersForTests({
+        id: ID,
+        state: 'working',
+        from: REQUESTER,
+        to: RECIPIENT,
+        event: {
+          version: 1,
+          event: 'expired',
+          actor: 'server',
+          at: earlyTime,
+          generation: 1,
+          claimedUntil: first.claimedUntil,
+          expiredAt: earlyTime,
+        },
+      }),
+    };
+    const expiryEarly = await parseCaptured(earlyDelivery, 6);
+    // Intentionally rejected at parser layer (readLeaseEventPayload requires expiredAt >= claimedUntil)
+    expect(expiryEarly).toBeNull();
+    expect(expiryEarly === null || taskFromMessages(ID, [submittedRaw(), claim1, expiryEarly]) === null).toBe(true);
+    // Defense-in-depth in taskFromMessages: durable reconstruction rejects early expiredAt
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, {
+      uid: 6,
+      from: REQUESTER,
+      to: RECIPIENT,
+      subject: 'Lease this task',
+      date: earlyTime,
+      state: 'working',
+      body: 'Lease expired.',
+      lease: {
+        version: 1,
+        event: 'expired',
+        actor: 'server',
+        at: earlyTime,
+        generation: 1,
+        claimedUntil: first.claimedUntil,
+        expiredAt: earlyTime,
+      },
+    }])).toBeNull();
+
+    // 5. at !== expiredAt
+    const mismatchedAtDelivery: SendInput = {
+      from: REQUESTER,
+      to: [RECIPIENT],
+      subject: 'Lease this task',
+      text: 'Lease expired.',
+      headers: claimLeaseHeadersForTests({
+        id: ID,
+        state: 'working',
+        from: REQUESTER,
+        to: RECIPIENT,
+        event: {
+          version: 1,
+          event: 'expired',
+          actor: 'server',
+          at: first.claimedUntil,
+          generation: 1,
+          claimedUntil: first.claimedUntil,
+          expiredAt: new Date(Date.parse(first.claimedUntil) + 5_000).toISOString(),
+        },
+      }),
+    };
+    const expiryMismatchedAt = await parseCaptured(mismatchedAtDelivery, 7);
+    // Intentionally rejected at parser layer (readLeaseEventPayload requires at === expiredAt)
+    expect(expiryMismatchedAt).toBeNull();
+    expect(expiryMismatchedAt === null || taskFromMessages(ID, [submittedRaw(), claim1, expiryMismatchedAt]) === null).toBe(true);
+    // Defense-in-depth in taskFromMessages: durable reconstruction rejects at !== expiredAt
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, {
+      uid: 7,
+      from: REQUESTER,
+      to: RECIPIENT,
+      subject: 'Lease this task',
+      date: first.claimedUntil,
+      state: 'working',
+      body: 'Lease expired.',
+      lease: {
+        version: 1,
+        event: 'expired',
+        actor: 'server',
+        at: first.claimedUntil,
+        generation: 1,
+        claimedUntil: first.claimedUntil,
+        expiredAt: new Date(Date.parse(first.claimedUntil) + 5_000).toISOString(),
+      },
+    }])).toBeNull();
+
+    // 6. Stale expiry after later authority when previous generation was NEVER expired
+    const claim2Delivery: SendInput = {
+      from: RECIPIENT,
+      to: [REQUESTER],
+      subject: 'Lease this task',
+      text: 'Lease claimed.',
+      headers: claimLeaseHeadersForTests({
+        id: ID,
+        state: 'working',
+        from: RECIPIENT,
+        to: REQUESTER,
+        event: {
+          version: 1,
+          event: 'claim',
+          actor: RECIPIENT,
+          at: first.claimedUntil,
+          generation: 2,
+          claimedUntil: new Date(Date.parse(first.claimedUntil) + 300_000).toISOString(),
+          tokenVerifier: 'a'.repeat(32),
+        },
+      }),
+    };
+    const claim2 = (await parseCaptured(claim2Delivery, 8))!;
+    expect(claim2).not.toBeNull();
+    const staleGen1Expiry = await parseCaptured(expiryDelivery({ claimedUntil: first.claimedUntil }), 9);
+    expect(staleGen1Expiry).not.toBeNull();
+    // Durable thread: root, claim1, claim2, staleGen1Expiry
+    // Since Gen 1 was never expired, this is NOT a retry of an applied expiry!
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, claim2, staleGen1Expiry!])).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
Fixes #97

### Problem
When the server reaper or inline materializer accepted lease expiry via SMTP and queued an in-memory overlay, if that overlay was lost (e.g. process restart) before IMAP indexed the message, a subsequent attempt would regenerate an authenticated expiry event for the same lease generation and `claimedUntil`, but with a later `expiredAt` transport timestamp. In `taskFromMessages`, duplicate expiry was recognized only when `generation`, `claimedUntil`, and `expiredAt` were all identical; otherwise, because the first expiry had already cleared `leaseAuthority`, the second expiry reached authority validation and failed closed, returning `null` and corrupting task reconstruction. Similarly, in `eventIsIndexed`, the queued retry was not recognized as satisfied by the first indexed expiry because their `expiredAt` timestamps differed.

### Solution
- Defined `isSameLeaseExpiryIdentity` in `packages/api/src/lib/tasks-internal.ts` based on stable lease identity: same lease generation and exact canonical `claimedUntil`.
- In `taskFromMessages`:
  - Maintained full intrinsic validity checks on expiry events (server actor, `at === expiredAt`, valid timestamps, and `expiredAt >= claimedUntil`).
  - When an expiry for a generation has already been applied (`appliedExpiryReceipts.get(generation)`), recognized subsequent authenticated expiry events matching `isSameLeaseExpiryIdentity` as idempotent duplicate/retry noise, filtering them out of public messages and preserving the first applied receipt/timestamp.
  - Same-generation expiry events with mismatched `claimedUntil` continue to fail closed (`return null`).
  - Stale expiry events after later authorities (or when that generation was never expired) continue to fail closed.
- In `eventIsIndexed`, retired queued expiry retries when `task.expiredLease` matches the stable `isSameLeaseExpiryIdentity` (generation and `claimedUntil`), regardless of differing `expiredAt` timestamps.
- Added comprehensive deterministic regression tests in `packages/api/test/task-lease-reaper-red.test.ts` covering:
  1. Full acceptance-loss-retry path where retry B with a later timestamp reconstructs idempotently with expiry A, exposing one logical expiry receipt and suppressing duplicate audit messages.
  2. Queued indexed detection retiring retry B when durable expiry A is present, without appending duplicate messages or overwriting A's timestamp.
  3. Direct reconstruction idempotency of two valid authenticated expiry events with same generation and `claimedUntil` but different timestamps.
  4. Strict fail-closed controls: mismatched `claimedUntil`, forged actor, malformed dates, `expiredAt < claimedUntil`, `at !== expiredAt`, and unexpired stale expiry.

### Test Evidence
- `bun test test/task-lease-reaper-red.test.ts` (21/21 pass)
- `bun test test/task-lease-core.test.ts test/task-lease-admin-override.test.ts test/task-lease-gate.test.ts test/task-board.test.ts test/task-list-overlays.test.ts test/parent-child-root.test.ts` (80/80 pass)
- `bun run check:approval-publication` (passed)
- `bun test` (550/550 pass across 58 files)
- `git diff origin/main --check` (clean, 0 whitespace/newline issues)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of repeated lease-expiry events during retry processing.
  - Prevented duplicate expiry records when retries share the same lease identity but have different timestamps.
  - Preserved the original expiry timestamp during reconstruction.
  - Strengthened validation to reject inconsistent, malformed, forged, or stale expiry events.
  - Ensured recognized retry events are retired instead of being appended again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->