### PR TITLE
feat(auth): enforce read-only identity token scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ Create an identity and hand your agent its scoped token (shown once):
 ```bash
 curl -X POST http://localhost:3100/v1/identities \
   -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" \
-  -d '{"name":"signup-bot"}'
-# → 201 {"address":"fox-k7d2@example.com","name":"signup-bot","token":"oa_…"}
+  -d '{"name":"signup-bot","scopes":["read:messages"]}'
+# → 201 {"address":"fox-k7d2@example.com","name":"signup-bot","token":"oa_…","scopes":["read:messages"]}
 ```
 
 The API binds to `127.0.0.1` by default — reach it from other hosts over an
@@ -402,7 +402,7 @@ Or the raw JSON config (Claude Desktop, Cursor, Kimi Code):
 
 | Tool | Description |
 | --- | --- |
-| `mail_new_identity(name?, localpart?)` | Create an identity; pass `localpart` for a custom address (e.g. `qa-bot`), or omit for a random one like `fox-k7d2` |
+| `mail_new_identity(name?, localpart?, scopes?)` | Admin only: create an identity and one-time token; pass `scopes: ["read:messages"]` for read-only own-mailbox access, `scopes: []` for no API operation permissions, or omit for legacy full identity permissions |
 | `mail_list_identities()` | List all identities |
 | `mail_list_messages(address, limit?)` | List messages for an address (id/from/to/subject/date/seen/snippet) |
 | `mail_read_message(address, id)` | Full message: text, html?, and `otp:{codes:[],links:[]}` |

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -49,10 +49,21 @@ All `/v1/*` require `Authorization: Bearer <key>`.
 Task REST creation accepts optional `parentTaskId` for ordinary and approval roots; the authenticated caller remains the sender. The pointer is immutable after creation: it is authenticated inside the signed creation root and survives IMAP reconstruction. `GET /v1/tasks/:id/children?limit=20|50|100&cursor=` lists only direct readable children after ACL filtering, with a parent/viewer/limit-bound opaque cursor and no hidden or global totals or descendants. Parent and child state remain independent. This backend/API change adds no automatic completion or failure propagation, scheduling, agent selection, result sharing, or descendant automation; dashboard ancestry and rollup are deliberately not included (the UI remains frozen).
 - OAuth 存储：`DATA_DIR/oauth.json`（只存哈希；与 identities.json 同模式）
 - `GET /v1/audit/events?limit=&event=` → `{events:[…]}`（**admin only**；scrubbed JSONL `DATA_DIR/audit.jsonl`；见 docs/security.md）
-- `POST /v1/identities` `{name?, localpart?}` → `201 {address, name?, pushContentTier, token}` (409 if taken)
-- `GET /v1/identities` → `{identities:[{address,name?,createdAt,pushContentTier,...}]}`
+- `POST /v1/identities` `{name?, localpart?, canNotifyUser?, scopes?: string[]}` → `201 {address, name?, pushContentTier, token, scopes?}` (admin only; 409 if taken). Optional `scopes` restricts the token (e.g. `['read:messages']`); absent means legacy full power. Unknown or misspelled fields are rejected rather than silently minting a full token.
+- `GET /v1/identities` → `{identities:[{address,name?,createdAt,pushContentTier,scopes?...}]}` (admin only; includes `scopes` when present, including `[]`)
+- `POST /v1/identities/:address/token` optional `{scopes?: string[]}` → `{address, token, scopes?}` (admin only). A truly empty body mints an unscoped/full token; any non-empty body must be a strict JSON object with `scopes` (e.g. `scopes: []` mints a token with no permissions; unknown or misspelled fields are rejected with 400).
 - `GET /v1/identities/:address/push-tier` → `{address, pushContentTier, warning?}` (admin any; identity own only)
 - `PUT /v1/identities/:address/push-tier` `{pushContentTier:1|2|3, confirm_risk?}` → admin only; tier 3 requires `confirm_risk: true`
+- **Identity Token Scopes**:
+  - Subtractive permission model: `scopes === undefined` retains legacy full-power identity access. Supplying `scopes` restricts privileges to only the explicitly granted capabilities (default deny for all other routes).
+  - Supported scopes:
+    - `read:messages`: Grants read-only access to messages for the token's own identity:
+      - REST: `GET /v1/messages`, `GET /v1/messages/:id`, `POST /v1/messages/wait` (long-poll read).
+      - MCP: `mail_list_messages`, `mail_read_message`, `mail_wait_for`.
+      - Denied: All mutations (`POST /v1/send`, `POST /v1/messages/:id/seen`, tasks, identities, notifications) and unrelated reads (`GET /v1/identities`, `GET /v1/send/history`, etc.) return 403 `forbidden: insufficient_scope`.
+    - `[]` (empty scopes): No `/v1` operation permissions; MCP protocol discovery may authenticate, but every MCP tool execution fails at its `/v1` operation.
+  - Scoped identity tokens are rejected from UI session creation and cannot access the web dashboard.
+  - Per-mailbox cross-identity delegation is not included in this batch and is tracked by #125.
 - `GET /v1/messages?address=&limit=50` → `{messages:[{id,from,to,subject,date,seen,snippet}]}`. Only the **newest 500 messages in the shared catch-all** are scanned for a match, so on a very busy instance an identity's older mail can fall outside that window and stop being listed even though retention has not deleted it yet
 - `GET /v1/messages/:id?address=` → `{id,from,to,subject,date,text,html?,otp:{codes,links}}`
 - `POST /v1/messages/:id/seen` `{address, seen}` → `{id, seen}` (404 unless the message is TO `address` **or** a server-trusted Sent item (From match **and** Message-ID in the outbound registry) — #26 PR 2 / 返工第2轮；reading never sets `\Seen` by itself — agents mark messages processed through here)

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -9,6 +9,7 @@ import {
 } from './lib/auth.ts';
 import { config } from './lib/config.ts';
 import { JSON_BODY_LIMIT_BYTES } from './lib/limits.ts';
+import { scopePolicyMiddleware } from './lib/scope-policy.ts';
 import {
   UiSessionStore,
   createUiSessionRoutes,
@@ -101,6 +102,7 @@ export function createApp(options: AppOptions = {}): Hono {
     }),
   );
   app.use('/v1/*', bearerAuth);
