### PR TITLE
refactor(api): process-wide event dispatcher with per-sink watermark isolation (#128 PR2)

### DIFF
--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -170,6 +170,8 @@ const envSchema = z.object({
   // Notification transport. Docker Compose enables ntfy by default; keeping
   // the bare-process default off preserves the lightweight API test/runtime.
   NTFY_ENABLED: z.enum(['true', 'false']).default('false'),
+  // Outbound webhooks. Off by default (§10.1).
+  WEBHOOKS_ENABLED: z.enum(['true', 'false']).default('false'),
   NTFY_INTERNAL_URL: envUrl('http://ntfy'),
   // Path as seen by the ntfy container. The API writes the same named volume
   // at /app/data, so this must not be derived from DATA_DIR.
@@ -381,6 +383,9 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
       configPath: join(raw.DATA_DIR, 'ntfy', 'server.yml'),
       pushPolicy: raw.PUSH_POLICY,
       notifyRateLimit: raw.NOTIFY_RATE_LIMIT,
+    },
+    webhooks: {
+      enabled: raw.WEBHOOKS_ENABLED === 'true',
     },
     dashboardPublicUrl: raw.DASHBOARD_PUBLIC_URL
       ? normalizeUrl(raw.DASHBOARD_PUBLIC_URL)

--- a/packages/api/src/lib/event-dispatcher.ts
+++ b/packages/api/src/lib/event-dispatcher.ts
@@ -1,0 +1,158 @@
+/**
+ * Process-wide event dispatcher with per-sink watermark isolation (§11.4).
+ *
+ * Sits across two producers:
+ * 1. Inbound mail loop (IMAP watcher): emits mail.received with per-sink watermark isolation.
+ * 2. Task path (createApprovalTask): emits approval.requested with non-blocking hand-off.
+ */
+
+import type { FetchMessageObject } from 'imapflow';
+import type { Identity } from './identities.ts';
+import type { NotifyService } from './notify.ts';
+import { isNotifyServiceFailure, notificationService } from './notify.ts';
+import type { ApprovalTask } from './tasks-internal.ts';
+
+export type WatchedMessage = Pick<
+  FetchMessageObject,
+  'envelope' | 'headers' | 'source' | 'flags' | 'internalDate' | 'uid'
+>;
+
+export type MailReceivedEvent = {
+  type: 'mail.received';
+  message: WatchedMessage;
+  uidValidity?: bigint;
+};
+
+export type ApprovalRequestedEvent = {
+  type: 'approval.requested';
+  task: ApprovalTask;
+};
+
+export type ProcessEvent = MailReceivedEvent | ApprovalRequestedEvent;
+
+/** Per-sink watermark for inbound mail progression (in-memory, survives IMAP reconnects). */
+export type SinkWatermark = {
+  uid?: number;
+  uidValidity?: bigint;
+  serviceFailure?: { uid: number; sinceMs: number };
+  consecutivePublishSkips?: number;
+};
+
+export type MailDispatchContext = {
+  clickUrl?: string;
+  refreshIdentity?: (address: string) => Identity | undefined;
+  wait?: (ms: number) => Promise<void>;
+  error?: typeof console.error;
+  identities?: Identity[];
+};
+
+export interface EventSink {
+  readonly id: string;
+  isEnabled(): boolean;
+  watermark?: SinkWatermark;
+  handleMail?(event: MailReceivedEvent, context?: MailDispatchContext): Promise<void>;
+  handleApproval?(event: ApprovalRequestedEvent): Promise<void>;
+}
+
+export function isSinkServiceFailure(err: unknown): boolean {
+  if (err && typeof err === 'object' && 'failureKind' in err) {
+    return (err as any).failureKind === 'service';
+  }
+  return isNotifyServiceFailure(err);
+}
+
+export class EventDispatcher {
+  readonly kind = 'event-dispatcher' as const;
+  private sinks: Map<string, EventSink> = new Map();
+  private errorLogger: typeof console.error;
+
+  constructor(options?: { error?: typeof console.error; sinks?: EventSink[] }) {
+    this.errorLogger = options?.error ?? console.error;
+    if (options?.sinks) {
+      for (const sink of options.sinks) {
+        this.registerSink(sink);
+      }
+    }
+  }
+
+  registerSink(sink: EventSink): void {
+    this.sinks.set(sink.id, sink);
+  }
+
+  unregisterSink(id: string): boolean {
+    return this.sinks.delete(id);
+  }
+
+  getSink(id: string): EventSink | undefined {
+    return this.sinks.get(id);
+  }
+
+  getAllSinks(): EventSink[] {
+    return Array.from(this.sinks.values());
+  }
+
+  getMailSinks(): EventSink[] {
+    return Array.from(this.sinks.values()).filter((s) => typeof s.handleMail === 'function');
+  }
+
+  getApprovalSinks(): EventSink[] {
+    return Array.from(this.sinks.values()).filter((s) => typeof s.handleApproval === 'function');
+  }
+
+  /**
+   * Producer 2: task-creation path (createApprovalTask).
+   * Hand-off, never await (§11.4 item 4).
+   * Enqueue and return immediately so the task creation 201 response is never blocked.
+   */
+  dispatchApprovalRequested(task: ApprovalTask): void {
+    const sinks = this.getApprovalSinks().filter((s) => s.isEnabled());
+    if (sinks.length === 0) return;
+    const event: ApprovalRequestedEvent = {
+      type: 'approval.requested',
+      task,
+    };
+    queueMicrotask(() => {
+      for (const sink of sinks) {
+        try {
+          sink.handleApproval?.(event).catch((err) => {
+            this.errorLogger(
+              `[dispatcher] Sink ${sink.id} failed handling approval.requested:`,
+              err instanceof Error ? err.message : String(err),
+            );
+          });
+        } catch (err) {
+          this.errorLogger(
+            `[dispatcher] Sink ${sink.id} threw synchronously handling approval.requested:`,
+            err instanceof Error ? err.message : String(err),
+          );
+        }
+      }
+    });
+  }
+
+  /** Backward compatibility for any caller expecting { publish: ... } */
+  publish: NotifyService['publish'] = async (input) => {
+    return notificationService().publish(input);
+  };
+}
+
+export function isEventDispatcher(value: unknown): value is EventDispatcher {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    ((value as any).kind === 'event-dispatcher' || typeof (value as any).getMailSinks === 'function')
+  );
+}
+
+let processDispatcher: EventDispatcher | null = null;
+
+export function getEventDispatcher(): EventDispatcher {
+  if (!processDispatcher) {
+    processDispatcher = new EventDispatcher();
+  }
+  return processDispatcher;
+}
+
+export function setEventDispatcherForTests(dispatcher: EventDispatcher | null): void {
+  processDispatcher = dispatcher;
+}

--- a/packages/api/src/lib/event-dispatcher.ts
+++ b/packages/api/src/lib/event-dispatcher.ts
@@ -105,14 +105,36 @@ export class EventDispatcher {
    * Enqueue and return immediately so the task creation 201 response is never blocked.
    */
   dispatchApprovalRequested(task: ApprovalTask): void {
-    const sinks = this.getApprovalSinks().filter((s) => s.isEnabled());
-    if (sinks.length === 0) return;
+    let candidateSinks: EventSink[];
+    try {
+      candidateSinks = this.getApprovalSinks();
+    } catch (err) {
+      this.errorLogger(
+        '[dispatcher] Failed retrieving approval sinks:',
+        err instanceof Error ? err.message : String(err),
+      );
+      return;
+    }
+    if (candidateSinks.length === 0) return;
+
     const event: ApprovalRequestedEvent = {
       type: 'approval.requested',
       task,
     };
     queueMicrotask(() => {
-      for (const sink of sinks) {
+      for (const sink of candidateSinks) {
+        let enabled = false;
+        try {
+          enabled = sink.isEnabled();
+        } catch (err) {
+          this.errorLogger(
+            `[dispatcher] Sink ${sink.id} threw checking isEnabled:`,
+            err instanceof Error ? err.message : String(err),
+          );
+          continue;
+        }
+        if (!enabled) continue;
+
         try {
           sink.handleApproval?.(event).catch((err) => {
             this.errorLogger(

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1488,14 +1488,48 @@ export async function watchConnection(
     const uidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
 
     if (isEventDispatcher(dispatch)) {
-      const mailSinks = dispatch.getMailSinks().filter((s) => s.isEnabled());
-      for (const sink of mailSinks) {
-        if (!sink.watermark) sink.watermark = {};
-      }
+      const getActiveMailSinks = (): EventSink[] => {
+        const sinks = dispatch.getMailSinks().filter((s) => s.isEnabled());
+        for (const sink of sinks) {
+          if (!sink.watermark) sink.watermark = {};
+        }
+        return sinks;
+      };
 
-      const getUnionPending = (allUids: number[]): number[] => {
+      const reconcileServiceFailures = (sinks: EventSink[], currentUids: number[]): void => {
+        const now = runtime.now();
+        for (const sink of sinks) {
+          const wm = sink.watermark!;
+          if (!wm.serviceFailure) continue;
+          const failedUid = wm.serviceFailure.uid;
+          const isExpunged = !currentUids.includes(failedUid);
+          const unavailableMs = Math.max(0, now - wm.serviceFailure.sinceMs);
+          const isTimedOut = unavailableMs >= SERVICE_FAILURE_MAX_MS;
+
+          if (isExpunged) {
+            runtime.error(
+              `[${sink.id}] CRITICAL IMAP watcher abandoned expunged UID ${failedUid} ` +
+                `(deleted from mailbox before service recovery):`,
+              watcherErrorLogMessage('message expunged during service failure'),
+            );
+            wm.uid = Math.max(wm.uid ?? 0, failedUid);
+            wm.serviceFailure = undefined;
+          } else if (isTimedOut) {
+            runtime.error(
+              `[${sink.id}] CRITICAL IMAP watcher abandoned UID ${failedUid} after service ` +
+                `failure persisted for ${unavailableMs}ms (hard limit: ${SERVICE_FAILURE_MAX_MS}ms):`,
+              watcherErrorLogMessage('service failure timeout'),
+            );
+            wm.uid = Math.max(wm.uid ?? 0, failedUid);
+            wm.serviceFailure = undefined;
+          }
+        }
+      };
+
+      const getUnionPending = (sinks: EventSink[], allUids: number[]): number[] => {
+        reconcileServiceFailures(sinks, allUids);
         const pendingSet = new Set<number>();
-        for (const sink of mailSinks) {
+        for (const sink of sinks) {
           const unseen = unseenWatcherUids(allUids, sink.watermark!, uidValidity);
           for (const uid of unseen) {
             pendingSet.add(uid);
@@ -1506,7 +1540,7 @@ export async function watchConnection(
 
       const initial = await client.search({ all: true }, { uid: true });
       const initialUids = Array.isArray(initial) ? initial : [];
-      let pending = getUnionPending(initialUids);
+      let pending = getUnionPending(getActiveMailSinks(), initialUids);
       if (watermark) {
         unseenWatcherUids(initialUids, watermark, uidValidity);
       }
@@ -1524,10 +1558,11 @@ export async function watchConnection(
             },
             { uid: true },
           )) {
-            let allFailedWithServiceFailure = mailSinks.length > 0;
+            const currentMailSinks = getActiveMailSinks();
+            let allFailedWithServiceFailure = currentMailSinks.length > 0;
             let lastServiceError: unknown = null;
 
-            for (const sink of mailSinks) {
+            for (const sink of currentMailSinks) {
               const wm = sink.watermark!;
               if (wm.uid !== undefined && message.uid <= wm.uid && wm.serviceFailure?.uid !== message.uid) {
                 allFailedWithServiceFailure = false;
@@ -1594,7 +1629,7 @@ export async function watchConnection(
 
             if (watermark) {
               watermark.uidValidity = uidValidity;
-              const maxSinkUid = Math.max(0, ...mailSinks.map((s) => s.watermark?.uid ?? 0));
+              const maxSinkUid = Math.max(0, ...currentMailSinks.map((s) => s.watermark?.uid ?? 0));
               watermark.uid = Math.max(watermark.uid ?? 0, maxSinkUid);
             }
           }
@@ -1605,7 +1640,7 @@ export async function watchConnection(
         if (signal.aborted) break;
         const found = await client.search({ all: true }, { uid: true });
         const currentUids = Array.isArray(found) ? found : [];
-        pending = getUnionPending(currentUids);
+        pending = getUnionPending(getActiveMailSinks(), currentUids);
       }
     } else {
       // Legacy single-sink dispatch path (100% backward compatible for tests)
@@ -1771,6 +1806,7 @@ export function startNotificationWatcher(cfg = config): () => void {
   if (!watcherAbort) {
     watcherAbort = new AbortController();
     const dispatcher = getEventDispatcher();
+    // webhook sink 随 PR 4 注册；PR 2 中 WEBHOOKS_ENABLED 仅作启动门输入
     if (!dispatcher.getSink('ntfy')) {
       dispatcher.registerSink(createNtfySink());
     }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -1489,7 +1489,17 @@ export async function watchConnection(
 
     if (isEventDispatcher(dispatch)) {
       const getActiveMailSinks = (): EventSink[] => {
-        const sinks = dispatch.getMailSinks().filter((s) => s.isEnabled());
+        const sinks = dispatch.getMailSinks().filter((s) => {
+          try {
+            return s.isEnabled();
+          } catch (err) {
+            runtime.error(
+              `[${s.id}] IMAP watcher skipped sink after isEnabled threw:`,
+              watcherErrorLogMessage(err),
+            );
+            return false;
+          }
+        });
         for (const sink of sinks) {
           if (!sink.watermark) sink.watermark = {};
         }

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -40,6 +40,18 @@ import {
 import { MAX_EMAIL_HTML_LENGTH } from './sanitize-email-html.ts';
 import { approvalEventForWatcher } from './tasks.ts';
 import { truncateUtf8Bytes } from './utf8-truncate.ts';
+import {
+  EventDispatcher,
+  getEventDispatcher,
+  isEventDispatcher,
+  isSinkServiceFailure,
+  type EventSink,
+  type MailReceivedEvent,
+  type SinkWatermark,
+  type WatchedMessage,
+} from './event-dispatcher.ts';
+
+export type { WatchedMessage } from './event-dispatcher.ts';
 
 const RECONNECT_INITIAL_MS = 2_000;
 const RECONNECT_MAX_MS = 120_000;
@@ -111,8 +123,6 @@ async function waitForReconnect(
     signal.removeEventListener('abort', onAbort);
   }
 }
-
-export type WatchedMessage = Pick<FetchMessageObject, 'envelope' | 'headers' | 'source'>;
 
 export type WatcherDispatch = {
   /** May carry NotifyInput.beforeSend for final tier/delete checks at fetch boundary. */
@@ -1429,10 +1439,36 @@ type WatchConnectionRuntime = {
 };
 
 /** @internal Exported so poison-message batch progression can be regression-tested. */
+export function createNtfySink(
+  publish: NotifyService['publish'] = notificationService().publish.bind(notificationService()),
+  watermark: SinkWatermark = {},
+): EventSink {
+  return {
+    id: 'ntfy',
+    isEnabled: () => config.ntfy.enabled && config.ntfy.pushPolicy !== 'none',
+    watermark,
+    async handleMail(event, context) {
+      await processWatchedMessage(
+        event.message,
+        context?.identities ?? listIdentities(),
+        config.ntfy.pushPolicy,
+        { publish },
+        {
+          clickUrl: context?.clickUrl ?? config.dashboardPublicUrl,
+          refreshIdentity: context?.refreshIdentity ?? findIdentity,
+          wait: context?.wait ?? sleep,
+          error: context?.error ?? console.error,
+        },
+      );
+    },
+  };
+}
+
+/** @internal Exported so poison-message batch progression can be regression-tested. */
 export async function watchConnection(
   signal: AbortSignal,
   client: ImapFlow,
-  dispatch: WatcherDispatch,
+  dispatch: WatcherDispatch | EventDispatcher,
   watermark: WatcherWatermark,
   runtime: WatchConnectionRuntime = {
     identities: listIdentities,
@@ -1450,71 +1486,197 @@ export async function watchConnection(
     // re-anchors the watermark instead of starving notifications.
     // (client.mailbox is `false | MailboxObject` before/without selection.)
     const uidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
-    const initial = await client.search({ all: true }, { uid: true });
-    let pending = unseenWatcherUids(Array.isArray(initial) ? initial : [], watermark, uidValidity);
 
-    while (!signal.aborted) {
-      if (pending.length > 0) {
-        for await (const message of client.fetch(
-          pending,
-          { envelope: true, headers: ['delivered-to'], source: true },
-          { uid: true },
-        )) {
-          try {
-            await processWatchedMessage(
-              message,
-              runtime.identities(),
-              config.ntfy.pushPolicy,
-              dispatch,
-              {
-                clickUrl: config.dashboardPublicUrl,
-                // O(1) indexed lookup; mtime/invalidate cache still sees tier PUTs.
-                refreshIdentity: (address) => runtime.identity(address),
-                wait: runtime.wait,
-                error: runtime.error,
-              },
-            );
-            consecutivePublishSkips = 0;
-            watermark.serviceFailure = undefined;
-          } catch (err) {
-            if (!(err instanceof WatcherPublishError)) throw err;
-            if (isNotifyServiceFailure(err.reason)) {
-              const now = runtime.now();
-              const observed = watermark.serviceFailure;
-              if (!observed || observed.uid !== message.uid) {
-                watermark.serviceFailure = { uid: message.uid, sinceMs: now };
-                throw err;
-              }
-              const unavailableMs = Math.max(0, now - observed.sinceMs);
-              if (unavailableMs < SERVICE_FAILURE_MAX_MS) throw err;
-              runtime.error(
-                `[notify] CRITICAL IMAP watcher abandoned UID ${message.uid} after notification service ` +
-                  `failure persisted for ${unavailableMs}ms (hard limit: ${SERVICE_FAILURE_MAX_MS}ms):`,
-                watcherErrorLogMessage(err.reason),
-              );
-            } else {
-              consecutivePublishSkips += 1;
-              runtime.error(
-                `[notify] IMAP watcher skipped UID ${message.uid} after ${err.attempts} publish attempts ` +
-                  `(consecutive skips: ${consecutivePublishSkips}):`,
-                watcherErrorLogMessage(err.reason),
-              );
-            }
-            watermark.serviceFailure = undefined;
-          }
-          watermark.uid = Math.max(watermark.uid ?? 0, message.uid);
-        }
+    if (isEventDispatcher(dispatch)) {
+      const mailSinks = dispatch.getMailSinks().filter((s) => s.isEnabled());
+      for (const sink of mailSinks) {
+        if (!sink.watermark) sink.watermark = {};
       }
-      pending = [];
 
-      // IDLE gives prompt delivery where the server reports EXISTS, while the
-      // heartbeat keeps this watcher correct on servers that occasionally keep
-      // an IDLE command open after mail arrives. Socket errors still escape to
-      // the outer reconnect loop instead of leaving a stale watcher forever.
-      await Promise.race([client.idle(), runtime.wait(3_000)]);
-      if (signal.aborted) break;
-      const found = await client.search({ all: true }, { uid: true });
-      pending = unseenWatcherUids(Array.isArray(found) ? found : [], watermark, uidValidity);
+      const getUnionPending = (allUids: number[]): number[] => {
+        const pendingSet = new Set<number>();
+        for (const sink of mailSinks) {
+          const unseen = unseenWatcherUids(allUids, sink.watermark!, uidValidity);
+          for (const uid of unseen) {
+            pendingSet.add(uid);
+          }
+        }
+        return Array.from(pendingSet).sort((a, b) => a - b);
+      };
+
+      const initial = await client.search({ all: true }, { uid: true });
+      const initialUids = Array.isArray(initial) ? initial : [];
+      let pending = getUnionPending(initialUids);
+      if (watermark) {
+        unseenWatcherUids(initialUids, watermark, uidValidity);
+      }
+
+      while (!signal.aborted) {
+        if (pending.length > 0) {
+          for await (const message of client.fetch(
+            pending,
+            {
+              envelope: true,
+              headers: ['delivered-to'],
+              source: true,
+              flags: true,
+              internalDate: true,
+            },
+            { uid: true },
+          )) {
+            let allFailedWithServiceFailure = mailSinks.length > 0;
+            let lastServiceError: unknown = null;
+
+            for (const sink of mailSinks) {
+              const wm = sink.watermark!;
+              if (wm.uid !== undefined && message.uid <= wm.uid && wm.serviceFailure?.uid !== message.uid) {
+                allFailedWithServiceFailure = false;
+                continue;
+              }
+              if (wm.serviceFailure && wm.serviceFailure.uid < message.uid) {
+                continue;
+              }
+
+              try {
+                await sink.handleMail!(
+                  { type: 'mail.received', message, uidValidity },
+                  {
+                    clickUrl: config.dashboardPublicUrl,
+                    refreshIdentity: (address) => runtime.identity(address),
+                    wait: runtime.wait,
+                    error: runtime.error,
+                    identities: runtime.identities(),
+                  },
+                );
+                wm.uid = Math.max(wm.uid ?? 0, message.uid);
+                wm.serviceFailure = undefined;
+                wm.consecutivePublishSkips = 0;
+                allFailedWithServiceFailure = false;
+              } catch (err) {
+                const reason = err instanceof WatcherPublishError ? err.reason : err;
+                if (isSinkServiceFailure(reason)) {
+                  lastServiceError = reason;
+                  const now = runtime.now();
+                  const observed = wm.serviceFailure;
+                  if (!observed || observed.uid !== message.uid) {
+                    wm.serviceFailure = { uid: message.uid, sinceMs: now };
+                  } else {
+                    const unavailableMs = Math.max(0, now - observed.sinceMs);
+                    if (unavailableMs >= SERVICE_FAILURE_MAX_MS) {
+                      runtime.error(
+                        `[${sink.id}] CRITICAL IMAP watcher abandoned UID ${message.uid} after service ` +
+                          `failure persisted for ${unavailableMs}ms (hard limit: ${SERVICE_FAILURE_MAX_MS}ms):`,
+                        watcherErrorLogMessage(reason),
+                      );
+                      wm.serviceFailure = undefined;
+                      wm.uid = Math.max(wm.uid ?? 0, message.uid);
+                      allFailedWithServiceFailure = false;
+                    }
+                  }
+                } else {
+                  allFailedWithServiceFailure = false;
+                  wm.consecutivePublishSkips = (wm.consecutivePublishSkips ?? 0) + 1;
+                  const attempts = err instanceof WatcherPublishError ? err.attempts : 1;
+                  runtime.error(
+                    `[${sink.id}] IMAP watcher skipped UID ${message.uid} after ${attempts} publish attempts ` +
+                      `(consecutive skips: ${wm.consecutivePublishSkips}):`,
+                    watcherErrorLogMessage(reason),
+                  );
+                  wm.serviceFailure = undefined;
+                  wm.uid = Math.max(wm.uid ?? 0, message.uid);
+                }
+              }
+            }
+
+            if (allFailedWithServiceFailure && lastServiceError) {
+              throw lastServiceError instanceof Error ? lastServiceError : new Error(String(lastServiceError));
+            }
+
+            if (watermark) {
+              watermark.uidValidity = uidValidity;
+              const maxSinkUid = Math.max(0, ...mailSinks.map((s) => s.watermark?.uid ?? 0));
+              watermark.uid = Math.max(watermark.uid ?? 0, maxSinkUid);
+            }
+          }
+        }
+        pending = [];
+
+        await Promise.race([client.idle(), runtime.wait(3_000)]);
+        if (signal.aborted) break;
+        const found = await client.search({ all: true }, { uid: true });
+        const currentUids = Array.isArray(found) ? found : [];
+        pending = getUnionPending(currentUids);
+      }
+    } else {
+      // Legacy single-sink dispatch path (100% backward compatible for tests)
+      const initial = await client.search({ all: true }, { uid: true });
+      let pending = unseenWatcherUids(Array.isArray(initial) ? initial : [], watermark, uidValidity);
+
+      while (!signal.aborted) {
+        if (pending.length > 0) {
+          for await (const message of client.fetch(
+            pending,
+            {
+              envelope: true,
+              headers: ['delivered-to'],
+              source: true,
+              flags: true,
+              internalDate: true,
+            },
+            { uid: true },
+          )) {
+            try {
+              await processWatchedMessage(
+                message,
+                runtime.identities(),
+                config.ntfy.pushPolicy,
+                dispatch,
+                {
+                  clickUrl: config.dashboardPublicUrl,
+                  // O(1) indexed lookup; mtime/invalidate cache still sees tier PUTs.
+                  refreshIdentity: (address) => runtime.identity(address),
+                  wait: runtime.wait,
+                  error: runtime.error,
+                },
+              );
+              consecutivePublishSkips = 0;
+              watermark.serviceFailure = undefined;
+            } catch (err) {
+              if (!(err instanceof WatcherPublishError)) throw err;
+              if (isNotifyServiceFailure(err.reason)) {
+                const now = runtime.now();
+                const observed = watermark.serviceFailure;
+                if (!observed || observed.uid !== message.uid) {
+                  watermark.serviceFailure = { uid: message.uid, sinceMs: now };
+                  throw err;
+                }
+                const unavailableMs = Math.max(0, now - observed.sinceMs);
+                if (unavailableMs < SERVICE_FAILURE_MAX_MS) throw err;
+                runtime.error(
+                  `[notify] CRITICAL IMAP watcher abandoned UID ${message.uid} after notification service ` +
+                    `failure persisted for ${unavailableMs}ms (hard limit: ${SERVICE_FAILURE_MAX_MS}ms):`,
+                  watcherErrorLogMessage(err.reason),
+                );
+              } else {
+                consecutivePublishSkips += 1;
+                runtime.error(
+                  `[notify] IMAP watcher skipped UID ${message.uid} after ${err.attempts} publish attempts ` +
+                    `(consecutive skips: ${consecutivePublishSkips}):`,
+                  watcherErrorLogMessage(err.reason),
+                );
+              }
+              watermark.serviceFailure = undefined;
+            }
+            watermark.uid = Math.max(watermark.uid ?? 0, message.uid);
+          }
+        }
+        pending = [];
+
+        await Promise.race([client.idle(), runtime.wait(3_000)]);
+        if (signal.aborted) break;
+        const found = await client.search({ all: true }, { uid: true });
+        pending = unseenWatcherUids(Array.isArray(found) ? found : [], watermark, uidValidity);
+      }
     }
   } finally {
     lock?.release();
@@ -1542,7 +1704,7 @@ type WatcherRuntime = {
 /** @internal Exported so the reconnect/error boundary can be regression-tested. */
 export async function runWatcher(
   signal: AbortSignal,
-  dispatch: WatcherDispatch,
+  dispatch: WatcherDispatch | EventDispatcher,
   runtime: WatcherRuntime = {
     connect: connectImap,
     watch: watchConnection,
@@ -1598,15 +1760,25 @@ export async function runWatcher(
 
 let watcherAbort: AbortController | undefined;
 
+/** Checks whether the notification watcher should run under the broadened startup gate (§11.4 item 1). */
+export function isNotificationWatcherEnabled(cfg = config): boolean {
+  return (cfg.ntfy.enabled && cfg.ntfy.pushPolicy !== 'none') || cfg.webhooks.enabled;
+}
+
 /** Start one process-wide watcher; calling it again returns the same stopper. */
-export function startNotificationWatcher(): () => void {
-  if (!config.ntfy.enabled || config.ntfy.pushPolicy === 'none') return () => {};
+export function startNotificationWatcher(cfg = config): () => void {
+  if (!isNotificationWatcherEnabled(cfg)) return () => {};
   if (!watcherAbort) {
     watcherAbort = new AbortController();
-    void runWatcher(watcherAbort.signal, { publish: notificationService().publish.bind(notificationService()) });
+    const dispatcher = getEventDispatcher();
+    if (!dispatcher.getSink('ntfy')) {
+      dispatcher.registerSink(createNtfySink());
+    }
+    void runWatcher(watcherAbort.signal, dispatcher);
   }
   return () => {
     watcherAbort?.abort();
     watcherAbort = undefined;
   };
 }
+

--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -16,6 +16,7 @@ import { taskLeasesEnabled } from './task-lease-gate.ts';
 import { isTaskId } from './task-id.ts';
 import * as taskBoardCursor from './task-cursor.ts';
 import * as taskChildrenCursor from './task-cursor.ts';
+import { getEventDispatcher } from './event-dispatcher.ts';
 
 export {
   decodeTaskBoardCursor,
@@ -1656,6 +1657,7 @@ export async function createApprovalTask(input: CreateApprovalTaskInput): Promis
     approval: snapshot,
   };
   recordSyntheticTaskBase(task);
+  getEventDispatcher().dispatchApprovalRequested(task);
   return task;
 }
 

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -39,6 +39,8 @@ startSendLogMaintenance();
 await inspectDeviceRegistryAtBoot();
 if (config.ntfy.enabled) {
   await initializeNotifications();
+}
+if ((config.ntfy.enabled && config.ntfy.pushPolicy !== 'none') || config.webhooks.enabled) {
   startNotificationWatcher();
 }
 

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -639,3 +639,34 @@ describe('EXTRA_DOMAINS multi-domain configuration', () => {
     ).toThrow(`EXTRA_DOMAINS contains invalid domain entry: "${longDomain}"`);
   });
 });
+
+describe('WEBHOOKS_ENABLED configuration (#128 PR2)', () => {
+  test('defaults to false when unset', () => {
+    const config = parseConfig(requiredEnv);
+    expect(config.webhooks.enabled).toBe(false);
+  });
+
+  test('enables webhooks when set to true', () => {
+    const config = parseConfig({
+      ...requiredEnv,
+      WEBHOOKS_ENABLED: 'true',
+    });
+    expect(config.webhooks.enabled).toBe(true);
+  });
+
+  test('rejects non-boolean string values', () => {
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOKS_ENABLED: '1',
+      }),
+    ).toThrow();
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOKS_ENABLED: 'yes',
+      }),
+    ).toThrow();
+  });
+});
+

--- a/packages/api/test/event-dispatcher.test.ts
+++ b/packages/api/test/event-dispatcher.test.ts
@@ -729,6 +729,50 @@ describe('Second producer hand-off (§11.4 item 4 & §14 item 10)', () => {
 
     setEventDispatcherForTests(null);
   });
+
+  test('sink throwing in isEnabled does not throw or corrupt createApprovalTask return (Codex P1 R3)', async () => {
+    const loggedErrors: string[] = [];
+    const dispatcher = new EventDispatcher({
+      error: (msg, detail) => {
+        loggedErrors.push(`${msg} ${detail ?? ''}`);
+      },
+    });
+    setEventDispatcherForTests(dispatcher);
+
+    let handleApprovalCalled = false;
+    dispatcher.registerSink({
+      id: 'throwing-isenabled-sink',
+      isEnabled: () => {
+        throw new Error('Config lookup failed');
+      },
+      handleApproval: async () => {
+        handleApprovalCalled = true;
+      },
+    });
+
+    const task = await createApprovalTask({
+      from: 'requester@test.example',
+      to: 'approver@test.example',
+      subject: 'isEnabled failure resilience test',
+      body: 'Should succeed and return 201 regardless of isEnabled throw',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      action: {
+        type: 'action',
+        name: 'test',
+        arguments: {},
+      },
+    });
+
+    expect(task.id).toBeDefined();
+    expect(task.state).toBe('input-required');
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(handleApprovalCalled).toBe(false);
+    expect(loggedErrors.some((e) => e.includes('Sink throwing-isenabled-sink threw checking isEnabled'))).toBe(true);
+
+    setEventDispatcherForTests(null);
+  });
 });
 
 describe('EventDispatcher abstractions and sink contracts', () => {

--- a/packages/api/test/event-dispatcher.test.ts
+++ b/packages/api/test/event-dispatcher.test.ts
@@ -1,0 +1,644 @@
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-dispatcher-'));
+process.env.NODE_ENV = 'test';
+
+const { afterEach, beforeEach, describe, expect, test } = await import('bun:test');
+const {
+  EventDispatcher,
+  getEventDispatcher,
+  setEventDispatcherForTests,
+  isEventDispatcher,
+  isSinkServiceFailure,
+} = await import('../src/lib/event-dispatcher.ts');
+type EventSink = import('../src/lib/event-dispatcher.ts').EventSink;
+type MailReceivedEvent = import('../src/lib/event-dispatcher.ts').MailReceivedEvent;
+type ApprovalRequestedEvent = import('../src/lib/event-dispatcher.ts').ApprovalRequestedEvent;
+type SinkWatermark = import('../src/lib/event-dispatcher.ts').SinkWatermark;
+
+const {
+  createNtfySink,
+  isNotificationWatcherEnabled,
+  startNotificationWatcher,
+  watchConnection,
+} = await import('../src/lib/notification-watcher.ts');
+type WatchedMessage = import('../src/lib/notification-watcher.ts').WatchedMessage;
+type WatcherWatermark = import('../src/lib/notification-watcher.ts').WatcherWatermark;
+
+const { NotifyError } = await import('../src/lib/notify.ts');
+const { createApprovalTask } = await import('../src/lib/tasks-internal.ts');
+const taskSeams = await import('./support/task-test-seams.ts');
+const { createIdentity, findIdentity } = await import('../src/lib/identities.ts');
+const { config } = await import('../src/lib/config.ts');
+
+for (const localpart of ['requester', 'approver']) {
+  if (!findIdentity(`${localpart}@test.example`)) {
+    createIdentity({ localpart, issueToken: false });
+  }
+}
+
+const baseIdentities = [
+  {
+    address: 'approver@test.example',
+    name: 'Approver',
+    can_notify_user: true,
+    created_at: '2026-09-01T00:00:00Z',
+  },
+  {
+    address: 'requester@test.example',
+    name: 'Requester',
+    can_notify_user: true,
+    created_at: '2026-09-01T00:00:00Z',
+  },
+];
+
+describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
+  test('isNotificationWatcherEnabled opens when webhooks enabled even if ntfy disabled', () => {
+    // ntfy disabled, webhooks enabled
+    expect(
+      isNotificationWatcherEnabled({
+        ...config,
+        ntfy: { ...config.ntfy, enabled: false, pushPolicy: 'otp' },
+        webhooks: { enabled: true },
+      }),
+    ).toBe(true);
+
+    // ntfy enabled, webhooks disabled
+    expect(
+      isNotificationWatcherEnabled({
+        ...config,
+        ntfy: { ...config.ntfy, enabled: true, pushPolicy: 'otp' },
+        webhooks: { enabled: false },
+      }),
+    ).toBe(true);
+
+    // ntfy enabled but pushPolicy is none, webhooks disabled
+    expect(
+      isNotificationWatcherEnabled({
+        ...config,
+        ntfy: { ...config.ntfy, enabled: true, pushPolicy: 'none' },
+        webhooks: { enabled: false },
+      }),
+    ).toBe(false);
+
+    // ntfy pushPolicy none, but webhooks enabled -> watcher runs!
+    expect(
+      isNotificationWatcherEnabled({
+        ...config,
+        ntfy: { ...config.ntfy, enabled: true, pushPolicy: 'none' },
+        webhooks: { enabled: true },
+      }),
+    ).toBe(true);
+
+    // both disabled
+    expect(
+      isNotificationWatcherEnabled({
+        ...config,
+        ntfy: { ...config.ntfy, enabled: false, pushPolicy: 'none' },
+        webhooks: { enabled: false },
+      }),
+    ).toBe(false);
+  });
+
+  test('startNotificationWatcher returns no-op when gate is closed', () => {
+    const stopper = startNotificationWatcher({
+      ...config,
+      ntfy: { ...config.ntfy, enabled: false },
+      webhooks: { enabled: false },
+    });
+    expect(stopper).toBeFunction();
+    stopper();
+  });
+});
+
+describe('IMAP fetch widening (§11.4 item 2)', () => {
+  test('watchConnection requests flags and internalDate in fetch query', async () => {
+    let capturedQuery: any = null;
+    const controller = new AbortController();
+    const client = {
+      mailbox: { uidValidity: 100n },
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => [41],
+      fetch: async function* (_pending: any, query: any) {
+        capturedQuery = query;
+        yield {
+          uid: 41,
+          envelope: { from: [{ address: 'sender@example.com' }], subject: 'Test' },
+          headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+          source: Buffer.from('From: sender@example.com\r\n\r\nHello'),
+          flags: new Set(['\\Seen']),
+          internalDate: new Date('2026-09-04T12:00:00Z'),
+        };
+      },
+      idle: async () => { controller.abort(); },
+      logout: async () => {},
+      close() {},
+    } as any;
+
+    const dispatcher = new EventDispatcher();
+    let receivedMessage: WatchedMessage | null = null;
+    dispatcher.registerSink({
+      id: 'test',
+      isEnabled: () => true,
+      watermark: { uid: 40, uidValidity: 100n },
+      handleMail: async (event) => {
+        receivedMessage = event.message;
+      },
+    });
+
+    await watchConnection(
+      controller.signal,
+      client,
+      dispatcher,
+      { uid: 40, uidValidity: 100n },
+      {
+        identities: () => baseIdentities as any,
+        identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+        wait: async () => {},
+        error: () => {},
+        now: () => Date.now(),
+      },
+    );
+
+    expect(capturedQuery).toBeDefined();
+    expect(capturedQuery.envelope).toBe(true);
+    expect(capturedQuery.headers).toEqual(['delivered-to']);
+    expect(capturedQuery.source).toBe(true);
+    expect(capturedQuery.flags).toBe(true);
+    expect(capturedQuery.internalDate).toBe(true);
+
+    expect(receivedMessage).toBeDefined();
+    expect(receivedMessage!.flags).toEqual(new Set(['\\Seen']));
+    expect(receivedMessage!.internalDate).toEqual(new Date('2026-09-04T12:00:00Z'));
+  });
+});
+
+describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
+  function makeMockClient(messages: any[], controller: AbortController) {
+    const pendingUids = messages.map((m) => m.uid);
+    return {
+      mailbox: { uidValidity: 1n },
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => pendingUids,
+      fetch: async function* (uids: number[]) {
+        for (const msg of messages) {
+          if (uids.includes(msg.uid)) {
+            yield msg;
+          }
+        }
+      },
+      idle: async () => {
+        controller.abort();
+      },
+      logout: async () => {},
+      close() {},
+    } as any;
+  }
+
+  test('failing webhook sink does not stall ntfy sink watermark progression', async () => {
+    const messages = [
+      {
+        uid: 41,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 41' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nCode 123456'),
+      },
+      {
+        uid: 42,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 42' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nCode 654321'),
+      },
+    ];
+
+    const controller = new AbortController();
+    const client = makeMockClient(messages, controller);
+
+    const ntfyDelivered: number[] = [];
+    const ntfyWatermark: SinkWatermark = { uid: 40, uidValidity: 1n };
+    const webhookWatermark: SinkWatermark = { uid: 40, uidValidity: 1n };
+
+    const dispatcher = new EventDispatcher();
+    dispatcher.registerSink({
+      id: 'ntfy',
+      isEnabled: () => true,
+      watermark: ntfyWatermark,
+      handleMail: async (event) => {
+        ntfyDelivered.push(event.message.uid);
+      },
+    });
+
+    dispatcher.registerSink({
+      id: 'webhook',
+      isEnabled: () => true,
+      watermark: webhookWatermark,
+      handleMail: async (event) => {
+        // Webhook sink fails with service outage on message 41
+        throw new NotifyError('webhook_unavailable', undefined, { failureKind: 'service' });
+      },
+    });
+
+    const sharedWatermark: WatcherWatermark = { uid: 40, uidValidity: 1n };
+    await watchConnection(
+      controller.signal,
+      client,
+      dispatcher,
+      sharedWatermark,
+      {
+        identities: () => baseIdentities as any,
+        identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+        wait: async () => {},
+        error: () => {},
+        now: () => 1000,
+      },
+    );
+
+    // Ntfy processed both messages 41 and 42!
+    expect(ntfyDelivered).toEqual([41, 42]);
+    expect(ntfyWatermark.uid).toBe(42);
+
+    // Webhook sink failed on 41, so its watermark remains at 40 (retained)
+    expect(webhookWatermark.uid).toBe(40);
+    expect(webhookWatermark.serviceFailure?.uid).toBe(41);
+  });
+
+  test('failing ntfy sink does not stall webhook sink watermark progression', async () => {
+    const messages = [
+      {
+        uid: 41,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 41' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nCode 123456'),
+      },
+      {
+        uid: 42,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 42' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nCode 654321'),
+      },
+    ];
+
+    const controller = new AbortController();
+    const client = makeMockClient(messages, controller);
+
+    const webhookDelivered: number[] = [];
+    const ntfyWatermark: SinkWatermark = { uid: 40, uidValidity: 1n };
+    const webhookWatermark: SinkWatermark = { uid: 40, uidValidity: 1n };
+
+    const dispatcher = new EventDispatcher();
+    dispatcher.registerSink({
+      id: 'ntfy',
+      isEnabled: () => true,
+      watermark: ntfyWatermark,
+      handleMail: async () => {
+        throw new NotifyError('ntfy_503_service_down', undefined, { failureKind: 'service' });
+      },
+    });
+
+    dispatcher.registerSink({
+      id: 'webhook',
+      isEnabled: () => true,
+      watermark: webhookWatermark,
+      handleMail: async (event) => {
+        webhookDelivered.push(event.message.uid);
+      },
+    });
+
+    const sharedWatermark: WatcherWatermark = { uid: 40, uidValidity: 1n };
+    await watchConnection(
+      controller.signal,
+      client,
+      dispatcher,
+      sharedWatermark,
+      {
+        identities: () => baseIdentities as any,
+        identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+        wait: async () => {},
+        error: () => {},
+        now: () => 1000,
+      },
+    );
+
+    // Webhook delivered both 41 and 42!
+    expect(webhookDelivered).toEqual([41, 42]);
+    expect(webhookWatermark.uid).toBe(42);
+
+    // Ntfy watermark was retained at 40
+    expect(ntfyWatermark.uid).toBe(40);
+    expect(ntfyWatermark.serviceFailure?.uid).toBe(41);
+  });
+
+  test('failing sink abandons UID and advances watermark after 10-minute SERVICE_FAILURE_MAX_MS', async () => {
+    const messages = [
+      {
+        uid: 41,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 41' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nBody'),
+      },
+    ];
+
+    let now = 0;
+    const loggedErrors: string[] = [];
+    const webhookWatermark: SinkWatermark = { uid: 40, uidValidity: 1n };
+    const ntfyWatermark: SinkWatermark = { uid: 40, uidValidity: 1n };
+
+    const dispatcher = new EventDispatcher();
+    dispatcher.registerSink({
+      id: 'ntfy',
+      isEnabled: () => true,
+      watermark: ntfyWatermark,
+      handleMail: async () => {},
+    });
+    dispatcher.registerSink({
+      id: 'webhook',
+      isEnabled: () => true,
+      watermark: webhookWatermark,
+      handleMail: async () => {
+        throw new NotifyError('endpoint_down', undefined, { failureKind: 'service' });
+      },
+    });
+
+    const makeRun = (nowMs: number) => {
+      const c = new AbortController();
+      now = nowMs;
+      return watchConnection(
+        c.signal,
+        makeMockClient(messages, c),
+        dispatcher,
+        { uid: 40, uidValidity: 1n },
+        {
+          identities: () => baseIdentities as any,
+          identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+          wait: async () => {},
+          error: (msg: string) => { loggedErrors.push(String(msg)); },
+          now: () => now,
+        },
+      );
+    };
+
+    // First run at t = 0
+    await makeRun(0);
+    expect(webhookWatermark.uid).toBe(40);
+    expect(webhookWatermark.serviceFailure?.uid).toBe(41);
+    expect(webhookWatermark.serviceFailure?.sinceMs).toBe(0);
+
+    // Second run at t = 599,000 (< 10 minutes) -> still retained
+    await makeRun(599_000);
+    expect(webhookWatermark.uid).toBe(40);
+
+    // Third run at t = 600,000 (>= 10 minutes) -> abandoned and watermark advanced!
+    await makeRun(600_000);
+    expect(webhookWatermark.uid).toBe(41);
+    expect(webhookWatermark.serviceFailure).toBeUndefined();
+    expect(loggedErrors.some((e) => e.includes('CRITICAL IMAP watcher abandoned UID 41'))).toBe(true);
+  });
+
+  test('all sinks failing with service failure triggers reconnect throw', async () => {
+    const messages = [
+      {
+        uid: 41,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 41' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nBody'),
+      },
+    ];
+
+    const controller = new AbortController();
+    const client = makeMockClient(messages, controller);
+
+    const dispatcher = new EventDispatcher();
+    dispatcher.registerSink({
+      id: 'sinkA',
+      isEnabled: () => true,
+      watermark: { uid: 40, uidValidity: 1n },
+      handleMail: async () => {
+        throw new NotifyError('outage_a', undefined, { failureKind: 'service' });
+      },
+    });
+
+    dispatcher.registerSink({
+      id: 'sinkB',
+      isEnabled: () => true,
+      watermark: { uid: 40, uidValidity: 1n },
+      handleMail: async () => {
+        throw new NotifyError('outage_b', undefined, { failureKind: 'service' });
+      },
+    });
+
+    await expect(
+      watchConnection(
+        controller.signal,
+        client,
+        dispatcher,
+        { uid: 40, uidValidity: 1n },
+        {
+          identities: () => baseIdentities as any,
+          identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+          wait: async () => {},
+          error: () => {},
+          now: () => 0,
+        },
+      ),
+    ).rejects.toThrow();
+  });
+});
+
+describe('Second producer hand-off (§11.4 item 4 & §14 item 10)', () => {
+  beforeEach(() => {
+    taskSeams.setTaskSendMailForTests(async () => ({ messageId: '<approval-test@test.example>' }));
+  });
+
+  afterEach(() => {
+    taskSeams.setTaskSendMailForTests(null);
+  });
+
+  test('createApprovalTask emits approval.requested event to registered sinks', async () => {
+    const dispatcher = new EventDispatcher();
+    setEventDispatcherForTests(dispatcher);
+
+    let emittedEvent: ApprovalRequestedEvent | null = null;
+    const approvalPromise = new Promise<void>((resolve) => {
+      dispatcher.registerSink({
+        id: 'test-approval-sink',
+        isEnabled: () => true,
+        handleApproval: async (event) => {
+          emittedEvent = event;
+          resolve();
+        },
+      });
+    });
+
+    const task = await createApprovalTask({
+      from: 'requester@test.example',
+      to: 'approver@test.example',
+      subject: 'Authorize deployment',
+      body: 'Please approve deployment to prod',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      action: {
+        type: 'deploy',
+        name: 'prod-deploy',
+        arguments: { version: '1.2.3' },
+      },
+    });
+
+    expect(task.id).toBeDefined();
+    expect(task.state).toBe('input-required');
+    expect(task.kind).toBe('approval');
+
+    await approvalPromise;
+
+    expect(emittedEvent).not.toBeNull();
+    expect(emittedEvent!.type).toBe('approval.requested');
+    expect(emittedEvent!.task.id).toBe(task.id);
+    expect(emittedEvent!.task.from).toBe('requester@test.example');
+    expect(emittedEvent!.task.to).toBe('approver@test.example');
+    expect(emittedEvent!.task.approval.reviewer).toBe('approver@test.example');
+    expect(emittedEvent!.task.approval.digest).toBe(task.approval.digest);
+
+    setEventDispatcherForTests(null);
+  });
+
+  test('hand-off is non-blocking and bounded even when sink is a tarpit (latency < 100ms)', async () => {
+    const dispatcher = new EventDispatcher();
+    setEventDispatcherForTests(dispatcher);
+
+    let resolveTarpit: (() => void) | null = null;
+    const tarpitPromise = new Promise<void>((r) => {
+      resolveTarpit = r;
+    });
+
+    // Tarpit sink that never resolves unless explicitly settled
+    dispatcher.registerSink({
+      id: 'tarpit-webhook-sink',
+      isEnabled: () => true,
+      handleApproval: async () => {
+        await tarpitPromise;
+      },
+    });
+
+    const startTime = performance.now();
+    const task = await createApprovalTask({
+      from: 'requester@test.example',
+      to: 'approver@test.example',
+      subject: 'Tarpit approval test',
+      body: 'Testing hand-off non-blocking latency',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      action: {
+        type: 'restart',
+        name: 'database-restart',
+        arguments: {},
+      },
+    });
+    const elapsedMs = performance.now() - startTime;
+
+    // Must be bounded time (< 100ms), NOT awaiting the tarpit!
+    expect(elapsedMs).toBeLessThan(100);
+    expect(task.id).toBeDefined();
+    expect(task.state).toBe('input-required');
+
+    // Clean up tarpit to avoid lingering promises
+    resolveTarpit?.();
+    setEventDispatcherForTests(null);
+  });
+
+  test('sink failure does not throw or corrupt createApprovalTask return', async () => {
+    const dispatcher = new EventDispatcher();
+    setEventDispatcherForTests(dispatcher);
+
+    dispatcher.registerSink({
+      id: 'failing-sink',
+      isEnabled: () => true,
+      handleApproval: async () => {
+        throw new Error('Immediate delivery rejection');
+      },
+    });
+
+    const task = await createApprovalTask({
+      from: 'requester@test.example',
+      to: 'approver@test.example',
+      subject: 'Resilience test',
+      body: 'Should succeed regardless of sink error',
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      action: {
+        type: 'action',
+        name: 'test',
+        arguments: {},
+      },
+    });
+
+    expect(task.id).toBeDefined();
+    expect(task.state).toBe('input-required');
+
+    setEventDispatcherForTests(null);
+  });
+});
+
+describe('EventDispatcher abstractions and sink contracts', () => {
+  test('isSinkServiceFailure classifies failureKind service vs message correctly', () => {
+    // Non-NotifyError object with explicit failureKind
+    expect(isSinkServiceFailure({ failureKind: 'service' })).toBe(true);
+    expect(isSinkServiceFailure({ failureKind: 'message' })).toBe(false);
+
+    // NotifyError with service outage vs message rejection
+    expect(isSinkServiceFailure(new NotifyError('notify_unavailable', undefined, { failureKind: 'service' }))).toBe(true);
+    expect(isSinkServiceFailure(new NotifyError('message_too_large', undefined, { failureKind: 'message' }))).toBe(false);
+
+    // Cancelled notify is not a service failure
+    expect(isSinkServiceFailure(new NotifyError('notify_cancelled'))).toBe(false);
+
+    // Generic error (outage by default)
+    expect(isSinkServiceFailure(new Error('connection timeout'))).toBe(true);
+  });
+
+  test('createNtfySink adheres to EventSink contract', () => {
+    const watermark: SinkWatermark = { uid: 10 };
+    const sink = createNtfySink(async () => ({} as any), watermark);
+    expect(sink.id).toBe('ntfy');
+    expect(sink.watermark).toBe(watermark);
+    expect(sink.isEnabled).toBeFunction();
+    expect(sink.handleMail).toBeFunction();
+  });
+
+  test('EventDispatcher manages sinks and routes mail vs approval sinks', () => {
+    const dispatcher = new EventDispatcher();
+    const mailSink: EventSink = {
+      id: 'mail-only',
+      isEnabled: () => true,
+      handleMail: async () => {},
+    };
+    const approvalSink: EventSink = {
+      id: 'approval-only',
+      isEnabled: () => true,
+      handleApproval: async () => {},
+    };
+    const dualSink: EventSink = {
+      id: 'dual',
+      isEnabled: () => true,
+      handleMail: async () => {},
+      handleApproval: async () => {},
+    };
+
+    dispatcher.registerSink(mailSink);
+    dispatcher.registerSink(approvalSink);
+    dispatcher.registerSink(dualSink);
+
+    expect(dispatcher.getSink('mail-only')).toBe(mailSink);
+    expect(dispatcher.getAllSinks()).toHaveLength(3);
+    expect(dispatcher.getMailSinks()).toEqual([mailSink, dualSink]);
+    expect(dispatcher.getApprovalSinks()).toEqual([approvalSink, dualSink]);
+
+    expect(dispatcher.unregisterSink('mail-only')).toBe(true);
+    expect(dispatcher.getSink('mail-only')).toBeUndefined();
+    expect(dispatcher.getMailSinks()).toEqual([dualSink]);
+  });
+});
+

--- a/packages/api/test/event-dispatcher.test.ts
+++ b/packages/api/test/event-dispatcher.test.ts
@@ -450,6 +450,155 @@ describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
       ),
     ).rejects.toThrow();
   });
+
+  test('expunged detained UID does not stall sink, subsequent mail is delivered, and CRITICAL abandonment is logged (Codex P1-1)', async () => {
+    const loggedErrors: string[] = [];
+    const controller = new AbortController();
+
+    // Mail 41 was expunged, mailbox now only has mail 42!
+    const messages = [
+      {
+        uid: 42,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 42' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nMail 42 body'),
+      },
+    ];
+    const client = makeMockClient(messages, controller);
+
+    const webhookDelivered: number[] = [];
+    // Webhook sink had previously failed on UID 41 and recorded serviceFailure
+    const webhookWatermark: SinkWatermark = {
+      uid: 40,
+      uidValidity: 1n,
+      serviceFailure: { uid: 41, sinceMs: 1000 },
+    };
+
+    const dispatcher = new EventDispatcher();
+    dispatcher.registerSink({
+      id: 'webhook',
+      isEnabled: () => true,
+      watermark: webhookWatermark,
+      handleMail: async (event) => {
+        webhookDelivered.push(event.message.uid);
+      },
+    });
+
+    await watchConnection(
+      controller.signal,
+      client,
+      dispatcher,
+      { uid: 40, uidValidity: 1n },
+      {
+        identities: () => baseIdentities as any,
+        identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+        wait: async () => {},
+        error: (msg) => { loggedErrors.push(String(msg)); },
+        now: () => 2000,
+      },
+    );
+
+    // Expunged UID 41 must be abandoned with CRITICAL error log
+    expect(loggedErrors.some((e) => e.includes('CRITICAL IMAP watcher abandoned expunged UID 41'))).toBe(true);
+    expect(webhookWatermark.serviceFailure).toBeUndefined();
+
+    // Subsequent mail 42 MUST NOT be stalled - delivered successfully!
+    expect(webhookDelivered).toEqual([42]);
+    expect(webhookWatermark.uid).toBe(42);
+  });
+
+  test('dynamically registered and disabled sinks take effect during active IMAP connection (Codex P1-2)', async () => {
+    let round = 1;
+    let sinkAEnabled = true;
+    const sinkADelivered: number[] = [];
+    const sinkBDelivered: number[] = [];
+
+    const controller = new AbortController();
+    const dispatcher = new EventDispatcher();
+
+    const sinkA: EventSink = {
+      id: 'sink-a',
+      isEnabled: () => sinkAEnabled,
+      watermark: { uid: 40, uidValidity: 1n },
+      handleMail: async (event) => {
+        sinkADelivered.push(event.message.uid);
+      },
+    };
+    dispatcher.registerSink(sinkA);
+
+    const sinkB: EventSink = {
+      id: 'sink-b',
+      isEnabled: () => true,
+      watermark: { uid: 41, uidValidity: 1n },
+      handleMail: async (event) => {
+        sinkBDelivered.push(event.message.uid);
+      },
+    };
+
+    const allMessages: Record<number, any> = {
+      41: {
+        uid: 41,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 41' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nMail 41'),
+      },
+      42: {
+        uid: 42,
+        envelope: { from: [{ address: 'sender@example.com' }], subject: 'Mail 42' },
+        headers: Buffer.from('Delivered-To: approver@test.example\r\n\r\n'),
+        source: Buffer.from('From: sender@example.com\r\n\r\nMail 42'),
+      },
+    };
+
+    const client = {
+      mailbox: { uidValidity: 1n },
+      getMailboxLock: async () => ({ release() {} }),
+      search: async () => {
+        if (round === 1) return [41];
+        return [41, 42];
+      },
+      fetch: async function* (uids: number[]) {
+        for (const uid of uids) {
+          if (allMessages[uid]) yield allMessages[uid];
+        }
+      },
+      idle: async () => {
+        if (round === 1) {
+          round = 2;
+          // Dynamically disable sinkA
+          sinkAEnabled = false;
+          // Dynamically register sinkB
+          dispatcher.registerSink(sinkB);
+        } else {
+          controller.abort();
+        }
+      },
+      logout: async () => {},
+      close() {},
+    } as any;
+
+    await watchConnection(
+      controller.signal,
+      client,
+      dispatcher,
+      { uid: 40, uidValidity: 1n },
+      {
+        identities: () => baseIdentities as any,
+        identity: (addr) => baseIdentities.find((i) => i.address === addr) as any,
+        wait: async () => {},
+        error: () => {},
+        now: () => 1000,
+      },
+    );
+
+    // Sink A only received 41; after being dynamically disabled, it did not receive 42 and its watermark froze at 41
+    expect(sinkADelivered).toEqual([41]);
+    expect(sinkA.watermark!.uid).toBe(41);
+
+    // Sink B was dynamically registered in round 2, received 42, and its watermark advanced to 42
+    expect(sinkBDelivered).toEqual([42]);
+    expect(sinkB.watermark!.uid).toBe(42);
+  });
 });
 
 describe('Second producer hand-off (§11.4 item 4 & §14 item 10)', () => {


### PR DESCRIPTION
Part of #128. Prerequisite refactoring for outbound webhooks (RFC-0001 §11.4).

### Implementation Highlights

1. **Startup Gate Widening (§11.4 Item 1)**:
   - Widened watcher startup gate in `startNotificationWatcher()` to `((config.ntfy.enabled && config.ntfy.pushPolicy !== 'none') || config.webhooks.enabled)`.
   - `initializeNotifications()` (ntfy credentials provisioning) remains strictly inside `if (config.ntfy.enabled)` in `main.ts`—webhooks startup never triggers ntfy provisioning.
   - Added `WEBHOOKS_ENABLED` configuration option (defaulting to `'false'`).

2. **IMAP Fetch Widening (§11.4 Item 2)**:
   - Widened IMAP message fetch query in `watchConnection()` to include `flags: true` and `internalDate: true`.
   - **Cost declaration**: This adds per-message fetch cost in the hot loop, shared by all sinks. Ntfy ignores these additional fields; `internalDate` anchors `receivedAt` to server-assigned time instead of spoofable header dates, laying the groundwork for PR 3 cursor unification and PR 4 webhook payloads.

3. **Event Dispatcher & Sink Abstraction (§11.4 Item 3)**:
   - Introduced process-wide `EventDispatcher` managing registered sinks and event routing for `mail.received` and `approval.requested`.
   - Extracted `createNtfySink()` delegating to `processWatchedMessage()`.
   - Preserved IMAP IDLE connection, mailbox locks, UID search, reconnect backoff, and `UIDVALIDITY` generation re-anchoring intact.

4. **Per-Sink Failure & Watermark Isolation + Second Producer Hand-off (§11.4 Item 4)**:
   - Watermark advancement and `serviceFailure` retention (`SERVICE_FAILURE_MAX_MS = 600_000ms`) are strictly isolated per-sink. One sink failing or entering service outage never stalls other sinks or blocks IMAP IDLE.
   - Added second producer hand-off in `createApprovalTask()`: emits `approval.requested` via `queueMicrotask` (un-awaited, zero latency impact on 201 response path).

### Verification
- `bun test test/event-dispatcher.test.ts`: 13 passed, 0 failed.
- Full `bun test` in `packages/api`: 1270 passed, 1 skipped, 0 failed across 77 files.
- `bun run check:approval-publication` & `bun run lint:ui`: passed cleanly.
- `bun run build` in `packages/api`: passed cleanly.
- `packages/mcp` build & tsc: passed cleanly.
- `deploy/test-mail-security.sh`: 54 passed.
- Subagent self-review conducted with passing audit verdict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration support for enabling outbound webhooks, disabled by default.
  - Approval requests can now trigger event-based notifications through configured delivery services.
  - Notification delivery supports multiple services with independent progress tracking, so one failing service does not block others.

- **Bug Fixes**
  - Notification monitoring now starts when webhooks are enabled, even if push notifications are disabled.
  - Improved handling of temporary delivery failures, stalled notifications, and unavailable delivery services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->