### PR TITLE
refactor(api): shared pinned fetcher + SSRF IPv6-embedded-IPv4 hardening (#128 PR1)

### DIFF
--- a/packages/api/src/lib/net.ts
+++ b/packages/api/src/lib/net.ts
@@ -85,16 +85,62 @@ export function isAwsImdsIpv6(host: string): boolean {
   return parts[0] === 'fd00' && parts[1] === '0ec2';
 }
 
-function expandIpv6Hextets(host: string): string[] | null {
-  const raw = host.toLowerCase();
-  if (raw.includes('.')) {
-    // IPv4-mapped 内嵌点分：先抽 v4 再展开前缀
-    const mapped = ipv4MappedFromV6(raw);
-    if (!mapped) return null;
+function parseIpv4Relaxed(str: string): string | null {
+  if (!str || typeof str !== 'string') return null;
+  if (str.includes(':') || str.includes('[') || str.includes(']')) return null;
+  const parts = str.trim().split('.');
+  if (parts.length > 4 || parts.length === 0) return null;
+  const nums: number[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const p = parts[i]!;
+    let n: number;
+    if (/^0x[0-9a-f]+$/i.test(p)) n = Number.parseInt(p, 16);
+    else if (/^0[0-7]+$/.test(p)) n = Number.parseInt(p, 8);
+    else if (/^[0-9]+$/.test(p)) n = Number.parseInt(p, 10);
+    else return null;
+    if (!Number.isFinite(n) || n < 0) return null;
+    nums.push(n);
   }
+  let val: number;
+  if (nums.length === 1) {
+    if (nums[0]! > 0xffffffff) return null;
+    val = nums[0]!;
+  } else if (nums.length === 2) {
+    if (nums[0]! > 255 || nums[1]! > 0xffffff) return null;
+    val = nums[0]! * 0x1000000 + nums[1]!;
+  } else if (nums.length === 3) {
+    if (nums[0]! > 255 || nums[1]! > 255 || nums[2]! > 0xffff) return null;
+    val = nums[0]! * 0x1000000 + nums[1]! * 0x10000 + nums[2]!;
+  } else if (nums.length === 4) {
+    if (nums.some((n) => n > 255)) return null;
+    val = nums[0]! * 0x1000000 + nums[1]! * 0x10000 + nums[2]! * 0x100 + nums[3]!;
+  } else {
+    return null;
+  }
+  return `${(val >>> 24) & 0xff}.${(val >>> 16) & 0xff}.${(val >>> 8) & 0xff}.${val & 0xff}`;
+}
+
+function hextetToIpv4(hiHex: string, loHex: string): string {
+  const hi = Number.parseInt(hiHex, 16);
+  const lo = Number.parseInt(loHex, 16);
+  return `${(hi >> 8) & 0xff}.${hi & 0xff}.${(lo >> 8) & 0xff}.${lo & 0xff}`;
+}
+
+function expandIpv6Hextets(host: string): string[] | null {
+  const raw = host.toLowerCase().replace(/^\[(.+)\]$/, '$1');
   let [head, tail] = raw.split('::');
   if (tail === undefined) {
     const parts = raw.split(':');
+    if (parts.length === 7 && parts[6]!.includes('.')) {
+      const v4 = parts.pop()!;
+      const nums = v4.split('.').map(Number);
+      if (nums.length !== 4 || nums.some((n) => n < 0 || n > 255)) return null;
+      parts.push(
+        ((nums[0]! << 8) | nums[1]!).toString(16).padStart(4, '0'),
+        ((nums[2]! << 8) | nums[3]!).toString(16).padStart(4, '0'),
+      );
+      return parts.map((p) => p.padStart(4, '0'));
+    }
     if (parts.length !== 8) return null;
     return parts.map((p) => p.padStart(4, '0'));
   }
@@ -114,6 +160,65 @@ function expandIpv6Hextets(host: string): string[] | null {
   if (missing < 0) return null;
   const mid = Array.from({ length: missing }, () => '0000');
   return [...left, ...mid, ...right].map((p) => p.padStart(4, '0'));
+}
+
+/**
+ * 提取 IPv6 各种内嵌 IPv4 形式（RFC-0001 §9.2, D16, Q21=A 提取式）：
+ * 1. IPv4-mapped (::ffff:0:0/96, RFC 4291)
+ * 2. NAT64 (64:ff9b::/96, RFC 6052)
+ * 3. 6to4 (2002::/16, RFC 3056)
+ * 4. Teredo (2001:0000::/32, RFC 4380) — 提取 server 与 client (XOR 0xFFFFFFFF)
+ */
+export function extractEmbeddedIpv4s(host: string): string[] {
+  const hextets = expandIpv6Hextets(host);
+  if (!hextets) return [];
+  const results = new Set<string>();
+
+  // 1. IPv4-mapped: ::ffff:a.b.c.d 或 ::ffff:HHHH:LLLL 或 ::ffff:0:a.b.c.d
+  if (
+    hextets[0] === '0000' &&
+    hextets[1] === '0000' &&
+    hextets[2] === '0000' &&
+    hextets[3] === '0000' &&
+    ((hextets[4] === '0000' && hextets[5] === 'ffff') ||
+      (hextets[4] === 'ffff' && hextets[5] === '0000'))
+  ) {
+    results.add(hextetToIpv4(hextets[6]!, hextets[7]!));
+  }
+
+  // 2. NAT64: 64:ff9b::/96 (Well-Known Prefix, RFC 6052)
+  if (
+    hextets[0] === '0064' &&
+    hextets[1] === 'ff9b' &&
+    hextets[2] === '0000' &&
+    hextets[3] === '0000' &&
+    hextets[4] === '0000' &&
+    hextets[5] === '0000'
+  ) {
+    results.add(hextetToIpv4(hextets[6]!, hextets[7]!));
+  }
+
+  // 3. 6to4: 2002::/16 (RFC 3056, bits 16..47)
+  if (hextets[0] === '2002') {
+    results.add(hextetToIpv4(hextets[1]!, hextets[2]!));
+  }
+
+  // 4. Teredo: 2001:0000::/32 (RFC 4380)
+  if (hextets[0] === '2001' && hextets[1] === '0000') {
+    // Server IPv4 (hextets 2, 3)
+    results.add(hextetToIpv4(hextets[2]!, hextets[3]!));
+    // Client IPv4 (hextets 6, 7 inverted per RFC 4380 §4)
+    const hiInv = (~Number.parseInt(hextets[6]!, 16)) & 0xffff;
+    const loInv = (~Number.parseInt(hextets[7]!, 16)) & 0xffff;
+    results.add(
+      hextetToIpv4(
+        hiInv.toString(16).padStart(4, '0'),
+        loInv.toString(16).padStart(4, '0'),
+      ),
+    );
+  }
+
+  return Array.from(results);
 }
 
 /**
@@ -152,10 +257,15 @@ export function ipv4MappedFromV6(host: string): string | null {
 /**
  * 永拒：169.254/16、0.0.0.0/8、fe80::/10、fd00:ec2::/16。
  * 与「私网放行清单」分离。
+ * 含 IPv4-mapped、NAT64、6to4、Teredo 等内嵌 IPv4 提取判定（Q21=A）。
  */
 export function isBlockedSsrfIp(ip: string): boolean {
   const host = normalizeHost(ip);
-  const v = isIP(host);
+  let v = isIP(host);
+  if (v === 0) {
+    const relaxed = parseIpv4Relaxed(host);
+    if (relaxed) return isBlockedSsrfIp(relaxed);
+  }
   if (v === 4) {
     const parts = host.split('.').map(Number);
     if (parts.length !== 4 || parts.some((n) => n < 0 || n > 255)) return true;
@@ -165,8 +275,10 @@ export function isBlockedSsrfIp(ip: string): boolean {
     return false;
   }
   if (v === 6) {
-    const mapped = ipv4MappedFromV6(host);
-    if (mapped) return isBlockedSsrfIp(mapped);
+    const embedded = extractEmbeddedIpv4s(host);
+    for (const v4 of embedded) {
+      if (isBlockedSsrfIp(v4)) return true;
+    }
     if (isFe80LinkLocalIpv6(host)) return true;
     if (isAwsImdsIpv6(host)) return true;
     return false;
@@ -207,10 +319,23 @@ function isUlaIpv6(host: string): boolean {
 export function isPrivateOrLoopbackHostname(hostname: string): boolean {
   const host = normalizeHost(hostname);
   if (host === 'localhost' || host === '::1') return true;
-  if (isIP(host) !== 0 && isBlockedSsrfIp(host)) return false;
-  const ipVersion = isIP(host);
+  if (isBlockedSsrfIp(host)) return false;
+  let ipVersion = isIP(host);
+  if (ipVersion === 0) {
+    const relaxed = parseIpv4Relaxed(host);
+    if (relaxed) {
+      return isAllowedPrivateIpv4(relaxed) || isLoopbackIpv4(relaxed);
+    }
+    return false;
+  }
   if (ipVersion === 4) return isAllowedPrivateIpv4(host) || isLoopbackIpv4(host);
-  if (ipVersion === 6) return isUlaIpv6(host);
+  if (ipVersion === 6) {
+    const embedded = extractEmbeddedIpv4s(host);
+    if (embedded.length > 0) {
+      return embedded.every((v4) => isAllowedPrivateIpv4(v4) || isLoopbackIpv4(v4));
+    }
+    return isUlaIpv6(host);
+  }
   return false;
 }
 
@@ -221,6 +346,7 @@ export const isPrivateOrLoopbackHost = isPrivateOrLoopbackHostname;
  * 解析后的每个 A/AAAA 必须通过 SSRF 策略。
  * 永拒名单见 isBlockedSsrfIp；RFC1918/CGNAT/loopback/ULA(fd) 默认因部署例外放行，
  * OAE_PUBLIC_EDGE / opts.publicEdge=true 时关闭该例外。
+ * 内嵌 IPv4（NAT64/6to4/Teredo）走既有 IPv4 策略评估（Q21=A）。
  */
 export function isSsrfBlockedResolvedIp(
   ip: string,
@@ -229,12 +355,21 @@ export function isSsrfBlockedResolvedIp(
   if (isBlockedSsrfIp(ip)) return true;
   const publicEdge = resolvePublicEdge(opts);
   const host = normalizeHost(ip);
-  const v = isIP(host);
-  if (v === 0) return true;
+  let v = isIP(host);
+  if (v === 0) {
+    const relaxed = parseIpv4Relaxed(host);
+    if (relaxed) return isSsrfBlockedResolvedIp(relaxed, opts);
+    return true;
+  }
   if (v === 4) {
     if (isAllowedPrivateIpv4(host)) return publicEdge;
     if (isSpecialUseIpv4BeyondAllowlist(host)) return true;
     return false;
+  }
+  // v === 6:
+  const embedded = extractEmbeddedIpv4s(host);
+  for (const v4 of embedded) {
+    if (isSsrfBlockedResolvedIp(v4, opts)) return true;
   }
   if (host === '::1' || isUlaIpv6(host)) return publicEdge;
   if (host === '::' || host.startsWith('ff')) return true;

--- a/packages/api/src/lib/oauth-cimd.ts
+++ b/packages/api/src/lib/oauth-cimd.ts
@@ -10,18 +10,21 @@
  * 对连接实际使用的每个解析结果跑 SSRF；https 保留 SNI/Host。
  */
 
-import { lookup as dnsLookupAll } from 'node:dns/promises';
-import http from 'node:http';
-import https from 'node:https';
-import { isIP, type LookupFunction } from 'node:net';
+import { isIP } from 'node:net';
 import {
   allowsPrivateCimdException,
   isPrivateOrLoopbackHostname,
   isSsrfBlockedResolvedIp,
   type SsrfPolicyOptions,
 } from './net.ts';
+import {
+  defaultDnsLookup,
+  pinnedFetch,
+  readBodyCapped,
+  type DnsLookup,
+} from './pinned-fetch.ts';
 
-// 再导出：既有测试从本模块导入 SSRF 助手；实现唯一在 lib/net.ts。
+// 再导出：既有测试从本模块导入 SSRF 助手与传输实现；实现分别在 lib/net.ts 与 lib/pinned-fetch.ts。
 export {
   allowsPrivateCimdException,
   isBlockedSsrfIp,
@@ -29,6 +32,8 @@ export {
   isSsrfBlockedResolvedIp,
 } from './net.ts';
 export type { SsrfPolicyOptions } from './net.ts';
+export { defaultDnsLookup, pinnedFetch, readBodyCapped } from './pinned-fetch.ts';
+export type { DnsLookup } from './pinned-fetch.ts';
 
 export const CIMD_FETCH_TIMEOUT_MS = 10_000;
 export const CIMD_MAX_BYTES = 5 * 1024;
@@ -52,10 +57,6 @@ export type Fetcher = (
   init: RequestInit,
 ) => Promise<Response>;
 
-/** 测试可注入的窄 DNS 查找（避免绑死 node:dns/promises lookup 全重载）。 */
-export type DnsLookup = (
-  hostname: string,
-) => Promise<Array<{ address: string; family: number }>>;
 
 type CacheEntry = {
   doc: CimdDocument;
@@ -127,18 +128,6 @@ function rawUrlPath(clientId: string): string {
   const pathIdx = afterScheme.indexOf('/');
   if (pathIdx < 0) return '/';
   return afterScheme.slice(pathIdx);
-}
-
-async function defaultDnsLookup(
-  hostname: string,
-): Promise<Array<{ address: string; family: number }>> {
-  const results = await dnsLookupAll(hostname, { all: true, verbatim: true });
-  const list = Array.isArray(results) ? results : [results];
-  return list.map((r) =>
-    typeof r === 'string'
-      ? { address: r, family: 0 }
-      : { address: r.address, family: r.family },
-  );
 }
 
 /**
@@ -335,154 +324,26 @@ function validateDocument(
   };
 }
 
-/** 流式读取响应体，超过 CIMD_MAX_BYTES 截断失败（不整缓冲 arrayBuffer）。 */
-async function readBodyCapped(
-  stream: NodeJS.ReadableStream,
-  maxBytes: number,
-): Promise<{ ok: true; buf: Buffer } | { ok: false; reason: 'response_too_large' }> {
-  const chunks: Buffer[] = [];
-  let total = 0;
-  for await (const chunk of stream) {
-    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    total += buf.byteLength;
-    if (total > maxBytes) {
-      // 尽早停读，避免大响应占内存
-      const maybeDestroy = (stream as unknown as { destroy?: () => void }).destroy;
-      if (typeof maybeDestroy === 'function') maybeDestroy.call(stream);
-      return { ok: false, reason: 'response_too_large' };
-    }
-    chunks.push(buf);
-  }
-  return { ok: true, buf: Buffer.concat(chunks) };
-}
-
 /**
- * 默认 CIMD 传输：node:http(s) + 连接时 lookup 钉死 SSRF。
- * Host / SNI 仍用原始 hostname；实际 TCP 目标由 lookup 结果决定。
+ * 默认 CIMD 传输：调用共享 pinnedFetch，传入 CIMD 规范参数与默认 lookup。
+ * 对外签名与行为保持零变化。
  */
 export async function pinnedCimdFetcher(
   urlStr: string,
   init: RequestInit = {},
   dnsLookup: DnsLookup = defaultDnsLookup,
 ): Promise<Response> {
-  const url = new URL(urlStr);
-  const isHttps = url.protocol === 'https:';
-  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
-    throw new Error('unsupported_protocol');
+  const initHeaders = new Headers(init.headers);
+  if (!initHeaders.has('accept')) {
+    initHeaders.set('accept', 'application/json');
   }
-
-  // IP 字面量：连接前即判黑名单（无 DNS TOCTOU）
-  const literal = url.hostname.replace(/^\[(.+)\]$/, '$1');
-  if (isIP(literal) && isSsrfBlockedResolvedIp(literal)) {
-    throw new Error('ssrf_blocked_ip');
-  }
-
-  const headers: Record<string, string> = {
-    accept: 'application/json',
-    host: url.host,
-  };
-  if (init.headers) {
-    const h = new Headers(init.headers);
-    h.forEach((v, k) => {
-      if (k.toLowerCase() === 'host') return;
-      headers[k] = v;
-    });
-  }
-
-  const lib = isHttps ? https : http;
-  const timeoutMs = CIMD_FETCH_TIMEOUT_MS;
-
-  return new Promise<Response>((resolve, reject) => {
-    const req = lib.request(
-      {
-        protocol: url.protocol,
-        hostname: url.hostname,
-        port: url.port || (isHttps ? 443 : 80),
-        path: `${url.pathname}${url.search}`,
-        method: (init.method as string) || 'GET',
-        headers,
-        // https：非 IP 字面量时显式 SNI；直连 IP 不设 servername（交系统默认）
-        servername: isHttps && !isIP(literal) ? literal : undefined,
-        // 连接时解析并对每个结果跑 SSRF（钉死，消灭校验/fetch 间 TOCTOU）
-        lookup: ((hostname, options, callback) => {
-          const fail = (err: NodeJS.ErrnoException) => {
-            // LookupFunction 要求 (err, address, family) 三参
-            callback(err, '', 4);
-          };
-          void (async () => {
-            try {
-              const list = await dnsLookup(hostname.replace(/^\[(.+)\]$/, '$1'));
-              if (list.length === 0) {
-                fail(Object.assign(new Error('dns_empty'), { code: 'ENOTFOUND' }));
-                return;
-              }
-              for (const r of list) {
-                if (isSsrfBlockedResolvedIp(r.address)) {
-                  fail(Object.assign(new Error('ssrf_blocked_ip'), { code: 'EACCES' }));
-                  return;
-                }
-              }
-              const mapped = list.map((r) => ({
-                address: r.address,
-                family: (r.family === 6 ? 6 : 4) as 4 | 6,
-              }));
-              const opts = options as { all?: boolean } | number | undefined;
-              const wantAll =
-                typeof opts === 'object' && opts !== null && Boolean(opts.all);
-              if (wantAll) {
-                (callback as (err: Error | null, addresses: typeof mapped) => void)(
-                  null,
-                  mapped,
-                );
-              } else {
-                const first = mapped[0]!;
-                callback(null, first.address, first.family);
-              }
-            } catch (err) {
-              fail(err as NodeJS.ErrnoException);
-            }
-          })();
-        }) as LookupFunction,
-      },
-      (res) => {
-        void (async () => {
-          try {
-            const capped = await readBodyCapped(res, CIMD_MAX_BYTES);
-            if (!capped.ok) {
-              res.resume();
-              reject(new Error(capped.reason));
-              return;
-            }
-            const headerInit: Record<string, string> = {};
-            for (const [k, v] of Object.entries(res.headers)) {
-              if (typeof v === 'string') headerInit[k] = v;
-              else if (Array.isArray(v)) headerInit[k] = v.join(', ');
-            }
-            resolve(
-              new Response(capped.buf, {
-                status: res.statusCode ?? 0,
-                headers: headerInit,
-              }),
-            );
-          } catch (err) {
-            reject(err);
-          }
-        })();
-      },
-    );
-
-    req.setTimeout(timeoutMs, () => {
-      req.destroy(new Error('timeout'));
-    });
-    req.on('error', reject);
-
-    // MUST NOT 跟随重定向：node http 默认不跟随；3xx 原样交上层
-    if (init.signal) {
-      const onAbort = () => req.destroy(new Error('aborted'));
-      if (init.signal.aborted) onAbort();
-      else init.signal.addEventListener('abort', onAbort, { once: true });
-    }
-    req.end();
+  return pinnedFetch(urlStr, {
+    ...init,
+    headers: initHeaders,
+    maxBytes: CIMD_MAX_BYTES,
+    timeoutMs: CIMD_FETCH_TIMEOUT_MS,
+    deadlineMs: CIMD_FETCH_TIMEOUT_MS,
+    dnsLookup,
   });
 }
 
@@ -534,6 +395,9 @@ export async function fetchClientMetadata(
     }
     if (msg === 'response_too_large') {
       return { ok: false, reason: 'response_too_large' };
+    }
+    if (msg === 'redirect_forbidden') {
+      return { ok: false, reason: 'redirect_forbidden' };
     }
     return { ok: false, reason: 'fetch_failed' };
   }

--- a/packages/api/src/lib/pinned-fetch.ts
+++ b/packages/api/src/lib/pinned-fetch.ts
@@ -1,0 +1,294 @@
+/**
+ * 共享 pinned fetcher：node:http(s) + 连接时 lookup 钉死 SSRF。
+ * 供 CIMD（OAuth metadata）与 Outbound Webhooks（RFC-0001 §9.1/§9.7）共享。
+ *
+ * 特性：
+ * - IP 字面量连接前预检
+ * - 连接时 lookup hook 对每一个解析地址跑 isSsrfBlockedResolvedIp（防 DNS-rebinding TOCTOU）
+ * - 3xx 重定向绝对拒绝（RFC-0001 §9.1/§9.4 redirect: 'manual'，内置行为，抛 redirect_forbidden）
+ * - 超时与字节上限参数化（timeoutMs, maxBytes）
+ * - 绝对墙钟死线（deadlineMs，RFC-0001 §9.7）：独立于 socket 空闲度，到期销毁请求（防 slowloris/tarpit 占坑）
+ */
+
+import http from 'node:http';
+import https from 'node:https';
+import { isIP, type LookupFunction } from 'node:net';
+import { lookup as dnsLookupAll } from 'node:dns/promises';
+import { isSsrfBlockedResolvedIp, type SsrfPolicyOptions } from './net.ts';
+
+export type DnsLookupResult = { address: string; family: 4 | 6 };
+
+/** 测试可注入的窄 DNS 查找（避免绑死 node:dns/promises lookup 全重载）。 */
+export type DnsLookup = (
+  hostname: string,
+) => Promise<Array<{ address: string; family: number }>>;
+
+/** 默认 DNS 解析实现。 */
+export async function defaultDnsLookup(
+  hostname: string,
+): Promise<Array<{ address: string; family: number }>> {
+  const results = await dnsLookupAll(hostname, { all: true, verbatim: true });
+  const list = Array.isArray(results) ? results : [results];
+  return list.map((r) =>
+    typeof r === 'string'
+      ? { address: r, family: 0 }
+      : { address: r.address, family: r.family },
+  );
+}
+
+/** 流式读取响应体，超过 maxBytes 截断失败（不整缓冲 arrayBuffer）。 */
+export async function readBodyCapped(
+  stream: NodeJS.ReadableStream,
+  maxBytes: number,
+): Promise<{ ok: true; buf: Buffer } | { ok: false; reason: 'response_too_large' }> {
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const chunk of stream) {
+    const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    total += buf.byteLength;
+    if (total > maxBytes) {
+      const maybeDestroy = (stream as unknown as { destroy?: () => void }).destroy;
+      if (typeof maybeDestroy === 'function') maybeDestroy.call(stream);
+      return { ok: false, reason: 'response_too_large' };
+    }
+    chunks.push(buf);
+  }
+  return { ok: true, buf: Buffer.concat(chunks) };
+}
+
+export type PinnedFetchOptions = RequestInit & {
+  /** 响应最大字节数；超出时抛 response_too_large。未设时不限。 */
+  maxBytes?: number;
+  /** Socket 空闲超时（毫秒，req.setTimeout）。默认 10_000 (10s)。 */
+  timeoutMs?: number;
+  /**
+   * 绝对墙钟死线（毫秒，RFC-0001 §9.7）。
+   * 从请求开始计时，无论 socket 是否有数据流动，到期均销毁请求并抛 deadline_exceeded。
+   * 独立于 socket 空闲度，防 slowloris / tarpit 占坑。
+   * 默认等于 timeoutMs 或 10_000。
+   */
+  deadlineMs?: number;
+  /** 测试或定制的可注入 DNS 查询钩子。 */
+  dnsLookup?: DnsLookup;
+  /** SSRF 判定选项（如 publicEdge: true）。 */
+  ssrfOptions?: SsrfPolicyOptions;
+};
+
+/**
+ * 默认通用 pinned fetcher：node:http(s) + 连接时 lookup 钉死 SSRF。
+ * Host / SNI 仍用原始 hostname；实际 TCP 目标由 lookup 结果决定。
+ */
+export async function pinnedFetch(
+  urlStr: string,
+  options: PinnedFetchOptions = {},
+): Promise<Response> {
+  const url = new URL(urlStr);
+  const isHttps = url.protocol === 'https:';
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('unsupported_protocol');
+  }
+
+  // IP 字面量：连接前即判黑名单（无 DNS TOCTOU）
+  const literal = url.hostname.replace(/^\[(.+)\]$/, '$1');
+  if (isIP(literal) && isSsrfBlockedResolvedIp(literal, options.ssrfOptions)) {
+    throw new Error('ssrf_blocked_ip');
+  }
+
+  const headers: Record<string, string> = {
+    host: url.host,
+  };
+  if (options.headers) {
+    const h = new Headers(options.headers);
+    h.forEach((v, k) => {
+      if (k.toLowerCase() === 'host') return;
+      headers[k] = v;
+    });
+  }
+
+  const lib = isHttps ? https : http;
+  const dnsLookup = options.dnsLookup ?? defaultDnsLookup;
+  const timeoutMs = options.timeoutMs ?? 10_000;
+  const deadlineMs = options.deadlineMs ?? (timeoutMs > 0 ? timeoutMs : 10_000);
+  const maxBytes = options.maxBytes;
+
+  return new Promise<Response>((resolve, reject) => {
+    let settled = false;
+    let activeRes: http.IncomingMessage | undefined;
+    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let abortListener: (() => void) | undefined;
+
+    const cleanup = () => {
+      if (deadlineTimer) {
+        clearTimeout(deadlineTimer);
+        deadlineTimer = undefined;
+      }
+      if (options.signal && abortListener) {
+        options.signal.removeEventListener('abort', abortListener);
+        abortListener = undefined;
+      }
+    };
+
+    const doReject = (err: Error) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err);
+    };
+
+    const doResolve = (res: Response) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(res);
+    };
+
+    const req = lib.request(
+      {
+        protocol: url.protocol,
+        hostname: url.hostname,
+        port: url.port || (isHttps ? 443 : 80),
+        path: `${url.pathname}${url.search}`,
+        method: (options.method as string) || 'GET',
+        headers,
+        servername: isHttps && !isIP(literal) ? literal : undefined,
+        // 连接时解析并对每个结果跑 SSRF（钉死，消灭校验/fetch 间 TOCTOU）
+        lookup: ((hostname, lookupOpts, callback) => {
+          const fail = (err: NodeJS.ErrnoException) => {
+            callback(err, '', 4);
+          };
+          void (async () => {
+            try {
+              const list = await dnsLookup(hostname.replace(/^\[(.+)\]$/, '$1'));
+              if (list.length === 0) {
+                fail(Object.assign(new Error('dns_empty'), { code: 'ENOTFOUND' }));
+                return;
+              }
+              for (const r of list) {
+                if (isSsrfBlockedResolvedIp(r.address, options.ssrfOptions)) {
+                  fail(Object.assign(new Error('ssrf_blocked_ip'), { code: 'EACCES' }));
+                  return;
+                }
+              }
+              const mapped = list.map((r) => ({
+                address: r.address,
+                family: (r.family === 6 ? 6 : 4) as 4 | 6,
+              }));
+              const opts = lookupOpts as { all?: boolean } | number | undefined;
+              const wantAll =
+                typeof opts === 'object' && opts !== null && Boolean(opts.all);
+              if (wantAll) {
+                (callback as (err: Error | null, addresses: typeof mapped) => void)(
+                  null,
+                  mapped,
+                );
+              } else {
+                const first = mapped[0]!;
+                callback(null, first.address, first.family);
+              }
+            } catch (err) {
+              fail(err as NodeJS.ErrnoException);
+            }
+          })();
+        }) as LookupFunction,
+      },
+      (res) => {
+        activeRes = res;
+        void (async () => {
+          try {
+            // 3xx：MUST NOT 跟随重定向，提升为共享 fetcher 内置行为（RFC-0001 §9.1/§9.4）
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
+              res.resume();
+              req.destroy();
+              doReject(new Error('redirect_forbidden'));
+              return;
+            }
+
+            let bodyBuf: Buffer;
+            if (maxBytes !== undefined) {
+              const capped = await readBodyCapped(res, maxBytes);
+              if (!capped.ok) {
+                res.resume();
+                req.destroy();
+                doReject(new Error(capped.reason));
+                return;
+              }
+              bodyBuf = capped.buf;
+            } else {
+              const chunks: Buffer[] = [];
+              for await (const chunk of res) {
+                chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+              }
+              bodyBuf = Buffer.concat(chunks);
+            }
+
+            const headerInit: Record<string, string> = {};
+            for (const [k, v] of Object.entries(res.headers)) {
+              if (typeof v === 'string') headerInit[k] = v;
+              else if (Array.isArray(v)) headerInit[k] = v.join(', ');
+            }
+
+            const isNullBody =
+              res.statusCode === 204 || res.statusCode === 205 || res.statusCode === 304;
+
+            doResolve(
+              new Response(isNullBody ? null : bodyBuf, {
+                status: res.statusCode ?? 200,
+                headers: headerInit,
+              }),
+            );
+          } catch (err) {
+            doReject(err instanceof Error ? err : new Error(String(err)));
+          }
+        })();
+      },
+    );
+
+    // 空闲超时（inactivity timeout）
+    if (timeoutMs > 0 && Number.isFinite(timeoutMs)) {
+      req.setTimeout(timeoutMs, () => {
+        const timeoutErr = new Error('timeout');
+        req.destroy(timeoutErr);
+        if (activeRes) activeRes.destroy(timeoutErr);
+        doReject(timeoutErr);
+      });
+    }
+
+    // 绝对墙钟死线（wall-clock deadline，§9.7）
+    if (deadlineMs > 0 && Number.isFinite(deadlineMs)) {
+      deadlineTimer = setTimeout(() => {
+        const deadlineErr = new Error('deadline_exceeded');
+        req.destroy(deadlineErr);
+        if (activeRes) activeRes.destroy(deadlineErr);
+        doReject(deadlineErr);
+      }, deadlineMs);
+      if (typeof deadlineTimer.unref === 'function') {
+        deadlineTimer.unref();
+      }
+    }
+
+    req.on('error', (err) => {
+      doReject(err);
+    });
+
+    if (options.signal) {
+      abortListener = () => {
+        const abortErr = new Error('aborted');
+        req.destroy(abortErr);
+        if (activeRes) activeRes.destroy(abortErr);
+        doReject(abortErr);
+      };
+      if (options.signal.aborted) abortListener();
+      else options.signal.addEventListener('abort', abortListener, { once: true });
+    }
+
+    if (options.body) {
+      if (typeof options.body === 'string' || Buffer.isBuffer(options.body)) {
+        req.write(options.body);
+      } else {
+        req.write(Buffer.from(options.body as ArrayBuffer));
+      }
+    }
+
+    req.end();
+  });
+}

--- a/packages/api/src/lib/pinned-fetch.ts
+++ b/packages/api/src/lib/pinned-fetch.ts
@@ -75,6 +75,26 @@ export type PinnedFetchOptions = RequestInit & {
 };
 
 /**
+ * 归一化请求体或早拒不支持的类型（CodeRabbit Major 修复）。
+ * 必须在创建连接和死线定时器前同步完成。
+ */
+function normalizeRequestBody(body: unknown): Buffer | undefined {
+  if (body === null || body === undefined) return undefined;
+  if (typeof body === 'string') return Buffer.from(body, 'utf8');
+  if (Buffer.isBuffer(body)) return body;
+  if (body instanceof Uint8Array) {
+    return Buffer.from(body.buffer, body.byteOffset, body.byteLength);
+  }
+  if (body instanceof ArrayBuffer) {
+    return Buffer.from(body);
+  }
+  if (body instanceof URLSearchParams) {
+    return Buffer.from(body.toString(), 'utf8');
+  }
+  throw new TypeError('unsupported_request_body_type');
+}
+
+/**
  * 默认通用 pinned fetcher：node:http(s) + 连接时 lookup 钉死 SSRF。
  * Host / SNI 仍用原始 hostname；实际 TCP 目标由 lookup 结果决定。
  */
@@ -93,6 +113,9 @@ export async function pinnedFetch(
   if (isIP(literal) && isSsrfBlockedResolvedIp(literal, options.ssrfOptions)) {
     throw new Error('ssrf_blocked_ip');
   }
+
+  // 请求体早拒/归一化（CodeRabbit Major：在创建底层请求与定时器前完成）
+  const normalizedBody = normalizeRequestBody(options.body);
 
   const headers: Record<string, string> = {
     host: url.host,
@@ -132,6 +155,21 @@ export async function pinnedFetch(
       if (settled) return;
       settled = true;
       cleanup();
+      try {
+        req.destroy(err);
+      } catch {
+        // ignore
+      }
+      try {
+        if (req.socket) req.socket.destroy(err);
+      } catch {
+        // ignore
+      }
+      try {
+        if (activeRes) activeRes.destroy(err);
+      } catch {
+        // ignore
+      }
       reject(err);
     };
 
@@ -150,6 +188,7 @@ export async function pinnedFetch(
         path: `${url.pathname}${url.search}`,
         method: (options.method as string) || 'GET',
         headers,
+        agent: false,
         servername: isHttps && !isIP(literal) ? literal : undefined,
         // 连接时解析并对每个结果跑 SSRF（钉死，消灭校验/fetch 间 TOCTOU）
         lookup: ((hostname, lookupOpts, callback) => {
@@ -246,20 +285,14 @@ export async function pinnedFetch(
     // 空闲超时（inactivity timeout）
     if (timeoutMs > 0 && Number.isFinite(timeoutMs)) {
       req.setTimeout(timeoutMs, () => {
-        const timeoutErr = new Error('timeout');
-        req.destroy(timeoutErr);
-        if (activeRes) activeRes.destroy(timeoutErr);
-        doReject(timeoutErr);
+        doReject(new Error('timeout'));
       });
     }
 
     // 绝对墙钟死线（wall-clock deadline，§9.7）
     if (deadlineMs > 0 && Number.isFinite(deadlineMs)) {
       deadlineTimer = setTimeout(() => {
-        const deadlineErr = new Error('deadline_exceeded');
-        req.destroy(deadlineErr);
-        if (activeRes) activeRes.destroy(deadlineErr);
-        doReject(deadlineErr);
+        doReject(new Error('deadline_exceeded'));
       }, deadlineMs);
       if (typeof deadlineTimer.unref === 'function') {
         deadlineTimer.unref();
@@ -272,21 +305,14 @@ export async function pinnedFetch(
 
     if (options.signal) {
       abortListener = () => {
-        const abortErr = new Error('aborted');
-        req.destroy(abortErr);
-        if (activeRes) activeRes.destroy(abortErr);
-        doReject(abortErr);
+        doReject(new Error('aborted'));
       };
       if (options.signal.aborted) abortListener();
       else options.signal.addEventListener('abort', abortListener, { once: true });
     }
 
-    if (options.body) {
-      if (typeof options.body === 'string' || Buffer.isBuffer(options.body)) {
-        req.write(options.body);
-      } else {
-        req.write(Buffer.from(options.body as ArrayBuffer));
-      }
+    if (normalizedBody && normalizedBody.length > 0) {
+      req.write(normalizedBody);
     }
 
     req.end();

--- a/packages/api/test/oauth-cimd.test.ts
+++ b/packages/api/test/oauth-cimd.test.ts
@@ -23,6 +23,7 @@ const {
   isBlockedSsrfIp,
   isSsrfBlockedResolvedIp,
   matchRedirectUri,
+  pinnedCimdFetcher,
   validateClientIdUrl,
 } = await import('../src/lib/oauth-cimd.ts');
 
@@ -343,3 +344,43 @@ describe('CIMD auth_method none 回退（ChatGPT 连接器）', () => {
     if (!missingNone.ok) expect(missingNone.reason).toBe('auth_method_unsupported');
   });
 });
+
+describe('CIMD 回归守卫与共享 fetcher 收紧验证 (#128 PR1)', () => {
+  test('pinnedCimdFetcher 对等性：保留原有签名与 IP 字面量/lookup 校验', async () => {
+    // IP 字面量预检
+    await expect(pinnedCimdFetcher('https://169.254.169.254/cimd.json')).rejects.toThrow('ssrf_blocked_ip');
+    await expect(pinnedCimdFetcher('https://[64:ff9b::a9fe:a9fe]/cimd.json')).rejects.toThrow('ssrf_blocked_ip');
+    await expect(pinnedCimdFetcher('https://[2002:a9fe:a9fe::1]/cimd.json')).rejects.toThrow('ssrf_blocked_ip');
+
+    // 注入 lookup
+    const badLookup = async () => [{ address: '64:ff9b::a9fe:a9fe', family: 6 }];
+    await expect(
+      pinnedCimdFetcher('https://client.example/cimd.json', {}, badLookup),
+    ).rejects.toThrow('ssrf_blocked_ip');
+  });
+
+  test('fetchClientMetadata 受益于 IPv6-embedded-IPv4 收紧', async () => {
+    // NAT64 unsafe
+    const r1 = await fetchClientMetadata('https://[64:ff9b::a9fe:a9fe]/oauth/client.json', {
+      dnsLookup: async () => [{ address: '64:ff9b::a9fe:a9fe', family: 6 }],
+    });
+    expect(r1.ok).toBe(false);
+    if (!r1.ok) expect(r1.reason).toBe('ssrf_blocked_ip');
+
+    // 6to4 unsafe
+    const r2 = await fetchClientMetadata('https://[2002:a9fe:a9fe::1]/oauth/client.json', {
+      dnsLookup: async () => [{ address: '2002:a9fe:a9fe::1', family: 6 }],
+    });
+    expect(r2.ok).toBe(false);
+    if (!r2.ok) expect(r2.reason).toBe('ssrf_blocked_ip');
+
+    // assertClientIdHostSafe 也同步受益
+    const safe1 = await assertClientIdHostSafe('64:ff9b::a9fe:a9fe');
+    expect(safe1.ok).toBe(false);
+    if (!safe1.ok) expect(safe1.reason).toBe('ssrf_blocked_ip');
+
+    const safe2 = await assertClientIdHostSafe('64:ff9b::5db8:d822');
+    expect(safe2.ok).toBe(true);
+  });
+});
+

--- a/packages/api/test/pinned-fetch-ssrf.test.ts
+++ b/packages/api/test/pinned-fetch-ssrf.test.ts
@@ -254,8 +254,59 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
     ).rejects.toThrow('dns_empty');
   });
 
+  function startTrackedHttpServer(handler: http.RequestListener) {
+    const sockets = new Set<net.Socket>();
+    const server = http.createServer(handler);
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+    });
+    const close = async () => {
+      for (const socket of sockets) {
+        try {
+          socket.destroy();
+        } catch {
+          // ignore
+        }
+      }
+      sockets.clear();
+      if (typeof (server as any).closeAllConnections === 'function') {
+        try {
+          (server as any).closeAllConnections();
+        } catch {
+          // ignore
+        }
+      }
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      server.unref();
+    };
+    return { server, close, sockets };
+  }
+
+  function startTrackedNetServer(handler: (socket: net.Socket) => void) {
+    const sockets = new Set<net.Socket>();
+    const server = net.createServer((socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+      handler(socket);
+    });
+    const close = async () => {
+      for (const socket of sockets) {
+        try {
+          socket.destroy();
+        } catch {
+          // ignore
+        }
+      }
+      sockets.clear();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      server.unref();
+    };
+    return { server, close, sockets };
+  }
+
   test('redirect 拒绝上移：3xx 响应内置失败且不跟随（RFC-0001 §9.1/§9.4）', async () => {
-    const server = http.createServer((req, res) => {
+    const { server, close } = startTrackedHttpServer((_req, res) => {
       res.writeHead(302, {
         Location: 'http://127.0.0.1:9999/other',
         'Content-Type': 'text/plain',
@@ -275,12 +326,12 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
         }),
       ).rejects.toThrow('redirect_forbidden');
     } finally {
-      server.close();
+      await close();
     }
   });
 
   test('maxBytes 字节上限截断：超出抛 response_too_large', async () => {
-    const server = http.createServer((req, res) => {
+    const { server, close } = startTrackedHttpServer((_req, res) => {
       res.writeHead(200, { 'Content-Type': 'text/plain' });
       // 发送 4KB 数据
       res.end('x'.repeat(4096));
@@ -311,24 +362,34 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
       const text = await res.text();
       expect(text.length).toBe(4096);
     } finally {
-      server.close();
+      await close();
     }
   });
 
   test('绝对墙钟死线（RFC-0001 §9.7）：slowloris 慢滴响应独立于空闲超时销毁', async () => {
-    const server = http.createServer((req, res) => {
+    let interval: ReturnType<typeof setInterval> | undefined;
+    const { server, close } = startTrackedHttpServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'text/plain' });
       res.write('first');
       // 每 20ms 发送一次数据，导致 socket 从不处于空闲状态
-      const interval = setInterval(() => {
+      interval = setInterval(() => {
         try {
           res.write(' chunk');
         } catch {
-          clearInterval(interval);
+          if (interval) clearInterval(interval);
         }
       }, 20);
+      if (interval && typeof interval.unref === 'function') {
+        interval.unref();
+      }
+      res.on('error', () => {
+        if (interval) clearInterval(interval);
+      });
+      res.on('close', () => {
+        if (interval) clearInterval(interval);
+      });
       req.on('close', () => {
-        clearInterval(interval);
+        if (interval) clearInterval(interval);
       });
     });
 
@@ -354,12 +415,13 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
       // 保证在死线附近被杀，而非等待 500ms
       expect(elapsed).toBeLessThan(400);
     } finally {
-      server.close();
+      if (interval) clearInterval(interval);
+      await close();
     }
   });
 
   test('绝对墙钟死线（RFC-0001 §9.7）：TCP tarpit 接受握手但不发数据时到期销毁', async () => {
-    const tarpitServer = net.createServer((socket) => {
+    const { server: tarpitServer, close } = startTrackedNetServer((_socket) => {
       // 接受 TCP 连接但不写入任何响应
     });
 
@@ -382,12 +444,12 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
       const elapsed = Date.now() - startedAt;
       expect(elapsed).toBeLessThan(400);
     } finally {
-      tarpitServer.close();
+      await close();
     }
   });
 
   test('正常成功请求：透传请求头与响应体', async () => {
-    const server = http.createServer((req, res) => {
+    const { server, close } = startTrackedHttpServer((req, res) => {
       const customHeader = req.headers['x-custom-test'];
       res.writeHead(200, {
         'Content-Type': 'application/json',
@@ -417,12 +479,12 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
       const body = await res.json();
       expect(body).toEqual({ status: 'ok', received: 'my-secret-val' });
     } finally {
-      server.close();
+      await close();
     }
   });
 
   test('HTTP 204 No Content：正确构建 null body 响应而不抛出 TypeError', async () => {
-    const server = http.createServer((_req, res) => {
+    const { server, close } = startTrackedHttpServer((_req, res) => {
       res.writeHead(204, { 'X-Status-Note': 'no-content-ack' });
       res.end();
     });
@@ -444,7 +506,7 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
       const text = await res.text();
       expect(text).toBe('');
     } finally {
-      server.close();
+      await close();
     }
   });
 
@@ -467,11 +529,19 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
   });
 
   test('AbortController signal 支持与监听器注销', async () => {
-    const server = http.createServer((_req, res) => {
-      setTimeout(() => {
-        res.writeHead(200);
-        res.end('done');
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const { server, close } = startTrackedHttpServer((_req, res) => {
+      timer = setTimeout(() => {
+        try {
+          res.writeHead(200);
+          res.end('done');
+        } catch {
+          // ignore
+        }
       }, 200);
+      if (timer && typeof timer.unref === 'function') {
+        timer.unref();
+      }
     });
 
     await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
@@ -490,7 +560,64 @@ describe('pinnedFetch: 传输层核心防护与行为', () => {
       setTimeout(() => ac.abort(), 30);
       await expect(fetchPromise).rejects.toThrow('aborted');
     } finally {
-      server.close();
+      if (timer) clearTimeout(timer);
+      await close();
+    }
+  });
+
+  test('options.body 归一化与早拒：不支持类型同步抛出 TypeError，支持类型正常透传', async () => {
+    // 1. 不支持类型早拒：在创建连接前直接抛出 TypeError（CodeRabbit Major 守护）
+    await expect(
+      pinnedFetch('http://127.0.0.1:8080/body', {
+        body: { foo: 'bar' } as unknown as BodyInit,
+      }),
+    ).rejects.toThrow(TypeError);
+
+    // 2. 支持类型（string, Uint8Array, URLSearchParams）正常透传
+    const { server, close } = startTrackedHttpServer(async (req, res) => {
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const received = Buffer.concat(chunks).toString('utf8');
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ received }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+
+      // string
+      const r1 = await pinnedFetch(`http://body.example:${port}/str`, {
+        dnsLookup,
+        method: 'POST',
+        body: 'hello-world',
+        ssrfOptions: { publicEdge: false },
+      });
+      expect(await r1.json()).toEqual({ received: 'hello-world' });
+
+      // Uint8Array
+      const r2 = await pinnedFetch(`http://body.example:${port}/u8`, {
+        dnsLookup,
+        method: 'POST',
+        body: new Uint8Array([104, 101, 121]), // 'hey'
+        ssrfOptions: { publicEdge: false },
+      });
+      expect(await r2.json()).toEqual({ received: 'hey' });
+
+      // URLSearchParams
+      const r3 = await pinnedFetch(`http://body.example:${port}/usp`, {
+        dnsLookup,
+        method: 'POST',
+        body: new URLSearchParams({ a: '1', b: '2' }),
+        ssrfOptions: { publicEdge: false },
+      });
+      expect(await r3.json()).toEqual({ received: 'a=1&b=2' });
+    } finally {
+      await close();
     }
   });
 });

--- a/packages/api/test/pinned-fetch-ssrf.test.ts
+++ b/packages/api/test/pinned-fetch-ssrf.test.ts
@@ -1,0 +1,496 @@
+/**
+ * Pinned Fetcher + SSRF 收紧测试矩阵（RFC-0001 §14 item 2, §15 PR 1, D16, Q21=A）。
+ *
+ * 覆盖：
+ * 1. SSRF 永拒范围（0.0.0.0/8, 169.254/16, fe80::/10, fd00:ec2::/16, ::, ff00::/8, Class E 240.0.0.0/4）
+ * 2. IPv4-mapped IPv6（点分、十六进制、0: 前缀）
+ * 3. NAT64 (64:ff9b::/96) 提取式评估（Unsafe 拒、公网放、私网按 publicEdge）
+ * 4. 6to4 (2002::/16) 提取式评估（Unsafe 拒、公网放、私网按 publicEdge）
+ * 5. Teredo (2001:0000::/32) 提取式评估（server/client 分别判定、client 按 XOR 取反）
+ * 6. 十进制/八进制/十六进制/单整数 IPv4 变体
+ * 7. DNS lookup 注入钉死与 DNS rebinding 防御（TOCTOU 消除）
+ * 8. 3xx 重定向拒绝上移（redirect_forbidden 内置）
+ * 9. publicEdge 组合双向
+ * 10. 绝对墙钟死线（slowloris 与 TCP tarpit 截断）与 maxBytes 响应限流
+ */
+
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'x';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'x';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-pinned-fetch-'));
+process.env.UI_ENABLED = 'false';
+
+import http from 'node:http';
+import net from 'node:net';
+const { describe, expect, test } = await import('bun:test');
+
+const {
+  isBlockedSsrfIp,
+  isSsrfBlockedResolvedIp,
+  isPrivateOrLoopbackHostname,
+  extractEmbeddedIpv4s,
+} = await import('../src/lib/net.ts');
+const {
+  pinnedFetch,
+} = await import('../src/lib/pinned-fetch.ts');
+type DnsLookup = import('../src/lib/pinned-fetch.ts').DnsLookup;
+
+describe('SSRF 策略纯函数：永拒与公私网判定', () => {
+  test('永拒段：0.0.0.0/8 与 169.254.0.0/16', () => {
+    expect(isBlockedSsrfIp('0.0.0.0')).toBe(true);
+    expect(isBlockedSsrfIp('0.1.2.3')).toBe(true);
+    expect(isBlockedSsrfIp('169.254.0.1')).toBe(true);
+    expect(isBlockedSsrfIp('169.254.169.254')).toBe(true);
+
+    expect(isSsrfBlockedResolvedIp('0.0.0.0')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('169.254.169.254')).toBe(true);
+  });
+
+  test('永拒段：fe80::/10 链路本地与 fd00:ec2::/16 AWS IMDS', () => {
+    expect(isBlockedSsrfIp('fe80::1')).toBe(true);
+    expect(isBlockedSsrfIp('febf::ffff')).toBe(true);
+    expect(isBlockedSsrfIp('fd00:ec2::254')).toBe(true);
+    expect(isBlockedSsrfIp('fd00:ec2::1')).toBe(true);
+
+    expect(isSsrfBlockedResolvedIp('fe80::1')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('fd00:ec2::254')).toBe(true);
+  });
+
+  test('永拒段：:: 未指定地址、ff00::/8 组播与 240.0.0.0/4 Class E 保留地址', () => {
+    expect(isSsrfBlockedResolvedIp('::')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('ff02::1')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('ff05::2')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('240.0.0.1')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('255.255.255.255')).toBe(true);
+  });
+
+  test('IPv4-mapped IPv6：各种格式映射提取', () => {
+    expect(isBlockedSsrfIp('::ffff:169.254.169.254')).toBe(true);
+    expect(isBlockedSsrfIp('::ffff:a9fe:a9fe')).toBe(true);
+    expect(isBlockedSsrfIp('::ffff:0:169.254.169.254')).toBe(true);
+
+    // 公网 IPv4-mapped 放行
+    expect(isBlockedSsrfIp('::ffff:93.184.216.34')).toBe(false);
+    expect(isBlockedSsrfIp('::ffff:5db8:d822')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('::ffff:93.184.216.34')).toBe(false);
+
+    // 私网 IPv4-mapped 受 publicEdge 约束
+    expect(isSsrfBlockedResolvedIp('::ffff:192.168.1.1', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('::ffff:192.168.1.1', { publicEdge: true })).toBe(true);
+  });
+
+  test('NAT64 (64:ff9b::/96) 提取式判定（Q21=A）：Unsafe 拒、公网放、私网受控', () => {
+    // 提取验证
+    expect(extractEmbeddedIpv4s('64:ff9b::a9fe:a9fe')).toEqual(['169.254.169.254']);
+    expect(extractEmbeddedIpv4s('64:ff9b::5db8:d822')).toEqual(['93.184.216.34']);
+    expect(extractEmbeddedIpv4s('64:ff9b::169.254.169.254')).toEqual(['169.254.169.254']);
+
+    // 邮件 #1355 / 任务卡首要判据：64:ff9b::a9fe:a9fe 必须拒、64:ff9b::5db8:d822 必须放
+    expect(isBlockedSsrfIp('64:ff9b::a9fe:a9fe')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('64:ff9b::a9fe:a9fe')).toBe(true);
+
+    expect(isBlockedSsrfIp('64:ff9b::5db8:d822')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('64:ff9b::5db8:d822')).toBe(false);
+
+    // 点分形式
+    expect(isBlockedSsrfIp('64:ff9b::169.254.169.254')).toBe(true);
+    expect(isBlockedSsrfIp('64:ff9b::93.184.216.34')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('64:ff9b::93.184.216.34')).toBe(false);
+
+    // 0.0.0.0 内嵌必须拒
+    expect(isBlockedSsrfIp('64:ff9b::0.0.0.0')).toBe(true);
+
+    // 私网内嵌受 publicEdge 约束
+    expect(isBlockedSsrfIp('64:ff9b::10.0.0.1')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('64:ff9b::10.0.0.1', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('64:ff9b::10.0.0.1', { publicEdge: true })).toBe(true);
+
+    expect(isSsrfBlockedResolvedIp('64:ff9b::127.0.0.1', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('64:ff9b::127.0.0.1', { publicEdge: true })).toBe(true);
+  });
+
+  test('6to4 (2002::/16) 提取式判定（Q21=A）：Unsafe 拒、公网放、私网受控', () => {
+    // 2002:WWXX:YYZZ:: 提取 bits 16..47
+    expect(extractEmbeddedIpv4s('2002:a9fe:a9fe::')).toEqual(['169.254.169.254']);
+    expect(extractEmbeddedIpv4s('2002:a9fe:a9fe::1')).toEqual(['169.254.169.254']);
+    expect(extractEmbeddedIpv4s('2002:5db8:d822::')).toEqual(['93.184.216.34']);
+
+    expect(isBlockedSsrfIp('2002:a9fe:a9fe::')).toBe(true);
+    expect(isBlockedSsrfIp('2002:a9fe:a9fe::1')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('2002:a9fe:a9fe::1')).toBe(true);
+
+    // 公网 6to4 放行
+    expect(isBlockedSsrfIp('2002:5db8:d822::')).toBe(false);
+    expect(isBlockedSsrfIp('2002:5db8:d822::1')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('2002:5db8:d822::1')).toBe(false);
+
+    // 私网 6to4
+    expect(isBlockedSsrfIp('2002:0a00:0001::')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('2002:0a00:0001::', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('2002:0a00:0001::', { publicEdge: true })).toBe(true);
+  });
+
+  test('Teredo (2001:0000::/32) 提取式判定（Q21=A）：server 与 client 双向判定', () => {
+    // Server unsafe (hextets 2-3 为 169.254.169.254 = a9fe:a9fe)
+    expect(isBlockedSsrfIp('2001:0000:a9fe:a9fe:8000:63bf:3fff:fdd2')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('2001:0000:a9fe:a9fe:8000:63bf:3fff:fdd2')).toBe(true);
+
+    // Client unsafe (hextets 6-7 取反后为 169.254.169.254 -> 5601:5601)
+    expect(isBlockedSsrfIp('2001:0000:5db8:d822:8000:63bf:5601:5601')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('2001:0000:5db8:d822:8000:63bf:5601:5601')).toBe(true);
+
+    // Server & Client 均为公网
+    // 0808:0808 = 8.8.8.8; a247:27dd 取反为 5db8:d822 = 93.184.216.34
+    const teredoPublic = '2001:0000:0808:0808:8000:63bf:a247:27dd';
+    expect(extractEmbeddedIpv4s(teredoPublic)).toEqual(['8.8.8.8', '93.184.216.34']);
+    expect(isBlockedSsrfIp(teredoPublic)).toBe(false);
+    expect(isSsrfBlockedResolvedIp(teredoPublic)).toBe(false);
+
+    // Client 为私网 10.0.0.1 (取反后为 f5ff:fffe)
+    const teredoPrivateClient = '2001:0000:5db8:d822:8000:63bf:f5ff:fffe';
+    expect(extractEmbeddedIpv4s(teredoPrivateClient)).toContain('10.0.0.1');
+    expect(isBlockedSsrfIp(teredoPrivateClient)).toBe(false);
+    expect(isSsrfBlockedResolvedIp(teredoPrivateClient, { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp(teredoPrivateClient, { publicEdge: true })).toBe(true);
+  });
+
+  test('十进制/八进制/十六进制 IPv4 变形解析', () => {
+    // 169.254.169.254 变体
+    expect(isBlockedSsrfIp('2852039166')).toBe(true);
+    expect(isBlockedSsrfIp('0xa9fea9fe')).toBe(true);
+    expect(isBlockedSsrfIp('0251.0376.0251.0376')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('2852039166')).toBe(true);
+    expect(isSsrfBlockedResolvedIp('0xa9fea9fe')).toBe(true);
+
+    // 127.0.0.1 变体
+    expect(isBlockedSsrfIp('2130706433')).toBe(false);
+    expect(isBlockedSsrfIp('0x7f000001')).toBe(false);
+    expect(isBlockedSsrfIp('0177.0.0.1')).toBe(false);
+    expect(isBlockedSsrfIp('0x7f.0.0.1')).toBe(false);
+
+    expect(isSsrfBlockedResolvedIp('2130706433', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('2130706433', { publicEdge: true })).toBe(true);
+    expect(isSsrfBlockedResolvedIp('0177.0.0.1', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('0177.0.0.1', { publicEdge: true })).toBe(true);
+    expect(isSsrfBlockedResolvedIp('0x7f.0.0.1', { publicEdge: false })).toBe(false);
+    expect(isSsrfBlockedResolvedIp('0x7f.0.0.1', { publicEdge: true })).toBe(true);
+
+    // 公网变体 (93.184.216.34)
+    expect(isBlockedSsrfIp('1567610914')).toBe(false);
+    expect(isSsrfBlockedResolvedIp('1567610914')).toBe(false);
+  });
+
+  test('isPrivateOrLoopbackHostname 对嵌入 IPv4 与变体的支持', () => {
+    expect(isPrivateOrLoopbackHostname('localhost')).toBe(true);
+    expect(isPrivateOrLoopbackHostname('127.0.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHostname('0177.0.0.1')).toBe(true);
+    expect(isPrivateOrLoopbackHostname('2130706433')).toBe(true);
+    expect(isPrivateOrLoopbackHostname('[64:ff9b::127.0.0.1]')).toBe(true);
+    expect(isPrivateOrLoopbackHostname('[64:ff9b::10.0.0.1]')).toBe(true);
+
+    // 永拒与公网地址不是合法的私网放行主机名
+    expect(isPrivateOrLoopbackHostname('169.254.169.254')).toBe(false);
+    expect(isPrivateOrLoopbackHostname('2852039166')).toBe(false);
+    expect(isPrivateOrLoopbackHostname('[64:ff9b::a9fe:a9fe]')).toBe(false);
+    expect(isPrivateOrLoopbackHostname('[64:ff9b::5db8:d822]')).toBe(false);
+    expect(isPrivateOrLoopbackHostname('example.com')).toBe(false);
+  });
+});
+
+describe('pinnedFetch: 传输层核心防护与行为', () => {
+  test('IP 字面量在发起连接前预检拦截', async () => {
+    // 169.254
+    await expect(pinnedFetch('http://169.254.169.254/')).rejects.toThrow('ssrf_blocked_ip');
+    // IPv4-mapped
+    await expect(pinnedFetch('http://[::ffff:169.254.169.254]/')).rejects.toThrow('ssrf_blocked_ip');
+    // NAT64 unsafe
+    await expect(pinnedFetch('http://[64:ff9b::a9fe:a9fe]/')).rejects.toThrow('ssrf_blocked_ip');
+    // 6to4 unsafe
+    await expect(pinnedFetch('http://[2002:a9fe:a9fe::1]/')).rejects.toThrow('ssrf_blocked_ip');
+    // 整数 / 十六进制形 IPv4
+    await expect(pinnedFetch('http://2852039166/')).rejects.toThrow('ssrf_blocked_ip');
+    await expect(pinnedFetch('http://0xa9fea9fe/')).rejects.toThrow('ssrf_blocked_ip');
+    // 不支持的协议
+    await expect(pinnedFetch('ftp://127.0.0.1/')).rejects.toThrow('unsupported_protocol');
+  });
+
+  test('DNS rebinding 防御：连接期 lookup 钩子钉死，消灭 TOCTOU', async () => {
+    // 模拟 DNS 返回 169.254.169.254
+    const unsafeLookup: DnsLookup = async () => [
+      { address: '169.254.169.254', family: 4 },
+    ];
+    await expect(
+      pinnedFetch('http://safe.example.com/api', { dnsLookup: unsafeLookup }),
+    ).rejects.toThrow('ssrf_blocked_ip');
+
+    // 模拟 DNS 返回 NAT64 unsafe
+    const nat64UnsafeLookup: DnsLookup = async () => [
+      { address: '64:ff9b::a9fe:a9fe', family: 6 },
+    ];
+    await expect(
+      pinnedFetch('http://safe.example.com/api', { dnsLookup: nat64UnsafeLookup }),
+    ).rejects.toThrow('ssrf_blocked_ip');
+
+    // 多 A/AAAA 记录，只要包含一条 blocked IP 即拒绝
+    const dualStackRebind: DnsLookup = async () => [
+      { address: '93.184.216.34', family: 4 },
+      { address: '169.254.169.254', family: 4 },
+    ];
+    await expect(
+      pinnedFetch('http://safe.example.com/api', { dnsLookup: dualStackRebind }),
+    ).rejects.toThrow('ssrf_blocked_ip');
+
+    // DNS 无结果
+    const emptyLookup: DnsLookup = async () => [];
+    await expect(
+      pinnedFetch('http://safe.example.com/api', { dnsLookup: emptyLookup }),
+    ).rejects.toThrow('dns_empty');
+  });
+
+  test('redirect 拒绝上移：3xx 响应内置失败且不跟随（RFC-0001 §9.1/§9.4）', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(302, {
+        Location: 'http://127.0.0.1:9999/other',
+        'Content-Type': 'text/plain',
+      });
+      res.end('redirecting');
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+      await expect(
+        pinnedFetch(`http://test-server.example:${port}/target`, {
+          dnsLookup,
+          ssrfOptions: { publicEdge: false },
+        }),
+      ).rejects.toThrow('redirect_forbidden');
+    } finally {
+      server.close();
+    }
+  });
+
+  test('maxBytes 字节上限截断：超出抛 response_too_large', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      // 发送 4KB 数据
+      res.end('x'.repeat(4096));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+
+      // 限制 1024 字节：失败
+      await expect(
+        pinnedFetch(`http://test-server.example:${port}/doc`, {
+          dnsLookup,
+          maxBytes: 1024,
+          ssrfOptions: { publicEdge: false },
+        }),
+      ).rejects.toThrow('response_too_large');
+
+      // 限制 8192 字节：成功
+      const res = await pinnedFetch(`http://test-server.example:${port}/doc`, {
+        dnsLookup,
+        maxBytes: 8192,
+        ssrfOptions: { publicEdge: false },
+      });
+      expect(res.status).toBe(200);
+      const text = await res.text();
+      expect(text.length).toBe(4096);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('绝对墙钟死线（RFC-0001 §9.7）：slowloris 慢滴响应独立于空闲超时销毁', async () => {
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.write('first');
+      // 每 20ms 发送一次数据，导致 socket 从不处于空闲状态
+      const interval = setInterval(() => {
+        try {
+          res.write(' chunk');
+        } catch {
+          clearInterval(interval);
+        }
+      }, 20);
+      req.on('close', () => {
+        clearInterval(interval);
+      });
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+      const startedAt = Date.now();
+
+      // timeoutMs（空闲超时）设为 500ms（若仅靠空闲超时则绝不会触发）
+      // deadlineMs 设为 60ms：绝对死线到期必须销毁
+      await expect(
+        pinnedFetch(`http://test-server.example:${port}/slow`, {
+          dnsLookup,
+          timeoutMs: 500,
+          deadlineMs: 60,
+          ssrfOptions: { publicEdge: false },
+        }),
+      ).rejects.toThrow('deadline_exceeded');
+
+      const elapsed = Date.now() - startedAt;
+      // 保证在死线附近被杀，而非等待 500ms
+      expect(elapsed).toBeLessThan(400);
+    } finally {
+      server.close();
+    }
+  });
+
+  test('绝对墙钟死线（RFC-0001 §9.7）：TCP tarpit 接受握手但不发数据时到期销毁', async () => {
+    const tarpitServer = net.createServer((socket) => {
+      // 接受 TCP 连接但不写入任何响应
+    });
+
+    await new Promise<void>((resolve) => tarpitServer.listen(0, '127.0.0.1', () => resolve()));
+    const port = (tarpitServer.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+      const startedAt = Date.now();
+
+      await expect(
+        pinnedFetch(`http://tarpit.example:${port}/trap`, {
+          dnsLookup,
+          timeoutMs: 500,
+          deadlineMs: 60,
+          ssrfOptions: { publicEdge: false },
+        }),
+      ).rejects.toThrow('deadline_exceeded');
+
+      const elapsed = Date.now() - startedAt;
+      expect(elapsed).toBeLessThan(400);
+    } finally {
+      tarpitServer.close();
+    }
+  });
+
+  test('正常成功请求：透传请求头与响应体', async () => {
+    const server = http.createServer((req, res) => {
+      const customHeader = req.headers['x-custom-test'];
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'X-Echo-Custom': String(customHeader),
+      });
+      res.end(JSON.stringify({ status: 'ok', received: customHeader }));
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+      const res = await pinnedFetch(`http://server.example:${port}/api/hello`, {
+        dnsLookup,
+        headers: {
+          'x-custom-test': 'my-secret-val',
+        },
+        timeoutMs: 5000,
+        deadlineMs: 5000,
+        maxBytes: 1024,
+        ssrfOptions: { publicEdge: false },
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('x-echo-custom')).toBe('my-secret-val');
+      const body = await res.json();
+      expect(body).toEqual({ status: 'ok', received: 'my-secret-val' });
+    } finally {
+      server.close();
+    }
+  });
+
+  test('HTTP 204 No Content：正确构建 null body 响应而不抛出 TypeError', async () => {
+    const server = http.createServer((_req, res) => {
+      res.writeHead(204, { 'X-Status-Note': 'no-content-ack' });
+      res.end();
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+      const res = await pinnedFetch(`http://server.example:${port}/webhook/ack`, {
+        dnsLookup,
+        timeoutMs: 2000,
+        deadlineMs: 2000,
+        ssrfOptions: { publicEdge: false },
+      });
+
+      expect(res.status).toBe(204);
+      expect(res.headers.get('x-status-note')).toBe('no-content-ack');
+      const text = await res.text();
+      expect(text).toBe('');
+    } finally {
+      server.close();
+    }
+  });
+
+  test('publicEdge: true 端到端防护：字面量与 DNS 解析私网均被拒绝', async () => {
+    // 1. IP 字面量私网地址被前置检查拒绝
+    await expect(
+      pinnedFetch('http://127.0.0.1:8080/hook', {
+        ssrfOptions: { publicEdge: true },
+      }),
+    ).rejects.toThrow('ssrf_blocked_ip');
+
+    // 2. DNS 解析到私网地址被 lookup hook 拒绝
+    const dnsLookup: DnsLookup = async () => [{ address: '10.0.0.1', family: 4 }];
+    await expect(
+      pinnedFetch('http://internal.service:8080/hook', {
+        dnsLookup,
+        ssrfOptions: { publicEdge: true },
+      }),
+    ).rejects.toThrow('ssrf_blocked_ip');
+  });
+
+  test('AbortController signal 支持与监听器注销', async () => {
+    const server = http.createServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('done');
+      }, 200);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', () => resolve()));
+    const port = (server.address() as net.AddressInfo).port;
+
+    try {
+      const dnsLookup: DnsLookup = async () => [{ address: '127.0.0.1', family: 4 }];
+      const ac = new AbortController();
+
+      const fetchPromise = pinnedFetch(`http://abort.example:${port}/long`, {
+        dnsLookup,
+        signal: ac.signal,
+        ssrfOptions: { publicEdge: false },
+      });
+
+      setTimeout(() => ac.abort(), 30);
+      await expect(fetchPromise).rejects.toThrow('aborted');
+    } finally {
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
Part of #128 (DO NOT close #128; this is PR 1 of 4).

## Summary
Implements PR 1 of RFC-0001 §15:
1. **Shared Pinned Fetcher**: Created `packages/api/src/lib/pinned-fetch.ts` with `pinnedFetch`, `readBodyCapped`, and `defaultDnsLookup`. Parameterizes `timeoutMs`, `deadlineMs`, and `maxBytes` while preserving connect-time `lookup` SSRF verification and IP literal pre-check. Delegated `pinnedCimdFetcher` in `oauth-cimd.ts` with 100% signature and behavior parity.
2. **Absolute Wall-Clock Deadline** (RFC-0001 §9.7): Independent of socket inactivity; terminates connection on deadline expiry (`deadline_exceeded`), preventing slowloris and TCP tarpits.
3. **Redirect Refusal Promotion** (RFC-0001 §9.1/§9.4): Built-in rejection of 3xx responses (`redirect_forbidden`) without following redirects.
4. **IPv6 Embedded-IPv4 Extraction Hardening** (RFC-0001 §9.2, D16, Q21=A): Extracts embedded IPv4 addresses from NAT64 (`64:ff9b::/96`), 6to4 (`2002::/16`), and Teredo (`2001:0000::/32`), evaluating them against existing IPv4 SSRF policies (`64:ff9b::a9fe:a9fe` blocked, `64:ff9b::5db8:d822` allowed).
5. **SSRF Matrix & CIMD Regression Guard**: Added comprehensive test suites in `pinned-fetch-ssrf.test.ts` (19 tests) and regression guard tests in `oauth-cimd.test.ts` (26 tests).

## Verification
- `bun test test/oauth-cimd.test.ts test/pinned-fetch-ssrf.test.ts`: 45 passed (100%).
- Full `bun test`: 1252 passed, 1 skipped, 0 failed across 76 files.
- `bun run build`: Clean build.
- `bun run lint:ui`: Clean lint.
- Subagent independent review passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Strengthened protection against private, loopback, link-local, and other restricted networks.
  - Added detection for additional IPv4 representations and IPv4 addresses embedded in IPv6 formats.
  - Improved defenses against DNS rebinding and unsafe redirects.

- **Reliability**
  - Added request timeouts, absolute deadlines, response-size limits, and cancellation support for protected network requests.
  - Improved handling of OAuth client metadata fetch failures, including clearer redirect-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->