+  app.use('/v1/*', scopePolicyMiddleware);
   app.route('/v1/identities', identitiesRoute);
   app.route('/v1/messages', messagesRoute);
   app.route('/v1/send', sendRoute);

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -34,7 +34,7 @@ function hashEquals(a: string, b: string): boolean {
 
 export type Auth =
   | { kind: 'admin' }
-  | { kind: 'identity'; address: string };
+  | { kind: 'identity'; address: string; scopes?: readonly string[] };
 
 /**
  * /mcp 审计与限量用的窄路身份（与 Auth 解耦：/v1 仍只读 auth，行为不变）。
@@ -89,7 +89,11 @@ export function resolveAccessToken(
   if (identity) {
     return {
       status: 'ok',
-      auth: { kind: 'identity', address: identity.address },
+      auth: {
+        kind: 'identity',
+        address: identity.address,
+        ...(identity.scopes !== undefined ? { scopes: identity.scopes } : {}),
+      },
       attribution: { kind: 'identity', address: identity.address },
     };
   }
@@ -155,26 +159,28 @@ export function resolveToken(
 }
 
 /**
- * Dashboard UI 会话交换专用：只认 admin API_KEYS 与 oa_ identity 票。
- * **永不**查 OAuth access 表——即使 MCP_PUBLIC_URL 已配置、aud 可解析，
- * OAuth 票也不能换浏览器会话（防注入邮件诱导的持久化 UI 入口）。
+ * Dashboard UI session exchange: recognizes only admin API_KEYS and unscoped oa_ identity tokens.
+ * Scoped tokens are rejected from UI session creation to prevent creating unrestricted UI sessions.
+ * Never checks the OAuth access table.
  */
 export function resolveUiSessionToken(token: string): Auth | null {
   if (config.apiKeys.has(token)) return { kind: 'admin' };
   const identity = findIdentityByToken(token);
-  return identity ? { kind: 'identity', address: identity.address } : null;
+  if (!identity || identity.scopes !== undefined) return null;
+  return { kind: 'identity', address: identity.address };
 }
 
 /**
- * UI session 持久化路径：仅凭 tokenHash 反解 principal（与 resolveUiSessionToken 同范围）。
- * 重启后内存里不再有明文 token，authenticate 走此入口。
+ * UI session persistence path: resolves principal by tokenHash only.
+ * Scoped identity tokens are rejected from UI session hash resolution.
  */
 export function resolveUiSessionTokenByHash(tokenHash: string): Auth | null {
   for (const key of config.apiKeys) {
     if (hashEquals(sha256Hex(key), tokenHash)) return { kind: 'admin' };
   }
   const identity = findIdentityByTokenHash(tokenHash);
-  return identity ? { kind: 'identity', address: identity.address } : null;
+  if (!identity || identity.scopes !== undefined) return null;
+  return { kind: 'identity', address: identity.address };
 }
 
 export const bearerAuth = createMiddleware(async (c, next) => {

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -35,6 +35,50 @@ export const DEFAULT_PUSH_CONTENT_TIER: PushContentTier = 1;
 export const PUSH_TIER3_WARNING =
   'Tier 3 includes message body previews and OTP codes/links in push notifications. That content leaves this server for the ntfy channel.';
 
+/** First-class supported identity token scopes. */
+export const SUPPORTED_SCOPES = ['read:messages'] as const;
+export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
+export const SUPPORTED_SCOPES_SET = new Set<string>(SUPPORTED_SCOPES);
+
+export function isSupportedScope(scope: string): scope is SupportedScope {
+  return SUPPORTED_SCOPES_SET.has(scope);
+}
+
+export const MAX_SCOPES_COUNT = 10;
+export const MAX_SCOPE_LENGTH = 64;
+
+export type ScopeValidationResult =
+  | { ok: true; scopes: string[] }
+  | { ok: false; error: string; details?: unknown };
+
+/**
+ * Validate scopes input on identity creation and token rotation.
+ * Enforces string array type, bounded count and item lengths, duplicate rejection,
+ * and known supported scope check.
+ */
+export function validateScopesInput(scopes: unknown): ScopeValidationResult {
+  if (!Array.isArray(scopes)) {
+    return { ok: false, error: 'invalid_request', details: 'scopes must be an array of strings' };
+  }
+  if (scopes.length > MAX_SCOPES_COUNT) {
+    return { ok: false, error: 'invalid_request', details: 'too_many_scopes' };
+  }
+  const seen = new Set<string>();
+  for (const item of scopes) {
+    if (typeof item !== 'string' || item.length === 0 || item.length > MAX_SCOPE_LENGTH) {
+      return { ok: false, error: 'invalid_request', details: 'invalid_scope_format' };
+    }
+    if (seen.has(item)) {
+      return { ok: false, error: 'invalid_request', details: 'duplicate_scope' };
+    }
+    seen.add(item);
+    if (!isSupportedScope(item)) {
+      return { ok: false, error: 'unsupported_scope', details: `Unsupported scope: ${item}` };
+    }
+  }
+  return { ok: true, scopes: [...scopes] };
+}
+
 export interface Identity {
   address: string;
   name?: string;
@@ -48,6 +92,12 @@ export interface Identity {
   pushContentTier?: PushContentTier;
   /** SHA-256 hex of the identity's API token. Absent on pre-token stores. */
   tokenHash?: string;
+  /**
+   * Optional token scopes.
+   * When undefined/absent, the token has legacy unscoped/full identity permissions.
+   * When present (including empty array []), privileges are subtractively restricted.
+   */
+  scopes?: string[];
 }
 
 export function resolvePushContentTier(identity: Pick<Identity, 'pushContentTier'>): PushContentTier {
@@ -85,7 +135,9 @@ function isIdentityShape(value: unknown): value is Record<string, unknown> {
     typeof identity.createdAt === 'string' &&
     (identity.name === undefined || typeof identity.name === 'string') &&
     (identity.canNotifyUser === undefined || typeof identity.canNotifyUser === 'boolean') &&
-    (identity.tokenHash === undefined || typeof identity.tokenHash === 'string')
+    (identity.tokenHash === undefined || typeof identity.tokenHash === 'string') &&
+    (identity.scopes === undefined ||
+      (Array.isArray(identity.scopes) && identity.scopes.every((s) => typeof s === 'string')))
   );
 }
 
@@ -316,6 +368,8 @@ export function createIdentity(input: {
    * 此时返回的 token 为空串。
    */
   issueToken?: boolean;
+  /** Optional token scopes; undefined means full-power identity token. */
+  scopes?: string[];
 }): { identity: Identity; token: string } | null {
   const identities = load();
   let localpart = input.localpart?.toLowerCase();
@@ -352,6 +406,7 @@ export function createIdentity(input: {
     ...(input.canNotifyUser ? { canNotifyUser: true } : {}),
     createdAt: new Date().toISOString(),
     ...(tokenHash ? { tokenHash } : {}),
+    ...(input.scopes !== undefined ? { scopes: [...input.scopes] } : {}),
   };
   identities.push(identity);
   save(identities);
@@ -360,15 +415,22 @@ export function createIdentity(input: {
 
 /**
  * Replace an identity's token (the old one stops working immediately).
+ * If `scopes` is provided (including empty array), the rotated token is scoped.
+ * If `scopes` is omitted/undefined, existing scope restrictions are preserved.
+ * Pass null only for an explicit reset to a legacy unscoped/full token.
  * Returns the new plaintext token, or null if the address doesn't exist.
  */
-export function rotateIdentityToken(address: string): string | null {
+export function rotateIdentityToken(address: string, scopes?: string[] | null): string | null {
   const identities = load();
   const needle = address.toLowerCase();
   const identity = identities.find((i) => i.address === needle);
   if (!identity) return null;
   const { token, tokenHash } = generateToken();
   identity.tokenHash = tokenHash;
+  if (scopes !== undefined) {
+    if (scopes === null) delete identity.scopes;
+    else identity.scopes = [...scopes];
+  }
   save(identities);
   return token;
 }

--- a/packages/api/src/lib/scope-policy.ts
+++ b/packages/api/src/lib/scope-policy.ts
@@ -1,0 +1,71 @@
+import { createMiddleware } from 'hono/factory';
+import { isSupportedScope, type SupportedScope } from './identities.ts';
+
+export interface OperationPolicy {
+  readonly id: string;
+  readonly requiredScope: SupportedScope;
+  matches(method: string, path: string): boolean;
+}
+
+/**
+ * Centralized operation policy table for scoped identity tokens.
+ *
+ * Scoped tokens are subtractive and default-deny: only operations explicitly
+ * listed here can be granted by their required scope. All other endpoints and
+ * unlisted methods are denied 403 for any scoped token.
+ */
+export const OPERATION_POLICIES: readonly OperationPolicy[] = [
+  {
+    id: 'messages:list',
+    requiredScope: 'read:messages',
+    matches: (method, path) => method === 'GET' && path === '/v1/messages',
+  },
+  {
+    id: 'messages:wait',
+    requiredScope: 'read:messages',
+    matches: (method, path) => method === 'POST' && path === '/v1/messages/wait',
+  },
+  {
+    id: 'messages:get',
+    requiredScope: 'read:messages',
+    matches: (method, path) => method === 'GET' && /^\/v1\/messages\/[^/]+$/.test(path),
+  },
+];
+
+/**
+ * Centralized scope policy enforcement middleware for all /v1/* REST routes.
+ *
+ * Evaluates after bearer authentication:
+ * - Admin keys, OAuth tokens, and legacy unscoped identity tokens (scopes === undefined) pass through.
+ * - Scoped identity tokens are subject to default-deny scope evaluation.
+ * - If stored scope metadata contains any unknown/unsupported scope, fails closed (403) on all routes.
+ * - If the operation is not granted by the token's scopes, rejects with 403 forbidden: insufficient_scope.
+ */
+export const scopePolicyMiddleware = createMiddleware(async (c, next) => {
+  const auth = c.get('auth');
+  if (!auth || auth.kind !== 'identity' || auth.scopes === undefined) {
+    await next();
+    return;
+  }
+
+  // Fail closed if any stored scope is unknown or unsupported
+  const hasUnsupportedScope = auth.scopes.some((scope) => !isSupportedScope(scope));
+  if (hasUnsupportedScope) {
+    return c.json({ error: 'forbidden: insufficient_scope' }, 403);
+  }
+
+  const method = c.req.method.toUpperCase();
+  const path = c.req.path.replace(/\/+$/, '') || '/';
+
+  const matchedPolicy = OPERATION_POLICIES.find((policy) => policy.matches(method, path));
+  if (!matchedPolicy) {
+    // Default-deny: endpoint has no scope granting it
+    return c.json({ error: 'forbidden: insufficient_scope' }, 403);
+  }
+
+  if (!auth.scopes.includes(matchedPolicy.requiredScope)) {
+    return c.json({ error: 'forbidden: insufficient_scope' }, 403);
+  }
+
+  await next();
+});

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -2,8 +2,9 @@
  * openagent.email REST 最小客户端（stdio MCP 与 HTTP /mcp 共用）。
  *
  * API 契约：
- *   POST /v1/identities            {name?, localpart?, canNotifyUser?} -> 201 {address, name?, token}
- *   GET  /v1/identities            -> {identities:[{address,name?,createdAt}]}
+ *   POST /v1/identities            {name?, localpart?, canNotifyUser?, scopes?} -> 201 {address, name?, token, scopes?}
+ *   GET  /v1/identities            -> {identities:[{address,name?,createdAt,scopes?}]}
+ *   POST /v1/identities/:address/token {scopes?} -> 200 {address, token, scopes?}
  *   GET  /v1/messages?address&limit -> {messages:[{id,from,to,subject,date,seen,snippet}]}
  *   GET  /v1/messages/:id?address  -> {id,from,to,subject,date,text,html?,otp:{codes:[],links:[]}}
  *   POST /v1/messages/:id/seen     {address, seen} -> 200 {id, seen}
@@ -49,6 +50,7 @@ export interface Identity {
   /** REST publicIdentity 始终带 1|2|3 */
   pushContentTier?: 1 | 2 | 3;
   pushContentTierWarning?: string;
+  scopes?: string[];
 }
 
 export interface MessageSummary {
@@ -274,7 +276,7 @@ export class OpenAgentEmailClient {
       if (res.status === 403) {
         throw new ApiError(
           403,
-          `Forbidden (403): ${serverMsg}. The 'from' address must be an existing identity — create one with mail_new_identity first.`,
+          `Forbidden (403): ${serverMsg}.`,
         );
       }
       if (res.status === 404) {
@@ -295,19 +297,42 @@ export class OpenAgentEmailClient {
     return data as T;
   }
 
-  createIdentity(opts: { name?: string; localpart?: string; canNotifyUser?: boolean }): Promise<{
+  createIdentity(opts: {
+    name?: string;
+    localpart?: string;
+    canNotifyUser?: boolean;
+    scopes?: string[];
+  }): Promise<{
     address: string;
     name?: string;
     canNotifyUser?: boolean;
     pushContentTier?: 1 | 2 | 3;
     /** 仅创建/轮换响应出现一次 */
     token?: string;
+    scopes?: string[];
   }> {
-    const body: Record<string, string | boolean> = {};
+    const body: Record<string, unknown> = {};
     if (opts.name) body.name = opts.name;
     if (opts.localpart) body.localpart = opts.localpart;
     if (opts.canNotifyUser) body.canNotifyUser = true;
+    if (opts.scopes !== undefined) body.scopes = opts.scopes;
     return this.request("POST", "/v1/identities", body);
+  }
+
+  rotateIdentityToken(
+    address: string,
+    opts?: { scopes?: string[] },
+  ): Promise<{
+    address: string;
+    token: string;
+    scopes?: string[];
+  }> {
+    const body = opts?.scopes !== undefined ? { scopes: opts.scopes } : undefined;
+    return this.request(
+      "POST",
+      `/v1/identities/${encodeURIComponent(address)}/token`,
+      body,
+    );
   }
 
   async listIdentities(): Promise<Identity[]> {

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -14,6 +14,7 @@ import {
   TOOL_TIER_SPEC,
   type ToolTier,
 } from "../lib/tool-tiers.ts";
+import { MAX_SCOPES_COUNT, SUPPORTED_SCOPES } from "../lib/identities.ts";
 import { isTaskId } from "../lib/task-id.ts";
 import { ApiError, OpenAgentEmailClient } from "./client.ts";
 import { prepareMailToolMessage } from "./fence.ts";
@@ -75,6 +76,7 @@ export function registerOpenAgentEmailTools(
     pushContentTier: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
     pushContentTierWarning: z.string().optional(),
     token: z.string().optional(),
+    scopes: z.array(z.string()).optional(),
   };
 
   // list / read 真交集。from/to 是服务端可信数据的契约声明（非输入消毒）：
@@ -262,7 +264,7 @@ export function registerOpenAgentEmailTools(
     {
       title: "Create Email Identity",
       description:
-        "Create a new email identity (mailbox address) on this openagent.email server. Pass 'localpart' for a custom address (e.g. 'qa-bot' gives qa-bot@domain), or omit it for a random one. Returns the full address; the address also gets a scoped API token.",
+        "Admin only: create a new email identity (mailbox address) on this openagent.email server. Pass 'localpart' for a custom address (e.g. 'qa-bot' gives qa-bot@domain), or omit it for a random one. Returns the full address and a one-time API token; omit scopes for legacy full identity permissions.",
       inputSchema: {
         // 约束与 REST API 的 zod 对齐：本地就能拒掉的输入不必往服务端跑一趟。
         name: z
@@ -285,11 +287,18 @@ export function registerOpenAgentEmailTools(
           .boolean()
           .optional()
           .describe("Admin only: allow this identity to send human-alert notifications"),
+        scopes: z
+          .array(z.enum(SUPPORTED_SCOPES))
+          .max(MAX_SCOPES_COUNT)
+          .refine((items) => new Set(items).size === items.length, "duplicate scopes are not allowed")
+          .optional()
+          .describe("Optional token scopes. Supported: read:messages. Use [] for no API operation permissions; omit for legacy full identity permissions."),
       },
       outputSchema: identitySchema,
       annotations: mutatingAnnotations,
     },
-    ({ name, localpart, canNotifyUser }) => callApi(() => client.createIdentity({ name, localpart, canNotifyUser })),
+    ({ name, localpart, canNotifyUser, scopes }) =>
+      callApi(() => client.createIdentity({ name, localpart, canNotifyUser, scopes })),
   );
 
   tier("mail_list_identities", "read");

--- a/packages/api/src/routes/identities.ts
+++ b/packages/api/src/routes/identities.ts
@@ -9,6 +9,7 @@ import {
   rotateIdentityToken,
   resolvePushContentTier,
   setIdentityPushContentTier,
+  validateScopesInput,
   LOCALPART_RE,
   PUSH_TIER3_WARNING,
   type Identity,
@@ -23,13 +24,20 @@ const createSchema = z.object({
   // This is intentionally opt-in and admin-only: it authorizes an identity
   // to interrupt the human notification channel.
   canNotifyUser: z.boolean().optional(),
-});
+  scopes: z.unknown().optional(),
+}).strict();
 
 const pushTierSchema = z
   .object({
     pushContentTier: z.union([z.literal(1), z.literal(2), z.literal(3)]),
     // Tier 3 ships body/OTP off-box via ntfy; require an explicit ack.
     confirm_risk: z.boolean().optional(),
+  })
+  .strict();
+
+const rotateTokenSchema = z
+  .object({
+    scopes: z.unknown(),
   })
   .strict();
 
@@ -59,6 +67,7 @@ function publicIdentity(identity: Identity) {
     ...(identity.canNotifyUser ? { canNotifyUser: true } : {}),
     pushContentTier: tier,
     ...(tier === 3 ? { pushContentTierWarning: PUSH_TIER3_WARNING } : {}),
+    ...(identity.scopes !== undefined ? { scopes: identity.scopes } : {}),
   };
 }
 
@@ -66,18 +75,34 @@ export const identitiesRoute = new Hono()
   .post('/', async (c) => {
     const denied = requireAdmin(c);
     if (denied) return denied;
-    let body: unknown;
-    try {
-      body = await c.req.json();
-    } catch {
-      body = {};
+    let body: unknown = {};
+    const text = await c.req.text();
+    if (text.trim().length > 0) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        return c.json({ error: 'invalid_json' }, 400);
+      }
     }
     const parsed = createSchema.safeParse(body ?? {});
     if (!parsed.success) {
       return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
     }
+    let requestedScopes: string[] | undefined = undefined;
+    if (body && typeof body === 'object' && 'scopes' in body) {
+      const validated = validateScopesInput((body as Record<string, unknown>).scopes);
+      if (!validated.ok) {
+        return c.json({ error: validated.error, details: validated.details }, 400);
+      }
+      requestedScopes = validated.scopes;
+    }
     try {
-      const created = createIdentity(parsed.data);
+      const created = createIdentity({
+        name: parsed.data.name,
+        localpart: parsed.data.localpart,
+        canNotifyUser: parsed.data.canNotifyUser,
+        scopes: requestedScopes,
+      });
       if (!created) {
         return c.json({ error: 'address_exists' }, 409);
       }
@@ -99,6 +124,7 @@ export const identitiesRoute = new Hono()
           ...(identity.name ? { name: identity.name } : {}),
           ...(identity.canNotifyUser ? { canNotifyUser: true } : {}),
           pushContentTier: resolvePushContentTier(identity),
+          ...(identity.scopes !== undefined ? { scopes: identity.scopes } : {}),
           // Shown exactly once — store it now. Only its hash persists.
           token,
         },
@@ -156,12 +182,44 @@ export const identitiesRoute = new Hono()
     if (!updated) return c.json({ error: 'not_found' }, 404);
     return c.json(pushTierResponse(updated.address, resolvePushContentTier(updated)));
   })
-  .post('/:address/token', (c) => {
+  .post('/:address/token', async (c) => {
     const denied = requireAdmin(c);
     if (denied) return denied;
-    const token = rotateIdentityToken(c.req.param('address'));
+    const address = c.req.param('address').toLowerCase();
+    const existing = findIdentity(address);
+    if (!existing) return c.json({ error: 'not_found' }, 404);
+
+    // A bodyless REST rotation is the explicit compatibility escape hatch
+    // back to a legacy full-permission token. Internal callers that omit the
+    // second argument preserve scopes instead.
+    let requestedScopes: string[] | null = null;
+    const text = await c.req.text();
+    if (text.trim().length > 0) {
+      let body: unknown;
+      try {
+        body = JSON.parse(text);
+      } catch {
+        return c.json({ error: 'invalid_json' }, 400);
+      }
+      const parsed = rotateTokenSchema.safeParse(body);
+      if (!parsed.success) {
+        return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+      }
+      const validated = validateScopesInput(parsed.data.scopes);
+      if (!validated.ok) {
+        return c.json({ error: validated.error, details: validated.details }, 400);
+      }
+      requestedScopes = validated.scopes;
+    }
+
+    const token = rotateIdentityToken(address, requestedScopes);
     if (!token) return c.json({ error: 'not_found' }, 404);
-    return c.json({ address: c.req.param('address').toLowerCase(), token });
+    const updated = findIdentity(address);
+    return c.json({
+      address,
+      token,
+      ...(updated?.scopes !== undefined ? { scopes: updated.scopes } : {}),
+    });
   })
   .delete('/:address', (c) => {
     const denied = requireAdmin(c);

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -607,9 +607,15 @@ export function createUiApiRoutes(
   routes.post('/identities/:address/token', (c) => {
     const denied = requireUiAdmin(c);
     if (denied) return denied;
-    const token = rotateIdentityToken(c.req.param('address'));
+    const address = c.req.param('address').toLowerCase();
+    const token = rotateIdentityToken(address);
     if (!token) return c.json({ error: 'not_found' }, 404);
-    return c.json({ address: c.req.param('address').toLowerCase(), token });
+    const updated = findIdentity(address);
+    return c.json({
+      address,
+      token,
+      ...(updated?.scopes !== undefined ? { scopes: updated.scopes } : {}),
+    });
   });
 
   routes.put('/identities/:address/push-tier', async (c) => {

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -1,0 +1,1252 @@
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key-scope-test';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-scopes-test-'));
+
+const { beforeAll, describe, expect, mock, test } = await import('bun:test');
+
+let fakeMessages: any[] = [
+  {
+    uid: 101,
+    flags: new Set(),
+    envelope: {
+      date: new Date('2026-09-01T00:00:00Z'),
+      subject: 'Hello scoped reader',
+      from: [{ address: 'sender@example.net', name: 'Sender' }],
+      to: [{ address: 'reader@test.example', name: 'Reader' }],
+    },
+    internalDate: new Date('2026-09-01T00:00:00Z'),
+    source: Buffer.from(
+      'From: sender@example.net\r\nTo: reader@test.example\r\nSubject: Hello scoped reader\r\n\r\nTest body content',
+    ),
+  },
+];
+
+class FakeImapFlow extends EventEmitter {
+  async connect() {}
+  async getMailboxLock() {
+    return { release() {} };
+  }
+  async search() {
+    return fakeMessages.map((m) => m.uid);
+  }
+  async *fetch() {
+    yield* fakeMessages;
+  }
+  async fetchOne(uid: number) {
+    const msg = fakeMessages.find((m) => m.uid === uid);
+    if (!msg) return false;
+    return {
+      ...msg,
+      source: msg.source ?? Buffer.from('From: sender@example.net\r\n\r\nbody'),
+    };
+  }
+  async messageFlagsAdd() {}
+  async messageFlagsRemove() {}
+  async logout() {}
+  close() {}
+}
+
+mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
+const sendMailMock = mock(async () => ({ messageId: '<test-send@test.example>' }));
+mock.module('../src/lib/smtp.ts', () => ({ sendMail: sendMailMock }));
+
+const { config } = await import('../src/lib/config.ts');
+const { createApp } = await import('../src/app.ts');
+const {
+  createIdentity,
+  findIdentity,
+  findIdentityByToken,
+  listIdentities,
+  rotateIdentityToken,
+  validateScopesInput,
+  SUPPORTED_SCOPES,
+} = await import('../src/lib/identities.ts');
+const {
+  resolveAccessToken,
+  resolveToken,
+  resolveUiSessionToken,
+  resolveUiSessionTokenByHash,
+} = await import('../src/lib/auth.ts');
+const { createHash } = await import('node:crypto');
+const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
+
+const sha256Hex = (val: string) => createHash('sha256').update(val).digest('hex');
+const adminKey = [...config.apiKeys][0]!;
+const app = createApp({ uiEnabled: true });
+
+describe('Issue #114: read-only API token scopes', () => {
+  describe('Scope validation and registry', () => {
+    test('SUPPORTED_SCOPES contains read:messages', () => {
+      expect(SUPPORTED_SCOPES).toEqual(['read:messages']);
+    });
+
+    test('validateScopesInput accepts valid scopes array and empty array', () => {
+      expect(validateScopesInput(['read:messages'])).toEqual({
+        ok: true,
+        scopes: ['read:messages'],
+      });
+      expect(validateScopesInput([])).toEqual({
+        ok: true,
+        scopes: [],
+      });
+    });
+
+    test('validateScopesInput rejects non-arrays', () => {
+      const res = validateScopesInput('read:messages');
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.error).toBe('invalid_request');
+    });
+
+    test('validateScopesInput rejects duplicate scopes', () => {
+      const res = validateScopesInput(['read:messages', 'read:messages']);
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toBe('invalid_request');
+        expect(res.details).toBe('duplicate_scope');
+      }
+    });
+
+    test('validateScopesInput rejects unsupported scopes with unsupported_scope', () => {
+      const res = validateScopesInput(['unsupported:scope']);
+      expect(res.ok).toBe(false);
+      if (!res.ok) {
+        expect(res.error).toBe('unsupported_scope');
+      }
+    });
+
+    test('validateScopesInput rejects oversized scope count or item length', () => {
+      const tooMany = Array.from({ length: 11 }, (_, i) => `scope:${i}`);
+      const resCount = validateScopesInput(tooMany);
+      expect(resCount.ok).toBe(false);
+      if (!resCount.ok) expect(resCount.details).toBe('too_many_scopes');
+
+      const longScope = 'a'.repeat(65);
+      const resLong = validateScopesInput([longScope]);
+      expect(resLong.ok).toBe(false);
+      if (!resLong.ok) expect(resLong.details).toBe('invalid_scope_format');
+    });
+  });
+
+  describe('Identity creation & token rotation with scopes', () => {
+    test('createIdentity with absent scopes creates an unscoped token', () => {
+      const created = createIdentity({ localpart: 'unscoped-user' })!;
+      expect(created).not.toBeNull();
+      expect(created.identity.scopes).toBeUndefined();
+
+      const identityInList = listIdentities().find((i) => i.address === created.identity.address)!;
+      expect(identityInList.scopes).toBeUndefined();
+
+      const resolved = resolveAccessToken(created.token);
+      expect(resolved.status).toBe('ok');
+      if (resolved.status === 'ok') {
+        expect(resolved.auth.kind).toBe('identity');
+        if (resolved.auth.kind === 'identity') {
+          expect(resolved.auth.scopes).toBeUndefined();
+        }
+      }
+    });
+
+    test('createIdentity with explicit read:messages stores and surfaces scopes', () => {
+      const created = createIdentity({
+        localpart: 'scoped-user',
+        scopes: ['read:messages'],
+      })!;
+      expect(created).not.toBeNull();
+      expect(created.identity.scopes).toEqual(['read:messages']);
+
+      const identityInList = listIdentities().find((i) => i.address === created.identity.address)!;
+      expect(identityInList.scopes).toEqual(['read:messages']);
+
+      const resolved = resolveAccessToken(created.token);
+      expect(resolved.status).toBe('ok');
+      if (resolved.status === 'ok') {
+        expect(resolved.auth.kind).toBe('identity');
+        if (resolved.auth.kind === 'identity') {
+          expect(resolved.auth.scopes).toEqual(['read:messages']);
+        }
+      }
+    });
+
+    test('createIdentity with explicit empty array [] stores scopes: []', () => {
+      const created = createIdentity({
+        localpart: 'empty-scope-user',
+        scopes: [],
+      })!;
+      expect(created).not.toBeNull();
+      expect(created.identity.scopes).toEqual([]);
+
+      const identityInList = listIdentities().find((i) => i.address === created.identity.address)!;
+      expect(identityInList.scopes).toEqual([]);
+
+      const resolved = resolveAccessToken(created.token);
+      expect(resolved.status).toBe('ok');
+      if (resolved.status === 'ok') {
+        expect(resolved.auth.kind).toBe('identity');
+        if (resolved.auth.kind === 'identity') {
+          expect(resolved.auth.scopes).toEqual([]);
+        }
+      }
+    });
+
+    test('POST /v1/identities returns scopes only when present, rejects invalid scopes', async () => {
+      // 1. Unscoped creation
+      const resUnscoped = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ localpart: 'rest-unscoped' }),
+      });
+      expect(resUnscoped.status).toBe(201);
+      const dataUnscoped = (await resUnscoped.json()) as { scopes?: string[] };
+      expect(dataUnscoped.scopes).toBeUndefined();
+
+      // 2. Scoped creation
+      const resScoped = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          localpart: 'rest-scoped',
+          scopes: ['read:messages'],
+        }),
+      });
+      expect(resScoped.status).toBe(201);
+      const dataScoped = (await resScoped.json()) as { scopes?: string[] };
+      expect(dataScoped.scopes).toEqual(['read:messages']);
+
+      // 3. Scoped with empty array
+      const resEmpty = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          localpart: 'rest-empty',
+          scopes: [],
+        }),
+      });
+      expect(resEmpty.status).toBe(201);
+      const dataEmpty = (await resEmpty.json()) as { scopes?: string[] };
+      expect(dataEmpty.scopes).toEqual([]);
+
+      // 4. Unsupported scope rejection
+      const resBad = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          localpart: 'rest-bad',
+          scopes: ['write:all'],
+        }),
+      });
+      expect(resBad.status).toBe(400);
+      expect(await resBad.json()).toEqual({
+        error: 'unsupported_scope',
+        details: 'Unsupported scope: write:all',
+      });
+      expect(findIdentity(`rest-bad@${config.domain}`)).toBeUndefined();
+
+      // 5. Duplicate scope rejection
+      const resDup = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          localpart: 'rest-dup',
+          scopes: ['read:messages', 'read:messages'],
+        }),
+      });
+      expect(resDup.status).toBe(400);
+      expect(findIdentity(`rest-dup@${config.domain}`)).toBeUndefined();
+    });
+
+    test('POST /v1/identities rejects misspelled or unknown fields without minting a full token', async () => {
+      for (const [localpart, extra] of [
+        ['rest-scope-typo', { scope: ['read:messages'] }],
+        ['rest-scope-unknown', { unexpected: true }],
+      ] as const) {
+        const response = await app.request('/v1/identities', {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${adminKey}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify({ localpart, ...extra }),
+        });
+        expect(response.status).toBe(400);
+        expect(findIdentity(`${localpart}@${config.domain}`)).toBeUndefined();
+      }
+    });
+
+    test('POST /v1/identities/:address/token rotation with absent vs explicit scopes', async () => {
+      const created = createIdentity({
+        localpart: 'rotate-target',
+        scopes: ['read:messages'],
+      })!;
+      const addr = created.identity.address;
+
+      // 1. Rotation with absent body -> resets to unscoped token
+      const resReset = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${adminKey}` },
+      });
+      expect(resReset.status).toBe(200);
+      const dataReset = (await resReset.json()) as { token: string; scopes?: string[] };
+      expect(dataReset.token).toBeTruthy();
+      expect(dataReset.scopes).toBeUndefined();
+      expect(findIdentity(addr)!.scopes).toBeUndefined();
+
+      // Verify the new token is unscoped
+      const resAuthReset = resolveAccessToken(dataReset.token);
+      expect(resAuthReset.status).toBe('ok');
+      if (resAuthReset.status === 'ok') {
+        expect((resAuthReset.auth as any).scopes).toBeUndefined();
+      }
+
+      // 2. Rotation with explicit read:messages
+      const resScoped = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: ['read:messages'] }),
+      });
+      expect(resScoped.status).toBe(200);
+      const dataScoped = (await resScoped.json()) as { scopes?: string[] };
+      expect(dataScoped.scopes).toEqual(['read:messages']);
+      expect(findIdentity(addr)!.scopes).toEqual(['read:messages']);
+
+      // 3. Rotation with explicit []
+      const resEmpty = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: [] }),
+      });
+      expect(resEmpty.status).toBe(200);
+      const dataEmpty = (await resEmpty.json()) as { scopes?: string[] };
+      expect(dataEmpty.scopes).toEqual([]);
+      expect(findIdentity(addr)!.scopes).toEqual([]);
+
+      // 4. Rotation with invalid scopes fails with 400 and does not mutate old token
+      const oldTokenHash = findIdentity(addr)!.tokenHash;
+      const resInvalid = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: ['invalid:scope'] }),
+      });
+      expect(resInvalid.status).toBe(400);
+      expect(findIdentity(addr)!.tokenHash).toBe(oldTokenHash);
+      expect(findIdentity(addr)!.scopes).toEqual([]);
+
+      // 5. Rotation with malformed nonempty JSON returns 400 invalid_json without mutating token
+      const resMalformed = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: '{"scopes": [not-valid-json',
+      });
+      expect(resMalformed.status).toBe(400);
+      expect(await resMalformed.json()).toEqual({ error: 'invalid_json' });
+      expect(findIdentity(addr)!.tokenHash).toBe(oldTokenHash);
+
+      // 6. Rotation with non-object JSON returns 400 invalid_request without mutating token
+      const resNonObj = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: '["read:messages"]',
+      });
+      expect(resNonObj.status).toBe(400);
+      expect(findIdentity(addr)!.tokenHash).toBe(oldTokenHash);
+
+      // 7. Rotation with typo field (e.g. "scpoes") returns 400 and does NOT mint unscoped token
+      const resTypo = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scpoes: ['read:messages'] }),
+      });
+      expect(resTypo.status).toBe(400);
+      expect(findIdentity(addr)!.tokenHash).toBe(oldTokenHash);
+      expect(findIdentity(addr)!.scopes).toEqual([]);
+
+      // 8. Rotation with unknown extra field returns 400 and does NOT mutate token
+      const resUnknown = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ foo: 1 }),
+      });
+      expect(resUnknown.status).toBe(400);
+      expect(findIdentity(addr)!.tokenHash).toBe(oldTokenHash);
+      expect(findIdentity(addr)!.scopes).toEqual([]);
+
+      // 9. Rotation with nonempty body containing empty object {} returns 400 (strict schema requires scopes)
+      const resEmptyObj = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: '{}',
+      });
+      expect(resEmptyObj.status).toBe(400);
+      expect(findIdentity(addr)!.tokenHash).toBe(oldTokenHash);
+      expect(findIdentity(addr)!.scopes).toEqual([]);
+    });
+
+    test('OpenAgentEmailClient forwards scopes on token rotation', async () => {
+      const created = createIdentity({ localpart: 'client-rotate-scope' })!;
+      const client = new OpenAgentEmailClient(
+        'http://localhost',
+        adminKey,
+        (input, init) => {
+          if (input instanceof Request) return app.fetch(new Request(input, init));
+          return app.fetch(new Request(input.toString(), init));
+        },
+      );
+      const rotated = await client.rotateIdentityToken(created.identity.address, {
+        scopes: ['read:messages'],
+      });
+      expect(rotated.scopes).toEqual(['read:messages']);
+      expect(findIdentityByToken(rotated.token)?.scopes).toEqual(['read:messages']);
+    });
+  });
+
+  describe('Persistence and future scope compatibility', () => {
+    test('persisted scoped token reloads with identical scopes', () => {
+      const created = createIdentity({
+        localpart: 'persist-scope',
+        scopes: ['read:messages'],
+      })!;
+      const addr = created.identity.address;
+
+      const loaded = findIdentity(addr);
+      expect(loaded?.scopes).toEqual(['read:messages']);
+
+      const resolved = findIdentityByToken(created.token);
+      expect(resolved?.scopes).toEqual(['read:messages']);
+    });
+
+    test('structurally valid future/unknown scope loads safely and fails closed on all routes', async () => {
+      // Simulate a newer version writing a future scope to the identities file
+      const storePath = join(config.dataDir, 'identities.json');
+      const raw = JSON.parse(readFileSync(storePath, 'utf8'));
+      const futureToken = 'oa_future_token_12345678901234567890';
+      const futureHash = sha256Hex(futureToken);
+      const futureIdentity = {
+        address: `future@${config.domain}`,
+        createdAt: new Date().toISOString(),
+        tokenHash: futureHash,
+        scopes: ['read:messages', 'future:delegation:read'],
+      };
+      raw.push(futureIdentity);
+      writeFileSync(storePath, JSON.stringify(raw, null, 2));
+
+      // The store must NOT be corrupt: other identities and future identity load cleanly
+      const loaded = findIdentity(`future@${config.domain}`);
+      expect(loaded).toBeDefined();
+      expect(loaded?.scopes).toEqual(['read:messages', 'future:delegation:read']);
+
+      // Attempting to use this token must FAIL CLOSED on all routes (even message reads)
+      const resList = await app.request(`/v1/messages?address=future@${config.domain}`, {
+        headers: { authorization: `Bearer ${futureToken}` },
+      });
+      expect(resList.status).toBe(403);
+      expect(await resList.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      const resSend = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${futureToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: `future@${config.domain}`,
+          to: 'recipient@example.net',
+          subject: 'Hi',
+          text: 'Body',
+        }),
+      });
+      expect(resSend.status).toBe(403);
+      expect(await resSend.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('malformed scope field fails closed as identity_store_corrupt', () => {
+      const storePath = join(config.dataDir, 'identities.json');
+      const raw = JSON.parse(readFileSync(storePath, 'utf8'));
+      raw.push({
+        address: `corrupt-scope@${config.domain}`,
+        createdAt: new Date().toISOString(),
+        tokenHash: 'abc',
+        scopes: 'not-an-array', // Malformed!
+      });
+      writeFileSync(storePath, JSON.stringify(raw, null, 2));
+
+      try {
+        expect(() => listIdentities()).toThrow('identity_store_corrupt');
+      } finally {
+        const cleaned = raw.filter((i: any) => i.address !== `corrupt-scope@${config.domain}`);
+        writeFileSync(storePath, JSON.stringify(cleaned, null, 2));
+      }
+    });
+  });
+
+  describe('Route authorization: read:messages permissions and denials', () => {
+    let scopedReaderToken: string;
+    let readerAddress: string;
+
+    beforeAll(() => {
+      const created = createIdentity({
+        localpart: 'reader',
+        scopes: ['read:messages'],
+      })!;
+      scopedReaderToken = created.token;
+      readerAddress = created.identity.address;
+    });
+
+    test('read:messages permits GET /v1/messages for own address', async () => {
+      const res = await app.request(`/v1/messages?address=${readerAddress}`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { messages: unknown[] };
+      expect(Array.isArray(data.messages)).toBe(true);
+    });
+
+    test('read:messages permits GET /v1/messages/:id for own address', async () => {
+      const res = await app.request(`/v1/messages/101?address=${readerAddress}`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { id: string; subject: string };
+      expect(data.id).toBe('101');
+      expect(data.subject).toBe('Hello scoped reader');
+    });
+
+    test('read:messages permits POST /v1/messages/wait for own address', async () => {
+      // Mock waitForMessage or test wait rejection on timeout
+      const res = await app.request('/v1/messages/wait', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          address: readerAddress,
+          timeoutSec: 1,
+        }),
+      });
+      // 408 timeout proves scope check passed and reached IMAP wait logic!
+      expect([200, 408]).toContain(res.status);
+    });
+
+    test('read:messages is denied 403 when attempting to read another mailbox', async () => {
+      const otherAddr = 'victim@test.example';
+      const resList = await app.request(`/v1/messages?address=${otherAddr}`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resList.status).toBe(403);
+      expect(await resList.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+
+      const resGet = await app.request(`/v1/messages/101?address=${otherAddr}`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resGet.status).toBe(403);
+      expect(await resGet.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+
+      const resWait = await app.request('/v1/messages/wait', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          address: otherAddr,
+          timeoutSec: 1,
+        }),
+      });
+      expect(resWait.status).toBe(403);
+      expect(await resWait.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+    });
+
+    test('read:messages is denied 403 on POST /v1/messages/:id/seen', async () => {
+      const res = await app.request('/v1/messages/101/seen', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          address: readerAddress,
+          seen: true,
+        }),
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('read:messages is denied 403 on POST /v1/send before SMTP dispatch', async () => {
+      sendMailMock.mockClear();
+      const res = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: readerAddress,
+          to: 'recipient@example.net',
+          subject: 'Unauthorized send',
+          text: 'Blocked',
+        }),
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+      expect(sendMailMock).toHaveBeenCalledTimes(0);
+    });
+
+    test('read:messages is denied 403 on identities management routes', async () => {
+      // 1. GET /v1/identities
+      const resList = await app.request('/v1/identities', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resList.status).toBe(403);
+      expect(await resList.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // 2. POST /v1/identities
+      const resCreate = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ localpart: 'cannot-create' }),
+      });
+      expect(resCreate.status).toBe(403);
+      expect(await resCreate.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // 3. POST /v1/identities/:address/token
+      const resRotate = await app.request(`/v1/identities/${readerAddress}/token`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resRotate.status).toBe(403);
+      expect(await resRotate.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // 4. DELETE /v1/identities/:address
+      const resDelete = await app.request(`/v1/identities/${readerAddress}`, {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resDelete.status).toBe(403);
+      expect(await resDelete.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // 5. GET /v1/identities/:address/push-tier
+      const resGetTier = await app.request(`/v1/identities/${readerAddress}/push-tier`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resGetTier.status).toBe(403);
+      expect(await resGetTier.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // 6. PUT /v1/identities/:address/push-tier
+      const resPutTier = await app.request(`/v1/identities/${readerAddress}/push-tier`, {
+        method: 'PUT',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ pushContentTier: 1 }),
+      });
+      expect(resPutTier.status).toBe(403);
+      expect(await resPutTier.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('read:messages is denied 403 on notify and device routes', async () => {
+      // POST /v1/notify
+      const resNotify = await app.request('/v1/notify', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ target: 'user', title: 'Alert', message: 'Hi' }),
+      });
+      expect(resNotify.status).toBe(403);
+      expect(await resNotify.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // GET /v1/notify/messages
+      const resNotifyHistory = await app.request('/v1/notify/messages?topic=self', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resNotifyHistory.status).toBe(403);
+      expect(await resNotifyHistory.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // GET /v1/notify/devices
+      const resGetDev = await app.request('/v1/notify/devices', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resGetDev.status).toBe(403);
+      expect(await resGetDev.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // POST /v1/notify/devices
+      const resPostDev = await app.request('/v1/notify/devices', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ publicUrl: 'https://ntfy.example.com' }),
+      });
+      expect(resPostDev.status).toBe(403);
+      expect(await resPostDev.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // DELETE /v1/notify/devices/:id
+      const resDelDev = await app.request('/v1/notify/devices/dev_123', {
+        method: 'DELETE',
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resDelDev.status).toBe(403);
+      expect(await resDelDev.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // POST /v1/notify/verify
+      const resVerify = await app.request('/v1/notify/verify', {
+        method: 'POST',
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resVerify.status).toBe(403);
+      expect(await resVerify.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('read:messages is denied 403 on tasks and audit routes', async () => {
+      const taskId = '00000000-0000-4000-8000-000000000001';
+      const expectInsufficientScope = async (response: Response) => {
+        expect(response.status).toBe(403);
+        expect(await response.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+      };
+
+      // GET /v1/tasks
+      const resTasks = await app.request('/v1/tasks', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resTasks.status).toBe(403);
+      expect(await resTasks.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // POST /v1/tasks
+      const resCreateTask = await app.request('/v1/tasks', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${scopedReaderToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          to: 'other@test.example',
+          subject: 'Task',
+          body: 'Do something',
+        }),
+      });
+      expect(resCreateTask.status).toBe(403);
+      expect(await resCreateTask.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // GET /v1/tasks/:id
+      const resGetTask = await app.request(`/v1/tasks/${taskId}`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resGetTask.status).toBe(403);
+      expect(await resGetTask.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      await expectInsufficientScope(await app.request(`/v1/tasks/${taskId}/children`, {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      }));
+
+      for (const [operation, body] of [
+        ['claim', { leaseSec: 60 }],
+        ['lease', { leaseToken: 'lease-token', leaseSec: 60 }],
+        ['release', { leaseToken: 'lease-token' }],
+        ['decision', { decision: 'approved' }],
+        ['state', { state: 'working', body: 'Blocked' }],
+      ] as const) {
+        await expectInsufficientScope(await app.request(`/v1/tasks/${taskId}/${operation}`, {
+          method: 'POST',
+          headers: {
+            authorization: `Bearer ${scopedReaderToken}`,
+            'content-type': 'application/json',
+          },
+          body: JSON.stringify(body),
+        }));
+      }
+
+      // GET /v1/send/history
+      const resSendHist = await app.request('/v1/send/history', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resSendHist.status).toBe(403);
+      expect(await resSendHist.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      await expectInsufficientScope(await app.request('/v1/send/history/snd_test', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      }));
+
+      // GET /v1/audit/events
+      const resAudit = await app.request('/v1/audit/events', {
+        headers: { authorization: `Bearer ${scopedReaderToken}` },
+      });
+      expect(resAudit.status).toBe(403);
+      expect(await resAudit.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('empty scopes [] is denied 403 on ALL operations including message reads', async () => {
+      const emptyUser = createIdentity({
+        localpart: 'zero-perms',
+        scopes: [],
+      })!;
+      const token = emptyUser.token;
+      const addr = emptyUser.identity.address;
+
+      const resList = await app.request(`/v1/messages?address=${addr}`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(resList.status).toBe(403);
+      expect(await resList.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      const resGet = await app.request(`/v1/messages/101?address=${addr}`, {
+        headers: { authorization: `Bearer ${token}` },
+      });
+      expect(resGet.status).toBe(403);
+      expect(await resGet.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      const resWait = await app.request('/v1/messages/wait', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ address: addr, timeoutSec: 1 }),
+      });
+      expect(resWait.status).toBe(403);
+      expect(await resWait.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+  });
+
+  describe('UI session bypass prevention', () => {
+    test('resolveUiSessionToken and resolveUiSessionTokenByHash reject scoped tokens', () => {
+      const scopedUser = createIdentity({
+        localpart: 'ui-test-scoped',
+        scopes: ['read:messages'],
+      })!;
+      const unscopedUser = createIdentity({
+        localpart: 'ui-test-unscoped',
+      })!;
+
+      // 1. Scoped token rejected
+      expect(resolveUiSessionToken(scopedUser.token)).toBeNull();
+      expect(resolveUiSessionTokenByHash(sha256Hex(scopedUser.token))).toBeNull();
+
+      // 2. Unscoped token accepted
+      expect(resolveUiSessionToken(unscopedUser.token)).toEqual({
+        kind: 'identity',
+        address: unscopedUser.identity.address,
+      });
+      expect(resolveUiSessionTokenByHash(sha256Hex(unscopedUser.token))).toEqual({
+        kind: 'identity',
+        address: unscopedUser.identity.address,
+      });
+
+      // 3. Admin key accepted
+      expect(resolveUiSessionToken(adminKey)).toEqual({ kind: 'admin' });
+      expect(resolveUiSessionTokenByHash(sha256Hex(adminKey))).toEqual({ kind: 'admin' });
+    });
+
+    test('POST /ui/api/session rejects scoped token with 401 invalid_token', async () => {
+      const scopedUser = createIdentity({
+        localpart: 'ui-api-scoped',
+        scopes: ['read:messages'],
+      })!;
+      const unscopedUser = createIdentity({
+        localpart: 'ui-api-unscoped',
+      })!;
+
+      // Scoped login attempt
+      const resScoped = await app.request('/ui/api/session', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://localhost',
+        },
+        body: JSON.stringify({ token: scopedUser.token }),
+      });
+      expect(resScoped.status).toBe(401);
+      expect(await resScoped.json()).toEqual({ error: 'invalid_token' });
+
+      // Unscoped login attempt
+      const resUnscoped = await app.request('/ui/api/session', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://localhost',
+        },
+        body: JSON.stringify({ token: unscopedUser.token }),
+      });
+      expect(resUnscoped.status).toBe(200);
+      const dataUnscoped = await resUnscoped.json();
+      expect(dataUnscoped).toEqual({
+        kind: 'identity',
+        address: unscopedUser.identity.address,
+      });
+    });
+
+    test('dashboard token rotation preserves existing scope restrictions', async () => {
+      const scopedUser = createIdentity({
+        localpart: 'ui-rotate-scoped',
+        scopes: ['read:messages'],
+      })!;
+      const oldToken = scopedUser.token;
+      const login = await app.request('/ui/api/session', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          origin: 'http://localhost',
+        },
+        body: JSON.stringify({ token: adminKey }),
+      });
+      expect(login.status).toBe(200);
+      const cookie = login.headers.get('set-cookie')?.split(';', 1)[0];
+      expect(cookie).toBeTruthy();
+
+      const rotated = await app.request(
+        `/ui/api/identities/${encodeURIComponent(scopedUser.identity.address)}/token`,
+        {
+          method: 'POST',
+          headers: {
+            cookie: cookie!,
+            origin: 'http://localhost',
+          },
+        },
+      );
+      expect(rotated.status).toBe(200);
+      const data = (await rotated.json()) as { address: string; token: string; scopes?: string[] };
+      expect(data.address).toBe(scopedUser.identity.address);
+      expect(data.scopes).toEqual(['read:messages']);
+      expect(findIdentityByToken(data.token)?.scopes).toEqual(['read:messages']);
+      expect(findIdentityByToken(oldToken)).toBeUndefined();
+
+      const denied = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${data.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: scopedUser.identity.address,
+          to: 'recipient@example.net',
+          subject: 'Still blocked after rotation',
+          text: 'Blocked',
+        }),
+      });
+      expect(denied.status).toBe(403);
+      expect(await denied.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+  });
+
+  describe('MCP loopback and body-limit safety', () => {
+    async function readMcpJson(res: Response): Promise<unknown> {
+      const text = await res.text();
+      const dataLine = text.split('\n').find((line) => line.startsWith('data: '));
+      if (dataLine) return JSON.parse(dataLine.slice('data: '.length));
+      return JSON.parse(text);
+    }
+
+    function mcpRequest(token: string, method: string, params: Record<string, unknown> = {}) {
+      return app.request('/mcp', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${token}`,
+          'content-type': 'application/json',
+          accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method,
+          params,
+        }),
+      });
+    }
+
+    function mcpCall(token: string, name: string, args: Record<string, unknown> = {}) {
+      return mcpRequest(token, 'tools/call', { name, arguments: args });
+    }
+
+    test('MCP advertises and enforces the canonical scope input constraints', async () => {
+      const resList = await mcpRequest(adminKey, 'tools/list');
+      expect(resList.status).toBe(200);
+      const listData = (await readMcpJson(resList)) as {
+        result?: {
+          tools?: Array<{
+            name: string;
+            inputSchema?: {
+              properties?: Record<string, {
+                type?: string;
+                items?: { enum?: string[] };
+                maxItems?: number;
+              }>;
+            };
+          }>;
+        };
+      };
+      const createTool = listData.result?.tools?.find((tool) => tool.name === 'mail_new_identity');
+      expect(createTool).toBeDefined();
+      expect(createTool?.inputSchema?.properties?.scopes).toMatchObject({
+        type: 'array',
+        items: { enum: ['read:messages'] },
+        maxItems: 10,
+      });
+
+      for (const [localpart, scopes] of [
+        ['mcp-unsupported-scope', ['write:all']],
+        ['mcp-duplicate-scope', ['read:messages', 'read:messages']],
+      ] as const) {
+        const response = await mcpCall(adminKey, 'mail_new_identity', { localpart, scopes });
+        expect(response.status).toBe(200);
+        const data = (await readMcpJson(response)) as {
+          error?: { code?: number };
+          result?: { isError?: boolean; content?: Array<{ text?: string }> };
+        };
+        if (data.error) {
+          expect(data.error.code).toBe(-32602);
+        } else {
+          expect(data.result?.isError).toBe(true);
+          expect(data.result?.content?.[0]?.text).toMatch(/invalid|duplicate/i);
+        }
+        expect(findIdentity(`${localpart}@${config.domain}`)).toBeUndefined();
+      }
+    });
+
+    test('MCP mail_new_identity preserves requested scopes end to end', async () => {
+      const resMint = await mcpCall(adminKey, 'mail_new_identity', {
+        localpart: 'mcp-minted-reader',
+        scopes: ['read:messages'],
+      });
+      expect(resMint.status).toBe(200);
+      const mintData = (await readMcpJson(resMint)) as any;
+      expect(mintData.result.isError).toBeFalsy();
+      const minted = mintData.result.structuredContent as {
+        address: string;
+        token: string;
+        scopes: string[];
+      };
+      expect(minted.scopes).toEqual(['read:messages']);
+      expect(findIdentity(minted.address)?.scopes).toEqual(['read:messages']);
+
+      const resRead = await app.request(`/v1/messages?address=${minted.address}`, {
+        headers: { authorization: `Bearer ${minted.token}` },
+      });
+      expect(resRead.status).toBe(200);
+
+      sendMailMock.mockClear();
+      const resWrite = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${minted.token}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: minted.address,
+          to: 'recipient@example.net',
+          subject: 'Blocked scoped send',
+          text: 'Blocked',
+        }),
+      });
+      expect(resWrite.status).toBe(403);
+      expect(await resWrite.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+      expect(sendMailMock).toHaveBeenCalledTimes(0);
+    });
+
+    test('MCP tool execution loops back to REST and enforces scopes', async () => {
+      const scopedUser = createIdentity({
+        localpart: 'mcp-reader',
+        scopes: ['read:messages'],
+      })!;
+
+      fakeMessages.push({
+        uid: 102,
+        flags: new Set(),
+        envelope: {
+          date: new Date('2026-09-01T00:00:00Z'),
+          subject: 'MCP test message',
+          from: [{ address: 'sender@example.net', name: 'Sender' }],
+          to: [{ address: scopedUser.identity.address, name: 'MCP Reader' }],
+        },
+        internalDate: new Date('2026-09-01T00:00:00Z'),
+        source: Buffer.from(
+          `From: sender@example.net\r\nTo: ${scopedUser.identity.address}\r\nSubject: MCP test message\r\n\r\nBody`,
+        ),
+      });
+
+      // 1. Allowed read tool: mail_list_messages
+      const resList = await mcpCall(scopedUser.token, 'mail_list_messages', {
+        address: scopedUser.identity.address,
+      });
+      expect(resList.status).toBe(200);
+      const listData = (await readMcpJson(resList)) as any;
+      expect(listData.result).toBeDefined();
+      expect(listData.result.isError).toBeFalsy();
+
+      // 2. Allowed read tool: mail_read_message
+      const resGet = await mcpCall(scopedUser.token, 'mail_read_message', {
+        address: scopedUser.identity.address,
+        id: '102',
+      });
+      expect(resGet.status).toBe(200);
+      const getData = (await readMcpJson(resGet)) as any;
+      expect(getData.result).toBeDefined();
+      expect(getData.result.isError).toBeFalsy();
+
+      // 3. Allowed read tool: mail_wait_for
+      const resWait = await mcpCall(scopedUser.token, 'mail_wait_for', {
+        address: scopedUser.identity.address,
+        timeoutSec: 1,
+      });
+      expect(resWait.status).toBe(200);
+      const waitData = (await readMcpJson(resWait)) as any;
+      expect(waitData.result).toBeDefined();
+      // timeout returns a response or message without 403 scope rejection
+      if (waitData.result.isError) {
+        expect(waitData.result.content[0].text).not.toContain('403');
+      }
+
+      // 4. Denied write tool: mail_send cannot bypass scope
+      const resSend = await mcpCall(scopedUser.token, 'mail_send', {
+        from: scopedUser.identity.address,
+        to: 'recipient@example.net',
+        subject: 'Try MCP bypass',
+        text: 'Blocked',
+      });
+      expect(resSend.status).toBe(200);
+      const sendData = (await readMcpJson(resSend)) as any;
+      // Tools catch ApiError and return isError: true
+      expect(sendData.result.isError).toBe(true);
+      expect(sendData.result.content[0].text).toContain('403');
+      expect(sendData.result.content[0].text).toContain('forbidden: insufficient_scope');
+
+      // 5. Denied write tool: mail_mark_seen cannot bypass scope
+      const resSeen = await mcpCall(scopedUser.token, 'mail_mark_seen', {
+        address: scopedUser.identity.address,
+        id: '101',
+        seen: true,
+      });
+      expect(resSeen.status).toBe(200);
+      const seenData = (await readMcpJson(resSeen)) as any;
+      expect(seenData.result.isError).toBe(true);
+      expect(seenData.result.content[0].text).toContain('403');
+      expect(seenData.result.content[0].text).toContain('forbidden: insufficient_scope');
+
+      // 6. Denied write tool: task_create cannot bypass scope
+      const resTask = await mcpCall(scopedUser.token, 'task_create', {
+        to: 'other@test.example',
+        subject: 'Try MCP task create',
+        body: 'Blocked',
+      });
+      expect(resTask.status).toBe(200);
+      const taskData = (await readMcpJson(resTask)) as any;
+      expect(taskData.result.isError).toBe(true);
+      expect(taskData.result.content[0].text).toContain('403');
+      expect(taskData.result.content[0].text).toContain('forbidden: insufficient_scope');
+
+      // A scoped token cannot mint another identity through the MCP tool.
+      const resMint = await mcpCall(scopedUser.token, 'mail_new_identity', {
+        localpart: 'mcp-escalation-attempt',
+      });
+      expect(resMint.status).toBe(200);
+      const mintData = (await readMcpJson(resMint)) as any;
+      expect(mintData.result.isError).toBe(true);
+      expect(mintData.result.content[0].text).toContain('forbidden: insufficient_scope');
+      expect(findIdentity(`mcp-escalation-attempt@${config.domain}`)).toBeUndefined();
+    });
+
+    test('bad-auth-before-scope: bad token returns 401 unauthorized before scope checks', async () => {
+      // POST /v1/send with bad token -> 401 unauthorized (not 403)
+      const resSend = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer bad-token-12345',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'someone@test.example',
+          to: 'recipient@example.net',
+          subject: 'test',
+          text: 'test',
+        }),
+      });
+      expect(resSend.status).toBe(401);
+      expect(await resSend.json()).toEqual({ error: 'unauthorized' });
+
+      // GET /v1/messages with bad token -> 401 unauthorized (not 403)
+      const resMessages = await app.request('/v1/messages?address=someone@test.example', {
+        headers: { authorization: 'Bearer bad-token-12345' },
+      });
+      expect(resMessages.status).toBe(401);
+      expect(await resMessages.json()).toEqual({ error: 'unauthorized' });
+    });
+
+    test('body limit 413 triggers before authentication and scope checks', async () => {
+      // 16MB+ body rejected by bodyLimit
+      const hugeBody = JSON.stringify({
+        from: 'reader@test.example',
+        to: 'recipient@example.net',
+        subject: 'huge',
+        text: 'x'.repeat(17 * 1024 * 1024),
+      });
+      const res = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: 'Bearer bad-token',
+          'content-type': 'application/json',
+        },
+        body: hugeBody,
+      });
+      expect(res.status).toBe(413);
+      expect(await res.json()).toEqual({ error: 'request_too_large' });
+    });
+  });
+});

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -32,7 +32,7 @@ If `OPENAGENTEMAIL_API_KEY` is missing the server exits immediately with a clear
 
 | Tool | Description |
 | --- | --- |
