### PR TITLE
fix(test): derive admin credentials from active config

### DIFF
--- a/packages/api/test/notify.test.ts
+++ b/packages/api/test/notify.test.ts
@@ -448,8 +448,9 @@ describe('phone device ACL', () => {
       const health = await app.request('/healthz');
       expect(health.status).toBe(200);
       expect(await health.json()).toEqual({ ok: true });
+      const adminKey = [...config.apiKeys][0]!;
       const devices = await app.request('/v1/notify/devices', {
-        headers: { authorization: 'Bearer admin-key' },
+        headers: { authorization: `Bearer ${adminKey}` },
       });
       expect(devices.status).toBe(500);
       expect(await devices.json()).toEqual({ error: 'device_registry_corrupt' });

--- a/packages/api/test/request-size.test.ts
+++ b/packages/api/test/request-size.test.ts
@@ -15,12 +15,14 @@ process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-request-size-'));
 process.env.RETENTION_DAYS = '0';
 
 const server = (await import('../src/main.ts')).default;
+const { config } = await import('../src/lib/config.ts');
+const adminKey = [...config.apiKeys][0]!;
 
 function sendRequest(text: string) {
   return server.fetch(
     new Request('http://localhost/v1/send', {
       method: 'POST',
-      headers: { authorization: 'Bearer admin-key', 'content-type': 'application/json' },
+      headers: { authorization: `Bearer ${adminKey}`, 'content-type': 'application/json' },
       body: JSON.stringify({
         from: 'sender@test.example',
         to: 'recipient@example.net',

--- a/packages/api/test/ui-session.test.ts
+++ b/packages/api/test/ui-session.test.ts
@@ -502,19 +502,23 @@ describe('UI session persistence', () => {
   });
 
   test('生产 resolveUiSessionTokenByHash：identity 命中；OAuth access hash 永不命中', async () => {
+    const { config } = await import('../src/lib/config.ts');
     const { createIdentity } = await import('../src/lib/identities.ts');
     const { resolveUiSessionToken, resolveUiSessionTokenByHash } = await import(
       '../src/lib/auth.ts'
     );
     const { putAccessTokenForTests } = await import('../src/lib/oauth-store.ts');
 
+    // config is a process singleton and may have been frozen by an earlier test file;
+    // select an active configured admin key from the live singleton.
+    const configuredAdminKey = [...config.apiKeys][0]!;
     const issued = createIdentity({ localpart: 'ui-sess-hash' })!;
     const idHash = sha256Hex(issued.token);
     expect(resolveUiSessionTokenByHash(idHash)).toEqual({
       kind: 'identity',
       address: 'ui-sess-hash@test.example',
     });
-    expect(resolveUiSessionTokenByHash(sha256Hex('admin-key'))).toEqual({ kind: 'admin' });
+    expect(resolveUiSessionTokenByHash(sha256Hex(configuredAdminKey))).toEqual({ kind: 'admin' });
 
     const oauthTok = 'ui-sess-byhash-must-reject-oauth!!!!';
     putAccessTokenForTests({


### PR DESCRIPTION
## Summary
Resolves cross-test environment contamination in `packages/api` where individual test files set `process.env.API_KEYS` but executed against a process-wide `config` singleton already frozen by whichever file imported it first.

## Changes
1. **`test/ui-session.test.ts`**:
   - Replaced literal `'admin-key'` in `resolveUiSessionTokenByHash(sha256Hex(...))` with an active configured admin key derived dynamically from `config.apiKeys` (`[...config.apiKeys][0]!`).
   - Retained identity token hash and OAuth rejection assertions intact.
2. **`test/notify.test.ts`**:
   - Updated the corrupt-registry boot test to send the active admin key from `config.apiKeys` in the `Authorization: Bearer <key>` header instead of literal `'admin-key'`.
   - Preserved all fail-closed (500 / `device_registry_corrupt`) assertions, the `expect(await health.json()).toEqual({ ok: true })` check, and log redaction validations.
3. **`test/request-size.test.ts`**:
   - Strengthened `sendRequest` helper to authenticate using the active admin key from `config.apiKeys` so that normal-size payload test requests genuinely exercise the route handler rather than passing on an unrelated pre-body 401.

## Audit Findings
Audited all occurrences of literal keys and authorization tokens in `packages/api/test`:
- `test/ui-authz.test.ts`: Line 210 sends `Bearer admin-key` against `/ui/api/overview`. This is intentionally testing that UI session endpoints reject all Bearer tokens with 401 `invalid_token` regardless of whether the token is valid; no singleton key lookup occurs.
- `test/send-history.test.ts`: Line 231 passes literal `'admin-key'` to `OpenAgentEmailClient`, but the test harness uses a custom `bearerApp` middleware that directly sets `c.set('auth', { kind: 'admin' })` without checking `config.apiKeys`.
- `test/config.test.ts`, `test/p4-code-edge.test.ts`, `test/task-lease-core.test.ts`: Pass literal keys to isolated `parseConfig({...})` unit tests, not the singleton.
- `test/task-lease-reaper-red.test.ts`: Spawns an isolated subprocess with its own `env` block, initializing its own singleton cleanly.
- `test/ui-foundation.test.ts`, `test/audit-tiering.test.ts`, `test/mcp-http.test.ts`, `test/oauth-as.test.ts`: Already derive admin keys dynamically via `[...config.apiKeys][0]!`.

## Validation Matrix
- **Isolated Target Files**:
  - `test/ui-session.test.ts` alone: 22 pass, 0 fail
  - `test/notify.test.ts` alone: 51 pass, 0 fail
  - `test/request-size.test.ts` alone: 2 pass, 0 fail
  - Target pair (`ui-session.test.ts` + `notify.test.ts`): 73 pass, 0 fail
- **Contaminant Pair Matrix** (exercising both targets after each distinct `API_KEYS` declaration):
  - `identities.test.ts` (`admin-key-1,admin-key-2`): 101 pass, 0 fail
  - `ui-foundation.test.ts` (`ui-admin-key`): 75 pass, 0 fail
  - `audit-tiering.test.ts` (`admin-audit-key`): 90 pass, 0 fail
  - `oauth-as.test.ts` (`admin-oauth-key`): 86 pass, 0 fail
  - `approval-canonical-vectors.test.ts` (`test-key`): 75 pass, 0 fail
  - `imap-match.test.ts` (`admin-key-1`): 112 pass, 0 fail
- **Contaminant Permutations** (7-file suite):
  - Forward order: 173 pass, 0 fail (9.49s)
  - Reverse order: 173 pass, 0 fail (8.16s)
  - 5 Shuffled permutations: all 5 runs passed 173/173 (0 fail, ~8-10s per run)
- **Full Suite**:
  - `bun test`: 1111 pass, 1 skip, 0 fail (7321 expect calls across 72 files)
- **Build**:
  - `bun run build`: Clean (578 modules bundled)
- **Diff Check**:
  - `git diff origin/main --check`: Clean (0 whitespace errors)

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated API tests to use the active configured admin key instead of a hard-coded value.
  * Improved test reliability across startup, request-size, and UI-session scenarios when API key configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->