### PR TITLE
fix(auth): inherit identity scopes during oauth access token resolution

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -51,7 +51,7 @@ Task REST creation accepts optional `parentTaskId` for ordinary and approval roo
 - `GET /v1/audit/events?limit=&event=` → `{events:[…]}`（**admin only**；scrubbed JSONL `DATA_DIR/audit.jsonl`；见 docs/security.md）
 - `POST /v1/identities` `{name?, localpart?, canNotifyUser?, scopes?: string[]}` → `201 {address, name?, pushContentTier, token, scopes?}` (admin only; 409 if taken). Optional `scopes` restricts the token (e.g. `['read:messages']`); absent means legacy full power. Unknown or misspelled fields are rejected rather than silently minting a full token.
 - `GET /v1/identities` → `{identities:[{address,name?,createdAt,pushContentTier,scopes?...}]}` (admin only; includes `scopes` when present, including `[]`)
-- `POST /v1/identities/:address/token` optional `{scopes?: string[]}` → `{address, token, scopes?}` (admin only). A truly empty body mints an unscoped/full token; any non-empty body must be a strict JSON object with `scopes` (e.g. `scopes: []` mints a token with no permissions; unknown or misspelled fields are rejected with 400).
+- `POST /v1/identities/:address/token` optional `{scopes?: string[] | null}` → `{address, token, scopes?}` (admin only). A truly empty body preserves existing scopes; `{"scopes": null}` resets to an unscoped/full token; any non-empty body must be a strict JSON object with `scopes` (e.g. `scopes: []` mints a token with no permissions; unknown or misspelled fields are rejected with 400).
 - `GET /v1/identities/:address/push-tier` → `{address, pushContentTier, warning?}` (admin any; identity own only)
 - `PUT /v1/identities/:address/push-tier` `{pushContentTier:1|2|3, confirm_risk?}` → admin only; tier 3 requires `confirm_risk: true`
 - **Identity Token Scopes**:

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -47,6 +47,8 @@ export type AuditEvent = {
   durationMs?: number;
   /** 客户端 IP（非秘密；OAuth 端点事件可选带上）。 */
   ip?: string;
+  /** 变更后的 scope 集合（scrubbed 字符串数组）。 */
+  scopes?: string[];
 };
 
 function auditPath(): string {
@@ -124,6 +126,9 @@ export function recordAuditEvent(
     ...(partial.durationMs !== undefined ? { durationMs: partial.durationMs } : {}),
     // IP 非秘密；仍剥控制字符并截断（IPv6 字面量 + zone id 足够 64）
     ...(partial.ip !== undefined ? { ip: scrubAuditField(partial.ip, 64) } : {}),
+    ...(partial.scopes !== undefined
+      ? { scopes: partial.scopes.map((s) => scrubAuditField(s, 64)) }
+      : {}),
   };
 
   try {

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -85,7 +85,12 @@ export function resolveAccessToken(
     };
   }
 
-  const identity = findIdentityByToken(token);
+  let identity: ReturnType<typeof findIdentityByToken>;
+  try {
+    identity = findIdentityByToken(token);
+  } catch {
+    identity = undefined;
+  }
   if (identity) {
     return {
       status: 'ok',

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -88,7 +88,15 @@ export function resolveAccessToken(
   let identity: ReturnType<typeof findIdentityByToken>;
   try {
     identity = findIdentityByToken(token);
-  } catch {
+  } catch (err) {
+    // If the identity store is damaged, distinguish credential classes:
+    // Only OAuth credentials (present in oauth-store) take the fail-closed 401 path.
+    // Non-OAuth credentials (oa_ identity tokens or garbage) must rethrow to surface 500
+    // and log the storage outage per the integrity contract.
+    const oauthProbe = lookupAccessToken(token, options.now);
+    if (oauthProbe.status === 'missing') {
+      throw err;
+    }
     identity = undefined;
   }
   if (identity) {

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -122,7 +122,14 @@ export function resolveAccessToken(
   }
 
   // 身份已删：票作废（与级联吊销互补；防竞态/旧库残留）
-  if (!findIdentity(oauth.address)) {
+  // 读库抛错时 fail-closed 拒认（401），不回退到无 scope 全权票
+  let oauthIdentity: ReturnType<typeof findIdentity>;
+  try {
+    oauthIdentity = findIdentity(oauth.address);
+  } catch {
+    return { status: 'unauthorized' };
+  }
+  if (!oauthIdentity) {
     return { status: 'unauthorized' };
   }
 
@@ -132,8 +139,12 @@ export function resolveAccessToken(
 
   return {
     status: 'ok',
-    // /v1 行为：仍是 identity scope，不含 grant 字段
-    auth: { kind: 'identity', address: oauth.address },
+    // /v1 行为：仍是 identity scope，不含 grant 字段；继承身份当前落盘的 scopes
+    auth: {
+      kind: 'identity',
+      address: oauth.address,
+      ...(oauthIdentity.scopes !== undefined ? { scopes: oauthIdentity.scopes } : {}),
+    },
     attribution: {
       kind: 'oauth',
       address: oauth.address,

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -18,7 +18,7 @@ import { createMiddleware } from 'hono/factory';
 import type { Context } from 'hono';
 import { config } from './config.ts';
 import { findIdentity, findIdentityByToken, findIdentityByTokenHash } from './identities.ts';
-import { getGrant, lookupAccessToken } from './oauth-store.ts';
+import { getGrant, lookupAccessToken, peekAccessToken } from './oauth-store.ts';
 import { resolveResourceUri } from './oauth-url.ts';
 
 function sha256Hex(value: string): string {
@@ -90,11 +90,11 @@ export function resolveAccessToken(
     identity = findIdentityByToken(token);
   } catch (err) {
     // If the identity store is damaged, distinguish credential classes:
-    // Only OAuth credentials (present in oauth-store) take the fail-closed 401 path.
+    // Only OAuth credentials (present in oauth-store access table, even if expired)
+    // take the fail-closed 401 path.
     // Non-OAuth credentials (oa_ identity tokens or garbage) must rethrow to surface 500
     // and log the storage outage per the integrity contract.
-    const oauthProbe = lookupAccessToken(token, options.now);
-    if (oauthProbe.status === 'missing') {
+    if (!peekAccessToken(token)) {
       throw err;
     }
     identity = undefined;

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -202,6 +202,48 @@ function pruneExpired(data: OAuthStoreFile, now = Date.now()): boolean {
   return changed;
 }
 
+function loadRaw(): OAuthStoreFile {
+  const path = storePath();
+  if (!existsSync(path)) {
+    if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
+      return storeCache.data;
+    }
+    storeCache = { version: MISSING_STORE_VERSION, data: emptyStore() };
+    return storeCache.data;
+  }
+  try {
+    const version = fileVersionFromStat(statSync(path));
+    if (storeCache && storeVersionsEqual(storeCache.version, version)) {
+      return storeCache.data;
+    }
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isStoreShape(parsed)) {
+      throw new Error('invalid oauth store shape');
+    }
+    storeCache = { version, data: parsed };
+    return storeCache.data;
+  } catch (err) {
+    invalidateStoreCache();
+    if ((err as Error).message === 'oauth_store_corrupt') throw err;
+    throw new Error('oauth_store_corrupt');
+  }
+}
+
+/**
+ * Non-destructive existence check in access table without pruning and without
+ * expiry evaluation. Used exclusively by auth credential discrimination when
+ * the identity store is damaged.
+ */
+export function peekAccessToken(token: string): boolean {
+  try {
+    const data = loadRaw();
+    const hash = hashSecret(token);
+    return Boolean(data.access[hash]);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * @param persistPrune 冷读发现过期行时是否写回磁盘。
  * 公开 /oauth/revoke 用 false：未知 token 路径必须零磁盘写（防未鉴权写放大）。
@@ -652,7 +694,7 @@ export function putAccessTokenForTests(input: {
   expiresAt: number;
   ensureGrant?: { clientId: string; clientName: string };
 }): void {
-  const data = load();
+  const data = loadRaw();
   if (input.ensureGrant && !data.grants[input.grantId]) {
     const nowIso = new Date().toISOString();
     data.grants[input.grantId] = {
@@ -670,5 +712,7 @@ export function putAccessTokenForTests(input: {
     aud: input.aud,
     expiresAt: input.expiresAt,
   };
-  save(data);
+  invalidateStoreCache();
+  const version = writeStoreFile(data);
+  storeCache = { version, data };
 }

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -82,6 +82,7 @@ type StoreCache = {
 };
 
 let storeCache: StoreCache | undefined;
+let rawCache: StoreCache | undefined;
 
 function storePath(): string {
   return join(config.dataDir, 'oauth.json');
@@ -93,6 +94,7 @@ function emptyStore(): OAuthStoreFile {
 
 function invalidateStoreCache(): void {
   storeCache = undefined;
+  rawCache = undefined;
 }
 
 function fileVersionFromStat(st: {
@@ -205,25 +207,25 @@ function pruneExpired(data: OAuthStoreFile, now = Date.now()): boolean {
 function loadRaw(): OAuthStoreFile {
   const path = storePath();
   if (!existsSync(path)) {
-    if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
-      return storeCache.data;
+    if (rawCache && storeVersionsEqual(rawCache.version, MISSING_STORE_VERSION)) {
+      return rawCache.data;
     }
-    storeCache = { version: MISSING_STORE_VERSION, data: emptyStore() };
-    return storeCache.data;
+    rawCache = { version: MISSING_STORE_VERSION, data: emptyStore() };
+    return rawCache.data;
   }
   try {
     const version = fileVersionFromStat(statSync(path));
-    if (storeCache && storeVersionsEqual(storeCache.version, version)) {
-      return storeCache.data;
+    if (rawCache && storeVersionsEqual(rawCache.version, version)) {
+      return rawCache.data;
     }
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
     if (!isStoreShape(parsed)) {
       throw new Error('invalid oauth store shape');
     }
-    storeCache = { version, data: parsed };
-    return storeCache.data;
+    rawCache = { version, data: parsed };
+    return rawCache.data;
   } catch (err) {
-    invalidateStoreCache();
+    rawCache = undefined;
     if ((err as Error).message === 'oauth_store_corrupt') throw err;
     throw new Error('oauth_store_corrupt');
   }
@@ -306,7 +308,8 @@ function save(data: OAuthStoreFile): void {
   pruneExpired(data);
   invalidateStoreCache();
   const version = writeStoreFile(data);
-  storeCache = { version, data };
+  storeCache = { version, data: structuredClone(data) };
+  rawCache = { version, data: structuredClone(data) };
 }
 
 export function hashSecret(value: string): string {
@@ -714,5 +717,6 @@ export function putAccessTokenForTests(input: {
   };
   invalidateStoreCache();
   const version = writeStoreFile(data);
-  storeCache = { version, data };
+  rawCache = { version, data: structuredClone(data) };
+  storeCache = { version, data: structuredClone(data) };
 }

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -84,6 +84,33 @@ type StoreCache = {
 let storeCache: StoreCache | undefined;
 let rawCache: StoreCache | undefined;
 
+/** Bounded in-process tombstone set for pruned OAuth access-token hashes. */
+export const PRUNED_ACCESS_HASHES_CAP = 10_000;
+const prunedAccessHashes = new Set<string>();
+
+export function recordPrunedAccessHash(hash: string): void {
+  if (prunedAccessHashes.has(hash)) {
+    prunedAccessHashes.delete(hash);
+    prunedAccessHashes.add(hash);
+    return;
+  }
+  if (prunedAccessHashes.size >= PRUNED_ACCESS_HASHES_CAP) {
+    const oldest = prunedAccessHashes.values().next().value;
+    if (oldest !== undefined) {
+      prunedAccessHashes.delete(oldest);
+    }
+  }
+  prunedAccessHashes.add(hash);
+}
+
+export function getPrunedAccessHashesCountForTests(): number {
+  return prunedAccessHashes.size;
+}
+
+export function clearPrunedAccessHashesForTests(): void {
+  prunedAccessHashes.clear();
+}
+
 function storePath(): string {
   return join(config.dataDir, 'oauth.json');
 }
@@ -92,7 +119,7 @@ function emptyStore(): OAuthStoreFile {
   return { grants: {}, codes: {}, access: {}, refresh: {} };
 }
 
-function invalidateStoreCache(): void {
+export function invalidateStoreCache(): void {
   storeCache = undefined;
   rawCache = undefined;
 }
@@ -192,6 +219,7 @@ function pruneExpired(data: OAuthStoreFile, now = Date.now()): boolean {
   for (const [hash, row] of Object.entries(data.access)) {
     if (row.expiresAt <= now) {
       delete data.access[hash];
+      recordPrunedAccessHash(hash);
       changed = true;
     }
   }
@@ -234,12 +262,16 @@ function loadRaw(): OAuthStoreFile {
 /**
  * Non-destructive existence check in access table without pruning and without
  * expiry evaluation. Used exclusively by auth credential discrimination when
- * the identity store is damaged.
+ * the identity store is damaged. Returns true if the token exists in the access
+ * table OR has been recorded in the bounded prunedAccessHashes tombstone set.
  */
 export function peekAccessToken(token: string): boolean {
   try {
-    const data = loadRaw();
     const hash = hashSecret(token);
+    if (prunedAccessHashes.has(hash)) {
+      return true;
+    }
+    const data = loadRaw();
     return Boolean(data.access[hash]);
   } catch {
     return false;
@@ -363,7 +395,10 @@ export function revokeGrantsForAddress(address: string): number {
       if (row.grantId === grantId) delete data.codes[hash];
     }
     for (const [hash, row] of Object.entries(data.access)) {
-      if (row.grantId === grantId) delete data.access[hash];
+      if (row.grantId === grantId) {
+        delete data.access[hash];
+        recordPrunedAccessHash(hash);
+      }
     }
     for (const [hash, row] of Object.entries(data.refresh)) {
       if (row.grantId === grantId) delete data.refresh[hash];
@@ -389,7 +424,10 @@ export function revokeGrant(grantId: string): boolean {
     if (row.grantId === grantId) delete data.codes[hash];
   }
   for (const [hash, row] of Object.entries(data.access)) {
-    if (row.grantId === grantId) delete data.access[hash];
+    if (row.grantId === grantId) {
+      delete data.access[hash];
+      recordPrunedAccessHash(hash);
+    }
   }
   for (const [hash, row] of Object.entries(data.refresh)) {
     if (row.grantId === grantId) delete data.refresh[hash];
@@ -652,6 +690,7 @@ export function revokeToken(token: string, clientId?: string): boolean {
   let changed = false;
   if (access) {
     delete data.access[hash];
+    recordPrunedAccessHash(hash);
     changed = true;
   }
   if (refresh) {
@@ -715,8 +754,17 @@ export function putAccessTokenForTests(input: {
     aud: input.aud,
     expiresAt: input.expiresAt,
   };
-  invalidateStoreCache();
-  const version = writeStoreFile(data);
-  rawCache = { version, data: structuredClone(data) };
-  storeCache = { version, data: structuredClone(data) };
+  if (input.runSave) {
+    save(data);
+  } else {
+    invalidateStoreCache();
+    const version = writeStoreFile(data);
+    rawCache = { version, data: structuredClone(data) };
+    storeCache = { version, data: structuredClone(data) };
+  }
+}
+
+export function saveStoreForTests(): void {
+  const data = loadRaw();
+  save(data);
 }

--- a/packages/api/src/lib/oauth-store.ts
+++ b/packages/api/src/lib/oauth-store.ts
@@ -735,6 +735,7 @@ export function putAccessTokenForTests(input: {
   aud: string;
   expiresAt: number;
   ensureGrant?: { clientId: string; clientName: string };
+  runSave?: boolean;
 }): void {
   const data = loadRaw();
   if (input.ensureGrant && !data.grants[input.grantId]) {

--- a/packages/api/src/lib/scope-policy.ts
+++ b/packages/api/src/lib/scope-policy.ts
@@ -36,8 +36,8 @@ export const OPERATION_POLICIES: readonly OperationPolicy[] = [
  * Centralized scope policy enforcement middleware for all /v1/* REST routes.
  *
  * Evaluates after bearer authentication:
- * - Admin keys, OAuth tokens, and legacy unscoped identity tokens (scopes === undefined) pass through.
- * - Scoped identity tokens are subject to default-deny scope evaluation.
+ * - Admin keys and legacy unscoped identity/OAuth tokens (scopes === undefined) pass through.
+ * - Scoped identity and OAuth tokens are subject to default-deny scope evaluation.
  * - If stored scope metadata contains any unknown/unsupported scope, fails closed (403) on all routes.
  * - If the operation is not granted by the token's scopes, rejects with 403 forbidden: insufficient_scope.
  */

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -321,7 +321,7 @@ export class OpenAgentEmailClient {
 
   rotateIdentityToken(
     address: string,
-    opts?: { scopes?: string[] },
+    opts?: { scopes?: string[] | null },
   ): Promise<{
     address: string;
     token: string;

--- a/packages/api/src/routes/identities.ts
+++ b/packages/api/src/routes/identities.ts
@@ -23,7 +23,13 @@ import { clientIp } from '../lib/net.ts';
 function classifyScopeChange(
   prev: string[] | undefined,
   next: string[] | undefined,
-): 'identity.scopes.set' | 'identity.scopes.narrow' | 'identity.scopes.widen' | 'identity.scopes.clear' | null {
+):
+  | 'identity.scopes.set'
+  | 'identity.scopes.narrow'
+  | 'identity.scopes.widen'
+  | 'identity.scopes.clear'
+  | 'identity.scopes.replace'
+  | null {
   if (prev === undefined && next === undefined) return null;
   if (prev === undefined && next !== undefined) return 'identity.scopes.set';
   if (prev !== undefined && next === undefined) return 'identity.scopes.clear';
@@ -38,7 +44,7 @@ function classifyScopeChange(
   if ([...prevSet].every((s) => nextSet.has(s))) {
     return 'identity.scopes.widen';
   }
-  return next.length > prev.length ? 'identity.scopes.widen' : 'identity.scopes.narrow';
+  return 'identity.scopes.replace';
 }
 
 const createSchema = z.object({
@@ -220,7 +226,6 @@ export const identitiesRoute = new Hono()
     const address = c.req.param('address').toLowerCase();
     const existing = findIdentity(address);
     if (!existing) return c.json({ error: 'not_found' }, 404);
-    const prevScopes = existing.scopes !== undefined ? [...existing.scopes] : undefined;
 
     // Empty body preserves existing scopes (aligned with UI rotate).
     // Explicit {"scopes": null} resets to an unscoped full-permission token.
@@ -247,6 +252,12 @@ export const identitiesRoute = new Hono()
         requestedScopes = validated.scopes;
       }
     }
+
+    // Re-read and snapshot scopes immediately before rotation (no intervening await)
+    // to avoid comparing against a stale snapshot if a concurrent rotation landed.
+    const current = findIdentity(address);
+    if (!current) return c.json({ error: 'not_found' }, 404);
+    const prevScopes = current.scopes !== undefined ? [...current.scopes] : undefined;
 
     const token = rotateIdentityToken(address, requestedScopes);
     if (!token) return c.json({ error: 'not_found' }, 404);

--- a/packages/api/src/routes/identities.ts
+++ b/packages/api/src/routes/identities.ts
@@ -17,6 +17,29 @@ import {
 } from '../lib/identities.ts';
 import { NotifyError, provisionIdentityNotifications } from '../lib/notify.ts';
 import { getAuth } from '../lib/auth.ts';
+import { recordAuditEvent } from '../lib/audit.ts';
+import { clientIp } from '../lib/net.ts';
+
+function classifyScopeChange(
+  prev: string[] | undefined,
+  next: string[] | undefined,
+): 'identity.scopes.set' | 'identity.scopes.narrow' | 'identity.scopes.widen' | 'identity.scopes.clear' | null {
+  if (prev === undefined && next === undefined) return null;
+  if (prev === undefined && next !== undefined) return 'identity.scopes.set';
+  if (prev !== undefined && next === undefined) return 'identity.scopes.clear';
+  const prevSet = new Set(prev);
+  const nextSet = new Set(next);
+  if (prevSet.size === nextSet.size && [...prevSet].every((s) => nextSet.has(s))) {
+    return null;
+  }
+  if ([...nextSet].every((s) => prevSet.has(s))) {
+    return 'identity.scopes.narrow';
+  }
+  if ([...prevSet].every((s) => nextSet.has(s))) {
+    return 'identity.scopes.widen';
+  }
+  return next.length > prev.length ? 'identity.scopes.widen' : 'identity.scopes.narrow';
+}
 
 const createSchema = z.object({
   name: z.string().min(1).max(100).optional(),
@@ -118,6 +141,15 @@ export const identitiesRoute = new Hono()
         }
         throw err;
       }
+      if (requestedScopes !== undefined) {
+        recordAuditEvent({
+          event: 'identity.scopes.create',
+          address: identity.address,
+          outcome: 'ok',
+          scopes: requestedScopes,
+          ip: clientIp(c),
+        });
+      }
       return c.json(
         {
           address: identity.address,
@@ -188,11 +220,11 @@ export const identitiesRoute = new Hono()
     const address = c.req.param('address').toLowerCase();
     const existing = findIdentity(address);
     if (!existing) return c.json({ error: 'not_found' }, 404);
+    const prevScopes = existing.scopes !== undefined ? [...existing.scopes] : undefined;
 
-    // A bodyless REST rotation is the explicit compatibility escape hatch
-    // back to a legacy full-permission token. Internal callers that omit the
-    // second argument preserve scopes instead.
-    let requestedScopes: string[] | null = null;
+    // Empty body preserves existing scopes (aligned with UI rotate).
+    // Explicit {"scopes": null} resets to an unscoped full-permission token.
+    let requestedScopes: string[] | null | undefined = undefined;
     const text = await c.req.text();
     if (text.trim().length > 0) {
       let body: unknown;
@@ -205,16 +237,32 @@ export const identitiesRoute = new Hono()
       if (!parsed.success) {
         return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
       }
-      const validated = validateScopesInput(parsed.data.scopes);
-      if (!validated.ok) {
-        return c.json({ error: validated.error, details: validated.details }, 400);
+      if (parsed.data.scopes === null) {
+        requestedScopes = null;
+      } else {
+        const validated = validateScopesInput(parsed.data.scopes);
+        if (!validated.ok) {
+          return c.json({ error: validated.error, details: validated.details }, 400);
+        }
+        requestedScopes = validated.scopes;
       }
-      requestedScopes = validated.scopes;
     }
 
     const token = rotateIdentityToken(address, requestedScopes);
     if (!token) return c.json({ error: 'not_found' }, 404);
     const updated = findIdentity(address);
+
+    const scopeEvent = classifyScopeChange(prevScopes, updated?.scopes);
+    if (scopeEvent) {
+      recordAuditEvent({
+        event: scopeEvent,
+        address,
+        outcome: 'ok',
+        ...(updated?.scopes !== undefined ? { scopes: updated.scopes } : {}),
+        ip: clientIp(c),
+      });
+    }
+
     return c.json({
       address,
       token,

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -80,7 +80,15 @@ const {
 } = await import('../src/lib/auth.ts');
 const { createHash } = await import('node:crypto');
 const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
-const { putAccessTokenForTests, peekAccessToken } = await import('../src/lib/oauth-store.ts');
+const {
+  putAccessTokenForTests,
+  peekAccessToken,
+  invalidateStoreCache,
+  recordPrunedAccessHash,
+  getPrunedAccessHashesCountForTests,
+  clearPrunedAccessHashesForTests,
+  PRUNED_ACCESS_HASHES_CAP,
+} = await import('../src/lib/oauth-store.ts');
 const { resolveResourceUri } = await import('../src/lib/oauth-url.ts');
 
 const sha256Hex = (val: string) => createHash('sha256').update(val).digest('hex');
@@ -1795,6 +1803,87 @@ describe('Issue #114: read-only API token scopes', () => {
       } finally {
         writeFileSync(storePath, goodData);
       }
+    });
+
+    test('6e. Real save-path prune + disk persistence + cache invalidation + corrupt store -> 401 unauthorized (not 500)', async () => {
+      const user = createIdentity({ localpart: 'tombstone-user', scopes: ['read:messages'] })!;
+      const expiredToken = 'tombstone_expired_oauth_token_88888';
+      const newToken = 'tombstone_new_oauth_token_99999';
+
+      // 1. Seed an OAuth token with past expiresAt
+      putAccessTokenForTests({
+        token: expiredToken,
+        grantId: 'grant-tombstone-1',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: Date.now() - 1000,
+        ensureGrant: { clientId: 'client-tombstone', clientName: 'Client Tombstone' },
+      });
+
+      // 2. Perform a REAL save-path mutation (seed another access token via save-path).
+      // This drives pruneExpired() which deletes expiredToken from access table, records its hash
+      // into prunedAccessHashes tombstone set, and writes the pruned state to disk.
+      putAccessTokenForTests({
+        token: newToken,
+        grantId: 'grant-tombstone-2',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-tombstone', clientName: 'Client Tombstone' },
+        runSave: true,
+      });
+
+      // 3. Invalidate caches to force disk reload (rawCache and storeCache both cleared)
+      invalidateStoreCache();
+
+      // Verify that expiredToken is indeed gone from disk raw store
+      const { readFileSync } = await import('node:fs');
+      const oauthDisk = JSON.parse(readFileSync(join(config.dataDir, 'oauth.json'), 'utf8'));
+      expect(oauthDisk.access[sha256Hex(expiredToken)]).toBeUndefined();
+
+      // 4. Corrupt identity store
+      const storePath = join(config.dataDir, 'identities.json');
+      const goodData = readFileSync(storePath, 'utf8');
+
+      try {
+        writeFileSync(storePath, '[{ malformed json');
+
+        // 5. Real HTTP request with the expired token:
+        // Although gone from disk and cache, the in-process tombstone set remembers it as an OAuth credential.
+        // peekAccessToken returns true, so resolveAccessToken fails closed with 401, NOT 500.
+        const res = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${expiredToken}` },
+        });
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'unauthorized' });
+
+        const direct = resolveAccessToken(expiredToken, { resource });
+        expect(direct.status).toBe('unauthorized');
+      } finally {
+        writeFileSync(storePath, goodData);
+      }
+    });
+
+    test('6f. Tombstone boundedness: prunedAccessHashes respects capacity limit with FIFO eviction', () => {
+      clearPrunedAccessHashesForTests();
+      expect(getPrunedAccessHashesCountForTests()).toBe(0);
+
+      // Record entries up to cap
+      for (let i = 0; i < PRUNED_ACCESS_HASHES_CAP; i++) {
+        recordPrunedAccessHash(`hash_${i}`);
+      }
+      expect(getPrunedAccessHashesCountForTests()).toBe(PRUNED_ACCESS_HASHES_CAP);
+
+      // Add 10 more entries beyond cap
+      for (let i = 0; i < 10; i++) {
+        recordPrunedAccessHash(`overflow_hash_${i}`);
+      }
+      // Capacity must be strictly bounded at PRUNED_ACCESS_HASHES_CAP
+      expect(getPrunedAccessHashesCountForTests()).toBe(PRUNED_ACCESS_HASHES_CAP);
+
+      // Re-recording an existing entry refreshes position without expanding size
+      recordPrunedAccessHash('overflow_hash_0');
+      expect(getPrunedAccessHashesCountForTests()).toBe(PRUNED_ACCESS_HASHES_CAP);
     });
   });
 });

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -1630,11 +1630,15 @@ describe('Issue #114: read-only API token scopes', () => {
       expect(res5.status).toBe(400);
     });
 
-    test('6. Fail-closed: real corrupt-store path returns 401 unauthorized on app request for OAuth tokens', async () => {
+    test('6. Fail-closed: real corrupt-store path distinguishes credential classes (OAuth vs oa_/garbage)', async () => {
       const user = createIdentity({ localpart: 'failclosed-user', scopes: ['read:messages'] })!;
-      const oauthToken = 'oauth_valid_failclosed_token_11111';
+      const oaToken = user.token; // valid oa_ token
+      const validOAuthToken = 'oauth_valid_failclosed_token_11111';
+      const expiredOAuthToken = 'oauth_expired_failclosed_token_22222';
+      const garbageToken = 'some_garbage_non_oauth_token_xyz';
+
       putAccessTokenForTests({
-        token: oauthToken,
+        token: validOAuthToken,
         grantId: 'grant-failclosed-4',
         address: user.identity.address,
         aud: resource,
@@ -1642,33 +1646,49 @@ describe('Issue #114: read-only API token scopes', () => {
         ensureGrant: { clientId: 'client-failclosed', clientName: 'Client Failclosed' },
       });
 
+      const now = Date.now();
+      putAccessTokenForTests({
+        token: expiredOAuthToken,
+        grantId: 'grant-failclosed-5',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: now + 10_000,
+        ensureGrant: { clientId: 'client-failclosed-exp', clientName: 'Client Failclosed Exp' },
+      });
+
       const storePath = join(config.dataDir, 'identities.json');
       const goodData = readFileSync(storePath, 'utf8');
 
       try {
         // Write malformed JSON to identities store file on disk.
-        // Both findIdentityByToken probe and findIdentity OAuth lookup encounter this error.
         writeFileSync(storePath, '[{ malformed json');
 
-        // 1. resolveAccessToken directly fails-closed with unauthorized (not 500 error)
-        const resolved = resolveAccessToken(oauthToken, { resource });
-        expect(resolved.status).toBe('unauthorized');
+        // 1. oa_ identity token + malformed store -> 500 internal_error (error propagates per integrity contract)
+        const resOa = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${oaToken}` },
+        });
+        expect(resOa.status).toBe(500);
+        expect(await resOa.json()).toEqual({ error: 'internal_error' });
 
-        // 2. Real HTTP app.request with valid OAuth token returns 401 unauthorized (not 500 internal_error)
+        // 2. Garbage token + malformed store -> 500 internal_error (pre-existing behavior preserved)
+        const resGarbage = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${garbageToken}` },
+        });
+        expect(resGarbage.status).toBe(500);
+        expect(await resGarbage.json()).toEqual({ error: 'internal_error' });
+
+        // 3. Valid OAuth token + malformed store -> 401 unauthorized (Issue #127 fail-closed path)
         const resOAuth = await app.request(`/v1/messages?address=${user.identity.address}`, {
-          headers: { authorization: `Bearer ${oauthToken}` },
+          headers: { authorization: `Bearer ${validOAuthToken}` },
         });
         expect(resOAuth.status).toBe(401);
         expect(await resOAuth.json()).toEqual({ error: 'unauthorized' });
 
-        // 3. Real HTTP app.request with non-OAuth token also returns 401 unauthorized (not 500 internal_error)
-        const resOther = await app.request(`/v1/messages?address=${user.identity.address}`, {
-          headers: { authorization: 'Bearer some_non_oauth_token' },
-        });
-        expect(resOther.status).toBe(401);
-        expect(await resOther.json()).toEqual({ error: 'unauthorized' });
+        // 4. Expired OAuth token + malformed store -> 401 unauthorized (not 500)
+        const resExpiredOAuth = resolveAccessToken(expiredOAuthToken, { resource, now: now + 20_000 });
+        expect(resExpiredOAuth.status).toBe('unauthorized');
 
-        // 4. Admin requests remain completely unaffected (never read identity store)
+        // 5. Admin key + malformed store -> fully functional (200 on admin endpoint)
         const resAdmin = await app.request(`/v1/audit/events?limit=1`, {
           headers: { authorization: `Bearer ${adminKey}` },
         });
@@ -1679,12 +1699,12 @@ describe('Issue #114: read-only API token scopes', () => {
       }
     });
 
-    test('6b. Fail-closed: findIdentityByToken probe throw falls through to OAuth branch and fails closed (401)', async () => {
+    test('6b. Fail-closed: findIdentityByToken probe throw falls through for OAuth credentials and fails closed (401)', async () => {
       const user = createIdentity({ localpart: 'probe-throw-user', scopes: ['read:messages'] })!;
-      const oauthToken = 'oauth_probe_throw_token_22222';
+      const oauthToken = 'oauth_probe_throw_token_33333';
       putAccessTokenForTests({
         token: oauthToken,
-        grantId: 'grant-probe-5',
+        grantId: 'grant-probe-6',
         address: user.identity.address,
         aud: resource,
         expiresAt: Date.now() + 3600_000,

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events';
-import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,9 +9,10 @@ process.env.IMAP_USER = 'agent@test.example';
 process.env.IMAP_PASS = 'imap-secret';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
+process.env.MCP_PUBLIC_URL = 'http://localhost';
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-scopes-test-'));
 
-const { beforeAll, describe, expect, mock, test } = await import('bun:test');
+const { beforeAll, describe, expect, mock, spyOn, test } = await import('bun:test');
 
 let fakeMessages: any[] = [
   {
@@ -61,6 +62,7 @@ mock.module('../src/lib/smtp.ts', () => ({ sendMail: sendMailMock }));
 
 const { config } = await import('../src/lib/config.ts');
 const { createApp } = await import('../src/app.ts');
+const identitiesModule = await import('../src/lib/identities.ts');
 const {
   createIdentity,
   findIdentity,
@@ -78,6 +80,8 @@ const {
 } = await import('../src/lib/auth.ts');
 const { createHash } = await import('node:crypto');
 const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
+const { putAccessTokenForTests } = await import('../src/lib/oauth-store.ts');
+const { resolveResourceUri } = await import('../src/lib/oauth-url.ts');
 
 const sha256Hex = (val: string) => createHash('sha256').update(val).digest('hex');
 const adminKey = [...config.apiKeys][0]!;
@@ -303,10 +307,32 @@ describe('Issue #114: read-only API token scopes', () => {
       })!;
       const addr = created.identity.address;
 
-      // 1. Rotation with absent body -> resets to unscoped token
-      const resReset = await app.request(`/v1/identities/${addr}/token`, {
+      // 1. Rotation with absent body -> preserves existing scopes
+      const resPreserve = await app.request(`/v1/identities/${addr}/token`, {
         method: 'POST',
         headers: { authorization: `Bearer ${adminKey}` },
+      });
+      expect(resPreserve.status).toBe(200);
+      const dataPreserve = (await resPreserve.json()) as { token: string; scopes?: string[] };
+      expect(dataPreserve.token).toBeTruthy();
+      expect(dataPreserve.scopes).toEqual(['read:messages']);
+      expect(findIdentity(addr)!.scopes).toEqual(['read:messages']);
+
+      // Verify the new token has preserved scopes
+      const resAuthPreserve = resolveAccessToken(dataPreserve.token);
+      expect(resAuthPreserve.status).toBe('ok');
+      if (resAuthPreserve.status === 'ok') {
+        expect((resAuthPreserve.auth as any).scopes).toEqual(['read:messages']);
+      }
+
+      // 2. Rotation with explicit {"scopes": null} -> resets to unscoped full-permission token
+      const resReset = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: null }),
       });
       expect(resReset.status).toBe(200);
       const dataReset = (await resReset.json()) as { token: string; scopes?: string[] };
@@ -321,7 +347,7 @@ describe('Issue #114: read-only API token scopes', () => {
         expect((resAuthReset.auth as any).scopes).toBeUndefined();
       }
 
-      // 2. Rotation with explicit read:messages
+      // 3. Rotation with explicit read:messages
       const resScoped = await app.request(`/v1/identities/${addr}/token`, {
         method: 'POST',
         headers: {
@@ -1247,6 +1273,365 @@ describe('Issue #114: read-only API token scopes', () => {
       });
       expect(res.status).toBe(413);
       expect(await res.json()).toEqual({ error: 'request_too_large' });
+    });
+  });
+
+  describe('Issue #127: OAuth channel inherits identity scopes and audit events', () => {
+    const resource = resolveResourceUri('http://localhost');
+
+    function getAuditLogs(): any[] {
+      const p = join(config.dataDir, 'audit.jsonl');
+      if (!existsSync(p)) return [];
+      return readFileSync(p, 'utf8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+    }
+
+    test('1. OAuth access token inherits scoped identity scopes and is intercepted by scope policy', async () => {
+      const created = createIdentity({
+        localpart: 'oauth-scoped-user',
+        scopes: ['read:messages'],
+      })!;
+      const oauthToken = 'oa_oauth_scoped_token_12345';
+      putAccessTokenForTests({
+        token: oauthToken,
+        grantId: 'grant-oauth-scoped-1',
+        address: created.identity.address,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-1', clientName: 'Client 1' },
+      });
+
+      // Verification: resolveAccessToken inherits scopes
+      const authRes = resolveAccessToken(oauthToken, { resource });
+      expect(authRes.status).toBe('ok');
+      if (authRes.status === 'ok') {
+        expect(authRes.auth.kind).toBe('identity');
+        expect((authRes.auth as any).scopes).toEqual(['read:messages']);
+      }
+
+      // Read operation allowed
+      const resRead = await app.request(`/v1/messages?address=${created.identity.address}`, {
+        headers: { authorization: `Bearer ${oauthToken}` },
+      });
+      expect(resRead.status).toBe(200);
+
+      // Write operation denied 403 forbidden: insufficient_scope
+      const resSend = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${oauthToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: created.identity.address,
+          to: 'recipient@example.net',
+          subject: 'OAuth write attempt',
+          text: 'Should be denied',
+        }),
+      });
+      expect(resSend.status).toBe(403);
+      expect(await resSend.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // Seen status update denied 403
+      const resSeen = await app.request(`/v1/messages/101/seen`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${oauthToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ address: created.identity.address, seen: true }),
+      });
+      expect(resSeen.status).toBe(403);
+      expect(await resSeen.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('2. Revocation sync: rotating identity scopes immediately affects OAuth access token resolution', async () => {
+      const created = createIdentity({
+        localpart: 'oauth-sync-user',
+        scopes: ['read:messages'],
+      })!;
+      const oauthToken = 'oa_oauth_sync_token_54321';
+      putAccessTokenForTests({
+        token: oauthToken,
+        grantId: 'grant-oauth-sync-2',
+        address: created.identity.address,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-sync', clientName: 'Client Sync' },
+      });
+
+      // Before rotation: can read messages
+      const beforeRes = await app.request(`/v1/messages?address=${created.identity.address}`, {
+        headers: { authorization: `Bearer ${oauthToken}` },
+      });
+      expect(beforeRes.status).toBe(200);
+
+      // Rotate identity token to narrow scopes to empty array []
+      const rotateRes = await app.request(`/v1/identities/${created.identity.address}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: [] }),
+      });
+      expect(rotateRes.status).toBe(200);
+
+      // Now OAuth token immediately inherits [] on resolution and is denied on reads!
+      const afterRes = await app.request(`/v1/messages?address=${created.identity.address}`, {
+        headers: { authorization: `Bearer ${oauthToken}` },
+      });
+      expect(afterRes.status).toBe(403);
+      expect(await afterRes.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+
+    test('3. Old data: identity record without scopes field in store yields full power for both OAuth and oa_ tokens', async () => {
+      const storePath = join(config.dataDir, 'identities.json');
+      const raw = JSON.parse(readFileSync(storePath, 'utf8'));
+      const legacyToken = 'oa_legacy_unscoped_token_999999999999';
+      const legacyAddr = `legacy-user@${config.domain}`;
+      raw.push({
+        address: legacyAddr,
+        createdAt: new Date().toISOString(),
+        tokenHash: sha256Hex(legacyToken),
+      });
+      writeFileSync(storePath, JSON.stringify(raw, null, 2));
+
+      // 1. oa_ token has no scopes attached -> full power
+      const authOa = resolveAccessToken(legacyToken);
+      expect(authOa.status).toBe('ok');
+      if (authOa.status === 'ok') {
+        expect((authOa.auth as any).scopes).toBeUndefined();
+      }
+
+      // 2. OAuth token also has no scopes attached -> full power
+      const oauthLegacyToken = 'oa_oauth_legacy_token_88888';
+      putAccessTokenForTests({
+        token: oauthLegacyToken,
+        grantId: 'grant-legacy-3',
+        address: legacyAddr,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-legacy', clientName: 'Client Legacy' },
+      });
+
+      const authOauth = resolveAccessToken(oauthLegacyToken, { resource });
+      expect(authOauth.status).toBe('ok');
+      if (authOauth.status === 'ok') {
+        expect((authOauth.auth as any).scopes).toBeUndefined();
+      }
+
+      // Send mail with OAuth token succeeds (does not hit 403 scope check)
+      const resSend = await app.request('/v1/send', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${oauthLegacyToken}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: legacyAddr,
+          to: 'recipient@example.net',
+          subject: 'Legacy full power send',
+          text: 'Allowed',
+        }),
+      });
+      expect(resSend.status).toBe(200);
+    });
+
+    test('4. Audit events: scope set/changed paths append expected recordAuditEvent rows', async () => {
+      // (a) Creation with scopes
+      const resCreate = await app.request('/v1/identities', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          localpart: 'audit-user',
+          scopes: ['read:messages'],
+        }),
+      });
+      expect(resCreate.status).toBe(201);
+      const auditAddr = `audit-user@${config.domain}`;
+
+      let logs = getAuditLogs();
+      const createEvent = logs.find((l) => l.address === auditAddr && l.event === 'identity.scopes.create');
+      expect(createEvent).toBeDefined();
+      expect(createEvent.outcome).toBe('ok');
+      expect(createEvent.scopes).toEqual(['read:messages']);
+
+      // (b) Rotation narrowing scopes: ['read:messages'] -> []
+      const resNarrow = await app.request(`/v1/identities/${auditAddr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: [] }),
+      });
+      expect(resNarrow.status).toBe(200);
+
+      logs = getAuditLogs();
+      const narrowEvent = logs.find((l) => l.address === auditAddr && l.event === 'identity.scopes.narrow');
+      expect(narrowEvent).toBeDefined();
+      expect(narrowEvent.outcome).toBe('ok');
+      expect(narrowEvent.scopes).toEqual([]);
+
+      // (c) Rotation widening scopes: [] -> ['read:messages']
+      const resWiden = await app.request(`/v1/identities/${auditAddr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: ['read:messages'] }),
+      });
+      expect(resWiden.status).toBe(200);
+
+      logs = getAuditLogs();
+      const widenEvent = logs.find((l) => l.address === auditAddr && l.event === 'identity.scopes.widen');
+      expect(widenEvent).toBeDefined();
+      expect(widenEvent.outcome).toBe('ok');
+      expect(widenEvent.scopes).toEqual(['read:messages']);
+
+      // (d) Rotation clearing scopes: ['read:messages'] -> {"scopes": null}
+      const resClear = await app.request(`/v1/identities/${auditAddr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: null }),
+      });
+      expect(resClear.status).toBe(200);
+
+      logs = getAuditLogs();
+      const clearEvent = logs.find((l) => l.address === auditAddr && l.event === 'identity.scopes.clear');
+      expect(clearEvent).toBeDefined();
+      expect(clearEvent.outcome).toBe('ok');
+      expect(clearEvent.scopes).toBeUndefined();
+
+      // (e) Rotation setting scopes on previously cleared (unscoped) identity: undefined -> ['read:messages']
+      const resSet = await app.request(`/v1/identities/${auditAddr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: ['read:messages'] }),
+      });
+      expect(resSet.status).toBe(200);
+
+      logs = getAuditLogs();
+      const setEvent = logs.find((l) => l.address === auditAddr && l.event === 'identity.scopes.set');
+      expect(setEvent).toBeDefined();
+      expect(setEvent.outcome).toBe('ok');
+      expect(setEvent.scopes).toEqual(['read:messages']);
+
+      // (f) Rotation with empty body (preserving scopes) does NOT append a new scope event
+      const logsCountBefore = getAuditLogs().length;
+      const resEmptyBody = await app.request(`/v1/identities/${auditAddr}/token`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${adminKey}` },
+      });
+      expect(resEmptyBody.status).toBe(200);
+      expect(getAuditLogs().length).toBe(logsCountBefore);
+    });
+
+    test('5. Rotation semantics: empty body preserves, {"scopes": null} resets full power, invalid scopes 400', async () => {
+      const ident = createIdentity({
+        localpart: 'semantics-user',
+        scopes: ['read:messages'],
+      })!;
+      const addr = ident.identity.address;
+
+      // Empty body preserves
+      const res1 = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${adminKey}` },
+      });
+      expect(res1.status).toBe(200);
+      expect(((await res1.json()) as any).scopes).toEqual(['read:messages']);
+      expect(findIdentity(addr)?.scopes).toEqual(['read:messages']);
+
+      // Explicit {"scopes": null} resets full power
+      const res2 = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: null }),
+      });
+      expect(res2.status).toBe(200);
+      expect(((await res2.json()) as any).scopes).toBeUndefined();
+      expect(findIdentity(addr)?.scopes).toBeUndefined();
+
+      // Empty body on unscoped preserves unscoped
+      const res3 = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${adminKey}` },
+      });
+      expect(res3.status).toBe(200);
+      expect(((await res3.json()) as any).scopes).toBeUndefined();
+      expect(findIdentity(addr)?.scopes).toBeUndefined();
+
+      // Invalid scopes: string instead of array or null -> 400
+      const res4 = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: 'read:messages' }),
+      });
+      expect(res4.status).toBe(400);
+
+      // Unknown scope -> 400
+      const res5 = await app.request(`/v1/identities/${addr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: ['unsupported:scope'] }),
+      });
+      expect(res5.status).toBe(400);
+    });
+
+    test('6. Fail-closed: identity-store read error during OAuth exchange returns unauthorized', async () => {
+      const user = createIdentity({ localpart: 'failclosed-user', scopes: ['read:messages'] })!;
+      const oauthToken = 'oa_oauth_failclosed_token_11111';
+      putAccessTokenForTests({
+        token: oauthToken,
+        grantId: 'grant-failclosed-4',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-failclosed', clientName: 'Client Failclosed' },
+      });
+
+      const spy = spyOn(identitiesModule, 'findIdentity').mockImplementation(() => {
+        throw new Error('identity_store_corrupt');
+      });
+
+      try {
+        // resolveAccessToken directly fails-closed with unauthorized
+        const resolved = resolveAccessToken(oauthToken, { resource });
+        expect(resolved.status).toBe('unauthorized');
+
+        // API request with OAuth token fails with 401 unauthorized
+        const res = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${oauthToken}` },
+        });
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'unauthorized' });
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 });

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -1539,6 +1539,34 @@ describe('Issue #114: read-only API token scopes', () => {
       });
       expect(resEmptyBody.status).toBe(200);
       expect(getAuditLogs().length).toBe(logsCountBefore);
+
+      // (g) Rotation replacing incomparable scopes: ['future:scope'] -> ['read:messages']
+      const storePath = join(config.dataDir, 'identities.json');
+      const raw = JSON.parse(readFileSync(storePath, 'utf8'));
+      const incompAddr = `incomp-user@${config.domain}`;
+      raw.push({
+        address: incompAddr,
+        createdAt: new Date().toISOString(),
+        tokenHash: sha256Hex('oa_incomp_initial_token_12345'),
+        scopes: ['future:scope'],
+      });
+      writeFileSync(storePath, JSON.stringify(raw, null, 2));
+
+      const resReplace = await app.request(`/v1/identities/${incompAddr}/token`, {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${adminKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({ scopes: ['read:messages'] }),
+      });
+      expect(resReplace.status).toBe(200);
+
+      logs = getAuditLogs();
+      const replaceEvent = logs.find((l) => l.address === incompAddr && l.event === 'identity.scopes.replace');
+      expect(replaceEvent).toBeDefined();
+      expect(replaceEvent.outcome).toBe('ok');
+      expect(replaceEvent.scopes).toEqual(['read:messages']);
     });
 
     test('5. Rotation semantics: empty body preserves, {"scopes": null} resets full power, invalid scopes 400', async () => {
@@ -1602,9 +1630,9 @@ describe('Issue #114: read-only API token scopes', () => {
       expect(res5.status).toBe(400);
     });
 
-    test('6. Fail-closed: identity-store read error during OAuth exchange returns unauthorized', async () => {
+    test('6. Fail-closed: real corrupt-store path returns 401 unauthorized on app request for OAuth tokens', async () => {
       const user = createIdentity({ localpart: 'failclosed-user', scopes: ['read:messages'] })!;
-      const oauthToken = 'oa_oauth_failclosed_token_11111';
+      const oauthToken = 'oauth_valid_failclosed_token_11111';
       putAccessTokenForTests({
         token: oauthToken,
         grantId: 'grant-failclosed-4',
@@ -1614,23 +1642,73 @@ describe('Issue #114: read-only API token scopes', () => {
         ensureGrant: { clientId: 'client-failclosed', clientName: 'Client Failclosed' },
       });
 
-      const spy = spyOn(identitiesModule, 'findIdentity').mockImplementation(() => {
+      const storePath = join(config.dataDir, 'identities.json');
+      const goodData = readFileSync(storePath, 'utf8');
+
+      try {
+        // Write malformed JSON to identities store file on disk.
+        // Both findIdentityByToken probe and findIdentity OAuth lookup encounter this error.
+        writeFileSync(storePath, '[{ malformed json');
+
+        // 1. resolveAccessToken directly fails-closed with unauthorized (not 500 error)
+        const resolved = resolveAccessToken(oauthToken, { resource });
+        expect(resolved.status).toBe('unauthorized');
+
+        // 2. Real HTTP app.request with valid OAuth token returns 401 unauthorized (not 500 internal_error)
+        const resOAuth = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${oauthToken}` },
+        });
+        expect(resOAuth.status).toBe(401);
+        expect(await resOAuth.json()).toEqual({ error: 'unauthorized' });
+
+        // 3. Real HTTP app.request with non-OAuth token also returns 401 unauthorized (not 500 internal_error)
+        const resOther = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: 'Bearer some_non_oauth_token' },
+        });
+        expect(resOther.status).toBe(401);
+        expect(await resOther.json()).toEqual({ error: 'unauthorized' });
+
+        // 4. Admin requests remain completely unaffected (never read identity store)
+        const resAdmin = await app.request(`/v1/audit/events?limit=1`, {
+          headers: { authorization: `Bearer ${adminKey}` },
+        });
+        expect(resAdmin.status).toBe(200);
+      } finally {
+        // Restore good data
+        writeFileSync(storePath, goodData);
+      }
+    });
+
+    test('6b. Fail-closed: findIdentityByToken probe throw falls through to OAuth branch and fails closed (401)', async () => {
+      const user = createIdentity({ localpart: 'probe-throw-user', scopes: ['read:messages'] })!;
+      const oauthToken = 'oauth_probe_throw_token_22222';
+      putAccessTokenForTests({
+        token: oauthToken,
+        grantId: 'grant-probe-5',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-probe', clientName: 'Client Probe' },
+      });
+
+      // Force findIdentityByToken probe to throw
+      const spyProbe = spyOn(identitiesModule, 'findIdentityByToken').mockImplementation(() => {
+        throw new Error('identity_store_corrupt');
+      });
+      // Force findIdentity in OAuth branch to also throw
+      const spyFind = spyOn(identitiesModule, 'findIdentity').mockImplementation(() => {
         throw new Error('identity_store_corrupt');
       });
 
       try {
-        // resolveAccessToken directly fails-closed with unauthorized
-        const resolved = resolveAccessToken(oauthToken, { resource });
-        expect(resolved.status).toBe('unauthorized');
-
-        // API request with OAuth token fails with 401 unauthorized
         const res = await app.request(`/v1/messages?address=${user.identity.address}`, {
           headers: { authorization: `Bearer ${oauthToken}` },
         });
         expect(res.status).toBe(401);
         expect(await res.json()).toEqual({ error: 'unauthorized' });
       } finally {
-        spy.mockRestore();
+        spyProbe.mockRestore();
+        spyFind.mockRestore();
       }
     });
   });

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -80,7 +80,7 @@ const {
 } = await import('../src/lib/auth.ts');
 const { createHash } = await import('node:crypto');
 const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
-const { putAccessTokenForTests } = await import('../src/lib/oauth-store.ts');
+const { putAccessTokenForTests, peekAccessToken } = await import('../src/lib/oauth-store.ts');
 const { resolveResourceUri } = await import('../src/lib/oauth-url.ts');
 
 const sha256Hex = (val: string) => createHash('sha256').update(val).digest('hex');
@@ -1646,16 +1646,6 @@ describe('Issue #114: read-only API token scopes', () => {
         ensureGrant: { clientId: 'client-failclosed', clientName: 'Client Failclosed' },
       });
 
-      const now = Date.now();
-      putAccessTokenForTests({
-        token: expiredOAuthToken,
-        grantId: 'grant-failclosed-5',
-        address: user.identity.address,
-        aud: resource,
-        expiresAt: now + 10_000,
-        ensureGrant: { clientId: 'client-failclosed-exp', clientName: 'Client Failclosed Exp' },
-      });
-
       const storePath = join(config.dataDir, 'identities.json');
       const goodData = readFileSync(storePath, 'utf8');
 
@@ -1684,9 +1674,21 @@ describe('Issue #114: read-only API token scopes', () => {
         expect(resOAuth.status).toBe(401);
         expect(await resOAuth.json()).toEqual({ error: 'unauthorized' });
 
-        // 4. Expired OAuth token + malformed store -> 401 unauthorized (not 500)
-        const resExpiredOAuth = resolveAccessToken(expiredOAuthToken, { resource, now: now + 20_000 });
-        expect(resExpiredOAuth.status).toBe('unauthorized');
+        // 4. Real wall-clock expired OAuth token + malformed store -> 401 unauthorized (not 500)
+        putAccessTokenForTests({
+          token: expiredOAuthToken,
+          grantId: 'grant-failclosed-5',
+          address: user.identity.address,
+          aud: resource,
+          expiresAt: Date.now() - 1000, // real wall-clock expiry in the past
+          ensureGrant: { clientId: 'client-failclosed-exp', clientName: 'Client Failclosed Exp' },
+        });
+
+        const resExpiredOAuth = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${expiredOAuthToken}` },
+        });
+        expect(resExpiredOAuth.status).toBe(401);
+        expect(await resExpiredOAuth.json()).toEqual({ error: 'unauthorized' });
 
         // 5. Admin key + malformed store -> fully functional (200 on admin endpoint)
         const resAdmin = await app.request(`/v1/audit/events?limit=1`, {
@@ -1730,6 +1732,27 @@ describe('Issue #114: read-only API token scopes', () => {
         spyProbe.mockRestore();
         spyFind.mockRestore();
       }
+    });
+
+    test('6c. peekAccessToken is non-destructive and does not prune expired tokens', () => {
+      const expiredToken = 'peek_test_expired_oauth_token_99999';
+      putAccessTokenForTests({
+        token: expiredToken,
+        grantId: 'grant-peek-test',
+        address: 'peek@test.example',
+        aud: resource,
+        expiresAt: Date.now() - 5000, // expired in the past
+        ensureGrant: { clientId: 'client-peek', clientName: 'Client Peek' },
+      });
+
+      // 1. Peek detects the token exists in the access table
+      expect(peekAccessToken(expiredToken)).toBe(true);
+
+      // 2. Token is STILL present after peek (peek does not prune)
+      expect(peekAccessToken(expiredToken)).toBe(true);
+
+      // 3. Peek returns false for tokens never in the access table
+      expect(peekAccessToken('non_existent_token_abc')).toBe(false);
     });
   });
 });

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -1646,6 +1646,15 @@ describe('Issue #114: read-only API token scopes', () => {
         ensureGrant: { clientId: 'client-failclosed', clientName: 'Client Failclosed' },
       });
 
+      putAccessTokenForTests({
+        token: expiredOAuthToken,
+        grantId: 'grant-failclosed-5',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: Date.now() - 1000, // real wall-clock expiry in the past
+        ensureGrant: { clientId: 'client-failclosed-exp', clientName: 'Client Failclosed Exp' },
+      });
+
       const storePath = join(config.dataDir, 'identities.json');
       const goodData = readFileSync(storePath, 'utf8');
 
@@ -1675,15 +1684,6 @@ describe('Issue #114: read-only API token scopes', () => {
         expect(await resOAuth.json()).toEqual({ error: 'unauthorized' });
 
         // 4. Real wall-clock expired OAuth token + malformed store -> 401 unauthorized (not 500)
-        putAccessTokenForTests({
-          token: expiredOAuthToken,
-          grantId: 'grant-failclosed-5',
-          address: user.identity.address,
-          aud: resource,
-          expiresAt: Date.now() - 1000, // real wall-clock expiry in the past
-          ensureGrant: { clientId: 'client-failclosed-exp', clientName: 'Client Failclosed Exp' },
-        });
-
         const resExpiredOAuth = await app.request(`/v1/messages?address=${user.identity.address}`, {
           headers: { authorization: `Bearer ${expiredOAuthToken}` },
         });
@@ -1753,6 +1753,48 @@ describe('Issue #114: read-only API token scopes', () => {
 
       // 3. Peek returns false for tokens never in the access table
       expect(peekAccessToken('non_existent_token_abc')).toBe(false);
+    });
+
+    test('6d. Shared-mutable-cache isolation: normal lookup drives prune on storeCache, peekAccessToken on rawCache still retains expired OAuth credential (401, not 500)', async () => {
+      const user = createIdentity({ localpart: 'prune-iso-user', scopes: ['read:messages'] })!;
+      const expiredToken = 'prune_iso_expired_oauth_token_77777';
+
+      // 1. Seed an OAuth token with past expiresAt
+      putAccessTokenForTests({
+        token: expiredToken,
+        grantId: 'grant-prune-iso',
+        address: user.identity.address,
+        aud: resource,
+        expiresAt: Date.now() - 1000,
+        ensureGrant: { clientId: 'client-prune-iso', clientName: 'Client Prune Iso' },
+      });
+
+      // 2. Perform a NORMAL resolution first (healthy identity store).
+      // This drives lookupAccessToken -> load() -> pruneExpired() on storeCache.
+      const normalRes = resolveAccessToken(expiredToken, { resource });
+      expect(normalRes.status).toBe('unauthorized');
+
+      // 3. THEN corrupt the identity store
+      const storePath = join(config.dataDir, 'identities.json');
+      const goodData = readFileSync(storePath, 'utf8');
+
+      try {
+        writeFileSync(storePath, '[{ malformed json');
+
+        // 4. resolveAccessToken / real HTTP request with that expired token:
+        // peekAccessToken uses rawCache (isolated from storeCache prune),
+        // so it recognizes the expired token as an OAuth credential and returns 401, NOT 500.
+        const res = await app.request(`/v1/messages?address=${user.identity.address}`, {
+          headers: { authorization: `Bearer ${expiredToken}` },
+        });
+        expect(res.status).toBe(401);
+        expect(await res.json()).toEqual({ error: 'unauthorized' });
+
+        const direct = resolveAccessToken(expiredToken, { resource });
+        expect(direct.status).toBe('unauthorized');
+      } finally {
+        writeFileSync(storePath, goodData);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

Addresses Issue #127 where OAuth channel access tokens bypassed identity token scope restrictions because `resolveAccessToken` omitted `scopes` on the returned identity auth context.

## Fix Approach

1. **OAuth Scope Inheritance**: In `resolveAccessToken()`, the OAuth branch now attaches `oauthIdentity.scopes` to the returned `auth` context when defined. Scoped credentials immediately inherit stored scope policies at token resolution time.
2. **Fail-Closed Guarantee**: The identity lookup `findIdentity(oauth.address)` in `resolveAccessToken()` is wrapped in a dedicated `try ... catch` block. If reading the identity store throws, the resolution fails closed with `{ status: 'unauthorized' }` (401), preventing fall-through to an unscoped full-power grant.
3. **Audit Trail for Scope Changes**: Extended `AuditEvent` with an optional scrubbed `scopes?: string[]` field adhering to whitelist discipline. Logged distinct audit events:
   - `identity.scopes.create`: emitted on `POST /v1/identities` when scopes are explicitly provided.
   - `identity.scopes.set`: emitted on `POST /v1/identities/:address/token` when setting scopes on an unscoped identity.
   - `identity.scopes.narrow`: emitted when scopes are narrowed (e.g. `['read:messages']` -> `[]`).
   - `identity.scopes.widen`: emitted when scopes are widened (e.g. `[]` -> `['read:messages']`).
   - `identity.scopes.clear`: emitted when scopes are cleared via `{"scopes": null}`.
   - Preserves non-blocking audit write failure tolerance.
4. **Rotation Semantics Alignment**: Updated `POST /v1/identities/:address/token` so that an empty/omitted request body preserves existing scopes (aligned with UI session rotation), while explicit `{"scopes": null}` resets the identity to unscoped full power. Misspelled keys and extra fields remain strictly rejected with 400.
5. **Client & Documentation**: Updated `OpenAgentEmailClient.rotateIdentityToken` options to accept `scopes?: string[] | null`, updated `README.md`, and aligned comments.

## Tradeoffs: Inherit-at-Exchange vs Cascade-Revoke

Issue #127 considered two architectural approaches:
- **Cascade-revoke**: When an identity's scopes are narrowed or modified, synchronously revoke all existing OAuth grants and active access/refresh tokens for that address.
- **Inherit-at-exchange (Selected)**: The OAuth access token resolution branch dynamically inherits the identity's current persisted scopes upon evaluation.

**Tradeoff Rationale**:
Inherit-at-exchange was chosen because:
1. It avoids abruptly breaking existing client connections and requiring re-consent/re-authorization when an operator is merely adjusting permissions.
2. Scope restrictions take effect immediately across all active OAuth access tokens without relying on asynchronous cache invalidation or cascade sweeps.
3. It keeps grant lifecycle decoupled from token permissions, maintaining `deleteIdentity()` as the single cascade boundary for total revocation.
4. It ensures identical permission behavior regardless of whether an identity operates via `oa_` bearer tokens or OAuth access tokens.

Closes #127

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth authentication now inherits an identity’s configured scopes.
  * Identity token rotation supports explicitly clearing scopes with `{"scopes": null}`.
  * Scope changes are recorded in audit events, including mixed replacements.

* **Bug Fixes**
  * Empty token-rotation requests now preserve existing scopes.
  * OAuth authentication fails safely when the associated identity cannot be loaded.
  * Authentication errors are handled according to credential type.

* **Documentation**
  * Updated token-rotation guidance to clarify scope preservation and reset behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Breaking change (advisory)

REST `POST /v1/identities/:address/token` with an **empty body** now **preserves existing scopes** (previously: minted an unscoped/full-power token). An explicit `{"scopes": null}` is required to reset to full power. Automation relying on the old bodyless-rotation-to-full-power behavior will receive scoped tokens instead (fail-safe direction). See README + #127.

Advisory P2 findings from the review gates are batched in #130 (non-blocking).