-| `mail_new_identity(name?, localpart?)` | Create an identity; pass `localpart` for a custom address (e.g. `qa-bot`), or omit for a random one like `fox-k7d2` |
+| `mail_new_identity(name?, localpart?, scopes?)` | Admin only: create an identity and one-time token; pass `scopes: ["read:messages"]` for read-only own-mailbox access, `scopes: []` for no API operation permissions, or omit for legacy full identity permissions |
 | `mail_list_identities()` | List all identities |
 | `mail_list_messages(address, limit?)` | List messages for an address (id/from/to/subject/date/seen/snippet/hasOtp/source); `from`/`to` are RFC-5322 raw header text (may include display names), not bare addresses |
 | `mail_read_message(address, id)` | Full message: text, html?, `otp:{codes:[],links:[]}`, top-level `links`, and optional `taskId`/`taskState` |


### PR DESCRIPTION
## Summary

This PR implements Direction 1 for Issue #114, introducing a subtractive scope permission model for identity API tokens.

- **Scope model**: identity tokens without a `scopes` property retain full legacy permissions; an explicit list restricts access to named operations.
- **Initial scope**: `read:messages` permits only own-mailbox `GET /v1/messages`, `GET /v1/messages/:id`, and `POST /v1/messages/wait`, plus the corresponding MCP tools.
- **Default deny**: scoped credentials receive 403 `forbidden: insufficient_scope` for every other `/v1` operation; `scopes: []` has no `/v1` operation permissions.
- **Strict minting**: REST and MCP validate against one supported-scope registry, reject duplicates and unknown scopes, and reject misspelled or unknown REST fields instead of silently minting a full token.
- **Safe rotation**: internal and dashboard rotation preserves current restrictions; the documented bodyless REST rotation remains the explicit compatibility reset to legacy full permissions.
- **Fail closed**: unknown future stored scopes deny all operations without rewriting or corrupting the identity store.
- **UI isolation**: scoped identity tokens are rejected by both plaintext and hash UI-session resolvers.
- **End-to-end coverage**: tests prove MCP scope minting reaches persistent storage and REST authorization, assert the advertised MCP JSON Schema, cover the full task/notification/send-history denial matrix, verify dashboard rotation cannot widen authority, and assert denied sends never reach SMTP.
- **Future work**: per-mailbox cross-identity delegation is intentionally split into #125.

## Verification

- `bun test test/identity-scopes.test.ts test/ui-configure.test.ts test/identities.test.ts` (68 pass)
- `bun test` (1145 pass, 1 existing skip, 0 fail)
- `bun run build` in `packages/api`
- `bun run typecheck` reports pre-existing repository errors, with no errors from files changed by the final scope-rotation fix
- `git diff --check`

Refs #114