### PR TITLE
refactor(api): reuse parsed task messages during scans

### DIFF
--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -5,7 +5,7 @@
  */
 
 import { createHash, createHmac, randomBytes, randomUUID, timingSafeEqual } from 'node:crypto';
-import { simpleParser } from 'mailparser';
+import { simpleParser, type ParsedMail } from 'mailparser';
 import type { FetchMessageObject } from 'imapflow';
 import { config } from './config.ts';
 import { findIdentity } from './identities.ts';
@@ -917,14 +917,18 @@ function isStampedTaskMessage(
   return !!stamp && stamp === taskStamp(id, state, from, to);
 }
 
-async function parseTaskMessage(message: FetchMessageObject, id: string): Promise<RawTaskMessage | null> {
+async function parseTaskMessage(
+  message: FetchMessageObject,
+  id: string,
+  preParsed?: ParsedMail,
+): Promise<RawTaskMessage | null> {
   if (!message.source || !message.envelope) return null;
   const from = firstAddress(message.envelope.from);
   // A task response has a single peer recipient. Reject ambiguous external
   // mail rather than letting a copied header invent a participant set.
   const to = firstAddress(message.envelope.to);
   if (!from || !to) return null;
-  const parsed = await simpleParser(message.source);
+  const parsed = preParsed ?? await simpleParser(message.source);
   const headerId = parsed.headers.get('x-oa-task');
   const headerState = parsed.headers.get('x-oa-task-state');
   const stamp = parsed.headers.get('x-oa-task-stamp');
@@ -1081,10 +1085,11 @@ function isRelationshipIntegrityFailure(value: ParsedTaskMessage): value is Task
 async function relationshipIntegrityFailureFor(
   message: FetchMessageObject,
   id: string,
+  preParsed?: ParsedMail,
 ): Promise<TaskRelationshipIntegrityFailure | null> {
   if (!message.source) return null;
   try {
-    const parsed = await simpleParser(message.source);
+    const parsed = preParsed ?? await simpleParser(message.source);
     if (parsed.headers.get('x-oa-task') !== id) return null;
     const hasRootWitness = hasValidTaskRootWitness(
       message,
@@ -1099,12 +1104,16 @@ async function relationshipIntegrityFailureFor(
   }
 }
 
-async function parseTaskMessageWithIntegrity(message: FetchMessageObject, id: string): Promise<ParsedTaskMessage> {
+async function parseTaskMessageWithIntegrity(
+  message: FetchMessageObject,
+  id: string,
+  preParsed?: ParsedMail,
+): Promise<ParsedTaskMessage> {
   try {
-    const parsed = await parseTaskMessage(message, id);
-    return parsed ?? await relationshipIntegrityFailureFor(message, id);
+    const parsed = await parseTaskMessage(message, id, preParsed);
+    return parsed ?? await relationshipIntegrityFailureFor(message, id, preParsed);
   } catch (err) {
-    const failure = await relationshipIntegrityFailureFor(message, id);
+    const failure = await relationshipIntegrityFailureFor(message, id, preParsed);
     if (failure) return failure;
     throw err;
   }
@@ -1502,7 +1511,9 @@ type TaskListSnapshot = {
   hadMatchingRowsIds: Set<string>;
 };
 
-async function scanDurableTasks(): Promise<TaskListSnapshot> {
+async function scanDurableTasks(
+  parser: (source: Buffer | string) => Promise<ParsedMail> = simpleParser,
+): Promise<TaskListSnapshot> {
   return withInbox(async (client) => {
     const uids = await client.search({ header: { 'x-oa-task': true } }, { uid: true });
     if (!uids || uids.length === 0) return { tasks: [], hadMatchingRowsIds: new Set() };
@@ -1514,11 +1525,11 @@ async function scanDurableTasks(): Promise<TaskListSnapshot> {
       { uid: true },
     )) {
       if (!message.source) continue;
-      const parsed = await simpleParser(message.source);
+      const parsed = await parser(message.source);
       const id = parsed.headers.get('x-oa-task');
       if (typeof id !== 'string' || !isTaskId(id)) continue;
       hadMatchingRowsIds.add(id);
-      const taskMessage = await parseTaskMessageWithIntegrity(message, id);
+      const taskMessage = await parseTaskMessageWithIntegrity(message, id, parsed);
       if (!taskMessage) continue;
       const entries = grouped.get(id) ?? [];
       entries.push(taskMessage);
@@ -3008,7 +3019,14 @@ export async function parseTaskMessageWithIntegrityForTests(input: {
       subject: parsed.subject ?? undefined,
     },
     internalDate: new Date(input.internalDate),
-  } as FetchMessageObject, input.id);
+  } as FetchMessageObject, input.id, parsed);
+}
+
+/** @internal Test-only access to durable scan path with custom parser injection. */
+export async function scanDurableTasksForTests(
+  parser?: (source: Buffer | string) => Promise<ParsedMail>,
+): Promise<TaskListSnapshot> {
+  return scanDurableTasks(parser);
 }
 
 /** @internal Test-only reconstruction entry used by both IMAP read pipelines. */

--- a/packages/api/test/support/task-test-seams.ts
+++ b/packages/api/test/support/task-test-seams.ts
@@ -4,6 +4,7 @@ import {
   setTaskGetForTests,
   setTaskSendMailForTests,
   clearQueuedEventsForTests,
+  scanDurableTasksForTests,
 } from '../../src/lib/tasks-internal.ts';
 
 export {
@@ -12,4 +13,5 @@ export {
   setTaskGetForTests,
   setTaskSendMailForTests,
   clearQueuedEventsForTests,
+  scanDurableTasksForTests,
 };

--- a/packages/api/test/task-lease-seams.test.ts
+++ b/packages/api/test/task-lease-seams.test.ts
@@ -49,12 +49,52 @@ test('#92: production task facade and bundle exclude dependency-injection test s
   for (const seam of taskSeams) {
     expect(typeof (support as Record<string, unknown>)[seam]).toBe('function');
   }
+  expect(Object.hasOwn(tasks, 'scanDurableTasksForTests')).toBe(false);
+  expect(tasksSource).not.toContain('scanDurableTasksForTests');
+  expect(typeof (support as Record<string, unknown>).scanDurableTasksForTests).toBe('function');
 });
 
-test('#89 / #92 GREEN: canonical production bundle and final Docker stage exclude every test seam', () => {
+function assertSubprocessSuccess(
+  result: { exitCode: number | null; stdout?: Uint8Array | string | Buffer | null; stderr?: Uint8Array | string | Buffer | null },
+  cmd: string[] = ['bun', 'run', 'build'],
+): void {
+  if (result.exitCode === 0) return;
+  const stdout = typeof result.stdout === 'string'
+    ? result.stdout
+    : (result.stdout ? Buffer.from(result.stdout).toString('utf8') : '');
+  const stderr = typeof result.stderr === 'string'
+    ? result.stderr
+    : (result.stderr ? Buffer.from(result.stderr).toString('utf8') : '');
+  throw new Error(
+    `Subprocess failed: ${cmd.join(' ')}\n`
+    + `Exit code: ${result.exitCode}\n`
+    + `stdout:\n${stdout}\n`
+    + `stderr:\n${stderr}`,
+  );
+}
+
+test('#94: build diagnostic helper formats exit code, stdout, and stderr on failure', () => {
+  const fakeResult = {
+    exitCode: 42,
+    stdout: Buffer.from('build stdout details: out of memory'),
+    stderr: Buffer.from('build stderr details: syntax error on line 12'),
+  };
+  expect(() => assertSubprocessSuccess(fakeResult, ['fake', 'build', 'command'])).toThrow(
+    /Subprocess failed: fake build command[\s\S]*Exit code: 42[\s\S]*build stdout details: out of memory[\s\S]*build stderr details: syntax error on line 12/,
+  );
+
+  const fakeSuccess = {
+    exitCode: 0,
+    stdout: Buffer.from('success output'),
+    stderr: Buffer.from(''),
+  };
+  expect(() => assertSubprocessSuccess(fakeSuccess)).not.toThrow();
+});
+
+test('#89 / #92 / #94 GREEN: canonical production bundle and final Docker stage exclude every test seam', () => {
   const pkgDir = join(import.meta.dir, '..');
   const build = Bun.spawnSync(['bun', 'run', 'build'], { cwd: pkgDir });
-  expect(build.exitCode).toBe(0);
+  assertSubprocessSuccess(build, ['bun', 'run', 'build']);
   const bundle = readFileSync(join(pkgDir, 'dist', 'main.js'), 'utf8');
   for (const seam of [
     'claimLeaseHeadersForTests',
@@ -68,6 +108,7 @@ test('#89 / #92 GREEN: canonical production bundle and final Docker stage exclud
     'setTaskGetForTests',
     'setTaskSendMailForTests',
     'clearQueuedEventsForTests',
+    'scanDurableTasksForTests',
   ]) expect(bundle).not.toContain(seam);
 
   const runtimeStage = readFileSync(join(pkgDir, 'Dockerfile'), 'utf8').split('FROM oven/bun:1 AS runtime', 2)[1]!;

--- a/packages/api/test/task-scan-diagnostics.test.ts
+++ b/packages/api/test/task-scan-diagnostics.test.ts
@@ -1,0 +1,262 @@
+import { createHmac } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { simpleParser, type ParsedMail } from 'mailparser';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-task-scan-diagnostics-'));
+
+const { afterEach, beforeEach, describe, expect, mock, test } = await import('bun:test');
+
+type FakeMailMessage = {
+  uid: number;
+  envelope: {
+    from: { address: string }[];
+    to: { address: string }[];
+    subject?: string;
+    date: Date;
+  };
+  internalDate: Date;
+  source: Buffer;
+};
+
+let fakeInboxMessages: FakeMailMessage[] = [];
+
+class FakeImapFlow extends EventEmitter {
+  async connect() {}
+  async getMailboxLock() {
+    return { release() {} };
+  }
+  async search(query: { header?: Record<string, string | boolean> }) {
+    const taskHeader = query?.header?.['x-oa-task'];
+    if (typeof taskHeader === 'string') {
+      const match = taskHeader.toLowerCase();
+      return fakeInboxMessages
+        .filter((msg) => msg.source.toString('utf8').toLowerCase().includes(`x-oa-task: ${match}`))
+        .map((msg) => msg.uid);
+    }
+    return fakeInboxMessages.map((msg) => msg.uid);
+  }
+  async *fetch(uids: number[]) {
+    for (const msg of fakeInboxMessages) {
+      if (uids.includes(msg.uid)) {
+        yield msg;
+      }
+    }
+  }
+  close() {}
+}
+
+mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
+
+const { scanDurableTasksForTests, setTaskNowForTests, clearQueuedEventsForTests } = await import('./support/task-test-seams.ts');
+const { config } = await import('../src/lib/config.ts');
+
+const NOW = Date.parse('2026-08-12T12:00:00.000Z');
+
+beforeEach(() => {
+  setTaskNowForTests(() => NOW);
+  clearQueuedEventsForTests();
+  fakeInboxMessages = [];
+});
+
+afterEach(() => {
+  setTaskNowForTests(null);
+  clearQueuedEventsForTests();
+  fakeInboxMessages = [];
+});
+
+describe('#94: durable scan single-pass MIME parsing and integrity regressions', () => {
+  test('valid x-oa-task message is parsed exactly once and reconstructed normally', async () => {
+    const id = '10000000-0000-4000-8000-000000000001';
+    const from = 'fox@test.example';
+    const to = 'owl@test.example';
+    const stamp = createHmac('sha256', config.taskSigningSecret)
+      .update(`${id}\nsubmitted\n${from}\n${to}`)
+      .digest('base64url');
+
+    const source = Buffer.from([
+      `From: ${from}`,
+      `To: ${to}`,
+      'Subject: Single parse valid task',
+      `X-OA-Task: ${id}`,
+      'X-OA-Task-State: submitted',
+      `X-OA-Task-Stamp: ${stamp}`,
+      '',
+      'task payload body',
+    ].join('\r\n'));
+
+    fakeInboxMessages = [{
+      uid: 101,
+      envelope: {
+        from: [{ address: from }],
+        to: [{ address: to }],
+        subject: 'Single parse valid task',
+        date: new Date(NOW),
+      },
+      internalDate: new Date(NOW),
+      source,
+    }];
+
+    let parseCalls = 0;
+    const countingParser = async (src: Buffer | string): Promise<ParsedMail> => {
+      parseCalls += 1;
+      return simpleParser(src);
+    };
+
+    const snapshot = await scanDurableTasksForTests(countingParser);
+
+    // Proves the fetched source passed through MIME parsing exactly once
+    expect(parseCalls).toBe(1);
+    expect(snapshot.tasks).toHaveLength(1);
+    expect(snapshot.tasks[0]?.id).toBe(id);
+    expect(snapshot.tasks[0]?.state).toBe('submitted');
+    expect(snapshot.tasks[0]?.subject).toBe('Single parse valid task');
+    expect(snapshot.hadMatchingRowsIds.has(id)).toBe(true);
+  });
+
+  test('authenticated relationship-integrity failure is parsed exactly once and fails closed', async () => {
+    const id = '20000000-0000-4000-8000-000000000002';
+    const from = 'fox@test.example';
+    const to = 'owl@test.example';
+
+    const witness = createHmac('sha256', config.taskSigningSecret)
+      .update(`openagentemail-task-root-v2-witness\n${id}\nsubmitted\n${from}\n${to}`)
+      .digest('base64url');
+    // Tampered root mac triggers parseTaskMessage failure, falling back to relationshipIntegrityFailureFor
+    const poisonedStamp = `v2.${witness}.tampered-root-mac`;
+    const poisonedRootHeader = Buffer.from(
+      JSON.stringify({ version: 2, parentTaskId: '00000000-0000-4000-8000-000000000001' }),
+      'utf8',
+    ).toString('base64url');
+
+    const source = Buffer.from([
+      `From: ${from}`,
+      `To: ${to}`,
+      'Subject: Poison root task',
+      `X-OA-Task: ${id}`,
+      'X-OA-Task-State: submitted',
+      `X-OA-Task-Root: ${poisonedRootHeader}`,
+      `X-OA-Task-Stamp: ${poisonedStamp}`,
+      '',
+      'corrupted body',
+    ].join('\r\n'));
+
+    fakeInboxMessages = [{
+      uid: 102,
+      envelope: {
+        from: [{ address: from }],
+        to: [{ address: to }],
+        subject: 'Poison root task',
+        date: new Date(NOW),
+      },
+      internalDate: new Date(NOW),
+      source,
+    }];
+
+    let parseCalls = 0;
+    const countingParser = async (src: Buffer | string): Promise<ParsedMail> => {
+      parseCalls += 1;
+      return simpleParser(src);
+    };
+
+    const snapshot = await scanDurableTasksForTests(countingParser);
+
+    // Prior to #94, this would be parsed 3 times (scanDurableTasks -> parseTaskMessage -> relationshipIntegrityFailureFor).
+    // With #94, it is parsed exactly once.
+    expect(parseCalls).toBe(1);
+    // Authenticated relationship integrity failure poisons task reconstruction (fails closed)
+    expect(snapshot.tasks).toHaveLength(0);
+    // But hadMatchingRowsIds records that a matching row existed
+    expect(snapshot.hadMatchingRowsIds.has(id)).toBe(true);
+  });
+
+  test('multiple messages across distinct tasks are each parsed exactly once', async () => {
+    const id1 = '30000000-0000-4000-8000-000000000001';
+    const id2 = '30000000-0000-4000-8000-000000000002';
+    const from = 'fox@test.example';
+    const to = 'owl@test.example';
+
+    const stamp1 = createHmac('sha256', config.taskSigningSecret)
+      .update(`${id1}\nsubmitted\n${from}\n${to}`)
+      .digest('base64url');
+    const stamp2 = createHmac('sha256', config.taskSigningSecret)
+      .update(`${id2}\nsubmitted\n${from}\n${to}`)
+      .digest('base64url');
+
+    const source1 = Buffer.from([
+      `From: ${from}`,
+      `To: ${to}`,
+      'Subject: Task 1',
+      `X-OA-Task: ${id1}`,
+      'X-OA-Task-State: submitted',
+      `X-OA-Task-Stamp: ${stamp1}`,
+      '',
+      'task 1 body',
+    ].join('\r\n'));
+
+    const source2 = Buffer.from([
+      `From: ${from}`,
+      `To: ${to}`,
+      'Subject: Task 2',
+      `X-OA-Task: ${id2}`,
+      'X-OA-Task-State: submitted',
+      `X-OA-Task-Stamp: ${stamp2}`,
+      '',
+      'task 2 body',
+    ].join('\r\n'));
+
+    // Non-task message in the same fetch result
+    const sourceNoise = Buffer.from([
+      `From: ${from}`,
+      `To: ${to}`,
+      'Subject: Random email',
+      '',
+      'not a task email',
+    ].join('\r\n'));
+
+    fakeInboxMessages = [
+      {
+        uid: 201,
+        envelope: { from: [{ address: from }], to: [{ address: to }], subject: 'Task 1', date: new Date(NOW) },
+        internalDate: new Date(NOW),
+        source: source1,
+      },
+      {
+        uid: 202,
+        envelope: { from: [{ address: from }], to: [{ address: to }], subject: 'Task 2', date: new Date(NOW + 1000) },
+        internalDate: new Date(NOW + 1000),
+        source: source2,
+      },
+      {
+        uid: 203,
+        envelope: { from: [{ address: from }], to: [{ address: to }], subject: 'Random email', date: new Date(NOW + 2000) },
+        internalDate: new Date(NOW + 2000),
+        source: sourceNoise,
+      },
+    ];
+
+    let parseCalls = 0;
+    const countingParser = async (src: Buffer | string): Promise<ParsedMail> => {
+      parseCalls += 1;
+      return simpleParser(src);
+    };
+
+    const snapshot = await scanDurableTasksForTests(countingParser);
+
+    // Exactly 3 messages fetched -> exactly 3 parses
+    expect(parseCalls).toBe(3);
+    // Task 1 and Task 2 reconstructed; noise message ignored
+    expect(snapshot.tasks).toHaveLength(2);
+    expect(snapshot.hadMatchingRowsIds.has(id1)).toBe(true);
+    expect(snapshot.hadMatchingRowsIds.has(id2)).toBe(true);
+    expect(snapshot.hadMatchingRowsIds.size).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
Completes the two maintenance items in #94:

1. **Scan single-pass MIME parsing**:
   - Updated `parseTaskMessage`, `relationshipIntegrityFailureFor`, and `parseTaskMessageWithIntegrity` in `packages/api/src/lib/tasks-internal.ts` to accept an optional `preParsed?: ParsedMail` instance.
   - In `scanDurableTasks`, parse fetched `message.source` once and forward the resulting parsed MIME object for downstream header, stamp, and relationship-integrity validation, eliminating duplicate/triplicate parses during scans.
   - Preserved non-scan caller behavior (callers without preParsed parse internally).
   - Added `scanDurableTasksForTests` to `packages/api/test/support/task-test-seams.ts` with narrow parser injection.
   - Added `packages/api/test/task-scan-diagnostics.test.ts` verifying single-pass parsing across valid tasks, authenticated relationship-integrity failures (fail-closed), and multi-task scans.

2. **Subprocess build diagnostics**:
   - In `packages/api/test/task-lease-seams.test.ts`, introduced `assertSubprocessSuccess` to format command, exit code, decoded stdout, and decoded stderr upon subprocess failure.
   - Added a unit regression test validating the error message output on failure.
   - Verified that `scanDurableTasksForTests` is absent from `tasks.ts` public exports and excluded from canonical `dist/main.js`.

Closes #94

## Validation
- Focused scan regression (`bun test test/task-scan-diagnostics.test.ts`): 3 pass, 0 fail (14 expect calls).
- Structural seam test (`bun test test/task-lease-seams.test.ts`): 4 pass, 0 fail (59 expect calls).
- Task-board, task-list, parent-child/integrity tests (`task-board`, `task-list-overlays`, `parent-child-root`, `r3-parent-child-routes`): 72 pass, 0 fail (545 expect calls).
- `bun run build`: Built cleanly (578 modules).
- Full suite (`bun test`): 1107 pass, 1 skip, 0 fail (7315 expect calls).
- `bun run typecheck`: 124 verified pre-existing errors in 13 files, matching clean `origin/main` baseline (0 new errors).
- `git diff origin/main --check`: 0 issues.