### PR TITLE
feat(api): revocable mailbox delegation ACLs (#125)

### DIFF
--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -20,6 +20,7 @@ import { getMcpLoopbackBase } from './lib/mcp-loopback.ts';
 import { registerMcpHttpRoutes } from './mcp/http.ts';
 import { auditRoute } from './routes/audit.ts';
 import { identitiesRoute } from './routes/identities.ts';
+import { delegationsRoute } from './routes/delegations.ts';
 import { messagesRoute } from './routes/messages.ts';
 import { sendRoute } from './routes/send.ts';
 import { notifyRoute } from './routes/notify.ts';
@@ -104,6 +105,7 @@ export function createApp(options: AppOptions = {}): Hono {
   app.use('/v1/*', bearerAuth);
   app.use('/v1/*', scopePolicyMiddleware);
   app.route('/v1/identities', identitiesRoute);
+  app.route('/v1/delegations', delegationsRoute);
   app.route('/v1/messages', messagesRoute);
   app.route('/v1/send', sendRoute);
   app.route('/v1/notify', notifyRoute);

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -41,6 +41,9 @@ export type AuditEvent = {
   clientId?: string;
   grantId?: string;
   address?: string;
+  actor?: string;
+  mailbox?: string;
+  grantee?: string;
   tool?: string;
   tier?: string;
   outcome: AuditOutcome;
@@ -116,6 +119,15 @@ export function recordAuditEvent(
       : {}),
     ...(partial.address !== undefined
       ? { address: scrubAuditField(partial.address) }
+      : {}),
+    ...(partial.actor !== undefined
+      ? { actor: scrubAuditField(partial.actor) }
+      : {}),
+    ...(partial.mailbox !== undefined
+      ? { mailbox: scrubAuditField(partial.mailbox) }
+      : {}),
+    ...(partial.grantee !== undefined
+      ? { grantee: scrubAuditField(partial.grantee) }
       : {}),
     ...(partial.tool !== undefined
       ? { tool: scrubAuditField(partial.tool, 128) }

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -51,6 +51,7 @@ export type TokenAttribution =
 declare module 'hono' {
   interface ContextVariableMap {
     auth: Auth;
+    attribution?: TokenAttribution;
   }
 }
 
@@ -224,6 +225,7 @@ export const bearerAuth = createMiddleware(async (c, next) => {
   const result = resolveAccessToken(token, { resource });
   if (result.status === 'ok') {
     c.set('auth', result.auth);
+    c.set('attribution', result.attribution);
     await next();
     return;
   }
@@ -235,6 +237,10 @@ export const bearerAuth = createMiddleware(async (c, next) => {
 
 export function getAuth(c: Context): Auth {
   return c.get('auth');
+}
+
+export function getAttribution(c: Context): TokenAttribution | undefined {
+  return c.get('attribution');
 }
 
 /**

--- a/packages/api/src/lib/auth.ts
+++ b/packages/api/src/lib/auth.ts
@@ -20,6 +20,7 @@ import { config } from './config.ts';
 import { findIdentity, findIdentityByToken, findIdentityByTokenHash } from './identities.ts';
 import { getGrant, lookupAccessToken, peekAccessToken } from './oauth-store.ts';
 import { resolveResourceUri } from './oauth-url.ts';
+import { hasActiveDelegation } from './delegations.ts';
 
 function sha256Hex(value: string): string {
   return createHash('sha256').update(value).digest('hex');
@@ -247,3 +248,26 @@ export function forbidUnlessAddress(c: Context, address: string) {
   if (auth.address === address.toLowerCase()) return null;
   return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
 }
+
+/**
+ * Check that the caller may access `mailbox` (for read operations):
+ * 1. Admin may access any mailbox;
+ * 2. Identity may access its own mailbox;
+ * 3. Identity may access a mailbox with an active, unrevoked delegation grant.
+ * Returns null if allowed, or 403 Response if denied.
+ */
+export function forbidUnlessMailboxAccess(
+  c: Context,
+  mailbox: string,
+  requiredScope: string = 'read:messages',
+) {
+  const auth = getAuth(c);
+  if (auth.kind === 'admin') return null;
+  const targetMailbox = mailbox.trim().toLowerCase();
+  if (auth.address.toLowerCase() === targetMailbox) return null;
+  if (hasActiveDelegation(targetMailbox, auth.address, requiredScope)) {
+    return null;
+  }
+  return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+}
+

--- a/packages/api/src/lib/delegations.ts
+++ b/packages/api/src/lib/delegations.ts
@@ -1,0 +1,364 @@
+import {
+  existsSync,
+  mkdirSync,
+  chmodSync,
+  readFileSync,
+  writeFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import { config } from './config.ts';
+import { recordAuditEvent } from './audit.ts';
+
+export const DELEGATION_STORE_SCHEMA_VERSION = 1;
+export const DELEGATION_STORE_FILE = 'delegations.json';
+
+export interface DelegationGrant {
+  id: string;
+  mailbox: string;
+  grantee: string;
+  scopes: string[];
+  createdAt: string;
+  createdBy: string;
+  revokedAt: string | null;
+  revokedBy: string | null;
+  [key: string]: unknown;
+}
+
+export interface DelegationStoreFile {
+  schemaVersion: typeof DELEGATION_STORE_SCHEMA_VERSION;
+  grants: DelegationGrant[];
+  [key: string]: unknown;
+}
+
+function storePath(): string {
+  return join(config.dataDir, DELEGATION_STORE_FILE);
+}
+
+function isGrantShape(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object') return false;
+  const g = value as Record<string, unknown>;
+  return (
+    typeof g.id === 'string' &&
+    typeof g.mailbox === 'string' &&
+    typeof g.grantee === 'string' &&
+    Array.isArray(g.scopes) &&
+    g.scopes.every((s) => typeof s === 'string') &&
+    typeof g.createdAt === 'string' &&
+    typeof g.createdBy === 'string' &&
+    (g.revokedAt === null || typeof g.revokedAt === 'string') &&
+    (g.revokedBy === null || g.revokedBy === undefined || typeof g.revokedBy === 'string')
+  );
+}
+
+function coerceGrant(raw: Record<string, unknown>): DelegationGrant {
+  return {
+    ...raw,
+    id: raw.id as string,
+    mailbox: (raw.mailbox as string).trim().toLowerCase(),
+    grantee: (raw.grantee as string).trim().toLowerCase(),
+    scopes: Array.isArray(raw.scopes) ? (raw.scopes as string[]) : [],
+    createdAt: raw.createdAt as string,
+    createdBy: raw.createdBy as string,
+    revokedAt: (raw.revokedAt as string | null) ?? null,
+    revokedBy: (raw.revokedBy as string | null) ?? null,
+  };
+}
+
+function isDelegationStoreShape(
+  value: unknown,
+): value is { schemaVersion: number; grants: unknown[]; [key: string]: unknown } {
+  if (!value || typeof value !== 'object') return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    obj.schemaVersion === DELEGATION_STORE_SCHEMA_VERSION &&
+    Array.isArray(obj.grants) &&
+    obj.grants.every(isGrantShape)
+  );
+}
+
+type StoreFileVersion = {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+};
+
+const MISSING_STORE_VERSION: StoreFileVersion = {
+  dev: 0,
+  ino: 0,
+  mtimeMs: -1,
+  ctimeMs: -1,
+  size: -1,
+};
+
+type StoreCache = {
+  version: StoreFileVersion;
+  store: DelegationStoreFile;
+};
+
+let storeCache: StoreCache | undefined;
+
+export function invalidateDelegationStoreCache(): void {
+  storeCache = undefined;
+}
+
+function fileVersionFromStat(st: {
+  dev: number;
+  ino: number;
+  mtimeMs: number;
+  ctimeMs: number;
+  size: number;
+}): StoreFileVersion {
+  return {
+    dev: st.dev,
+    ino: st.ino,
+    mtimeMs: st.mtimeMs,
+    ctimeMs: st.ctimeMs,
+    size: st.size,
+  };
+}
+
+function storeVersionsEqual(a: StoreFileVersion, b: StoreFileVersion): boolean {
+  return (
+    a.dev === b.dev &&
+    a.ino === b.ino &&
+    a.mtimeMs === b.mtimeMs &&
+    a.ctimeMs === b.ctimeMs &&
+    a.size === b.size
+  );
+}
+
+function load(): DelegationStoreFile {
+  const path = storePath();
+  if (!existsSync(path)) {
+    if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
+      return storeCache.store;
+    }
+    storeCache = {
+      version: MISSING_STORE_VERSION,
+      store: {
+        schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
+        grants: [],
+      },
+    };
+    return storeCache.store;
+  }
+  try {
+    const version = fileVersionFromStat(statSync(path));
+    if (storeCache && storeVersionsEqual(storeCache.version, version)) {
+      return storeCache.store;
+    }
+    const parsed = JSON.parse(readFileSync(path, 'utf8'));
+    if (!isDelegationStoreShape(parsed)) {
+      throw new Error('invalid delegation store shape');
+    }
+    const grants = parsed.grants.map((entry) => coerceGrant(entry as Record<string, unknown>));
+    const store: DelegationStoreFile = {
+      ...parsed,
+      schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
+      grants,
+    };
+    storeCache = {
+      version,
+      store,
+    };
+    return storeCache.store;
+  } catch (err) {
+    invalidateDelegationStoreCache();
+    if ((err as Error).message === 'delegation_store_corrupt') throw err;
+    throw new Error('delegation_store_corrupt');
+  }
+}
+
+function save(store: DelegationStoreFile): void {
+  invalidateDelegationStoreCache();
+  mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(config.dataDir, 0o700);
+  } catch {
+    // best effort
+  }
+  const path = storePath();
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+}
+
+export function createDelegation(params: {
+  mailbox: string;
+  grantee: string;
+  scopes?: string[];
+  createdBy: string;
+  id?: string;
+  createdAt?: string;
+}): DelegationGrant {
+  const store = load();
+  const mailbox = params.mailbox.trim().toLowerCase();
+  const grantee = params.grantee.trim().toLowerCase();
+  const grant: DelegationGrant = {
+    id: params.id ?? `delg_${randomBytes(12).toString('hex')}`,
+    mailbox,
+    grantee,
+    scopes: params.scopes && params.scopes.length > 0 ? [...params.scopes] : ['read:messages'],
+    createdAt: params.createdAt ?? new Date().toISOString(),
+    createdBy: params.createdBy,
+    revokedAt: null,
+    revokedBy: null,
+  };
+  store.grants.push(grant);
+  save(store);
+  return grant;
+}
+
+export function getDelegation(id: string): DelegationGrant | undefined {
+  const store = load();
+  return store.grants.find((g) => g.id === id);
+}
+
+export function listDelegations(filter?: {
+  mailbox?: string;
+  grantee?: string;
+}): DelegationGrant[] {
+  const store = load();
+  let result = store.grants;
+  if (filter?.mailbox) {
+    const mb = filter.mailbox.trim().toLowerCase();
+    result = result.filter((g) => g.mailbox === mb);
+  }
+  if (filter?.grantee) {
+    const gt = filter.grantee.trim().toLowerCase();
+    result = result.filter((g) => g.grantee === gt);
+  }
+  return result;
+}
+
+export function findActiveDelegation(
+  mailbox: string,
+  grantee: string,
+  requiredScope?: string,
+): DelegationGrant | undefined {
+  const grants = listDelegations({ mailbox, grantee });
+  return grants.find((g) => {
+    if (g.revokedAt !== null) return false;
+    if (requiredScope && !g.scopes.includes(requiredScope)) return false;
+    return true;
+  });
+}
+
+export function hasActiveDelegation(
+  mailbox: string,
+  grantee: string,
+  requiredScope?: string,
+): boolean {
+  return findActiveDelegation(mailbox, grantee, requiredScope) !== undefined;
+}
+
+/**
+ * 撤销委托：写入 revokedAt 墓碑。
+ * 幂等：若已撤销，保留原 revokedAt / revokedBy 返回。
+ */
+export function revokeDelegation(
+  id: string,
+  revokedBy: string,
+  revokedAt?: string,
+): DelegationGrant | null {
+  const store = load();
+  const grant = store.grants.find((g) => g.id === id);
+  if (!grant) return null;
+  if (grant.revokedAt !== null) {
+    return grant;
+  }
+  grant.revokedAt = revokedAt ?? new Date().toISOString();
+  grant.revokedBy = revokedBy;
+  save(store);
+  return grant;
+}
+
+/**
+ * 级联撤销：当某一身份被删除时，双向级联撤销（作为 owner 授出 + 作为 grantee 被授）。
+ */
+export function revokeDelegationsForAddress(
+  address: string,
+  opts?: { actor?: string; ts?: string },
+): number {
+  const store = load();
+  const needle = address.trim().toLowerCase();
+  const toRevoke = store.grants.filter(
+    (g) => g.revokedAt === null && (g.mailbox === needle || g.grantee === needle),
+  );
+  if (toRevoke.length === 0) return 0;
+
+  const now = opts?.ts ?? new Date().toISOString();
+  const actor = opts?.actor ?? 'cascade';
+
+  for (const grant of toRevoke) {
+    grant.revokedAt = now;
+    grant.revokedBy = actor;
+    recordAuditEvent({
+      event: 'delegation.revoke.cascade',
+      outcome: 'ok',
+      grantId: grant.id,
+      actor,
+      mailbox: grant.mailbox,
+      grantee: grant.grantee,
+      scopes: grant.scopes,
+      ...(opts?.ts ? { ts: opts.ts } : {}),
+    });
+  }
+  save(store);
+  return toRevoke.length;
+}
+
+/**
+ * 级联撤销：当受托人（grantee）轮换 token 时级联撤销（owner 轮换不撤）。
+ */
+export function revokeDelegationsOnGranteeTokenRotate(
+  granteeAddress: string,
+  opts?: { actor?: string; ts?: string },
+): number {
+  const store = load();
+  const needle = granteeAddress.trim().toLowerCase();
+  const toRevoke = store.grants.filter(
+    (g) => g.revokedAt === null && g.grantee === needle,
+  );
+  if (toRevoke.length === 0) return 0;
+
+  const now = opts?.ts ?? new Date().toISOString();
+  const actor = opts?.actor ?? 'cascade';
+
+  for (const grant of toRevoke) {
+    grant.revokedAt = now;
+    grant.revokedBy = actor;
+    recordAuditEvent({
+      event: 'delegation.revoke.cascade',
+      outcome: 'ok',
+      grantId: grant.id,
+      actor,
+      mailbox: grant.mailbox,
+      grantee: grant.grantee,
+      scopes: grant.scopes,
+      ...(opts?.ts ? { ts: opts.ts } : {}),
+    });
+  }
+  save(store);
+  return toRevoke.length;
+}
+
+/** 测试辅助：清空存储与缓存 */
+export function resetDelegationStoreForTests(): void {
+  invalidateDelegationStoreCache();
+  const path = storePath();
+  if (existsSync(path)) {
+    try {
+      unlinkSync(path);
+    } catch {
+      // best effort
+    }
+  }
+}

--- a/packages/api/src/lib/delegations.ts
+++ b/packages/api/src/lib/delegations.ts
@@ -1,3 +1,9 @@
+// Single-writer process assumption: Like identities.json, delegations.json assumes a
+// single-writer process and does not support multi-process concurrent mutations on the same DATA_DIR.
+// Scope note: Currently delegations only support 'read:messages'. If additional scopes are
+// introduced in the future, all forbidUnlessMailboxAccess call sites must be audited to ensure
+// delegations do not unintentionally grant write or admin capabilities.
+
 import {
   existsSync,
   mkdirSync,
@@ -201,6 +207,12 @@ export function createDelegation(params: {
   const store = load();
   const mailbox = params.mailbox.trim().toLowerCase();
   const grantee = params.grantee.trim().toLowerCase();
+  const existing = store.grants.find(
+    (g) => g.revokedAt === null && g.mailbox === mailbox && g.grantee === grantee,
+  );
+  if (existing) {
+    return existing;
+  }
   const grant: DelegationGrant = {
     id: params.id ?? `delg_${randomBytes(12).toString('hex')}`,
     mailbox,
@@ -280,18 +292,12 @@ export function revokeDelegation(
   return grant;
 }
 
-/**
- * 级联撤销：当某一身份被删除时，双向级联撤销（作为 owner 授出 + 作为 grantee 被授）。
- */
-export function revokeDelegationsForAddress(
-  address: string,
+function cascadeRevokeGrants(
+  predicate: (grant: DelegationGrant) => boolean,
   opts?: { actor?: string; ts?: string },
 ): number {
   const store = load();
-  const needle = address.trim().toLowerCase();
-  const toRevoke = store.grants.filter(
-    (g) => g.revokedAt === null && (g.mailbox === needle || g.grantee === needle),
-  );
+  const toRevoke = store.grants.filter((g) => g.revokedAt === null && predicate(g));
   if (toRevoke.length === 0) return 0;
 
   const now = opts?.ts ?? new Date().toISOString();
@@ -300,6 +306,11 @@ export function revokeDelegationsForAddress(
   for (const grant of toRevoke) {
     grant.revokedAt = now;
     grant.revokedBy = actor;
+  }
+
+  save(store);
+
+  for (const grant of toRevoke) {
     recordAuditEvent({
       event: 'delegation.revoke.cascade',
       outcome: 'ok',
@@ -311,8 +322,19 @@ export function revokeDelegationsForAddress(
       ...(opts?.ts ? { ts: opts.ts } : {}),
     });
   }
-  save(store);
+
   return toRevoke.length;
+}
+
+/**
+ * 级联撤销：当某一身份被删除时，双向级联撤销（作为 owner 授出 + 作为 grantee 被授）。
+ */
+export function revokeDelegationsForAddress(
+  address: string,
+  opts?: { actor?: string; ts?: string },
+): number {
+  const needle = address.trim().toLowerCase();
+  return cascadeRevokeGrants((g) => g.mailbox === needle || g.grantee === needle, opts);
 }
 
 /**
@@ -322,32 +344,8 @@ export function revokeDelegationsOnGranteeTokenRotate(
   granteeAddress: string,
   opts?: { actor?: string; ts?: string },
 ): number {
-  const store = load();
   const needle = granteeAddress.trim().toLowerCase();
-  const toRevoke = store.grants.filter(
-    (g) => g.revokedAt === null && g.grantee === needle,
-  );
-  if (toRevoke.length === 0) return 0;
-
-  const now = opts?.ts ?? new Date().toISOString();
-  const actor = opts?.actor ?? 'cascade';
-
-  for (const grant of toRevoke) {
-    grant.revokedAt = now;
-    grant.revokedBy = actor;
-    recordAuditEvent({
-      event: 'delegation.revoke.cascade',
-      outcome: 'ok',
-      grantId: grant.id,
-      actor,
-      mailbox: grant.mailbox,
-      grantee: grant.grantee,
-      scopes: grant.scopes,
-      ...(opts?.ts ? { ts: opts.ts } : {}),
-    });
-  }
-  save(store);
-  return toRevoke.length;
+  return cascadeRevokeGrants((g) => g.grantee === needle, opts);
 }
 
 /** 测试辅助：清空存储与缓存 */

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -457,6 +457,7 @@ export function rotateIdentityToken(address: string, scopes?: string[] | null): 
   const needle = address.toLowerCase();
   const identity = identities.find((i) => i.address === needle);
   if (!identity) return null;
+  revokeDelegationsOnGranteeTokenRotate(needle);
   const { token, tokenHash } = generateToken();
   identity.tokenHash = tokenHash;
   if (scopes !== undefined) {
@@ -464,7 +465,6 @@ export function rotateIdentityToken(address: string, scopes?: string[] | null): 
     else identity.scopes = [...scopes];
   }
   save(identities);
-  revokeDelegationsOnGranteeTokenRotate(needle);
   return token;
 }
 
@@ -478,9 +478,9 @@ export function deleteIdentity(address: string): boolean {
   const needle = address.toLowerCase();
   const kept = identities.filter((i) => i.address !== needle);
   if (kept.length === identities.length) return false;
-  save(kept);
-  revokeGrantsForAddress(needle);
   revokeDelegationsForAddress(needle);
+  revokeGrantsForAddress(needle);
+  save(kept);
   return true;
 }
 

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -25,6 +25,10 @@ import { join } from 'node:path';
 import { createHash, randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
 import { config } from './config.ts';
 import { revokeGrantsForAddress } from './oauth-store.ts';
+import {
+  revokeDelegationsForAddress,
+  revokeDelegationsOnGranteeTokenRotate,
+} from './delegations.ts';
 
 /** Mail-arrival push content detail. 1 = interrupt only (default), 2 = +subject/from, 3 = +body preview/OTP. */
 export type PushContentTier = 1 | 2 | 3;
@@ -460,13 +464,14 @@ export function rotateIdentityToken(address: string, scopes?: string[] | null): 
     else identity.scopes = [...scopes];
   }
   save(identities);
+  revokeDelegationsOnGranteeTokenRotate(needle);
   return token;
 }
 
 /**
  * Remove an identity (its mail stays in the catch-all until retention
  * sweeps it). Returns false if the address didn't exist.
- * 同步级联吊销该身份下全部 OAuth grant + access/refresh。
+ * 同步级联吊销该身份下全部 OAuth grant + access/refresh 与 Delegation grants。
  */
 export function deleteIdentity(address: string): boolean {
   const identities = load();
@@ -475,6 +480,7 @@ export function deleteIdentity(address: string): boolean {
   if (kept.length === identities.length) return false;
   save(kept);
   revokeGrantsForAddress(needle);
+  revokeDelegationsForAddress(needle);
   return true;
 }
 

--- a/packages/api/src/lib/scope-policy.ts
+++ b/packages/api/src/lib/scope-policy.ts
@@ -30,6 +30,11 @@ export const OPERATION_POLICIES: readonly OperationPolicy[] = [
     requiredScope: 'read:messages',
     matches: (method, path) => method === 'GET' && /^\/v1\/messages\/[^/]+$/.test(path),
   },
+  {
+    id: 'delegations:list',
+    requiredScope: 'read:messages',
+    matches: (method, path) => method === 'GET' && path === '/v1/delegations',
+  },
 ];
 
 /**

--- a/packages/api/src/lib/scope-policy.ts
+++ b/packages/api/src/lib/scope-policy.ts
@@ -35,7 +35,15 @@ export const OPERATION_POLICIES: readonly OperationPolicy[] = [
     requiredScope: 'read:messages',
     matches: (method, path) => method === 'GET' && path === '/v1/delegations',
   },
+  {
+    id: 'delegations:get',
+    requiredScope: 'read:messages',
+    matches: (method, path) => method === 'GET' && /^\/v1\/delegations\/[^/]+$/.test(path),
+  },
 ];
+
+// Note on future expansion: If SUPPORTED_SCOPES is extended beyond 'read:messages',
+// audit all forbidUnlessMailboxAccess call sites to ensure delegation remains strictly read-only.
 
 /**
  * Centralized scope policy enforcement middleware for all /v1/* REST routes.

--- a/packages/api/src/routes/delegations.ts
+++ b/packages/api/src/routes/delegations.ts
@@ -1,0 +1,197 @@
+import { Hono } from 'hono';
+import { z } from 'zod';
+import { getAuth } from '../lib/auth.ts';
+import { validateScopesInput } from '../lib/identities.ts';
+import {
+  createDelegation,
+  getDelegation,
+  listDelegations,
+  revokeDelegation,
+} from '../lib/delegations.ts';
+import { recordAuditEvent } from '../lib/audit.ts';
+
+const postDelegationSchema = z.object({
+  mailbox: z.string().email().max(320),
+  grantee: z.string().email().max(320),
+  scopes: z.unknown().optional(),
+  ts: z.string().optional(),
+});
+
+const listQuerySchema = z.object({
+  mailbox: z.string().email().max(320).optional(),
+  grantee: z.string().email().max(320).optional(),
+}).strict();
+
+export const delegationsRoute = new Hono()
+  .post('/', async (c) => {
+    let body: unknown;
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: 'invalid_json' }, 400);
+    }
+    const parsed = postDelegationSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+
+    let requestedScopes: string[] = ['read:messages'];
+    if (body && typeof body === 'object' && 'scopes' in body) {
+      const rawScopes = (body as Record<string, unknown>).scopes;
+      const validated = validateScopesInput(rawScopes);
+      if (validated.ok) {
+        requestedScopes = validated.scopes;
+      } else {
+        return c.json({ error: validated.error, details: validated.details }, 400);
+      }
+    }
+
+    const mailbox = parsed.data.mailbox.trim().toLowerCase();
+    const grantee = parsed.data.grantee.trim().toLowerCase();
+    const auth = getAuth(c);
+    const actor = auth.kind === 'admin' ? 'admin' : auth.address.toLowerCase();
+    const isAdmin = auth.kind === 'admin';
+    const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === mailbox;
+
+    const auditTs = c.req.header('x-audit-ts') ?? parsed.data.ts;
+
+    if (!isAdmin && !isOwner) {
+      recordAuditEvent({
+        event: 'delegation.grant.denied',
+        outcome: 'denied',
+        actor,
+        mailbox,
+        grantee,
+        scopes: requestedScopes,
+        ...(auditTs ? { ts: auditTs } : {}),
+      });
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    const grant = createDelegation({
+      mailbox,
+      grantee,
+      scopes: requestedScopes,
+      createdBy: actor,
+      createdAt: auditTs,
+    });
+
+    recordAuditEvent({
+      event: 'delegation.grant',
+      outcome: 'ok',
+      grantId: grant.id,
+      actor,
+      mailbox,
+      grantee,
+      scopes: grant.scopes,
+      ...(auditTs ? { ts: auditTs } : {}),
+    });
+
+    return c.json(grant, 201);
+  })
+  .get('/', async (c) => {
+    const query = c.req.query();
+    const parsed = listQuerySchema.safeParse(query);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+
+    const auth = getAuth(c);
+    const isAdmin = auth.kind === 'admin';
+    const callerAddress = auth.kind === 'identity' ? auth.address.toLowerCase() : null;
+
+    const mailboxParam = parsed.data.mailbox ? parsed.data.mailbox.trim().toLowerCase() : undefined;
+    const granteeParam = parsed.data.grantee ? parsed.data.grantee.trim().toLowerCase() : undefined;
+
+    if (isAdmin) {
+      const delegations = listDelegations({ mailbox: mailboxParam, grantee: granteeParam });
+      return c.json({ delegations });
+    }
+
+    // Non-admin identity caller
+    if (!mailboxParam && !granteeParam) {
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    if (mailboxParam && mailboxParam !== callerAddress) {
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    if (granteeParam && granteeParam !== callerAddress && mailboxParam !== callerAddress) {
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    const delegations = listDelegations({ mailbox: mailboxParam, grantee: granteeParam });
+    return c.json({ delegations });
+  })
+  .get('/:id', async (c) => {
+    const id = c.req.param('id');
+    if (!id || typeof id !== 'string' || !id.startsWith('delg_')) {
+      return c.json({ error: 'invalid_request' }, 400);
+    }
+    const grant = getDelegation(id);
+    if (!grant) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const auth = getAuth(c);
+    const isAdmin = auth.kind === 'admin';
+    const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === grant.mailbox.toLowerCase();
+    const isGrantee = auth.kind === 'identity' && auth.address.toLowerCase() === grant.grantee.toLowerCase();
+
+    if (!isAdmin && !isOwner && !isGrantee) {
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+    return c.json(grant);
+  })
+  .delete('/:id', async (c) => {
+    const id = c.req.param('id');
+    if (!id || typeof id !== 'string' || !id.startsWith('delg_')) {
+      return c.json({ error: 'invalid_request' }, 400);
+    }
+
+    const grant = getDelegation(id);
+    if (!grant) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const auth = getAuth(c);
+    const actor = auth.kind === 'admin' ? 'admin' : auth.address.toLowerCase();
+    const isAdmin = auth.kind === 'admin';
+    const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === grant.mailbox.toLowerCase();
+
+    const auditTs = c.req.header('x-audit-ts');
+
+    if (!isAdmin && !isOwner) {
+      recordAuditEvent({
+        event: 'delegation.revoke',
+        outcome: 'denied',
+        grantId: grant.id,
+        actor,
+        mailbox: grant.mailbox,
+        grantee: grant.grantee,
+        scopes: grant.scopes,
+        ...(auditTs ? { ts: auditTs } : {}),
+      });
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    const revokedGrant = revokeDelegation(id, actor, auditTs);
+
+    recordAuditEvent({
+      event: 'delegation.revoke',
+      outcome: 'ok',
+      grantId: grant.id,
+      actor,
+      mailbox: grant.mailbox,
+      grantee: grant.grantee,
+      scopes: grant.scopes,
+      ...(auditTs ? { ts: auditTs } : {}),
+    });
+
+    return c.json({
+      ...revokedGrant,
+      revoked: true,
+      revokedAt: revokedGrant?.revokedAt ?? grant.revokedAt,
+    });
+  });

--- a/packages/api/src/routes/delegations.ts
+++ b/packages/api/src/routes/delegations.ts
@@ -1,9 +1,10 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { getAuth } from '../lib/auth.ts';
+import { getAuth, getAttribution } from '../lib/auth.ts';
 import { validateScopesInput } from '../lib/identities.ts';
 import {
   createDelegation,
+  findActiveDelegation,
   getDelegation,
   listDelegations,
   revokeDelegation,
@@ -14,7 +15,6 @@ const postDelegationSchema = z.object({
   mailbox: z.string().email().max(320),
   grantee: z.string().email().max(320),
   scopes: z.unknown().optional(),
-  ts: z.string().optional(),
 });
 
 const listQuerySchema = z.object({
@@ -38,6 +38,9 @@ export const delegationsRoute = new Hono()
     let requestedScopes: string[] = ['read:messages'];
     if (body && typeof body === 'object' && 'scopes' in body) {
       const rawScopes = (body as Record<string, unknown>).scopes;
+      if (Array.isArray(rawScopes) && rawScopes.length === 0) {
+        return c.json({ error: 'invalid_request', details: 'scopes cannot be empty' }, 400);
+      }
       const validated = validateScopesInput(rawScopes);
       if (validated.ok) {
         requestedScopes = validated.scopes;
@@ -49,11 +52,25 @@ export const delegationsRoute = new Hono()
     const mailbox = parsed.data.mailbox.trim().toLowerCase();
     const grantee = parsed.data.grantee.trim().toLowerCase();
     const auth = getAuth(c);
+    const attribution = getAttribution(c);
     const actor = auth.kind === 'admin' ? 'admin' : auth.address.toLowerCase();
     const isAdmin = auth.kind === 'admin';
     const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === mailbox;
 
-    const auditTs = c.req.header('x-audit-ts') ?? parsed.data.ts;
+    if (attribution?.kind === 'oauth') {
+      recordAuditEvent({
+        event: 'delegation.grant.denied',
+        outcome: 'denied',
+        actor,
+        mailbox,
+        grantee,
+        scopes: requestedScopes,
+      });
+      return c.json(
+        { error: 'forbidden: delegation management requires direct identity credentials' },
+        403,
+      );
+    }
 
     if (!isAdmin && !isOwner) {
       recordAuditEvent({
@@ -63,9 +80,13 @@ export const delegationsRoute = new Hono()
         mailbox,
         grantee,
         scopes: requestedScopes,
-        ...(auditTs ? { ts: auditTs } : {}),
       });
       return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    const existing = findActiveDelegation(mailbox, grantee);
+    if (existing) {
+      return c.json(existing, 200);
     }
 
     const grant = createDelegation({
@@ -73,7 +94,6 @@ export const delegationsRoute = new Hono()
       grantee,
       scopes: requestedScopes,
       createdBy: actor,
-      createdAt: auditTs,
     });
 
     recordAuditEvent({
@@ -84,12 +104,12 @@ export const delegationsRoute = new Hono()
       mailbox,
       grantee,
       scopes: grant.scopes,
-      ...(auditTs ? { ts: auditTs } : {}),
     });
 
     return c.json(grant, 201);
   })
   .get('/', async (c) => {
+    c.header('Cache-Control', 'no-store');
     const query = c.req.query();
     const parsed = listQuerySchema.safeParse(query);
     if (!parsed.success) {
@@ -109,15 +129,10 @@ export const delegationsRoute = new Hono()
     }
 
     // Non-admin identity caller
-    if (!mailboxParam && !granteeParam) {
-      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
-    }
+    const isGranteeSelf = granteeParam === callerAddress;
+    const isOwnerSelf = mailboxParam === callerAddress;
 
-    if (mailboxParam && mailboxParam !== callerAddress) {
-      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
-    }
-
-    if (granteeParam && granteeParam !== callerAddress && mailboxParam !== callerAddress) {
+    if (!isGranteeSelf && !isOwnerSelf) {
       return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
     }
 
@@ -125,6 +140,7 @@ export const delegationsRoute = new Hono()
     return c.json({ delegations });
   })
   .get('/:id', async (c) => {
+    c.header('Cache-Control', 'no-store');
     const id = c.req.param('id');
     if (!id || typeof id !== 'string' || !id.startsWith('delg_')) {
       return c.json({ error: 'invalid_request' }, 400);
@@ -156,11 +172,26 @@ export const delegationsRoute = new Hono()
     }
 
     const auth = getAuth(c);
+    const attribution = getAttribution(c);
     const actor = auth.kind === 'admin' ? 'admin' : auth.address.toLowerCase();
     const isAdmin = auth.kind === 'admin';
     const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === grant.mailbox.toLowerCase();
 
-    const auditTs = c.req.header('x-audit-ts');
+    if (attribution?.kind === 'oauth') {
+      recordAuditEvent({
+        event: 'delegation.revoke',
+        outcome: 'denied',
+        grantId: grant.id,
+        actor,
+        mailbox: grant.mailbox,
+        grantee: grant.grantee,
+        scopes: grant.scopes,
+      });
+      return c.json(
+        { error: 'forbidden: delegation management requires direct identity credentials' },
+        403,
+      );
+    }
 
     if (!isAdmin && !isOwner) {
       recordAuditEvent({
@@ -171,12 +202,11 @@ export const delegationsRoute = new Hono()
         mailbox: grant.mailbox,
         grantee: grant.grantee,
         scopes: grant.scopes,
-        ...(auditTs ? { ts: auditTs } : {}),
       });
       return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
     }
 
-    const revokedGrant = revokeDelegation(id, actor, auditTs);
+    const revokedGrant = revokeDelegation(id, actor);
 
     recordAuditEvent({
       event: 'delegation.revoke',
@@ -186,7 +216,6 @@ export const delegationsRoute = new Hono()
       mailbox: grant.mailbox,
       grantee: grant.grantee,
       scopes: grant.scopes,
-      ...(auditTs ? { ts: auditTs } : {}),
     });
 
     return c.json({

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { getMessage, listMessages, setMessageSeen, waitForMessage } from '../lib/imap.ts';
-import { forbidUnlessAddress } from '../lib/auth.ts';
+import { forbidUnlessAddress, forbidUnlessMailboxAccess } from '../lib/auth.ts';
 import { clampWaitSeconds } from '../lib/config.ts';
 import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
 
@@ -34,7 +34,7 @@ export const messagesRoute = new Hono()
     if (!parsed.success) {
       return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
     }
-    const denied = forbidUnlessAddress(c, parsed.data.address);
+    const denied = forbidUnlessMailboxAccess(c, parsed.data.address);
     if (denied) return denied;
     const messages = await listMessages(parsed.data.address, parsed.data.limit);
     return c.json({ messages });
@@ -44,7 +44,7 @@ export const messagesRoute = new Hono()
     if (!parsed.success) {
       return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
     }
-    const denied = forbidUnlessAddress(c, parsed.data.address);
+    const denied = forbidUnlessMailboxAccess(c, parsed.data.address);
     if (denied) return denied;
     const message = await getMessage(parsed.data.address, c.req.param('id'));
     if (!message) {
@@ -87,7 +87,7 @@ export const messagesRoute = new Hono()
       return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
     }
     const { address, fromContains, subjectContains, timeoutSec } = parsed.data;
-    const denied = forbidUnlessAddress(c, address);
+    const denied = forbidUnlessMailboxAccess(c, address);
     if (denied) return denied;
     // schema 仍允许 ≤600（历史客户端）；服务端静默钳到 MCP_MAX_WAIT_SECONDS
     const effectiveTimeout = clampWaitSeconds(timeoutSec);

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -1,0 +1,675 @@
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key-delg-test';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.MCP_PUBLIC_URL = 'http://localhost';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-delg-test-'));
+
+const { beforeEach, describe, expect, mock, test } = await import('bun:test');
+
+let fakeMessages: any[] = [
+  {
+    uid: 101,
+    flags: new Set(),
+    envelope: {
+      date: new Date('2026-09-04T00:00:00Z'),
+      subject: 'Delegated message',
+      from: [{ address: 'sender@example.net', name: 'Sender' }],
+      to: [{ address: 'alice@test.example', name: 'Alice' }],
+    },
+    internalDate: new Date('2026-09-04T00:00:00Z'),
+    source: Buffer.from(
+      'From: sender@example.net\r\nTo: alice@test.example\r\nSubject: Delegated message\r\n\r\nDelegated body',
+    ),
+  },
+];
+
+class FakeImapFlow extends EventEmitter {
+  async connect() {}
+  async getMailboxLock() {
+    return { release() {} };
+  }
+  async search() {
+    return fakeMessages.map((m) => m.uid);
+  }
+  async *fetch() {
+    yield* fakeMessages;
+  }
+  async fetchOne(uid: number) {
+    const msg = fakeMessages.find((m) => m.uid === uid);
+    if (!msg) return false;
+    return {
+      ...msg,
+      source: msg.source ?? Buffer.from('From: sender@example.net\r\n\r\nbody'),
+    };
+  }
+  async messageFlagsAdd() {}
+  async messageFlagsRemove() {}
+  async logout() {}
+  close() {}
+}
+
+mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
+const sendMailMock = mock(async () => ({ messageId: '<test-send@test.example>' }));
+mock.module('../src/lib/smtp.ts', () => ({ sendMail: sendMailMock }));
+
+const { config } = await import('../src/lib/config.ts');
+const { createApp } = await import('../src/app.ts');
+const {
+  createIdentity,
+  deleteIdentity,
+  findIdentity,
+  rotateIdentityToken,
+} = await import('../src/lib/identities.ts');
+const {
+  createDelegation,
+  getDelegation,
+  listDelegations,
+  hasActiveDelegation,
+  findActiveDelegation,
+  revokeDelegation,
+  revokeDelegationsForAddress,
+  revokeDelegationsOnGranteeTokenRotate,
+  invalidateDelegationStoreCache,
+  resetDelegationStoreForTests,
+  DELEGATION_STORE_SCHEMA_VERSION,
+} = await import('../src/lib/delegations.ts');
+const { readAuditEvents, resetAuditForTests } = await import('../src/lib/audit.ts');
+
+const adminKey = [...config.apiKeys][0]!;
+let app = createApp({ uiEnabled: true });
+
+function resetIdentitiesStore(): void {
+  writeFileSync(join(config.dataDir, 'identities.json'), '[]', { mode: 0o600 });
+}
+
+describe('Issue #125: Revocable mailbox delegation ACLs', () => {
+  beforeEach(() => {
+    resetIdentitiesStore();
+    resetDelegationStoreForTests();
+    resetAuditForTests();
+  });
+
+  describe('1. Store layer (delegations.json)', () => {
+    test('creates delegation grant with delg_* id, lowercase normalization and tombstone semantics', () => {
+      const grant = createDelegation({
+        mailbox: ' Alice@Test.Example ',
+        grantee: ' Bob@Test.Example ',
+        createdBy: 'admin',
+      });
+
+      expect(grant.id.startsWith('delg_')).toBe(true);
+      expect(grant.mailbox).toBe('alice@test.example');
+      expect(grant.grantee).toBe('bob@test.example');
+      expect(grant.scopes).toEqual(['read:messages']);
+      expect(grant.revokedAt).toBeNull();
+      expect(grant.revokedBy).toBeNull();
+
+      const stored = getDelegation(grant.id);
+      expect(stored).toBeDefined();
+      expect(stored?.id).toBe(grant.id);
+
+      const filePath = join(config.dataDir, 'delegations.json');
+      expect(existsSync(filePath)).toBe(true);
+      const raw = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(raw.schemaVersion).toBe(DELEGATION_STORE_SCHEMA_VERSION);
+      expect(raw.grants.length).toBe(1);
+    });
+
+    test('revokeDelegation is an idempotent tombstone', () => {
+      const grant = createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob@test.example',
+        createdBy: 'admin',
+      });
+
+      const firstRevoke = revokeDelegation(grant.id, 'admin', '2026-09-04T10:00:00.000Z');
+      expect(firstRevoke).toBeDefined();
+      expect(firstRevoke?.revokedAt).toBe('2026-09-04T10:00:00.000Z');
+      expect(firstRevoke?.revokedBy).toBe('admin');
+
+      // Idempotent: second revoke returns existing revokedAt/revokedBy without changing
+      const secondRevoke = revokeDelegation(grant.id, 'someone-else', '2026-09-04T11:00:00.000Z');
+      expect(secondRevoke?.revokedAt).toBe('2026-09-04T10:00:00.000Z');
+      expect(secondRevoke?.revokedBy).toBe('admin');
+    });
+
+    test('preserves unknown fields at root and grant levels (forward compatibility)', () => {
+      const filePath = join(config.dataDir, 'delegations.json');
+      const customStore = {
+        schemaVersion: 1,
+        futureFeatureFlag: true,
+        grants: [
+          {
+            id: 'delg_future123',
+            mailbox: 'alice@test.example',
+            grantee: 'bob@test.example',
+            scopes: ['read:messages'],
+            createdAt: '2026-09-04T00:00:00.000Z',
+            createdBy: 'admin',
+            revokedAt: null,
+            revokedBy: null,
+            futureMetadata: { note: 'keep me safe' },
+          },
+        ],
+      };
+      writeFileSync(filePath, JSON.stringify(customStore, null, 2), { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      // Read preserved
+      const grant = getDelegation('delg_future123');
+      expect(grant?.id).toBe('delg_future123');
+      expect((grant as any).futureMetadata).toEqual({ note: 'keep me safe' });
+
+      // Mutate by adding new grant and verify rewrite keeps future fields
+      createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'carol@test.example',
+        createdBy: 'admin',
+      });
+
+      const reloaded = JSON.parse(readFileSync(filePath, 'utf8'));
+      expect(reloaded.futureFeatureFlag).toBe(true);
+      const original = reloaded.grants.find((g: any) => g.id === 'delg_future123');
+      expect(original.futureMetadata).toEqual({ note: 'keep me safe' });
+    });
+
+    test('corrupted store fails closed and does not overwrite damaged file', () => {
+      const filePath = join(config.dataDir, 'delegations.json');
+      writeFileSync(filePath, 'NOT_VALID_JSON{', { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      expect(() => listDelegations()).toThrow('delegation_store_corrupt');
+
+      // Verify file was NOT overwritten
+      expect(readFileSync(filePath, 'utf8')).toBe('NOT_VALID_JSON{');
+    });
+  });
+
+  describe('2. REST API endpoints (/v1/delegations)', () => {
+    let aliceToken: string;
+    let bobToken: string;
+    let bobScopedToken: string;
+    let carolToken: string;
+
+    beforeEach(() => {
+      const alice = createIdentity({ localpart: 'alice' })!;
+      aliceToken = alice.token;
+      const bob = createIdentity({ localpart: 'bob' })!;
+      bobToken = bob.token;
+      const bobScoped = createIdentity({ localpart: 'bob-scoped', scopes: ['read:messages'] })!;
+      bobScopedToken = bobScoped.token;
+      const carol = createIdentity({ localpart: 'carol' })!;
+      carolToken = carol.token;
+    });
+
+    test('POST /v1/delegations authorizes admin and owner, forbids third-party and scoped tokens', async () => {
+      // 1. Owner can grant
+      const ownerRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Content-Type': 'application/json',
+          'x-audit-ts': '2026-09-04T12:00:00.000Z',
+        },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'bob@test.example',
+        }),
+      });
+      expect(ownerRes.status).toBe(201);
+      const ownerBody = (await ownerRes.json()) as any;
+      expect(ownerBody.id.startsWith('delg_')).toBe(true);
+      expect(ownerBody.mailbox).toBe('alice@test.example');
+      expect(ownerBody.grantee).toBe('bob@test.example');
+      expect(ownerBody.scopes).toEqual(['read:messages']);
+
+      // 2. Admin can grant for any mailbox
+      const adminRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${adminKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'carol@test.example',
+          scopes: ['read:messages'],
+        }),
+      });
+      expect(adminRes.status).toBe(201);
+
+      // 3. Non-owner (Carol) cannot grant for Alice
+      const deniedRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${carolToken}`,
+          'Content-Type': 'application/json',
+          'x-audit-ts': '2026-09-04T12:01:00.000Z',
+        },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'carol@test.example',
+        }),
+      });
+      expect(deniedRes.status).toBe(403);
+      expect(await deniedRes.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+
+      // 4. Scoped token cannot create delegations (not in OPERATION_POLICIES)
+      const scopedRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${bobScopedToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          mailbox: 'bob-scoped@test.example',
+          grantee: 'alice@test.example',
+        }),
+      });
+      expect(scopedRes.status).toBe(403);
+      expect(await scopedRes.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+
+      // Audit assertions
+      const audits = readAuditEvents();
+      const grantAudit = audits.find((e) => e.event === 'delegation.grant' && e.grantee === 'bob@test.example');
+      expect(grantAudit).toBeDefined();
+      expect(grantAudit?.actor).toBe('alice@test.example');
+      expect(grantAudit?.outcome).toBe('ok');
+      expect(grantAudit?.ts).toBe('2026-09-04T12:00:00.000Z');
+
+      const deniedAudit = audits.find((e) => e.event === 'delegation.grant.denied');
+      expect(deniedAudit).toBeDefined();
+      expect(deniedAudit?.actor).toBe('carol@test.example');
+      expect(deniedAudit?.outcome).toBe('denied');
+      expect(deniedAudit?.mailbox).toBe('alice@test.example');
+    });
+
+    test('GET /v1/delegations filtering, owner/grantee authorization, and non-disclosure 403', async () => {
+      // Alice grants to Bob
+      await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'bob@test.example' }),
+      });
+
+      // 1. Owner queries own mailbox grants: allowed
+      const ownerList = await app.request('/v1/delegations?mailbox=alice@test.example', {
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(ownerList.status).toBe(200);
+      const ownerJson = (await ownerList.json()) as any;
+      expect(ownerJson.delegations.length).toBe(1);
+
+      // 2. Grantee queries own received grants: allowed
+      const granteeList = await app.request('/v1/delegations?grantee=bob@test.example', {
+        headers: { Authorization: `Bearer ${bobToken}` },
+      });
+      expect(granteeList.status).toBe(200);
+      const granteeJson = (await granteeList.json()) as any;
+      expect(granteeJson.delegations.length).toBe(1);
+
+      // 3. Grantee with scoped read token queries own received grants: allowed via delegations:list policy
+      const scopedGrantee = createIdentity({ localpart: 'scoped-bob', scopes: ['read:messages'] })!;
+      await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'scoped-bob@test.example' }),
+      });
+      const scopedList = await app.request('/v1/delegations?grantee=scoped-bob@test.example', {
+        headers: { Authorization: `Bearer ${scopedGrantee.token}` },
+      });
+      expect(scopedList.status).toBe(200);
+
+      // 4. Carol queries Alice's mailbox: 403 forbidden without disclosure
+      const carolCheckAlice = await app.request('/v1/delegations?mailbox=alice@test.example', {
+        headers: { Authorization: `Bearer ${carolToken}` },
+      });
+      expect(carolCheckAlice.status).toBe(403);
+      expect(await carolCheckAlice.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+
+      // 5. Carol queries Bob's received grants: 403
+      const carolCheckBob = await app.request('/v1/delegations?grantee=bob@test.example', {
+        headers: { Authorization: `Bearer ${carolToken}` },
+      });
+      expect(carolCheckBob.status).toBe(403);
+
+      // 6. Identity caller queries without filter: 403
+      const noFilter = await app.request('/v1/delegations', {
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(noFilter.status).toBe(403);
+
+      // 7. Admin queries without filter: returns all
+      const adminList = await app.request('/v1/delegations', {
+        headers: { Authorization: `Bearer ${adminKey}` },
+      });
+      expect(adminList.status).toBe(200);
+      const adminJson = (await adminList.json()) as any;
+      expect(adminJson.delegations.length).toBe(2);
+    });
+
+    test('DELETE /v1/delegations/:id authorizes owner/admin, forbids third-party, idempotent tombstone', async () => {
+      const grant = createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob@test.example',
+        createdBy: 'alice@test.example',
+      });
+
+      // 1. Third party (Carol) tries to revoke -> 403
+      const deniedRevoke = await app.request(`/v1/delegations/${grant.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${carolToken}`,
+          'x-audit-ts': '2026-09-04T13:00:00.000Z',
+        },
+      });
+      expect(deniedRevoke.status).toBe(403);
+
+      // 2. Owner revokes -> 200 + audit
+      const okRevoke = await app.request(`/v1/delegations/${grant.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'x-audit-ts': '2026-09-04T13:01:00.000Z',
+        },
+      });
+      expect(okRevoke.status).toBe(200);
+      const okJson = (await okRevoke.json()) as any;
+      expect(okJson.revoked).toBe(true);
+      expect(okJson.revokedAt).toBe('2026-09-04T13:01:00.000Z');
+
+      // 3. Repeat revoke is idempotent and returns 200 with original revokedAt
+      const repeatRevoke = await app.request(`/v1/delegations/${grant.id}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'x-audit-ts': '2026-09-04T13:05:00.000Z',
+        },
+      });
+      expect(repeatRevoke.status).toBe(200);
+      const repeatJson = (await repeatRevoke.json()) as any;
+      expect(repeatJson.revoked).toBe(true);
+      expect(repeatJson.revokedAt).toBe('2026-09-04T13:01:00.000Z');
+
+      // Check audit trail
+      const audits = readAuditEvents();
+      const deniedAudit = audits.find((e) => e.event === 'delegation.revoke' && e.outcome === 'denied');
+      expect(deniedAudit).toBeDefined();
+      expect(deniedAudit?.actor).toBe('carol@test.example');
+
+      const okAudits = audits.filter((e) => e.event === 'delegation.revoke' && e.outcome === 'ok');
+      expect(okAudits.length).toBeGreaterThanOrEqual(1);
+      expect(okAudits.some((e) => e.actor === 'alice@test.example' && e.ts === '2026-09-04T13:01:00.000Z')).toBe(true);
+      expect(okAudits.some((e) => e.actor === 'alice@test.example' && e.ts === '2026-09-04T13:05:00.000Z')).toBe(true);
+    });
+  });
+
+  describe('3. Mailbox read authorization & guard rails', () => {
+    let aliceToken: string;
+    let bobScopedToken: string;
+    let bobNoScopeToken: string;
+    let grantId: string;
+
+    beforeEach(() => {
+      const alice = createIdentity({ localpart: 'alice' })!;
+      aliceToken = alice.token;
+      const bob = createIdentity({ localpart: 'bob', scopes: ['read:messages'] })!;
+      bobScopedToken = bob.token;
+      const bobNoScope = createIdentity({ localpart: 'bob-noscope', scopes: [] })!;
+      bobNoScopeToken = bobNoScope.token;
+
+      const grant = createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob@test.example',
+        createdBy: 'alice@test.example',
+      });
+      grantId = grant.id;
+    });
+
+    test('scoped grantee can read delegated mailbox (list, get, wait)', async () => {
+      // GET /v1/messages?address=alice@test.example
+      const listRes = await app.request('/v1/messages?address=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(listRes.status).toBe(200);
+      const listJson = (await listRes.json()) as any;
+      expect(Array.isArray(listJson.messages)).toBe(true);
+
+      // GET /v1/messages/101?address=alice@test.example
+      const getRes = await app.request('/v1/messages/101?address=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(getRes.status).toBe(200);
+
+      // POST /v1/messages/wait
+      const waitRes = await app.request('/v1/messages/wait', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${bobScopedToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: 'alice@test.example', timeoutSec: 1 }),
+      });
+      expect(waitRes.status).toBe(200);
+    });
+
+    test('scoped grantee CANNOT read non-delegated third-party mailbox (exact 403 message preserved)', async () => {
+      const res = await app.request('/v1/messages?address=carol@test.example', {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+    });
+
+    test('specification guard rail: delegate CANNOT mark seen or send', async () => {
+      // POST /v1/messages/:id/seen forbidden for delegate
+      const seenRes = await app.request('/v1/messages/101/seen', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${bobScopedToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: 'alice@test.example', seen: true }),
+      });
+      // Scoped token rejected by scope middleware (not in OPERATION_POLICIES)
+      expect(seenRes.status).toBe(403);
+
+      // Full unscoped token who is only a read-delegate also cannot mark seen
+      const fullBob = createIdentity({ localpart: 'full-bob' })!;
+      createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'full-bob@test.example',
+        createdBy: 'alice@test.example',
+      });
+      const fullSeenRes = await app.request('/v1/messages/101/seen', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${fullBob.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ address: 'alice@test.example', seen: true }),
+      });
+      expect(fullSeenRes.status).toBe(403);
+      expect(await fullSeenRes.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+
+      // POST /v1/send forbidden
+      const sendRes = await app.request('/v1/send', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${fullBob.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          from: 'alice@test.example',
+          to: 'recipient@example.com',
+          subject: 'Test',
+          text: 'Hello',
+        }),
+      });
+      expect(sendRes.status).toBe(403);
+      expect(await sendRes.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+    });
+
+    test('revocation is immediate and persists across app restarts', async () => {
+      // 1. Read works initially
+      const beforeRes = await app.request('/v1/messages?address=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(beforeRes.status).toBe(200);
+
+      // 2. Revoke grant
+      revokeDelegation(grantId, 'alice@test.example');
+
+      // 3. Immediately 403
+      const afterRes = await app.request('/v1/messages?address=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(afterRes.status).toBe(403);
+      expect(await afterRes.json()).toEqual({
+        error: 'forbidden: token is scoped to another address',
+      });
+
+      // 4. Reconstruct app instance (simulating server restart)
+      invalidateDelegationStoreCache();
+      const restartedApp = createApp({ uiEnabled: false });
+      const restartRes = await restartedApp.request('/v1/messages?address=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(restartRes.status).toBe(403);
+    });
+
+    test('double constraint: credential without read:messages scope rejected even if grant exists', async () => {
+      createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob-noscope@test.example',
+        createdBy: 'alice@test.example',
+      });
+
+      const res = await app.request('/v1/messages?address=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobNoScopeToken}` },
+      });
+      // scopePolicyMiddleware denies 403 insufficient_scope before reaching handler
+      expect(res.status).toBe(403);
+      expect(await res.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    });
+  });
+
+  describe('4. Cascade revocation & token lifecycle', () => {
+    test('grantee token rotation cascades revocation of received delegations; owner rotation does NOT', () => {
+      const alice = createIdentity({ localpart: 'alice-rot' })!;
+      const bob = createIdentity({ localpart: 'bob-rot', scopes: ['read:messages'] })!;
+
+      const grant = createDelegation({
+        mailbox: 'alice-rot@test.example',
+        grantee: 'bob-rot@test.example',
+        createdBy: 'alice-rot@test.example',
+      });
+
+      // 1. Owner rotates token -> grant stays active!
+      rotateIdentityToken('alice-rot@test.example');
+      const grantAfterOwnerRotate = getDelegation(grant.id);
+      expect(grantAfterOwnerRotate?.revokedAt).toBeNull();
+
+      // 2. Grantee rotates token -> grant is cascaded!
+      rotateIdentityToken('bob-rot@test.example');
+      const grantAfterGranteeRotate = getDelegation(grant.id);
+      expect(grantAfterGranteeRotate?.revokedAt).not.toBeNull();
+      expect(grantAfterGranteeRotate?.revokedBy).toBe('cascade');
+
+      // Verify audit event emitted
+      const audits = readAuditEvents();
+      const cascadeAudit = audits.find(
+        (e) => e.event === 'delegation.revoke.cascade' && e.grantId === grant.id,
+      );
+      expect(cascadeAudit).toBeDefined();
+      expect(cascadeAudit?.outcome).toBe('ok');
+    });
+
+    test('identity deletion cascades revocation bidirectionally (owner granted + grantee received)', () => {
+      const alice = createIdentity({ localpart: 'alice-del' })!;
+      const bob = createIdentity({ localpart: 'bob-del' })!;
+      const carol = createIdentity({ localpart: 'carol-del' })!;
+
+      // Alice grants to Bob
+      const g1 = createDelegation({
+        mailbox: 'alice-del@test.example',
+        grantee: 'bob-del@test.example',
+        createdBy: 'alice-del@test.example',
+      });
+      // Carol grants to Alice
+      const g2 = createDelegation({
+        mailbox: 'carol-del@test.example',
+        grantee: 'alice-del@test.example',
+        createdBy: 'carol-del@test.example',
+      });
+
+      // Delete Alice -> both g1 (Alice is owner) and g2 (Alice is grantee) cascaded!
+      deleteIdentity('alice-del@test.example');
+
+      const reloadedG1 = getDelegation(g1.id);
+      const reloadedG2 = getDelegation(g2.id);
+      expect(reloadedG1?.revokedAt).not.toBeNull();
+      expect(reloadedG2?.revokedAt).not.toBeNull();
+
+      const audits = readAuditEvents();
+      const cascades = audits.filter((e) => e.event === 'delegation.revoke.cascade');
+      expect(cascades.some((c) => c.grantId === g1.id)).toBe(true);
+      expect(cascades.some((c) => c.grantId === g2.id)).toBe(true);
+    });
+  });
+
+  describe('5. Edge cases, normalization & UI session isolation', () => {
+    test('case normalization works across API and store', async () => {
+      const alice = createIdentity({ localpart: 'alice-case' })!;
+      const bob = createIdentity({ localpart: 'bob-case', scopes: ['read:messages'] })!;
+
+      // Grant created with upper/mixed case
+      const res = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${alice.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mailbox: 'Alice-Case@Test.Example',
+          grantee: 'Bob-Case@Test.Example',
+        }),
+      });
+      expect(res.status).toBe(201);
+      const data = (await res.json()) as any;
+      expect(data.mailbox).toBe('alice-case@test.example');
+      expect(data.grantee).toBe('bob-case@test.example');
+
+      // Accessing with mixed case in query
+      const readRes = await app.request('/v1/messages?address=ALICE-CASE@TEST.EXAMPLE', {
+        headers: { Authorization: `Bearer ${bob.token}` },
+      });
+      expect(readRes.status).toBe(200);
+    });
+
+    test('UI session rejects scoped credential even if delegation grant exists', async () => {
+      const alice = createIdentity({ localpart: 'alice-ui' })!;
+      const bob = createIdentity({ localpart: 'bob-ui', scopes: ['read:messages'] })!;
+
+      createDelegation({
+        mailbox: 'alice-ui@test.example',
+        grantee: 'bob-ui@test.example',
+        createdBy: 'alice-ui@test.example',
+      });
+
+      // Try logging into UI with scoped token
+      const sessionRes = await app.request('/ui/api/session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Origin: 'http://localhost',
+        },
+        body: JSON.stringify({ token: bob.token }),
+      });
+      expect(sessionRes.status).toBe(401);
+    });
+  });
+});

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -82,6 +82,8 @@ const {
   DELEGATION_STORE_SCHEMA_VERSION,
 } = await import('../src/lib/delegations.ts');
 const { readAuditEvents, resetAuditForTests } = await import('../src/lib/audit.ts');
+const { putAccessTokenForTests } = await import('../src/lib/oauth-store.ts');
+const { resolveResourceUri } = await import('../src/lib/oauth-url.ts');
 
 const adminKey = [...config.apiKeys][0]!;
 let app = createApp({ uiEnabled: true });
@@ -217,7 +219,6 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
         headers: {
           Authorization: `Bearer ${aliceToken}`,
           'Content-Type': 'application/json',
-          'x-audit-ts': '2026-09-04T12:00:00.000Z',
         },
         body: JSON.stringify({
           mailbox: 'alice@test.example',
@@ -230,6 +231,8 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       expect(ownerBody.mailbox).toBe('alice@test.example');
       expect(ownerBody.grantee).toBe('bob@test.example');
       expect(ownerBody.scopes).toEqual(['read:messages']);
+      expect(typeof ownerBody.createdAt).toBe('string');
+      expect(Date.parse(ownerBody.createdAt)).not.toBeNaN();
 
       // 2. Admin can grant for any mailbox
       const adminRes = await app.request('/v1/delegations', {
@@ -252,7 +255,6 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
         headers: {
           Authorization: `Bearer ${carolToken}`,
           'Content-Type': 'application/json',
-          'x-audit-ts': '2026-09-04T12:01:00.000Z',
         },
         body: JSON.stringify({
           mailbox: 'alice@test.example',
@@ -285,82 +287,246 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       expect(grantAudit).toBeDefined();
       expect(grantAudit?.actor).toBe('alice@test.example');
       expect(grantAudit?.outcome).toBe('ok');
-      expect(grantAudit?.ts).toBe('2026-09-04T12:00:00.000Z');
+      expect(typeof grantAudit?.ts).toBe('string');
+      expect(Math.abs(Date.now() - new Date(grantAudit?.ts!).getTime())).toBeLessThan(10000);
 
       const deniedAudit = audits.find((e) => e.event === 'delegation.grant.denied');
       expect(deniedAudit).toBeDefined();
       expect(deniedAudit?.actor).toBe('carol@test.example');
       expect(deniedAudit?.outcome).toBe('denied');
       expect(deniedAudit?.mailbox).toBe('alice@test.example');
+      expect(typeof deniedAudit?.ts).toBe('string');
+      expect(Math.abs(Date.now() - new Date(deniedAudit?.ts!).getTime())).toBeLessThan(10000);
     });
 
-    test('GET /v1/delegations filtering, owner/grantee authorization, and non-disclosure 403', async () => {
+    test('Item A: POST /v1/delegations enforces server-generated ts and ignores client x-audit-ts and body ts', async () => {
+      const spoofedTs = '1999-01-01T00:00:00.000Z';
+      const res = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Content-Type': 'application/json',
+          'x-audit-ts': spoofedTs,
+        },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'bob@test.example',
+          ts: spoofedTs,
+        }),
+      });
+      expect(res.status).toBe(201);
+      const data = (await res.json()) as any;
+      expect(data.createdAt).not.toBe(spoofedTs);
+      expect(Math.abs(Date.now() - new Date(data.createdAt).getTime())).toBeLessThan(10000);
+
+      const audits = readAuditEvents();
+      const audit = audits.find((e) => e.event === 'delegation.grant' && e.grantId === data.id);
+      expect(audit).toBeDefined();
+      expect(audit?.ts).not.toBe(spoofedTs);
+      expect(Math.abs(Date.now() - new Date(audit?.ts!).getTime())).toBeLessThan(10000);
+    });
+
+    test('Item C: POST /v1/delegations rejects explicit empty scopes [] with 400 and defaults omitted scopes', async () => {
+      // 1. Explicit empty scopes array -> 400 invalid_request
+      const emptyRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'bob@test.example',
+          scopes: [],
+        }),
+      });
+      expect(emptyRes.status).toBe(400);
+      const emptyJson = (await emptyRes.json()) as any;
+      expect(emptyJson.error).toBe('invalid_request');
+      expect(emptyJson.details).toBe('scopes cannot be empty');
+
+      // 2. Omitted scopes -> defaults to ['read:messages'] with 201
+      const defaultRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'bob@test.example',
+        }),
+      });
+      expect(defaultRes.status).toBe(201);
+      const defaultJson = (await defaultRes.json()) as any;
+      expect(defaultJson.scopes).toEqual(['read:messages']);
+    });
+
+    test('Item F: POST /v1/delegations is idempotent on active grant (returns 200) and creates new after revoke', async () => {
+      // 1. Initial creation -> 201 Created
+      const res1 = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'bob@test.example' }),
+      });
+      expect(res1.status).toBe(201);
+      const grant1 = (await res1.json()) as any;
+      expect(grant1.id.startsWith('delg_')).toBe(true);
+
+      // Verify store has 1 grant and 1 audit event
+      expect(listDelegations({ mailbox: 'alice@test.example' }).length).toBe(1);
+      let grantAudits = readAuditEvents().filter((e) => e.event === 'delegation.grant');
+      expect(grantAudits.length).toBe(1);
+
+      // 2. Retry creation with same (mailbox, grantee) -> 200 OK with existing grant, no duplicate in store or audit
+      const res2 = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'bob@test.example' }),
+      });
+      expect(res2.status).toBe(200);
+      const grant2 = (await res2.json()) as any;
+      expect(grant2.id).toBe(grant1.id);
+      expect(grant2.createdAt).toBe(grant1.createdAt);
+
+      // Verify store STILL has only 1 grant and only 1 audit event
+      expect(listDelegations({ mailbox: 'alice@test.example' }).length).toBe(1);
+      grantAudits = readAuditEvents().filter((e) => e.event === 'delegation.grant');
+      expect(grantAudits.length).toBe(1);
+
+      // 3. Revoke the active grant
+      const delRes = await app.request(`/v1/delegations/${grant1.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(delRes.status).toBe(200);
+
+      // 4. Create again after revoke -> creates new active grant with 201 Created
+      const res3 = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'bob@test.example' }),
+      });
+      expect(res3.status).toBe(201);
+      const grant3 = (await res3.json()) as any;
+      expect(grant3.id).not.toBe(grant1.id);
+
+      // Verify store now has 2 total grants (1 tombstone + 1 active)
+      expect(listDelegations({ mailbox: 'alice@test.example' }).length).toBe(2);
+      grantAudits = readAuditEvents().filter((e) => e.event === 'delegation.grant');
+      expect(grantAudits.length).toBe(2);
+    });
+
+    test('Item E & H1: GET /v1/delegations grantee combined filtering, owner query, and Cache-Control: no-store', async () => {
       // Alice grants to Bob
       await app.request('/v1/delegations', {
         method: 'POST',
         headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
         body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'bob@test.example' }),
       });
-
-      // 1. Owner queries own mailbox grants: allowed
-      const ownerList = await app.request('/v1/delegations?mailbox=alice@test.example', {
-        headers: { Authorization: `Bearer ${aliceToken}` },
+      // Carol grants to Bob
+      await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${carolToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'carol@test.example', grantee: 'bob@test.example' }),
       });
-      expect(ownerList.status).toBe(200);
-      const ownerJson = (await ownerList.json()) as any;
-      expect(ownerJson.delegations.length).toBe(1);
-
-      // 2. Grantee queries own received grants: allowed
-      const granteeList = await app.request('/v1/delegations?grantee=bob@test.example', {
-        headers: { Authorization: `Bearer ${bobToken}` },
-      });
-      expect(granteeList.status).toBe(200);
-      const granteeJson = (await granteeList.json()) as any;
-      expect(granteeJson.delegations.length).toBe(1);
-
-      // 3. Grantee with scoped read token queries own received grants: allowed via delegations:list policy
-      const scopedGrantee = createIdentity({ localpart: 'scoped-bob', scopes: ['read:messages'] })!;
+      // Alice grants to Carol
       await app.request('/v1/delegations', {
         method: 'POST',
         headers: { Authorization: `Bearer ${aliceToken}`, 'Content-Type': 'application/json' },
-        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'scoped-bob@test.example' }),
+        body: JSON.stringify({ mailbox: 'alice@test.example', grantee: 'carol@test.example' }),
       });
-      const scopedList = await app.request('/v1/delegations?grantee=scoped-bob@test.example', {
-        headers: { Authorization: `Bearer ${scopedGrantee.token}` },
-      });
-      expect(scopedList.status).toBe(200);
 
-      // 4. Carol queries Alice's mailbox: 403 forbidden without disclosure
-      const carolCheckAlice = await app.request('/v1/delegations?mailbox=alice@test.example', {
+      // 1. Grantee (Bob) queries combined ?mailbox=alice@test.example&grantee=bob@test.example -> 200 with Alice's grant only
+      const combinedRes = await app.request(
+        '/v1/delegations?mailbox=alice@test.example&grantee=bob@test.example',
+        { headers: { Authorization: `Bearer ${bobToken}` } },
+      );
+      expect(combinedRes.status).toBe(200);
+      expect(combinedRes.headers.get('cache-control')).toBe('no-store');
+      const combinedJson = (await combinedRes.json()) as any;
+      expect(combinedJson.delegations.length).toBe(1);
+      expect(combinedJson.delegations[0].mailbox).toBe('alice@test.example');
+      expect(combinedJson.delegations[0].grantee).toBe('bob@test.example');
+
+      // 2. Grantee (Bob) queries all incoming ?grantee=bob@test.example -> 200 with 2 grants
+      const bobAllRes = await app.request('/v1/delegations?grantee=bob@test.example', {
+        headers: { Authorization: `Bearer ${bobToken}` },
+      });
+      expect(bobAllRes.status).toBe(200);
+      const bobAllJson = (await bobAllRes.json()) as any;
+      expect(bobAllJson.delegations.length).toBe(2);
+
+      // 3. Grantee (Bob) queries ?mailbox=alice@test.example WITHOUT grantee=self -> 403 (non-disclosure)
+      const bobOnlyMailboxRes = await app.request('/v1/delegations?mailbox=alice@test.example', {
+        headers: { Authorization: `Bearer ${bobToken}` },
+      });
+      expect(bobOnlyMailboxRes.status).toBe(403);
+
+      // 4. Bob queries someone else's grantee filter ?grantee=carol@test.example -> 403
+      const bobOtherGranteeRes = await app.request('/v1/delegations?grantee=carol@test.example', {
+        headers: { Authorization: `Bearer ${bobToken}` },
+      });
+      expect(bobOtherGranteeRes.status).toBe(403);
+
+      // 5. Carol queries ?mailbox=alice@test.example&grantee=bob@test.example (neither is self) -> 403
+      const carolProbeRes = await app.request(
+        '/v1/delegations?mailbox=alice@test.example&grantee=bob@test.example',
+        { headers: { Authorization: `Bearer ${carolToken}` } },
+      );
+      expect(carolProbeRes.status).toBe(403);
+
+      // 6. Owner (Alice) queries ?mailbox=alice@test.example -> 200 (outgoing grants)
+      const aliceOutRes = await app.request('/v1/delegations?mailbox=alice@test.example', {
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(aliceOutRes.status).toBe(200);
+      const aliceOutJson = (await aliceOutRes.json()) as any;
+      expect(aliceOutJson.delegations.length).toBe(2);
+    });
+
+    test('Item D & H1: GET /v1/delegations/:id scope policy read:messages, grantee/owner authorization, Cache-Control: no-store', async () => {
+      const grant = createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob-scoped@test.example',
+        createdBy: 'alice@test.example',
+      });
+
+      // 1. Scoped grantee with read:messages can GET /v1/delegations/:id -> 200
+      const scopedGetRes = await app.request(`/v1/delegations/${grant.id}`, {
+        headers: { Authorization: `Bearer ${bobScopedToken}` },
+      });
+      expect(scopedGetRes.status).toBe(200);
+      expect(scopedGetRes.headers.get('cache-control')).toBe('no-store');
+      const scopedGetJson = (await scopedGetRes.json()) as any;
+      expect(scopedGetJson.id).toBe(grant.id);
+      expect(scopedGetJson.mailbox).toBe('alice@test.example');
+
+      // 2. Owner can GET /v1/delegations/:id -> 200
+      const ownerGetRes = await app.request(`/v1/delegations/${grant.id}`, {
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(ownerGetRes.status).toBe(200);
+
+      // 3. Third-party (Carol) gets 403
+      const thirdPartyRes = await app.request(`/v1/delegations/${grant.id}`, {
         headers: { Authorization: `Bearer ${carolToken}` },
       });
-      expect(carolCheckAlice.status).toBe(403);
-      expect(await carolCheckAlice.json()).toEqual({
+      expect(thirdPartyRes.status).toBe(403);
+      expect(await thirdPartyRes.json()).toEqual({
         error: 'forbidden: token is scoped to another address',
       });
 
-      // 5. Carol queries Bob's received grants: 403
-      const carolCheckBob = await app.request('/v1/delegations?grantee=bob@test.example', {
-        headers: { Authorization: `Bearer ${carolToken}` },
+      // 4. Token without read:messages scope (e.g. empty scopes []) gets 403 insufficient_scope
+      const noScopeUser = createIdentity({ localpart: 'no-scope-user', scopes: [] })!;
+      createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'no-scope-user@test.example',
+        createdBy: 'alice@test.example',
       });
-      expect(carolCheckBob.status).toBe(403);
-
-      // 6. Identity caller queries without filter: 403
-      const noFilter = await app.request('/v1/delegations', {
-        headers: { Authorization: `Bearer ${aliceToken}` },
+      const noScopeGrant = listDelegations({ grantee: 'no-scope-user@test.example' })[0]!;
+      const noScopeRes = await app.request(`/v1/delegations/${noScopeGrant.id}`, {
+        headers: { Authorization: `Bearer ${noScopeUser.token}` },
       });
-      expect(noFilter.status).toBe(403);
-
-      // 7. Admin queries without filter: returns all
-      const adminList = await app.request('/v1/delegations', {
-        headers: { Authorization: `Bearer ${adminKey}` },
-      });
-      expect(adminList.status).toBe(200);
-      const adminJson = (await adminList.json()) as any;
-      expect(adminJson.delegations.length).toBe(2);
+      expect(noScopeRes.status).toBe(403);
+      expect(await noScopeRes.json()).toEqual({ error: 'forbidden: insufficient_scope' });
     });
 
-    test('DELETE /v1/delegations/:id authorizes owner/admin, forbids third-party, idempotent tombstone', async () => {
+    test('DELETE /v1/delegations/:id authorizes owner/admin, forbids third-party, idempotent tombstone with server ts', async () => {
       const grant = createDelegation({
         mailbox: 'alice@test.example',
         grantee: 'bob@test.example',
@@ -370,38 +536,31 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       // 1. Third party (Carol) tries to revoke -> 403
       const deniedRevoke = await app.request(`/v1/delegations/${grant.id}`, {
         method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${carolToken}`,
-          'x-audit-ts': '2026-09-04T13:00:00.000Z',
-        },
+        headers: { Authorization: `Bearer ${carolToken}` },
       });
       expect(deniedRevoke.status).toBe(403);
 
       // 2. Owner revokes -> 200 + audit
       const okRevoke = await app.request(`/v1/delegations/${grant.id}`, {
         method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${aliceToken}`,
-          'x-audit-ts': '2026-09-04T13:01:00.000Z',
-        },
+        headers: { Authorization: `Bearer ${aliceToken}` },
       });
       expect(okRevoke.status).toBe(200);
       const okJson = (await okRevoke.json()) as any;
       expect(okJson.revoked).toBe(true);
-      expect(okJson.revokedAt).toBe('2026-09-04T13:01:00.000Z');
+      expect(typeof okJson.revokedAt).toBe('string');
+      expect(Date.parse(okJson.revokedAt)).not.toBeNaN();
+      const initialRevokedAt = okJson.revokedAt;
 
       // 3. Repeat revoke is idempotent and returns 200 with original revokedAt
       const repeatRevoke = await app.request(`/v1/delegations/${grant.id}`, {
         method: 'DELETE',
-        headers: {
-          Authorization: `Bearer ${aliceToken}`,
-          'x-audit-ts': '2026-09-04T13:05:00.000Z',
-        },
+        headers: { Authorization: `Bearer ${aliceToken}` },
       });
       expect(repeatRevoke.status).toBe(200);
       const repeatJson = (await repeatRevoke.json()) as any;
       expect(repeatJson.revoked).toBe(true);
-      expect(repeatJson.revokedAt).toBe('2026-09-04T13:01:00.000Z');
+      expect(repeatJson.revokedAt).toBe(initialRevokedAt);
 
       // Check audit trail
       const audits = readAuditEvents();
@@ -411,8 +570,72 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
 
       const okAudits = audits.filter((e) => e.event === 'delegation.revoke' && e.outcome === 'ok');
       expect(okAudits.length).toBeGreaterThanOrEqual(1);
-      expect(okAudits.some((e) => e.actor === 'alice@test.example' && e.ts === '2026-09-04T13:01:00.000Z')).toBe(true);
-      expect(okAudits.some((e) => e.actor === 'alice@test.example' && e.ts === '2026-09-04T13:05:00.000Z')).toBe(true);
+      expect(okAudits.some((e) => e.actor === 'alice@test.example')).toBe(true);
+    });
+
+    test('Item G: POST and DELETE /v1/delegations reject OAuth-attributed credentials with 403', async () => {
+      const resource = resolveResourceUri('http://localhost');
+      const oauthToken = 'oa_oauth_token_delg_test';
+      putAccessTokenForTests({
+        token: oauthToken,
+        grantId: 'grant-oauth-delg-1',
+        address: 'alice@test.example',
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-delg-1', clientName: 'Client Delg 1' },
+      });
+
+      // 1. OAuth token calling POST /v1/delegations -> 403 forbidden
+      const postRes = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${oauthToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          mailbox: 'alice@test.example',
+          grantee: 'bob@test.example',
+        }),
+      });
+      expect(postRes.status).toBe(403);
+      expect(await postRes.json()).toEqual({
+        error: 'forbidden: delegation management requires direct identity credentials',
+      });
+
+      // Verify audit event delegation.grant.denied was logged
+      const audits = readAuditEvents();
+      const grantDeniedAudit = audits.find(
+        (e) => e.event === 'delegation.grant.denied' && e.grantee === 'bob@test.example',
+      );
+      expect(grantDeniedAudit).toBeDefined();
+      expect(grantDeniedAudit?.outcome).toBe('denied');
+
+      // 2. Direct identity token creates grant
+      const validGrant = createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob@test.example',
+        createdBy: 'alice@test.example',
+      });
+
+      // 3. OAuth token calling DELETE /v1/delegations/:id -> 403 forbidden
+      const deleteRes = await app.request(`/v1/delegations/${validGrant.id}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${oauthToken}` },
+      });
+      expect(deleteRes.status).toBe(403);
+      expect(await deleteRes.json()).toEqual({
+        error: 'forbidden: delegation management requires direct identity credentials',
+      });
+
+      // Verify grant was NOT revoked
+      const storedGrant = getDelegation(validGrant.id);
+      expect(storedGrant?.revokedAt).toBeNull();
+
+      // Verify audit event delegation.revoke denied was logged
+      const deleteDeniedAudit = readAuditEvents().find(
+        (e) => e.event === 'delegation.revoke' && e.outcome === 'denied' && e.grantId === validGrant.id,
+      );
+      expect(deleteDeniedAudit).toBeDefined();
     });
   });
 
@@ -621,6 +844,56 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       const cascades = audits.filter((e) => e.event === 'delegation.revoke.cascade');
       expect(cascades.some((c) => c.grantId === g1.id)).toBe(true);
       expect(cascades.some((c) => c.grantId === g2.id)).toBe(true);
+    });
+
+    test('Item B1: deleteIdentity fail-closed: corrupted delegations.json throws error and leaves identity intact', () => {
+      const alice = createIdentity({ localpart: 'alice-fail' })!;
+      createDelegation({
+        mailbox: 'alice-fail@test.example',
+        grantee: 'bob@test.example',
+        createdBy: 'alice-fail@test.example',
+      });
+
+      // Inject failure: corrupt delegations.json
+      const filePath = join(config.dataDir, 'delegations.json');
+      writeFileSync(filePath, 'CORRUPTED_JSON{', { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      // deleteIdentity must throw error and fail closed
+      expect(() => deleteIdentity('alice-fail@test.example')).toThrow('delegation_store_corrupt');
+
+      // Verify Alice is STILL present in identities.json
+      const identitiesRaw = JSON.parse(readFileSync(join(config.dataDir, 'identities.json'), 'utf8'));
+      const found = identitiesRaw.find((i: any) => i.address === 'alice-fail@test.example');
+      expect(found).toBeDefined();
+      expect(found.address).toBe('alice-fail@test.example');
+    });
+
+    test('Item B1: rotateIdentityToken fail-closed: corrupted delegations.json throws error and leaves tokenHash unchanged', () => {
+      const bob = createIdentity({ localpart: 'bob-fail' })!;
+      createDelegation({
+        mailbox: 'alice@test.example',
+        grantee: 'bob-fail@test.example',
+        createdBy: 'alice@test.example',
+      });
+
+      // Record original tokenHash from identities.json
+      const identitiesBefore = JSON.parse(readFileSync(join(config.dataDir, 'identities.json'), 'utf8'));
+      const bobBefore = identitiesBefore.find((i: any) => i.address === 'bob-fail@test.example');
+      const originalTokenHash = bobBefore.tokenHash;
+
+      // Inject failure: corrupt delegations.json
+      const filePath = join(config.dataDir, 'delegations.json');
+      writeFileSync(filePath, 'CORRUPTED_JSON{', { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      // rotateIdentityToken must throw error and fail closed
+      expect(() => rotateIdentityToken('bob-fail@test.example')).toThrow('delegation_store_corrupt');
+
+      // Verify Bob's tokenHash is UNCHANGED in identities.json
+      const identitiesAfter = JSON.parse(readFileSync(join(config.dataDir, 'identities.json'), 'utf8'));
+      const bobAfter = identitiesAfter.find((i: any) => i.address === 'bob-fail@test.example');
+      expect(bobAfter.tokenHash).toBe(originalTokenHash);
     });
   });
 


### PR DESCRIPTION
## Summary
Closes #125

Implements revocable mailbox delegation ACLs, enabling a mailbox owner or administrator to grant read-only message access to another identity without sharing admin credentials or full account tokens.

### Key Changes
1. **Delegation Storage Layer (`packages/api/src/lib/delegations.ts`)**:
   - Persists grants in `DATA_DIR/delegations.json` with explicit `schemaVersion: 1`.
   - Generates stable unique `delg_*` identifiers.
   - Conforms to single-writer tmp + 0600 + rename atomic writes with composite version caching (`statSync`).
   - Fails closed on corrupted store (`delegation_store_corrupt`).
   - Preserves unknown root and grant fields across rewrites (forward compatibility).
   - Normalizes addresses to lowercase at all entry points.

2. **REST API Endpoints (`packages/api/src/routes/delegations.ts`)**:
   - `POST /v1/delegations`: Admin or mailbox owner can create grants with optional scopes (defaults to `['read:messages']`). Rejects non-owners with 403 and records audit.
   - `GET /v1/delegations`: Admin can list all or filter; mailbox owners can query outgoing grants; grantees can query incoming grants. Non-owners/non-grantees receive 403 to prevent disclosure.
   - `DELETE /v1/delegations/:id`: Owner or admin can revoke grants using soft-delete tombstone semantics (`revokedAt`); repeat deletions are idempotent and return 200 with original `revokedAt`.

3. **Mailbox Read Authorization Upgrade (`packages/api/src/lib/auth.ts`)**:
   - Introduces `forbidUnlessMailboxAccess(c, mailbox, requiredScope)` supporting three channels: admin, self, and active unrevoked delegation grant.
   - Replaced checks in `routes/messages.ts` for `GET /`, `GET /:id`, and `POST /wait`.

4. **Specification Guard Rails**:
   - Mark seen (`POST /v1/messages/:id/seen`) and outbound send (`POST /v1/send`, `GET /v1/send/history/:id`) strictly retain `forbidUnlessAddress` and do not recognize delegation grants.

5. **Scope Policy Integration (`packages/api/src/lib/scope-policy.ts`)**:
   - Added `delegations:list` to `OPERATION_POLICIES` (`GET /v1/delegations` granted by `read:messages`).
   - POST and DELETE are excluded from the whitelist, preventing scoped tokens from managing delegations.

6. **Lifecycle & Cascading Revocations (`packages/api/src/lib/identities.ts`)**:
   - `deleteIdentity`: Cascades revocation bidirectionally (grants where address is mailbox owner or grantee).
   - `rotateIdentityToken`: Cascades revocation of received grants when grantee rotates token (owner token rotation does not revoke outgoing grants).

7. **Audit Trail (`packages/api/src/lib/audit.ts`)**:
   - Added optional `actor`, `mailbox`, and `grantee` fields to `AuditEvent` with `scrubAuditField` sanitization.
   - Emits `delegation.grant`, `delegation.revoke`, `delegation.grant.denied`, and `delegation.revoke.cascade`.

### Verification & Test Matrix
- **Unit & Integration Suite (`test/delegations.test.ts`)**: 16/16 pass.
  - Store persistence, atomic replace, unknown field preservation, corrupt store fail-closed.
  - REST authorization (owner, admin, unauthorized 403, scoped token 403).
  - Mailbox read (list, get, wait), cross-mailbox denial, mark-seen and send guard rails.
  - Immediate revocation and restart persistence across app instances.
  - Cascade revocation on identity deletion and token rotation.
  - Case normalization and UI session isolation.
- **Baseline 8 Test Suites**: 179/179 pass (100% backward compatible with existing unscoped and scoped token models).
- **TypeScript & Build**: `bun run build` bundled 581 modules without errors; ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added API support for creating, viewing, listing, and revoking mailbox delegations.
  - Delegated users can access authorized mailbox messages according to assigned scopes.
  - Added audit details for delegation activity.
  - Repeated active delegation requests no longer create duplicates.

- **Bug Fixes**
  - Delegations are automatically revoked when an identity is deleted or its token is rotated.
  - Improved authorization enforcement for mailbox message access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->