### PR TITLE
feat(api): forward since query + uidValidity generation precondition (#128 PR3)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -21,3 +21,12 @@ The website docs are canonical — edit them in the [website repo](https://githu
 预鉴权 IP 限量（应用层）：`OAUTH_RATE_PER_MIN` 覆盖上表 `/authorize`、`/oauth/token`、`/oauth/revoke`；`MCP_PREAUTH_RATE_PER_MIN` 覆盖 `POST /mcp` 无/坏 token 的 401 挑战。超限 `429` + `Retry-After`。键见 `TRUST_PROXY_HEADERS` / docs/security.md。
 
 不做：DCR（`/oauth/register`）、OIDC discovery、admin 级 OAuth 票。
+
+## Messages API (`GET /v1/messages`) 前向追补合同
+
+### 排序与完整性契约
+- **响应内排序**：单次响应内的 `messages` 列表严格按 `(receivedAt, uid)` 元组升序排列（oldest-first）。
+- **跨页排序与完整性**：跨页**不承诺全局元组序**（由于 IMAP `APPEND`/`COPY` 历史导入等可能导致非单调 `INTERNALDATE`）；系统承诺的是**完整性**——在当前信箱代际内，严格大于初始传入游标元组的所有匹配邮件，每封恰好送达一次（无损追补，不重不漏）。
+- **消费方自排**：对全局有序有强依赖的消费方，应遵循 RFC 0001 §8.4 口径，在消费端按 `(data.receivedAt, data.uid)` 进行二次排序。
+- **代际保护**：游标严格绑定 `uidValidity`；若信箱代际变更（UIDVALIDITY 不匹配），请求将 fail-closed 返回 `400 invalid_cursor`。`GET /v1/messages/:id` 支持可选的 `?uidValidity=` 参数，代际不匹配时返回 `404 stale_message_generation`。
+

--- a/docs/api.md
+++ b/docs/api.md
@@ -27,6 +27,8 @@ The website docs are canonical — edit them in the [website repo](https://githu
 ### 排序与完整性契约
 - **响应内排序**：单次响应内的 `messages` 列表严格按 `(receivedAt, uid)` 元组升序排列（oldest-first）。
 - **跨页排序与完整性**：跨页**不承诺全局元组序**（由于 IMAP `APPEND`/`COPY` 历史导入等可能导致非单调 `INTERNALDATE`）；系统承诺的是**完整性**——在当前信箱代际内，严格大于初始传入游标元组的所有匹配邮件，每封恰好送达一次（无损追补，不重不漏）。
+- **游标连续性与永不为 null**：`since` 前向查询的 `nextCursor` **永不返回 null**。当候选集全部扫尽或单批未达 `limit` 时，仍返回携带已检视最新进度 `scanUid` 的 checkpoint 游标，供客户端后续轮询继续向后追补，杜绝因回退重用旧游标而引发的终批邮件重复投递。
 - **消费方自排**：对全局有序有强依赖的消费方，应遵循 RFC 0001 §8.4 口径，在消费端按 `(data.receivedAt, data.uid)` 进行二次排序。
 - **代际保护**：游标严格绑定 `uidValidity`；若信箱代际变更（UIDVALIDITY 不匹配），请求将 fail-closed 返回 `400 invalid_cursor`。`GET /v1/messages/:id` 支持可选的 `?uidValidity=` 参数，代际不匹配时返回 `404 stale_message_generation`。
+- **服务端 SINCE 与 receivedAtMs 口径差异说明**：服务端 IMAP SEARCH SINCE 依据 RFC 3501 `INTERNALDATE` 检索（向前预留 1 天缓冲）；应用层 `receivedAtMs` 优先采用 `INTERNALDATE` 并回落至 `ENVELOPE.date`。若个别邮件缺失 `INTERNALDATE` 且其 `ENVELOPE.date` 晚于实际收信时间，此口径差异为 fail-safe（只漏不越权，后续追扫覆盖）。
 

--- a/docs/rfcs/0001-outbound-webhooks.md
+++ b/docs/rfcs/0001-outbound-webhooks.md
@@ -3768,7 +3768,7 @@ Reject:  otherwise, always, with no unsigned fallback
 Dedupe:  on the body's "id" field; deliveries are at-least-once
 Order:   not guaranteed; sort by data.receivedAt then data.uid within one
          data.uidValidity. data.cursor is OPAQUE — never sort or string-compare it
-Fetch:   full mail content via GET /v1/messages/:id with your own API token
+Fetch:   full mail content via GET /v1/messages/:id?uidValidity=<data.uidValidity> with your own API token
 ```
 
 ## Appendix B: relationship to other cards

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -891,8 +891,8 @@ async function buildMessageSummaries(
  * 每请求预算 scanBudget（默认 SCAN_BACK = 500）条候选。
  * 检视过程中一旦收集到第 limit 条匹配信立即停下，scanUid 设为停下时那封信的 UID（已检视全返回，无截断遗漏）。
  * 单页内按 (receivedAtMs asc, uid asc) 元组升序返回；跨页不承诺全局元组序，承诺完整性与代际 fail-closed。
- * 若单批扫描完毕未达 limit 但超出预算（hasMoreBeyondBudget），或达到 limit，产生带新 scanUid 的 nextCursor；
- * 仅当未达 limit 且全信箱候选集已扫尽时，nextCursor 为 null。
+ * 若单批扫描完毕未达 limit 但超出预算，或达到 limit，产生带新 scanUid 的 nextCursor；
+ * 即使全部候选集已扫尽，nextCursor 仍返回携带当前 scanUid 水位的 checkpoint 游标（永不返回 null），供下次轮询续用，杜绝重复投递。
  */
 async function listMessagesSinceWith(
   client: ImapFlow,
@@ -902,7 +902,7 @@ async function listMessagesSinceWith(
 ): Promise<MessageListPage> {
   const folder = opts.folder ?? 'inbox';
   const limit = opts.limit;
-  const scanBudget = opts.scanBudget ?? SCAN_BACK;
+  const scanBudget = Math.max(1, opts.scanBudget ?? SCAN_BACK);
   const normalized = address.toLowerCase();
 
   const cursor = decodeMailForwardCursor(sinceCursor, config.taskSigningSecret);
@@ -918,21 +918,37 @@ async function listMessagesSinceWith(
     throw new InvalidMailCursorError();
   }
 
+  const startScanUid = cursor.scanUid ?? 0;
+  const makeCheckpointCursor = (scanUid: number) =>
+    encodeMailForwardCursor(
+      {
+        folder,
+        address: normalized,
+        t: cursor.t,
+        uid: cursor.uid,
+        uidValidity: String(currentUidValidity),
+        scanUid,
+      },
+      config.taskSigningSecret,
+    );
+
   // 1. 服务端 SEARCH SINCE 收窄：按 cursor.t 往前退 1 天（86400000ms），防时区/日粒度边角
   const sinceDate = new Date(Math.max(0, cursor.t - 24 * 60 * 60 * 1000));
   const uids = await client.search({ since: sinceDate }, { uid: true });
-  if (!uids || uids.length === 0) return { messages: [], nextCursor: null };
+  if (!uids || uids.length === 0) {
+    return { messages: [], nextCursor: makeCheckpointCursor(startScanUid) };
+  }
 
   // 2. 候选集过滤：按 UID 升序检视 uid > scanUid 的候选
-  const startScanUid = cursor.scanUid ?? 0;
   const candidateUids = uids
     .filter((u) => u > startScanUid)
     .sort((a, b) => a - b);
-  if (candidateUids.length === 0) return { messages: [], nextCursor: null };
+  if (candidateUids.length === 0) {
+    return { messages: [], nextCursor: makeCheckpointCursor(startScanUid) };
+  }
 
   // 3. 每请求预算 scanBudget (默认 SCAN_BACK = 500) 条
   const batchUids = candidateUids.slice(0, scanBudget);
-  const hasMoreBeyondBudget = candidateUids.length > scanBudget;
 
   const fetched = new Map<number, FetchMessageObject>();
   for await (const msg of client.fetch(
@@ -945,7 +961,6 @@ async function listMessagesSinceWith(
 
   const matched: FetchMessageObject[] = [];
   let lastScannedUid = startScanUid;
-  let reachedLimit = false;
 
   for (const uid of batchUids) {
     lastScannedUid = uid;
@@ -957,7 +972,6 @@ async function listMessagesSinceWith(
     ) {
       matched.push(msg);
       if (matched.length >= limit) {
-        reachedLimit = true;
         break;
       }
     }
@@ -967,26 +981,13 @@ async function listMessagesSinceWith(
   matched.sort(compareOldestFirst);
   const summaries = await buildMessageSummaries(client, matched);
 
-  // 5. 游标推进规则（FC 终裁定稿）：
-  // 游标保持 (t_c, u_c 原始过滤锚点, 永不推进) + scanUid + uidValidity
+  // 5. 游标推进规则（FC 终裁定稿，R5 收口）：
+  // since 查询的 nextCursor 永不返回 null：
+  // 保持 (t_c, u_c 原始过滤锚点, 永不推进) + scanUid + uidValidity。
   // - 收集到 limit 条立即停下，scanUid = 停下时那封的 UID（已检视全返回，无截断遗漏）
   // - 若扫完全批预算仍未达 limit（含 0 命中），scanUid 推到已检视最大 UID
-  // - 仅当未达到 limit 且全部候选集已扫尽时，nextCursor 为 null
-  const hasMore = hasMoreBeyondBudget || lastScannedUid < candidateUids[candidateUids.length - 1];
-  let nextCursor: string | null = null;
-  if (hasMore) {
-    nextCursor = encodeMailForwardCursor(
-      {
-        folder,
-        address: normalized,
-        t: cursor.t,
-        uid: cursor.uid,
-        uidValidity: String(currentUidValidity),
-        scanUid: lastScannedUid,
-      },
-      config.taskSigningSecret,
-    );
-  }
+  // - 即使候选集已扫尽，仍返回 checkpoint 游标供后续轮询续用，彻底杜绝重用旧游标导致的重复投递
+  const nextCursor = makeCheckpointCursor(lastScannedUid);
 
   return { messages: summaries, nextCursor };
 }

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -885,16 +885,20 @@ async function buildMessageSummaries(
 
 /**
  * 前向 since 查询：从指定前向游标之后 oldest-first 遍历邮件（保证无损追补）。
- * 载荷绑定 uidValidity，当前代际不匹配则 fail-closed 抛 InvalidMailCursorError。
+ * 候选集由服务端 SEARCH SINCE 收窄（按 cursor.t 往前退 1 天），绝不用 UID 范围粗暴过滤原始游标（保护非单调信件）。
+ * 扫描按 UID 升序，每请求预算 SCAN_BACK (500) 条。
+ * 预算耗尽时返回已匹配部分 + 续扫游标（保留原始 (t_c, u_c) 与已扫 UID 水印 scanUid）。
+ * 扫完全部候选集才产出正式 nextCursor。
  */
 async function listMessagesSinceWith(
   client: ImapFlow,
   address: string,
   sinceCursor: string,
-  opts: { limit: number; folder?: MailFolder },
+  opts: { limit: number; folder?: MailFolder; scanBudget?: number },
 ): Promise<MessageListPage> {
   const folder = opts.folder ?? 'inbox';
   const limit = opts.limit;
+  const scanBudget = opts.scanBudget ?? SCAN_BACK;
   const normalized = address.toLowerCase();
 
   const cursor = decodeMailForwardCursor(sinceCursor, config.taskSigningSecret);
@@ -910,61 +914,82 @@ async function listMessagesSinceWith(
     throw new InvalidMailCursorError();
   }
 
-  const uids = await client.search({ all: true }, { uid: true });
+  // 1. 服务端 SEARCH SINCE 收窄：按 cursor.t 往前退 1 天（86400000ms），防时区/日粒度边角
+  const sinceDate = new Date(Math.max(0, cursor.t - 24 * 60 * 60 * 1000));
+  const uids = await client.search({ since: sinceDate }, { uid: true });
   if (!uids || uids.length === 0) return { messages: [], nextCursor: null };
 
-  const candidateUids = uids.filter((u) => u > cursor.uid).sort((a, b) => a - b);
+  // 2. 候选集过滤：若存在续扫水印 scanUid，过滤掉已扫过的 UID（u > cursor.scanUid）
+  const candidateUids = uids
+    .filter((u) => cursor.scanUid === undefined || u > cursor.scanUid)
+    .sort((a, b) => a - b);
   if (candidateUids.length === 0) return { messages: [], nextCursor: null };
 
+  // 3. 每请求预算 scanBudget (默认 SCAN_BACK = 500) 条
+  const batchUids = candidateUids.slice(0, scanBudget);
+  const hasMoreCandidates = candidateUids.length > scanBudget;
+  const maxScannedUid = batchUids[batchUids.length - 1];
+
   const matched: FetchMessageObject[] = [];
-  let chunkStart = 0;
-  while (chunkStart < candidateUids.length && matched.length <= limit) {
-    const chunk = candidateUids.slice(chunkStart, chunkStart + SCAN_BACK);
-    chunkStart += SCAN_BACK;
-    for await (const msg of client.fetch(
-      chunk,
-      { envelope: true, flags: true, internalDate: true, headers: ['delivered-to'] },
-      { uid: true },
-    )) {
-      if (
-        messageBelongsToFolder(msg, normalized, folder) &&
-        isAfterForwardCursor(msg, cursor.t, cursor.uid)
-      ) {
-        matched.push(msg);
-      }
+  for await (const msg of client.fetch(
+    batchUids,
+    { envelope: true, flags: true, internalDate: true, headers: ['delivered-to'] },
+    { uid: true },
+  )) {
+    if (
+      messageBelongsToFolder(msg, normalized, folder) &&
+      isAfterForwardCursor(msg, cursor.t, cursor.uid)
+    ) {
+      matched.push(msg);
     }
   }
 
+  // 4. 命中集全按 (receivedAtMs asc, uid asc) 元组序排序
   matched.sort(compareOldestFirst);
-  const page = matched.slice(0, limit);
-  const hasMore = matched.length > limit;
 
-  const summaries = await buildMessageSummaries(client, page);
+  // 5. 分页截断与续扫游标构造
+  if (matched.length > limit) {
+    const page = matched.slice(0, limit);
+    const summaries = await buildMessageSummaries(client, page);
+    const last = page[page.length - 1];
+    const nextCursor = encodeMailForwardCursor(
+      {
+        folder,
+        address: normalized,
+        t: receivedAtMs(last),
+        uid: last.uid,
+        uidValidity: Number(currentUidValidity),
+      },
+      config.taskSigningSecret,
+    );
+    return { messages: summaries, nextCursor };
+  }
 
-  const last = page[page.length - 1];
-  const nextCursor =
-    hasMore && last
-      ? encodeMailForwardCursor(
-          {
-            folder,
-            address: normalized,
-            t: receivedAtMs(last),
-            uid: last.uid,
-            uidValidity: Number(currentUidValidity),
-          },
-          config.taskSigningSecret,
-        )
-      : null;
+  const summaries = await buildMessageSummaries(client, matched);
+
+  const nextCursor = hasMoreCandidates
+    ? encodeMailForwardCursor(
+        {
+          folder,
+          address: normalized,
+          t: cursor.t,
+          uid: cursor.uid,
+          uidValidity: Number(currentUidValidity),
+          scanUid: maxScannedUid,
+        },
+        config.taskSigningSecret,
+      )
+    : null;
 
   return { messages: summaries, nextCursor };
 }
 
 export async function listMessagesPage(
   address: string,
-  opts: { limit?: number; folder?: MailFolder; cursor?: string; since?: string } = {},
+  opts: { limit?: number; folder?: MailFolder; cursor?: string; since?: string; scanBudget?: number } = {},
 ): Promise<MessageListPage> {
   if (opts.since) {
-    return listMessagesSince(address, opts.since, opts.limit, opts.folder);
+    return listMessagesSince(address, opts.since, opts.limit, opts.folder, { scanBudget: opts.scanBudget });
   }
   return withInbox((client) =>
     listMessagesPageWith(client, address, {
@@ -981,9 +1006,10 @@ export async function listMessagesSince(
   sinceCursor: string,
   limit = 50,
   folder: MailFolder = 'inbox',
+  opts?: { scanBudget?: number },
 ): Promise<MessageListPage> {
   return withInbox((client) =>
-    listMessagesSinceWith(client, address, sinceCursor, { limit, folder }),
+    listMessagesSinceWith(client, address, sinceCursor, { limit, folder, scanBudget: opts?.scanBudget }),
   );
 }
 

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -17,9 +17,12 @@ import type { AddressObject } from 'mailparser';
 import { config } from './config.ts';
 import {
   decodeMailCursor,
+  decodeMailForwardCursor,
   encodeMailCursor,
+  encodeMailForwardCursor,
   InvalidMailCursorError,
   type MailFolder,
+  type MailForwardCursorPayload,
 } from './mail-cursor.ts';
 import {
   classifyMailSource,
@@ -121,6 +124,15 @@ export interface MessageSourcePayload {
   source: string;
   truncated: boolean;
   byteLength: number;
+}
+
+/** 消息代际（uidValidity）不匹配。路由折成 404 stale_message_generation。 */
+export class StaleMessageGenerationError extends Error {
+  readonly code = 'stale_message_generation';
+  constructor() {
+    super('stale_message_generation');
+    this.name = 'StaleMessageGenerationError';
+  }
 }
 
 /** How far back listMessages scans for address matches. */
@@ -641,6 +653,21 @@ function isAfterCursor(msg: FetchMessageObject, t: number, uid: number): boolean
   return msg.uid < uid;
 }
 
+/** oldest-first：(receivedAtMs asc, uid asc)，保证前向追补顺序无损递进。 */
+export function compareOldestFirst(a: FetchMessageObject, b: FetchMessageObject): number {
+  const dt = receivedAtMs(a) - receivedAtMs(b);
+  if (dt !== 0) return dt;
+  return a.uid - b.uid;
+}
+
+/** 严格大于前向游标键，保证追补不重复、不跳过同毫秒条目。 */
+export function isAfterForwardCursor(msg: FetchMessageObject, t: number, uid: number): boolean {
+  const received = receivedAtMs(msg);
+  if (received > t) return true;
+  if (received < t) return false;
+  return msg.uid > uid;
+}
+
 /**
  * 这条消息按可信收件人头都投给了谁。无 envelope 一律空集合（保留 fail-closed）。
  *
@@ -796,6 +823,28 @@ async function listMessagesPageWith(
   const page = afterCursor.slice(0, limit);
   const hasMore = afterCursor.length > limit;
 
+  const summaries = await buildMessageSummaries(client, page);
+
+  const last = page[page.length - 1];
+  const nextCursor =
+    hasMore && last
+      ? encodeMailCursor(
+          {
+            folder,
+            address: normalized,
+            t: receivedAtMs(last),
+            uid: last.uid,
+          },
+          config.taskSigningSecret,
+        )
+      : null;
+  return { messages: summaries, nextCursor };
+}
+
+async function buildMessageSummaries(
+  client: ImapFlow,
+  page: FetchMessageObject[],
+): Promise<MessageSummary[]> {
   const summaries: MessageSummary[] = [];
   for (const msg of page) {
     let snippet = '';
@@ -831,33 +880,110 @@ async function listMessagesPageWith(
       source,
     });
   }
+  return summaries;
+}
+
+/**
+ * 前向 since 查询：从指定前向游标之后 oldest-first 遍历邮件（保证无损追补）。
+ * 载荷绑定 uidValidity，当前代际不匹配则 fail-closed 抛 InvalidMailCursorError。
+ */
+async function listMessagesSinceWith(
+  client: ImapFlow,
+  address: string,
+  sinceCursor: string,
+  opts: { limit: number; folder?: MailFolder },
+): Promise<MessageListPage> {
+  const folder = opts.folder ?? 'inbox';
+  const limit = opts.limit;
+  const normalized = address.toLowerCase();
+
+  const cursor = decodeMailForwardCursor(sinceCursor, config.taskSigningSecret);
+  if (cursor.folder !== folder || cursor.address !== normalized) {
+    throw new InvalidMailCursorError();
+  }
+
+  const currentUidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
+  if (
+    currentUidValidity === undefined ||
+    BigInt(cursor.uidValidity) !== BigInt(currentUidValidity)
+  ) {
+    throw new InvalidMailCursorError();
+  }
+
+  const uids = await client.search({ all: true }, { uid: true });
+  if (!uids || uids.length === 0) return { messages: [], nextCursor: null };
+
+  const candidateUids = uids.filter((u) => u > cursor.uid).sort((a, b) => a - b);
+  if (candidateUids.length === 0) return { messages: [], nextCursor: null };
+
+  const matched: FetchMessageObject[] = [];
+  let chunkStart = 0;
+  while (chunkStart < candidateUids.length && matched.length <= limit) {
+    const chunk = candidateUids.slice(chunkStart, chunkStart + SCAN_BACK);
+    chunkStart += SCAN_BACK;
+    for await (const msg of client.fetch(
+      chunk,
+      { envelope: true, flags: true, internalDate: true, headers: ['delivered-to'] },
+      { uid: true },
+    )) {
+      if (
+        messageBelongsToFolder(msg, normalized, folder) &&
+        isAfterForwardCursor(msg, cursor.t, cursor.uid)
+      ) {
+        matched.push(msg);
+      }
+    }
+  }
+
+  matched.sort(compareOldestFirst);
+  const page = matched.slice(0, limit);
+  const hasMore = matched.length > limit;
+
+  const summaries = await buildMessageSummaries(client, page);
 
   const last = page[page.length - 1];
   const nextCursor =
     hasMore && last
-      ? encodeMailCursor(
+      ? encodeMailForwardCursor(
           {
             folder,
             address: normalized,
             t: receivedAtMs(last),
             uid: last.uid,
+            uidValidity: Number(currentUidValidity),
           },
           config.taskSigningSecret,
         )
       : null;
+
   return { messages: summaries, nextCursor };
 }
 
 export async function listMessagesPage(
   address: string,
-  opts: { limit?: number; folder?: MailFolder; cursor?: string } = {},
+  opts: { limit?: number; folder?: MailFolder; cursor?: string; since?: string } = {},
 ): Promise<MessageListPage> {
+  if (opts.since) {
+    return listMessagesSince(address, opts.since, opts.limit, opts.folder);
+  }
   return withInbox((client) =>
     listMessagesPageWith(client, address, {
       limit: opts.limit ?? 50,
       folder: opts.folder ?? 'inbox',
       cursor: opts.cursor,
     }),
+  );
+}
+
+/** 前向 since 查询对外接口：从指定游标向后 oldest-first 追补。 */
+export async function listMessagesSince(
+  address: string,
+  sinceCursor: string,
+  limit = 50,
+  folder: MailFolder = 'inbox',
+): Promise<MessageListPage> {
+  return withInbox((client) =>
+    listMessagesSinceWith(client, address, sinceCursor, { limit, folder }),
   );
 }
 
@@ -904,7 +1030,17 @@ async function getMessageWith(
   client: ImapFlow,
   address: string,
   id: string,
+  opts?: { uidValidity?: number },
 ): Promise<MessageDetail | null> {
+  const currentUidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
+  if (opts?.uidValidity !== undefined) {
+    if (
+      currentUidValidity === undefined ||
+      BigInt(opts.uidValidity) !== BigInt(currentUidValidity)
+    ) {
+      throw new StaleMessageGenerationError();
+    }
+  }
   const uid = Number(id);
   if (!Number.isInteger(uid) || uid <= 0) return null;
   const msg = await client.fetchOne(uid, { source: true, envelope: true, headers: ['delivered-to'] }, { uid: true });
@@ -913,8 +1049,12 @@ async function getMessageWith(
   return toDetail(msg.uid, parsed);
 }
 
-export async function getMessage(address: string, id: string): Promise<MessageDetail | null> {
-  return withInbox((client) => getMessageWith(client, address, id));
+export async function getMessage(
+  address: string,
+  id: string,
+  opts?: { uidValidity?: number },
+): Promise<MessageDetail | null> {
+  return withInbox((client) => getMessageWith(client, address, id, opts));
 }
 
 /**

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -885,10 +885,14 @@ async function buildMessageSummaries(
 
 /**
  * 前向 since 查询：从指定前向游标之后 oldest-first 遍历邮件（保证无损追补）。
- * 候选集由服务端 SEARCH SINCE 收窄（按 cursor.t 往前退 1 天），绝不用 UID 范围粗暴过滤原始游标（保护非单调信件）。
- * 扫描按 UID 升序，每请求预算 SCAN_BACK (500) 条。
- * 预算耗尽时返回已匹配部分 + 续扫游标（保留原始 (t_c, u_c) 与已扫 UID 水印 scanUid）。
- * 扫完全部候选集才产出正式 nextCursor。
+ * 候选集由服务端 SEARCH SINCE 收窄（按 cursor.t 往前退 1 天防日粒度与时区边角）。
+ * 过滤锚点 (cursor.t, cursor.uid) 永不推进，保证非单调 internalDate 邮件（如 IMAP APPEND/COPY）无损遍历。
+ * UID 扫描进度通过单调递增的 scanUid 推进（u > cursor.scanUid），防重扫与死循环。
+ * 每请求预算 scanBudget（默认 SCAN_BACK = 500）条候选。
+ * 检视过程中一旦收集到第 limit 条匹配信立即停下，scanUid 设为停下时那封信的 UID（已检视全返回，无截断遗漏）。
+ * 单页内按 (receivedAtMs asc, uid asc) 元组升序返回；跨页不承诺全局元组序，承诺完整性与代际 fail-closed。
+ * 若单批扫描完毕未达 limit 但超出预算（hasMoreBeyondBudget），或达到 limit，产生带新 scanUid 的 nextCursor；
+ * 仅当未达 limit 且全信箱候选集已扫尽时，nextCursor 为 null。
  */
 async function listMessagesSinceWith(
   client: ImapFlow,
@@ -909,7 +913,7 @@ async function listMessagesSinceWith(
   const currentUidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
   if (
     currentUidValidity === undefined ||
-    BigInt(cursor.uidValidity) !== BigInt(currentUidValidity)
+    String(cursor.uidValidity) !== String(currentUidValidity)
   ) {
     throw new InvalidMailCursorError();
   }
@@ -919,62 +923,66 @@ async function listMessagesSinceWith(
   const uids = await client.search({ since: sinceDate }, { uid: true });
   if (!uids || uids.length === 0) return { messages: [], nextCursor: null };
 
-  // 2. 候选集过滤：若存在续扫水印 scanUid，过滤掉已扫过的 UID（u > cursor.scanUid）
+  // 2. 候选集过滤：按 UID 升序检视 uid > scanUid 的候选
+  const startScanUid = cursor.scanUid ?? 0;
   const candidateUids = uids
-    .filter((u) => cursor.scanUid === undefined || u > cursor.scanUid)
+    .filter((u) => u > startScanUid)
     .sort((a, b) => a - b);
   if (candidateUids.length === 0) return { messages: [], nextCursor: null };
 
   // 3. 每请求预算 scanBudget (默认 SCAN_BACK = 500) 条
   const batchUids = candidateUids.slice(0, scanBudget);
-  const hasMoreCandidates = candidateUids.length > scanBudget;
-  const maxScannedUid = batchUids[batchUids.length - 1];
+  const hasMoreBeyondBudget = candidateUids.length > scanBudget;
 
-  const matched: FetchMessageObject[] = [];
+  const fetched = new Map<number, FetchMessageObject>();
   for await (const msg of client.fetch(
     batchUids,
     { envelope: true, flags: true, internalDate: true, headers: ['delivered-to'] },
     { uid: true },
   )) {
+    fetched.set(msg.uid, msg);
+  }
+
+  const matched: FetchMessageObject[] = [];
+  let lastScannedUid = startScanUid;
+  let reachedLimit = false;
+
+  for (const uid of batchUids) {
+    lastScannedUid = uid;
+    const msg = fetched.get(uid);
+    if (!msg) continue;
     if (
       messageBelongsToFolder(msg, normalized, folder) &&
       isAfterForwardCursor(msg, cursor.t, cursor.uid)
     ) {
       matched.push(msg);
+      if (matched.length >= limit) {
+        reachedLimit = true;
+        break;
+      }
     }
   }
 
-  // 4. 命中集全按 (receivedAtMs asc, uid asc) 元组序排序
+  // 4. 响应内按 (receivedAtMs asc, uid asc) 元组序排序
   matched.sort(compareOldestFirst);
+  const summaries = await buildMessageSummaries(client, matched);
 
-  // 5. 分页截断与续扫游标构造：扫完候选集才产出正式元组游标
-  const page = matched.slice(0, limit);
-  const summaries = await buildMessageSummaries(client, page);
-
+  // 5. 游标推进规则（FC 终裁定稿）：
+  // 游标保持 (t_c, u_c 原始过滤锚点, 永不推进) + scanUid + uidValidity
+  // - 收集到 limit 条立即停下，scanUid = 停下时那封的 UID（已检视全返回，无截断遗漏）
+  // - 若扫完全批预算仍未达 limit（含 0 命中），scanUid 推到已检视最大 UID
+  // - 仅当未达到 limit 且全部候选集已扫尽时，nextCursor 为 null
+  const hasMore = hasMoreBeyondBudget || lastScannedUid < candidateUids[candidateUids.length - 1];
   let nextCursor: string | null = null;
-  if (hasMoreCandidates) {
-    // 只要候选集未扫尽（无论命中几条、是否超 limit），均保留原始 (t_c, u_c) 与 scanUid 续扫状态
+  if (hasMore) {
     nextCursor = encodeMailForwardCursor(
       {
         folder,
         address: normalized,
         t: cursor.t,
         uid: cursor.uid,
-        uidValidity: Number(currentUidValidity),
-        scanUid: maxScannedUid,
-      },
-      config.taskSigningSecret,
-    );
-  } else if (matched.length > limit) {
-    // 候选集已扫尽且超页：塌缩为页尾条目的纯元组游标；对 t 做下限 clamp（防 t=0 污染回退到 epoch）
-    const last = page[page.length - 1];
-    nextCursor = encodeMailForwardCursor(
-      {
-        folder,
-        address: normalized,
-        t: Math.max(receivedAtMs(last), cursor.t),
-        uid: last.uid,
-        uidValidity: Number(currentUidValidity),
+        uidValidity: String(currentUidValidity),
+        scanUid: lastScannedUid,
       },
       config.taskSigningSecret,
     );
@@ -1055,13 +1063,13 @@ async function getMessageWith(
   client: ImapFlow,
   address: string,
   id: string,
-  opts?: { uidValidity?: number },
+  opts?: { uidValidity?: string | number | bigint },
 ): Promise<MessageDetail | null> {
   const currentUidValidity = client.mailbox ? client.mailbox.uidValidity : undefined;
   if (opts?.uidValidity !== undefined) {
     if (
       currentUidValidity === undefined ||
-      BigInt(opts.uidValidity) !== BigInt(currentUidValidity)
+      String(opts.uidValidity) !== String(currentUidValidity)
     ) {
       throw new StaleMessageGenerationError();
     }
@@ -1077,7 +1085,7 @@ async function getMessageWith(
 export async function getMessage(
   address: string,
   id: string,
-  opts?: { uidValidity?: number },
+  opts?: { uidValidity?: string | number | bigint },
 ): Promise<MessageDetail | null> {
   return withInbox((client) => getMessageWith(client, address, id, opts));
 }

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -947,39 +947,38 @@ async function listMessagesSinceWith(
   // 4. 命中集全按 (receivedAtMs asc, uid asc) 元组序排序
   matched.sort(compareOldestFirst);
 
-  // 5. 分页截断与续扫游标构造
-  if (matched.length > limit) {
-    const page = matched.slice(0, limit);
-    const summaries = await buildMessageSummaries(client, page);
-    const last = page[page.length - 1];
-    const nextCursor = encodeMailForwardCursor(
+  // 5. 分页截断与续扫游标构造：扫完候选集才产出正式元组游标
+  const page = matched.slice(0, limit);
+  const summaries = await buildMessageSummaries(client, page);
+
+  let nextCursor: string | null = null;
+  if (hasMoreCandidates) {
+    // 只要候选集未扫尽（无论命中几条、是否超 limit），均保留原始 (t_c, u_c) 与 scanUid 续扫状态
+    nextCursor = encodeMailForwardCursor(
       {
         folder,
         address: normalized,
-        t: receivedAtMs(last),
+        t: cursor.t,
+        uid: cursor.uid,
+        uidValidity: Number(currentUidValidity),
+        scanUid: maxScannedUid,
+      },
+      config.taskSigningSecret,
+    );
+  } else if (matched.length > limit) {
+    // 候选集已扫尽且超页：塌缩为页尾条目的纯元组游标；对 t 做下限 clamp（防 t=0 污染回退到 epoch）
+    const last = page[page.length - 1];
+    nextCursor = encodeMailForwardCursor(
+      {
+        folder,
+        address: normalized,
+        t: Math.max(receivedAtMs(last), cursor.t),
         uid: last.uid,
         uidValidity: Number(currentUidValidity),
       },
       config.taskSigningSecret,
     );
-    return { messages: summaries, nextCursor };
   }
-
-  const summaries = await buildMessageSummaries(client, matched);
-
-  const nextCursor = hasMoreCandidates
-    ? encodeMailForwardCursor(
-        {
-          folder,
-          address: normalized,
-          t: cursor.t,
-          uid: cursor.uid,
-          uidValidity: Number(currentUidValidity),
-          scanUid: maxScannedUid,
-        },
-        config.taskSigningSecret,
-      )
-    : null;
 
   return { messages: summaries, nextCursor };
 }

--- a/packages/api/src/lib/mail-cursor.ts
+++ b/packages/api/src/lib/mail-cursor.ts
@@ -11,6 +11,9 @@ import { createHmac, timingSafeEqual } from 'node:crypto';
 /** 协议版本前缀；变更字段规约时递增。 */
 export const MAIL_CURSOR_PREFIX = 'mail-cursor-v1';
 
+/** 前向游标版本前缀；载荷含 uidValidity，与既有后向游标互不通用。 */
+export const MAIL_FORWARD_CURSOR_PREFIX = 'mail-fcursor-v1';
+
 /** Dashboard Inbox 首版文件夹。Scheduled/Trash 后端未具备，不得出现在此枚举。 */
 export const MAIL_FOLDERS = ['inbox', 'sent', 'all'] as const;
 export type MailFolder = (typeof MAIL_FOLDERS)[number];
@@ -25,6 +28,15 @@ export type MailCursorPayload = {
   address: string;
   t: number;
   uid: number;
+};
+
+/** 前向游标载荷：绑定 uidValidity 代际，语义为 (t asc, uid asc) 之后的条目。 */
+export type MailForwardCursorPayload = {
+  folder: MailFolder;
+  address: string;
+  t: number;
+  uid: number;
+  uidValidity: number;
 };
 
 /** 非法 / 篡改 / 跨 folder 错用游标。路由折成 400。 */
@@ -88,6 +100,95 @@ export function decodeMailCursor(token: string, key: string): MailCursorPayload 
     const a = Buffer.from(parts[2]);
     const b = Buffer.from(expected);
     if (a.length !== b.length || !timingSafeEqual(a, b)) throw new InvalidMailCursorError();
+  } catch (err) {
+    if (err instanceof InvalidMailCursorError) throw err;
+    throw new InvalidMailCursorError();
+  }
+  return payload;
+}
+
+function forwardCursorMac(payload: MailForwardCursorPayload, key: string): string {
+  return createHmac('sha256', key)
+    .update(
+      `${MAIL_FORWARD_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${payload.uidValidity}`,
+    )
+    .digest('base64url');
+}
+
+/** 编码不透明前向游标。address 必须已小写，含代际 uidValidity。 */
+export function encodeMailForwardCursor(
+  payload: MailForwardCursorPayload,
+  key: string,
+): string {
+  const body = Buffer.from(
+    JSON.stringify({
+      f: payload.folder,
+      a: payload.address,
+      t: payload.t,
+      u: payload.uid,
+      v: payload.uidValidity,
+    }),
+  ).toString('base64url');
+  return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.${forwardCursorMac(payload, key)}`;
+}
+
+/** 解码并校验前向 HMAC。任何失败一律 InvalidMailCursorError（fail-closed）。 */
+export function decodeMailForwardCursor(
+  token: string,
+  key: string,
+): MailForwardCursorPayload {
+  const parts = token.split('.');
+  if (
+    parts.length !== 3 ||
+    parts[0] !== MAIL_FORWARD_CURSOR_PREFIX ||
+    !parts[1] ||
+    !parts[2]
+  ) {
+    throw new InvalidMailCursorError();
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    throw new InvalidMailCursorError();
+  }
+  if (!parsed || typeof parsed !== 'object') throw new InvalidMailCursorError();
+  const raw = parsed as {
+    f?: unknown;
+    a?: unknown;
+    t?: unknown;
+    u?: unknown;
+    v?: unknown;
+  };
+  if (typeof raw.f !== 'string' || !isMailFolder(raw.f)) {
+    throw new InvalidMailCursorError();
+  }
+  if (typeof raw.a !== 'string' || !raw.a.includes('@')) {
+    throw new InvalidMailCursorError();
+  }
+  if (typeof raw.t !== 'number' || !Number.isFinite(raw.t)) {
+    throw new InvalidMailCursorError();
+  }
+  if (typeof raw.u !== 'number' || !Number.isInteger(raw.u) || raw.u <= 0) {
+    throw new InvalidMailCursorError();
+  }
+  if (typeof raw.v !== 'number' || !Number.isInteger(raw.v) || raw.v <= 0) {
+    throw new InvalidMailCursorError();
+  }
+  const payload: MailForwardCursorPayload = {
+    folder: raw.f,
+    address: raw.a.toLowerCase(),
+    t: raw.t,
+    uid: raw.u,
+    uidValidity: raw.v,
+  };
+  const expected = forwardCursorMac(payload, key);
+  try {
+    const a = Buffer.from(parts[2]);
+    const b = Buffer.from(expected);
+    if (a.length !== b.length || !timingSafeEqual(a, b)) {
+      throw new InvalidMailCursorError();
+    }
   } catch (err) {
     if (err instanceof InvalidMailCursorError) throw err;
     throw new InvalidMailCursorError();

--- a/packages/api/src/lib/mail-cursor.ts
+++ b/packages/api/src/lib/mail-cursor.ts
@@ -109,33 +109,43 @@ export function decodeMailCursor(token: string, key: string): MailCursorPayload 
 }
 
 function forwardCursorMac(payload: MailForwardCursorPayload, key: string): string {
-  const scanSuffix = payload.scanUid !== undefined ? `\n${payload.scanUid}` : '';
   const vStr = String(payload.uidValidity);
-  return createHmac('sha256', key)
-    .update(
-      `${MAIL_FORWARD_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${vStr}${scanSuffix}`,
-    )
-    .digest('base64url');
+  const parts: string[] = [
+    MAIL_FORWARD_CURSOR_PREFIX,
+    payload.folder,
+    payload.address,
+    String(payload.t),
+    String(payload.uid),
+    vStr,
+    ...(payload.scanUid !== undefined ? [String(payload.scanUid)] : []),
+  ];
+  const input = parts.map((p) => `${Buffer.byteLength(p, 'utf8')}:${p}`).join('');
+  return createHmac('sha256', key).update(input).digest('base64url');
 }
 
-/** 编码不透明前向游标。address 必须已小写，含代际 uidValidity 与可选 scanUid。 */
+/** 编码不透明前向游标。address 自动小写归一，含代际 uidValidity 与可选 scanUid。 */
 export function encodeMailForwardCursor(
   payload: MailForwardCursorPayload,
   key: string,
 ): string {
-  const vStr = String(payload.uidValidity);
+  const normalizedAddress = payload.address.toLowerCase();
+  const normalizedPayload: MailForwardCursorPayload = {
+    ...payload,
+    address: normalizedAddress,
+  };
+  const vStr = String(normalizedPayload.uidValidity);
   const bodyObj: Record<string, unknown> = {
-    f: payload.folder,
-    a: payload.address,
-    t: payload.t,
-    u: payload.uid,
+    f: normalizedPayload.folder,
+    a: normalizedPayload.address,
+    t: normalizedPayload.t,
+    u: normalizedPayload.uid,
     v: vStr,
   };
-  if (payload.scanUid !== undefined) {
-    bodyObj.s = payload.scanUid;
+  if (normalizedPayload.scanUid !== undefined) {
+    bodyObj.s = normalizedPayload.scanUid;
   }
   const body = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
-  return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.${forwardCursorMac(payload, key)}`;
+  return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.${forwardCursorMac(normalizedPayload, key)}`;
 }
 
 /** 解码并校验前向 HMAC。任何失败一律 InvalidMailCursorError（fail-closed）。 */
@@ -173,7 +183,7 @@ export function decodeMailForwardCursor(
   if (typeof raw.a !== 'string' || !raw.a.includes('@')) {
     throw new InvalidMailCursorError();
   }
-  if (typeof raw.t !== 'number' || !Number.isFinite(raw.t)) {
+  if (typeof raw.t !== 'number' || !Number.isInteger(raw.t) || raw.t < 0) {
     throw new InvalidMailCursorError();
   }
   if (typeof raw.u !== 'number' || !Number.isInteger(raw.u) || raw.u <= 0) {

--- a/packages/api/src/lib/mail-cursor.ts
+++ b/packages/api/src/lib/mail-cursor.ts
@@ -30,13 +30,14 @@ export type MailCursorPayload = {
   uid: number;
 };
 
-/** 前向游标载荷：绑定 uidValidity 代际，语义为 (t asc, uid asc) 之后的条目。 */
+/** 前向游标载荷：绑定 uidValidity 代际，语义为 (t asc, uid asc) 之后的条目；可选 scanUid 为扫描预算水印。 */
 export type MailForwardCursorPayload = {
   folder: MailFolder;
   address: string;
   t: number;
   uid: number;
   uidValidity: number;
+  scanUid?: number;
 };
 
 /** 非法 / 篡改 / 跨 folder 错用游标。路由折成 400。 */
@@ -108,27 +109,30 @@ export function decodeMailCursor(token: string, key: string): MailCursorPayload 
 }
 
 function forwardCursorMac(payload: MailForwardCursorPayload, key: string): string {
+  const scanSuffix = payload.scanUid !== undefined ? `\n${payload.scanUid}` : '';
   return createHmac('sha256', key)
     .update(
-      `${MAIL_FORWARD_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${payload.uidValidity}`,
+      `${MAIL_FORWARD_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${payload.uidValidity}${scanSuffix}`,
     )
     .digest('base64url');
 }
 
-/** 编码不透明前向游标。address 必须已小写，含代际 uidValidity。 */
+/** 编码不透明前向游标。address 必须已小写，含代际 uidValidity 与可选 scanUid。 */
 export function encodeMailForwardCursor(
   payload: MailForwardCursorPayload,
   key: string,
 ): string {
-  const body = Buffer.from(
-    JSON.stringify({
-      f: payload.folder,
-      a: payload.address,
-      t: payload.t,
-      u: payload.uid,
-      v: payload.uidValidity,
-    }),
-  ).toString('base64url');
+  const bodyObj: Record<string, unknown> = {
+    f: payload.folder,
+    a: payload.address,
+    t: payload.t,
+    u: payload.uid,
+    v: payload.uidValidity,
+  };
+  if (payload.scanUid !== undefined) {
+    bodyObj.s = payload.scanUid;
+  }
+  const body = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
   return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.${forwardCursorMac(payload, key)}`;
 }
 
@@ -159,6 +163,7 @@ export function decodeMailForwardCursor(
     t?: unknown;
     u?: unknown;
     v?: unknown;
+    s?: unknown;
   };
   if (typeof raw.f !== 'string' || !isMailFolder(raw.f)) {
     throw new InvalidMailCursorError();
@@ -175,12 +180,19 @@ export function decodeMailForwardCursor(
   if (typeof raw.v !== 'number' || !Number.isInteger(raw.v) || raw.v <= 0) {
     throw new InvalidMailCursorError();
   }
+  if (
+    raw.s !== undefined &&
+    (typeof raw.s !== 'number' || !Number.isInteger(raw.s) || raw.s <= 0)
+  ) {
+    throw new InvalidMailCursorError();
+  }
   const payload: MailForwardCursorPayload = {
     folder: raw.f,
     address: raw.a.toLowerCase(),
     t: raw.t,
     uid: raw.u,
     uidValidity: raw.v,
+    ...(raw.s !== undefined ? { scanUid: raw.s } : {}),
   };
   const expected = forwardCursorMac(payload, key);
   try {

--- a/packages/api/src/lib/mail-cursor.ts
+++ b/packages/api/src/lib/mail-cursor.ts
@@ -36,7 +36,7 @@ export type MailForwardCursorPayload = {
   address: string;
   t: number;
   uid: number;
-  uidValidity: number;
+  uidValidity: string | number | bigint;
   scanUid?: number;
 };
 
@@ -110,9 +110,10 @@ export function decodeMailCursor(token: string, key: string): MailCursorPayload 
 
 function forwardCursorMac(payload: MailForwardCursorPayload, key: string): string {
   const scanSuffix = payload.scanUid !== undefined ? `\n${payload.scanUid}` : '';
+  const vStr = String(payload.uidValidity);
   return createHmac('sha256', key)
     .update(
-      `${MAIL_FORWARD_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${payload.uidValidity}${scanSuffix}`,
+      `${MAIL_FORWARD_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${vStr}${scanSuffix}`,
     )
     .digest('base64url');
 }
@@ -122,12 +123,13 @@ export function encodeMailForwardCursor(
   payload: MailForwardCursorPayload,
   key: string,
 ): string {
+  const vStr = String(payload.uidValidity);
   const bodyObj: Record<string, unknown> = {
     f: payload.folder,
     a: payload.address,
     t: payload.t,
     u: payload.uid,
-    v: payload.uidValidity,
+    v: vStr,
   };
   if (payload.scanUid !== undefined) {
     bodyObj.s = payload.scanUid;
@@ -177,12 +179,17 @@ export function decodeMailForwardCursor(
   if (typeof raw.u !== 'number' || !Number.isInteger(raw.u) || raw.u <= 0) {
     throw new InvalidMailCursorError();
   }
-  if (typeof raw.v !== 'number' || !Number.isInteger(raw.v) || raw.v <= 0) {
+  let validV: string;
+  if (typeof raw.v === 'string' && /^\d+$/.test(raw.v) && BigInt(raw.v) > 0n) {
+    validV = raw.v;
+  } else if (typeof raw.v === 'number' && Number.isInteger(raw.v) && raw.v > 0) {
+    validV = String(raw.v);
+  } else {
     throw new InvalidMailCursorError();
   }
   if (
     raw.s !== undefined &&
-    (typeof raw.s !== 'number' || !Number.isInteger(raw.s) || raw.s <= 0)
+    (typeof raw.s !== 'number' || !Number.isInteger(raw.s) || raw.s < 0)
   ) {
     throw new InvalidMailCursorError();
   }
@@ -191,7 +198,7 @@ export function decodeMailForwardCursor(
     address: raw.a.toLowerCase(),
     t: raw.t,
     uid: raw.u,
-    uidValidity: raw.v,
+    uidValidity: validV,
     ...(raw.s !== undefined ? { scanUid: raw.s } : {}),
   };
   const expected = forwardCursorMac(payload, key);

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,6 +1,14 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { getMessage, listMessages, setMessageSeen, waitForMessage } from '../lib/imap.ts';
+import {
+  getMessage,
+  InvalidMailCursorError,
+  listMessages,
+  listMessagesSince,
+  setMessageSeen,
+  StaleMessageGenerationError,
+  waitForMessage,
+} from '../lib/imap.ts';
 import { forbidUnlessAddress, forbidUnlessMailboxAccess } from '../lib/auth.ts';
 import { clampWaitSeconds } from '../lib/config.ts';
 import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
@@ -8,10 +16,13 @@ import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
 const listQuerySchema = z.object({
   address: z.string().email(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
+  since: z.string().optional(),
+  cursor: z.string().optional(),
 });
 
 const getQuerySchema = z.object({
   address: z.string().email(),
+  uidValidity: z.coerce.number().int().positive().optional(),
 });
 
 const seenSchema = z
@@ -34,8 +45,23 @@ export const messagesRoute = new Hono()
     if (!parsed.success) {
       return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
     }
+    if (parsed.data.since && parsed.data.cursor && parsed.data.since !== parsed.data.cursor) {
+      return c.json({ error: 'invalid_request' }, 400);
+    }
     const denied = forbidUnlessMailboxAccess(c, parsed.data.address);
     if (denied) return denied;
+    const sinceToken = parsed.data.since ?? parsed.data.cursor;
+    if (sinceToken !== undefined) {
+      try {
+        const page = await listMessagesSince(parsed.data.address, sinceToken, parsed.data.limit);
+        return c.json({ messages: page.messages, nextCursor: page.nextCursor });
+      } catch (err) {
+        if (err instanceof InvalidMailCursorError) {
+          return c.json({ error: 'invalid_cursor' }, 400);
+        }
+        throw err;
+      }
+    }
     const messages = await listMessages(parsed.data.address, parsed.data.limit);
     return c.json({ messages });
   })
@@ -46,11 +72,20 @@ export const messagesRoute = new Hono()
     }
     const denied = forbidUnlessMailboxAccess(c, parsed.data.address);
     if (denied) return denied;
-    const message = await getMessage(parsed.data.address, c.req.param('id'));
-    if (!message) {
-      return c.json({ error: 'not_found' }, 404);
+    try {
+      const message = await getMessage(parsed.data.address, c.req.param('id'), {
+        uidValidity: parsed.data.uidValidity,
+      });
+      if (!message) {
+        return c.json({ error: 'not_found' }, 404);
+      }
+      return c.json(message);
+    } catch (err) {
+      if (err instanceof StaleMessageGenerationError) {
+        return c.json({ error: 'stale_message_generation' }, 404);
+      }
+      throw err;
     }
-    return c.json(message);
   })
   .post('/:id/seen', async (c) => {
     let body: unknown;

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -23,8 +23,14 @@ const getQuerySchema = z.object({
   address: z.string().email(),
   uidValidity: z
     .string()
-    .regex(/^\d+$/)
-    .refine((v) => BigInt(v) > 0n)
+    .refine((v) => {
+      if (!/^\d+$/.test(v)) return false;
+      try {
+        return BigInt(v) > 0n;
+      } catch {
+        return false;
+      }
+    })
     .optional(),
 });
 

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -21,7 +21,11 @@ const listQuerySchema = z.object({
 
 const getQuerySchema = z.object({
   address: z.string().email(),
-  uidValidity: z.coerce.number().int().positive().optional(),
+  uidValidity: z
+    .string()
+    .regex(/^\d+$/)
+    .refine((v) => BigInt(v) > 0n)
+    .optional(),
 });
 
 const seenSchema = z

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -16,8 +16,7 @@ import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
 const listQuerySchema = z.object({
   address: z.string().email(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
-  since: z.string().optional(),
-  cursor: z.string().optional(),
+  since: z.string().max(2048).optional(),
 });
 
 const getQuerySchema = z.object({
@@ -45,15 +44,11 @@ export const messagesRoute = new Hono()
     if (!parsed.success) {
       return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
     }
-    if (parsed.data.since && parsed.data.cursor && parsed.data.since !== parsed.data.cursor) {
-      return c.json({ error: 'invalid_request' }, 400);
-    }
     const denied = forbidUnlessMailboxAccess(c, parsed.data.address);
     if (denied) return denied;
-    const sinceToken = parsed.data.since ?? parsed.data.cursor;
-    if (sinceToken !== undefined) {
+    if (parsed.data.since !== undefined) {
       try {
-        const page = await listMessagesSince(parsed.data.address, sinceToken, parsed.data.limit);
+        const page = await listMessagesSince(parsed.data.address, parsed.data.since, parsed.data.limit);
         return c.json({ messages: page.messages, nextCursor: page.nextCursor });
       } catch (err) {
         if (err instanceof InvalidMailCursorError) {

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -528,7 +528,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     app.route('/v1/messages', messagesRoute);
   });
 
-  test('前向查询单页：按 oldest-first 排序返回，所有信均在单页中时 nextCursor 为 null', async () => {
+  test('前向查询单页：按 oldest-first 排序返回，所有信均在单页中时 nextCursor 为 checkpoint 游标（不为 null）', async () => {
     const m1 = inboxMessage(10, 'victim@test.example', 'victim@test.example');
     m1.internalDate = new Date('2026-08-01T10:00:00Z');
     m1.envelope.subject = 'Message 10';
@@ -561,7 +561,10 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(res.status).toBe(200);
     const json = (await res.json()) as any;
     expect(json.messages.map((m: any) => m.id)).toEqual(['10', '11', '12']);
-    expect(json.nextCursor).toBeNull();
+    expect(json.nextCursor).not.toBeNull();
+    const dec = decodeMailForwardCursor(json.nextCursor, config.taskSigningSecret);
+    expect(dec.scanUid).toBe(12);
+    expect(dec.uidValidity).toBe('17');
   });
 
   test('多页追补无损：逐页翻页逐封核对，每封邮件严格可达且不重不漏', async () => {
@@ -604,6 +607,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
         collectedIds.push(m.id);
       }
       currentCursor = data.nextCursor;
+      if (data.messages.length < limit) break;
     }
 
     // 10 封信按 limit=3 翻页：3 + 3 + 3 + 1 = 4 页
@@ -612,6 +616,10 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(collectedIds).toEqual([
       '100', '101', '102', '103', '104', '105', '106', '107', '108', '109',
     ]);
+    // 终批 nextCursor 依然有效，携带 scanUid = 109
+    expect(currentCursor).not.toBeNull();
+    const lastDec = decodeMailForwardCursor(currentCursor!, config.taskSigningSecret);
+    expect(lastDec.scanUid).toBe(109);
   });
 
   test('代际不匹配拒：游标 uidValidity 与信箱代际不符 → 400 invalid_cursor', async () => {
@@ -712,7 +720,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(await res.json()).toEqual({ error: 'invalid_cursor' });
   });
 
-  test('游标后无新邮件 → 返回空列表且 nextCursor 为 null', async () => {
+  test('游标后无新邮件 → 返回空列表且 nextCursor 为 checkpoint 游标（永不为 null）', async () => {
     const m1 = inboxMessage(10, 'victim@test.example', 'victim@test.example');
     m1.internalDate = new Date('2026-08-01T10:00:00Z');
     fakeMessages = [m1];
@@ -732,7 +740,11 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
       `/v1/messages?address=victim@test.example&since=${encodeURIComponent(upToDateCursor)}`,
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ messages: [], nextCursor: null });
+    const json = (await res.json()) as any;
+    expect(json.messages).toEqual([]);
+    expect(json.nextCursor).not.toBeNull();
+    const dec = decodeMailForwardCursor(json.nextCursor, config.taskSigningSecret);
+    expect(dec.scanUid).toBe(10);
   });
 
   test('P2-D: v1 列表路由已移除 cursor 别名，仅作为普通参数忽略，不触发前向翻页', async () => {
@@ -821,14 +833,16 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(body2.messages.map((m: any) => m.id)).toEqual(['150']);
     expect(body2.nextCursor).not.toBeNull();
 
-    // 第 3 页：检视剩余的 UID 200（时间 09:30 早于游标 10:00，不命中），候选集扫尽，nextCursor 为 null
+    // 第 3 页：检视剩余的 UID 200（时间 09:30 早于游标 10:00，不命中），候选集扫尽，返回 checkpoint 游标
     const res3 = await app.request(
       `/v1/messages?address=victim@test.example&since=${encodeURIComponent(body2.nextCursor)}&limit=1`,
     );
     expect(res3.status).toBe(200);
     const body3 = (await res3.json()) as any;
     expect(body3.messages).toEqual([]);
-    expect(body3.nextCursor).toBeNull();
+    expect(body3.nextCursor).not.toBeNull();
+    const dec3 = decodeMailForwardCursor(body3.nextCursor, config.taskSigningSecret);
+    expect(dec3.scanUid).toBe(200);
   });
 
   test('ZCode P1 回归：扫描预算耗尽时 0 命中产出带 scanUid 续扫游标，后续分页不重扫最终可达每一封信', async () => {
@@ -886,7 +900,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     const decoded2 = decodeMailForwardCursor(page2.nextCursor!, config.taskSigningSecret);
     expect(decoded2.scanUid).toBe(6);
 
-    // 第 3 批（扫 UID 7..8）：命中 victim 的两封邮件，且扫完全部候选集，分页结束 nextCursor 为 null
+    // 第 3 批（扫 UID 7..8）：命中 victim 的两封邮件，且扫完全部候选集，返回 checkpoint 游标
     const page3 = await listMessagesSince(
       'victim@test.example',
       page2.nextCursor!,
@@ -895,7 +909,9 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
       { scanBudget: 3 },
     );
     expect(page3.messages.map((m) => m.id)).toEqual(['7', '8']);
-    expect(page3.nextCursor).toBeNull();
+    expect(page3.nextCursor).not.toBeNull();
+    const decoded3 = decodeMailForwardCursor(page3.nextCursor!, config.taskSigningSecret);
+    expect(decoded3.scanUid).toBe(8);
   });
 
   test('端到端 550 封邮件在默认 500 预算下分批续扫无损到达', async () => {
@@ -935,7 +951,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     const dec1 = decodeMailForwardCursor(body1.nextCursor, config.taskSigningSecret);
     expect(dec1.scanUid).toBe(500);
 
-    // 请求 2：从 scanUid=500 继续，扫描剩余 50 封（UID 501..550），返回属于 victim 的 30 封信，全部完成 nextCursor 为 null
+    // 请求 2：从 scanUid=500 继续，扫描剩余 50 封（UID 501..550），返回属于 victim 的 30 封信，返回 checkpoint 游标
     const res2 = await app.request(
       `/v1/messages?address=victim@test.example&since=${encodeURIComponent(body1.nextCursor)}`,
     );
@@ -944,7 +960,9 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(body2.messages.length).toBe(30);
     expect(body2.messages[0].id).toBe('521');
     expect(body2.messages[29].id).toBe('550');
-    expect(body2.nextCursor).toBeNull();
+    expect(body2.nextCursor).not.toBeNull();
+    const dec2 = decodeMailForwardCursor(body2.nextCursor, config.taskSigningSecret);
+    expect(dec2.scanUid).toBe(550);
   });
 
   test('回归测试 1 (ZCode 丢信实例)：超限截断 + 未扫描区藏非单调信 → 后续请求必须送达', async () => {
@@ -1003,10 +1021,12 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     const dec3 = decodeMailForwardCursor(page3.nextCursor!, config.taskSigningSecret);
     expect(dec3.scanUid).toBe(600);
 
-    // 请求 4：从 scanUid = 600 继续，命中 m4 (700)，候选集扫尽，nextCursor 为 null
+    // 请求 4：从 scanUid = 600 继续，命中 m4 (700)，候选集扫尽，返回 checkpoint 游标
     const page4 = await listMessagesSince('victim@test.example', page3.nextCursor!, 1, 'inbox');
     expect(page4.messages.map((m) => m.id)).toEqual(['700']);
-    expect(page4.nextCursor).toBeNull();
+    expect(page4.nextCursor).not.toBeNull();
+    const dec4 = decodeMailForwardCursor(page4.nextCursor!, config.taskSigningSecret);
+    expect(dec4.scanUid).toBe(700);
   });
 
   test('回归测试 2：截断与补齐（同一条信不重投、被截的匹配信下请求补齐，完整送达）', async () => {
@@ -1044,10 +1064,12 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     const dec2 = decodeMailForwardCursor(page2.nextCursor!, config.taskSigningSecret);
     expect(dec2.scanUid).toBe(50);
 
-    // 请求 3 (limit=2)：返回最后一封 (UID 60)，全候选集扫完，nextCursor 为 null
+    // 请求 3 (limit=2)：返回最后一封 (UID 60)，全候选集扫完，返回 checkpoint 游标
     const page3 = await listMessagesSince('victim@test.example', page2.nextCursor!, 2, 'inbox');
     expect(page3.messages.map((m) => m.id)).toEqual(['60']);
-    expect(page3.nextCursor).toBeNull();
+    expect(page3.nextCursor).not.toBeNull();
+    const dec3 = decodeMailForwardCursor(page3.nextCursor!, config.taskSigningSecret);
+    expect(dec3.scanUid).toBe(60);
 
     // 验证完整性与不重不漏
     const allDelivered = [...page1.messages, ...page2.messages, ...page3.messages].map((m) => m.id);
@@ -1117,10 +1139,12 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
       config.taskSigningSecret,
     );
 
-    // 轮询 1：没有比 UID 200 更大的信，返回空且不发起 FETCH
+    // 轮询 1：没有比 UID 200 更大的信，返回空且不发起 FETCH，nextCursor 仍为 checkpoint 游标
     const poll1 = await listMessagesSince('victim@test.example', caughtUpCursor, 10, 'inbox');
     expect(poll1.messages).toEqual([]);
-    expect(poll1.nextCursor).toBeNull();
+    expect(poll1.nextCursor).not.toBeNull();
+    const decPoll1 = decodeMailForwardCursor(poll1.nextCursor!, config.taskSigningSecret);
+    expect(decPoll1.scanUid).toBe(200);
     expect(fetchedUidBatches).toEqual([]);
 
     // 新信件到来：UID 300
@@ -1131,7 +1155,9 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     // 轮询 2：使用相同的 caughtUpCursor 轮询，只检视 UID 300，绝不重扫 100 和 200
     const poll2 = await listMessagesSince('victim@test.example', caughtUpCursor, 10, 'inbox');
     expect(poll2.messages.map((m) => m.id)).toEqual(['300']);
-    expect(poll2.nextCursor).toBeNull();
+    expect(poll2.nextCursor).not.toBeNull();
+    const decPoll2 = decodeMailForwardCursor(poll2.nextCursor!, config.taskSigningSecret);
+    expect(decPoll2.scanUid).toBe(300);
     // 验证只 fetch 了 [300]
     expect(fetchedUidBatches).toEqual([[300]]);
   });
@@ -1165,5 +1191,85 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     // nextCursor.t 至少为 cursor.t，且非负数
     expect(dec.t).toBeGreaterThanOrEqual(0);
     expect(dec.t).toBe(Math.max(0, 0));
+  });
+
+  test('Codex P1 回归 (R5 Item A): GET /v1/messages/:id 带非法 uidValidity=abc 不抛 500，返回 400 invalid_request', async () => {
+    const res1 = await app.request('/v1/messages/100?address=victim@test.example&uidValidity=abc');
+    expect(res1.status).toBe(400);
+    const json1 = (await res1.json()) as any;
+    expect(json1.error).toBe('invalid_request');
+
+    const res2 = await app.request('/v1/messages/100?address=victim@test.example&uidValidity=0');
+    expect(res2.status).toBe(400);
+    const json2 = (await res2.json()) as any;
+    expect(json2.error).toBe('invalid_request');
+
+    const res3 = await app.request('/v1/messages/100?address=victim@test.example&uidValidity=-5');
+    expect(res3.status).toBe(400);
+    const json3 = (await res3.json()) as any;
+    expect(json3.error).toBe('invalid_request');
+  });
+
+  test('CR Major 回归 (R5 Item B): 终批返回 checkpoint nextCursor 永不为 null，追平后拿 checkpoint 游标再轮询 → 空页且不重投', async () => {
+    const m1 = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+    const m2 = inboxMessage(200, 'victim@test.example', 'victim@test.example');
+    m2.internalDate = new Date('2026-08-01T10:30:00Z');
+
+    fakeMessages = [m1, m2];
+    fetchedUidBatches = [];
+
+    const startCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 第一批查询（limit=10）：扫完全部 2 封信
+    const page1 = await listMessagesSince('victim@test.example', startCursor, 10, 'inbox');
+    expect(page1.messages.map((m) => m.id)).toEqual(['100', '200']);
+    expect(page1.nextCursor).not.toBeNull();
+    const dec1 = decodeMailForwardCursor(page1.nextCursor!, config.taskSigningSecret);
+    expect(dec1.scanUid).toBe(200);
+    expect(dec1.t).toBe(new Date('2026-08-01T09:00:00Z').getTime());
+    expect(dec1.uid).toBe(10);
+    expect(dec1.uidValidity).toBe('17');
+
+    // 追平后拿 checkpoint 游标继续轮询：返回空页且不重投，nextCursor 依然有效并保持 scanUid=200
+    const pollAgain = await listMessagesSince('victim@test.example', page1.nextCursor!, 10, 'inbox');
+    expect(pollAgain.messages).toEqual([]);
+    expect(pollAgain.nextCursor).not.toBeNull();
+    const decPoll = decodeMailForwardCursor(pollAgain.nextCursor!, config.taskSigningSecret);
+    expect(decPoll.scanUid).toBe(200);
+    expect(decPoll.t).toBe(dec1.t);
+    expect(decPoll.uid).toBe(dec1.uid);
+  });
+
+  test('ZCode P2-4 回归 (R5 Item F): scanBudget 传 0 或负数被 Math.max(1, ...) 兜底，正常步进', async () => {
+    const m1 = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+    fakeMessages = [m1];
+
+    const cursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await listMessagesSince('victim@test.example', cursor, 10, 'inbox', { scanBudget: 0 });
+    expect(res.messages.map((m) => m.id)).toEqual(['100']);
+    expect(res.nextCursor).not.toBeNull();
+    const dec = decodeMailForwardCursor(res.nextCursor!, config.taskSigningSecret);
+    expect(dec.scanUid).toBe(100);
   });
 });

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -29,6 +29,7 @@ let failMailboxLock = false;
 let fakeUidValidity = 17n;
 const createdClients: FakeImapFlow[] = [];
 let deletedUids: number[] = [];
+let fetchedUidBatches: number[][] = [];
 
 class FakeImapFlow extends EventEmitter {
   closed = false;
@@ -79,6 +80,7 @@ class FakeImapFlow extends EventEmitter {
 
   async *fetch(uids?: number[]) {
     if (Array.isArray(uids)) {
+      fetchedUidBatches.push([...uids]);
       const set = new Set(uids);
       yield* fakeMessages.filter((m) => set.has(m.uid));
     } else {
@@ -159,6 +161,7 @@ describe('IMAP identity isolation (end to end)', () => {
     failMailboxLock = false;
     createdClients.length = 0;
     deletedUids = [];
+    fetchedUidBatches = [];
   });
 
   test('别的身份的邮件不会出现在 listMessages 结果里', async () => {
@@ -933,5 +936,106 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(body2.messages[0].id).toBe('521');
     expect(body2.messages[29].id).toBe('550');
     expect(body2.nextCursor).toBeNull();
+  });
+
+  test('ZCode P1/R3 回归：候选>预算且批内命中>limit时保留 scanUid 续扫，未扫描区藏有时间介于游标与页尾间的信能正常送出且不重扫', async () => {
+    // 初始游标：(09:00, 10)
+    // 批 1（scanBudget = 2）：
+    //   m1: UID 100, t = 10:00:00 (victim)
+    //   m2: UID 150, t = 12:00:00 (victim)
+    // 批 2（未扫描区）：
+    //   m3: UID 600, t = 09:30:00 (victim, UID 更大但 internalDate 落在游标 09:00 与批 1 页尾 10:00 之间)
+    //   m4: UID 700, t = 13:00:00 (victim)
+    const m1 = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+
+    const m2 = inboxMessage(150, 'victim@test.example', 'victim@test.example');
+    m2.internalDate = new Date('2026-08-01T12:00:00Z');
+
+    const m3 = inboxMessage(600, 'victim@test.example', 'victim@test.example');
+    m3.internalDate = new Date('2026-08-01T09:30:00Z');
+
+    const m4 = inboxMessage(700, 'victim@test.example', 'victim@test.example');
+    m4.internalDate = new Date('2026-08-01T13:00:00Z');
+
+    fakeMessages = [m1, m2, m3, m4];
+    fetchedUidBatches = [];
+
+    const initialCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 请求 1：scanBudget = 2, limit = 1
+    // 候选 UIDs: [100, 150, 600, 700] > 预算 2
+    // 批 1 扫描 [100, 150]，两封均命中 > limit(1)
+    // 必须保留原始游标 (09:00, 10) 与 scanUid = 150，绝不能丢弃 scanUid 或提前塌缩游标
+    const page1 = await listMessagesSince(
+      'victim@test.example',
+      initialCursor,
+      1,
+      'inbox',
+      { scanBudget: 2 },
+    );
+    expect(page1.messages.map((m) => m.id)).toEqual(['100']);
+    expect(page1.nextCursor).not.toBeNull();
+    const dec1 = decodeMailForwardCursor(page1.nextCursor!, config.taskSigningSecret);
+    expect(dec1.scanUid).toBe(150);
+    expect(dec1.t).toBe(new Date('2026-08-01T09:00:00Z').getTime());
+    expect(dec1.uid).toBe(10);
+
+    // 请求 2：以 page1.nextCursor 续扫
+    // 从 scanUid = 150 之后继续，扫描剩余候选 [600, 700]
+    // m3 (UID 600, 09:30) 的时间在 09:00 之后，必须成功送出（若像 R2 提前推进到 10:00 则会被漏掉）
+    const page2 = await listMessagesSince(
+      'victim@test.example',
+      page1.nextCursor!,
+      1,
+      'inbox',
+      { scanBudget: 2 },
+    );
+    expect(page2.messages.map((m) => m.id)).toEqual(['600']);
+
+    // 断言不重扫：检查 fake fetch 的所有批次，同一个 UID 绝不被重复 fetch
+    const allFetchedUids = fetchedUidBatches.flat();
+    expect(fetchedUidBatches).toEqual([[100, 150], [600, 700]]);
+    expect(new Set(allFetchedUids).size).toBe(allFetchedUids.length);
+  });
+
+  test('ZCode P2-2 回归：t=0（internalDate 与 envelope.date 皆缺）信件作为页尾时，nextCursor.t 被下限 clamp 到 cursor.t，不回退到更小时间', async () => {
+    const m1 = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    (m1 as any).internalDate = undefined;
+    (m1.envelope as any).date = undefined;
+
+    const m2 = inboxMessage(200, 'victim@test.example', 'victim@test.example');
+    m2.internalDate = new Date('2026-08-01T10:00:00Z');
+
+    fakeMessages = [m1, m2];
+
+    const cursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: 0,
+        uid: 50,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // limit = 1，返回 m1 (t=0)
+    const page = await listMessagesSince('victim@test.example', cursor, 1, 'inbox');
+    expect(page.messages.map((m) => m.id)).toEqual(['100']);
+    expect(page.nextCursor).not.toBeNull();
+    const dec = decodeMailForwardCursor(page.nextCursor!, config.taskSigningSecret);
+    // nextCursor.t 至少为 cursor.t，且非负数
+    expect(dec.t).toBeGreaterThanOrEqual(0);
+    expect(dec.t).toBe(Math.max(0, 0));
   });
 });

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -26,6 +26,7 @@ type FakeMessage = {
 
 let fakeMessages: FakeMessage[] = [];
 let failMailboxLock = false;
+let fakeUidValidity = 17n;
 const createdClients: FakeImapFlow[] = [];
 let deletedUids: number[] = [];
 
@@ -36,6 +37,10 @@ class FakeImapFlow extends EventEmitter {
   constructor() {
     super();
     createdClients.push(this);
+  }
+
+  get mailbox() {
+    return { uidValidity: fakeUidValidity };
   }
 
   /** 连接是否已经被收掉（正常登出或强制关闭都算）。 */
@@ -55,11 +60,16 @@ class FakeImapFlow extends EventEmitter {
   }
 
   async search() {
-    return fakeMessages.map((message) => message.uid);
+    return fakeMessages.map((message) => message.uid).sort((a, b) => a - b);
   }
 
-  async *fetch() {
-    yield* fakeMessages;
+  async *fetch(uids?: number[]) {
+    if (Array.isArray(uids)) {
+      const set = new Set(uids);
+      yield* fakeMessages.filter((m) => set.has(m.uid));
+    } else {
+      yield* fakeMessages;
+    }
   }
 
   async fetchOne(uid: number) {
@@ -92,8 +102,18 @@ class FakeImapFlow extends EventEmitter {
 
 mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
 
-const { deleteMessagesBefore, getMessage, listMessages, waitForMessage } = await import('../src/lib/imap.ts');
+const {
+  deleteMessagesBefore,
+  getMessage,
+  listMessages,
+  listMessagesSince,
+  waitForMessage,
+} = await import('../src/lib/imap.ts');
 const { config } = await import('../src/lib/config.ts');
+const {
+  encodeMailCursor,
+  encodeMailForwardCursor,
+} = await import('../src/lib/mail-cursor.ts');
 const {
   MAIL_STAMP_HEADER,
   createMailStamp,
@@ -395,5 +415,329 @@ describe('IMAP 连接清理', () => {
     expect(await waitForMessage('victim@test.example', {}, 1)).toBeNull();
     expect(createdClients.length).toBeGreaterThan(0);
     expect(createdClients.every((client) => client.released)).toBe(true);
+  });
+});
+
+describe('GET /v1/messages/:id 代际前置条件 (R63)', () => {
+  let app: any;
+
+  beforeEach(async () => {
+    fakeMessages = [];
+    failMailboxLock = false;
+    fakeUidValidity = 17n;
+    createdClients.length = 0;
+
+    const { Hono } = await import('hono');
+    const { messagesRoute } = await import('../src/routes/messages.ts');
+    app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { kind: 'admin' });
+      await next();
+    });
+    app.route('/v1/messages', messagesRoute);
+  });
+
+  test('代际不匹配 → 404 stale_message_generation 而不是另一封信', async () => {
+    // 构造当前信箱中 UID 100 的信件（属于代际 17）
+    const msg = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    msg.envelope.subject = 'New generation message';
+    fakeMessages = [msg];
+
+    // 调用方传入旧代际 uidValidity=16
+    const res = await app.request('/v1/messages/100?address=victim@test.example&uidValidity=16');
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as any;
+    expect(json).toEqual({ error: 'stale_message_generation' });
+    // 绝不返回另一封信
+    expect(json.subject).toBeUndefined();
+  });
+
+  test('代际匹配 → 200 返回邮件内容', async () => {
+    const msg = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    msg.envelope.subject = 'Expected generation message';
+    fakeMessages = [msg];
+
+    const res = await app.request('/v1/messages/100?address=victim@test.example&uidValidity=17');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.id).toBe('100');
+    expect(json.subject).toBe('Expected generation message');
+  });
+
+  test('代际匹配但邮件不存在 → 404 not_found', async () => {
+    fakeMessages = [];
+
+    const res = await app.request('/v1/messages/999?address=victim@test.example&uidValidity=17');
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as any;
+    expect(json).toEqual({ error: 'not_found' });
+  });
+
+  test('省略 uidValidity 参数保持既有行为（兼容已有调用方）', async () => {
+    const msg = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    fakeMessages = [msg];
+
+    const res = await app.request('/v1/messages/100?address=victim@test.example');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.id).toBe('100');
+  });
+
+  test('非法 uidValidity（非正整数）返回 400 invalid_request', async () => {
+    const res = await app.request('/v1/messages/100?address=victim@test.example&uidValidity=0');
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as any;
+    expect(json.error).toBe('invalid_request');
+  });
+});
+
+describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
+  let app: any;
+
+  beforeEach(async () => {
+    fakeMessages = [];
+    failMailboxLock = false;
+    fakeUidValidity = 17n;
+    createdClients.length = 0;
+
+    const { Hono } = await import('hono');
+    const { messagesRoute } = await import('../src/routes/messages.ts');
+    app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('auth', { kind: 'admin' });
+      await next();
+    });
+    app.route('/v1/messages', messagesRoute);
+  });
+
+  test('前向查询单页：按 oldest-first 排序返回，所有信均在单页中时 nextCursor 为 null', async () => {
+    const m1 = inboxMessage(10, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+    m1.envelope.subject = 'Message 10';
+
+    const m2 = inboxMessage(11, 'victim@test.example', 'victim@test.example');
+    m2.internalDate = new Date('2026-08-01T10:01:00Z');
+    m2.envelope.subject = 'Message 11';
+
+    const m3 = inboxMessage(12, 'victim@test.example', 'victim@test.example');
+    m3.internalDate = new Date('2026-08-01T10:02:00Z');
+    m3.envelope.subject = 'Message 12';
+
+    fakeMessages = [m1, m2, m3];
+
+    // 起始游标位于 m1 之前（例如 UID 9，时间 09:59）
+    const initialCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:59:00Z').getTime(),
+        uid: 9,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(initialCursor)}&limit=10`,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.messages.map((m: any) => m.id)).toEqual(['10', '11', '12']);
+    expect(json.nextCursor).toBeNull();
+  });
+
+  test('多页追补无损：逐页翻页逐封核对，每封邮件严格可达且不重不漏', async () => {
+    // 构造 10 封邮件，模拟断线追补窗口
+    const baseTime = new Date('2026-08-01T10:00:00Z').getTime();
+    fakeMessages = Array.from({ length: 10 }, (_, i) => {
+      const uid = 100 + i;
+      const msg = inboxMessage(uid, 'victim@test.example', 'victim@test.example');
+      msg.internalDate = new Date(baseTime + i * 60000);
+      msg.envelope.subject = `Catch-up mail ${uid}`;
+      return msg;
+    });
+
+    // 游标指向 99（在所有 10 封信之前）
+    let currentCursor: string | null = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: baseTime - 60000,
+        uid: 99,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const collectedIds: string[] = [];
+    const limit = 3;
+    let pageCount = 0;
+
+    while (currentCursor) {
+      pageCount++;
+      const res = await app.request(
+        `/v1/messages?address=victim@test.example&since=${encodeURIComponent(currentCursor)}&limit=${limit}`,
+      );
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as any;
+      expect(Array.isArray(data.messages)).toBe(true);
+      expect(data.messages.length).toBeLessThanOrEqual(limit);
+      for (const m of data.messages) {
+        collectedIds.push(m.id);
+      }
+      currentCursor = data.nextCursor;
+    }
+
+    // 10 封信按 limit=3 翻页：3 + 3 + 3 + 1 = 4 页
+    expect(pageCount).toBe(4);
+    // 逐封核对：严格等于 100 到 109，无跳过无重复
+    expect(collectedIds).toEqual([
+      '100', '101', '102', '103', '104', '105', '106', '107', '108', '109',
+    ]);
+  });
+
+  test('代际不匹配拒：游标 uidValidity 与信箱代际不符 → 400 invalid_cursor', async () => {
+    fakeUidValidity = 18n; // 信箱已重建为 generation 18
+
+    const staleCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: 1000,
+        uid: 10,
+        uidValidity: 17, // 旧代际
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(staleCursor)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+  });
+
+  test('跨地址复用游标拒：游标绑定地址与查询地址不符 → 400 invalid_cursor', async () => {
+    const foreignCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'other@test.example',
+        t: 1000,
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(foreignCursor)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+  });
+
+  test('跨 folder 复用游标拒：游标 folder 为 sent 而不是 inbox → 400 invalid_cursor', async () => {
+    const sentCursor = encodeMailForwardCursor(
+      {
+        folder: 'sent',
+        address: 'victim@test.example',
+        t: 1000,
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(sentCursor)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+  });
+
+  test('后向游标错用于 since 查询拒 → 400 invalid_cursor', async () => {
+    const backwardCursor = encodeMailCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: 1000,
+        uid: 10,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(backwardCursor)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+  });
+
+  test('篡改 HMAC 拒 → 400 invalid_cursor', async () => {
+    const validCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: 1000,
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+    const parts = validCursor.split('.');
+    const tampered = `${parts[0]}.${parts[1]}.badhmac`;
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(tampered)}`,
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+  });
+
+  test('游标后无新邮件 → 返回空列表且 nextCursor 为 null', async () => {
+    const m1 = inboxMessage(10, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+    fakeMessages = [m1];
+
+    const upToDateCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: m1.internalDate.getTime(),
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(upToDateCursor)}`,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ messages: [], nextCursor: null });
+  });
+
+  test('cursor 参数作为 since 的等价别名亦可正常工作', async () => {
+    const m1 = inboxMessage(20, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+    fakeMessages = [m1];
+
+    const cursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 19,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&cursor=${encodeURIComponent(cursor)}`,
+    );
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as any;
+    expect(json.messages.map((m: any) => m.id)).toEqual(['20']);
   });
 });

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -812,14 +812,23 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(body1.messages.map((m: any) => m.id)).toEqual(['50']);
     expect(body1.nextCursor).not.toBeNull();
 
-    // 第 2 页：应命中 m3 (UID 150, t=12:00)；所有信件均已返回完毕，nextCursor 为 null
+    // 第 2 页：应命中 m3 (UID 150, t=12:00)；因候选集尚有未检视的 UID 200，nextCursor 不为 null
     const res2 = await app.request(
       `/v1/messages?address=victim@test.example&since=${encodeURIComponent(body1.nextCursor)}&limit=1`,
     );
     expect(res2.status).toBe(200);
     const body2 = (await res2.json()) as any;
     expect(body2.messages.map((m: any) => m.id)).toEqual(['150']);
-    expect(body2.nextCursor).toBeNull();
+    expect(body2.nextCursor).not.toBeNull();
+
+    // 第 3 页：检视剩余的 UID 200（时间 09:30 早于游标 10:00，不命中），候选集扫尽，nextCursor 为 null
+    const res3 = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(body2.nextCursor)}&limit=1`,
+    );
+    expect(res3.status).toBe(200);
+    const body3 = (await res3.json()) as any;
+    expect(body3.messages).toEqual([]);
+    expect(body3.nextCursor).toBeNull();
   });
 
   test('ZCode P1 回归：扫描预算耗尽时 0 命中产出带 scanUid 续扫游标，后续分页不重扫最终可达每一封信', async () => {
@@ -938,13 +947,12 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(body2.nextCursor).toBeNull();
   });
 
-  test('ZCode P1/R3 回归：候选>预算且批内命中>limit时保留 scanUid 续扫，未扫描区藏有时间介于游标与页尾间的信能正常送出且不重扫', async () => {
-    // 初始游标：(09:00, 10)
-    // 批 1（scanBudget = 2）：
+  test('回归测试 1 (ZCode 丢信实例)：超限截断 + 未扫描区藏非单调信 → 后续请求必须送达', async () => {
+    // 初始游标：(09:00:00, 10)
+    // 候选集包含：
     //   m1: UID 100, t = 10:00:00 (victim)
     //   m2: UID 150, t = 12:00:00 (victim)
-    // 批 2（未扫描区）：
-    //   m3: UID 600, t = 09:30:00 (victim, UID 更大但 internalDate 落在游标 09:00 与批 1 页尾 10:00 之间)
+    //   m3: UID 600, t = 09:30:00 (victim, UID 大于前面且 internalDate 早于 10:00:00，但晚于游标 09:00:00)
     //   m4: UID 700, t = 13:00:00 (victim)
     const m1 = inboxMessage(100, 'victim@test.example', 'victim@test.example');
     m1.internalDate = new Date('2026-08-01T10:00:00Z');
@@ -959,7 +967,6 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     m4.internalDate = new Date('2026-08-01T13:00:00Z');
 
     fakeMessages = [m1, m2, m3, m4];
-    fetchedUidBatches = [];
 
     const initialCursor = encodeMailForwardCursor(
       {
@@ -972,40 +979,161 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
       config.taskSigningSecret,
     );
 
-    // 请求 1：scanBudget = 2, limit = 1
-    // 候选 UIDs: [100, 150, 600, 700] > 预算 2
-    // 批 1 扫描 [100, 150]，两封均命中 > limit(1)
-    // 必须保留原始游标 (09:00, 10) 与 scanUid = 150，绝不能丢弃 scanUid 或提前塌缩游标
-    const page1 = await listMessagesSince(
-      'victim@test.example',
-      initialCursor,
-      1,
-      'inbox',
-      { scanBudget: 2 },
-    );
+    // 每页 limit = 1，逐页遍历
+    // 请求 1：命中 m1 (100)，达到 limit=1 立即停检视，scanUid = 100
+    const page1 = await listMessagesSince('victim@test.example', initialCursor, 1, 'inbox');
     expect(page1.messages.map((m) => m.id)).toEqual(['100']);
     expect(page1.nextCursor).not.toBeNull();
     const dec1 = decodeMailForwardCursor(page1.nextCursor!, config.taskSigningSecret);
-    expect(dec1.scanUid).toBe(150);
+    expect(dec1.scanUid).toBe(100);
+    expect(dec1.t).toBe(new Date('2026-08-01T09:00:00Z').getTime()); // 过滤锚点永不推进
+
+    // 请求 2：从 scanUid = 100 继续，命中 m2 (150)，停检视，scanUid = 150
+    const page2 = await listMessagesSince('victim@test.example', page1.nextCursor!, 1, 'inbox');
+    expect(page2.messages.map((m) => m.id)).toEqual(['150']);
+    expect(page2.nextCursor).not.toBeNull();
+    const dec2 = decodeMailForwardCursor(page2.nextCursor!, config.taskSigningSecret);
+    expect(dec2.scanUid).toBe(150);
+
+    // 请求 3：从 scanUid = 150 继续，检视到 m3 (600, 09:30:00)
+    // 因锚点 t 保持 09:00:00，m3 的 09:30:00 > 09:00:00 正常命中送出（绝不因 R2 的错误推进而丢失）
+    const page3 = await listMessagesSince('victim@test.example', page2.nextCursor!, 1, 'inbox');
+    expect(page3.messages.map((m) => m.id)).toEqual(['600']);
+    expect(page3.nextCursor).not.toBeNull();
+    const dec3 = decodeMailForwardCursor(page3.nextCursor!, config.taskSigningSecret);
+    expect(dec3.scanUid).toBe(600);
+
+    // 请求 4：从 scanUid = 600 继续，命中 m4 (700)，候选集扫尽，nextCursor 为 null
+    const page4 = await listMessagesSince('victim@test.example', page3.nextCursor!, 1, 'inbox');
+    expect(page4.messages.map((m) => m.id)).toEqual(['700']);
+    expect(page4.nextCursor).toBeNull();
+  });
+
+  test('回归测试 2：截断与补齐（同一条信不重投、被截的匹配信下请求补齐，完整送达）', async () => {
+    // 5 封属于 victim 的邮件，单页 limit = 2
+    const msgs = [20, 30, 40, 50, 60].map((uid, idx) => {
+      const m = inboxMessage(uid, 'victim@test.example', 'victim@test.example');
+      const minute = String(idx * 10).padStart(2, '0');
+      m.internalDate = new Date(`2026-08-01T10:${minute}:00Z`);
+      return m;
+    });
+    fakeMessages = msgs;
+
+    const initialCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 请求 1 (limit=2)：返回前 2 封 (UID 20, 30)，停检视，scanUid = 30
+    const page1 = await listMessagesSince('victim@test.example', initialCursor, 2, 'inbox');
+    expect(page1.messages.map((m) => m.id)).toEqual(['20', '30']);
+    expect(page1.nextCursor).not.toBeNull();
+    const dec1 = decodeMailForwardCursor(page1.nextCursor!, config.taskSigningSecret);
+    expect(dec1.scanUid).toBe(30);
+
+    // 请求 2 (limit=2)：从 scanUid=30 之后继续检视，返回后续 2 封 (UID 40, 50)，无重复也无遗漏
+    const page2 = await listMessagesSince('victim@test.example', page1.nextCursor!, 2, 'inbox');
+    expect(page2.messages.map((m) => m.id)).toEqual(['40', '50']);
+    expect(page2.nextCursor).not.toBeNull();
+    const dec2 = decodeMailForwardCursor(page2.nextCursor!, config.taskSigningSecret);
+    expect(dec2.scanUid).toBe(50);
+
+    // 请求 3 (limit=2)：返回最后一封 (UID 60)，全候选集扫完，nextCursor 为 null
+    const page3 = await listMessagesSince('victim@test.example', page2.nextCursor!, 2, 'inbox');
+    expect(page3.messages.map((m) => m.id)).toEqual(['60']);
+    expect(page3.nextCursor).toBeNull();
+
+    // 验证完整性与不重不漏
+    const allDelivered = [...page1.messages, ...page2.messages, ...page3.messages].map((m) => m.id);
+    expect(allDelivered).toEqual(['20', '30', '40', '50', '60']);
+    expect(new Set(allDelivered).size).toBe(5);
+  });
+
+  test('回归测试 3：0 命中推进 scanUid 不推进 (t_c, u_c)', async () => {
+    // 候选集全为 other@test.example 的信，victim 0 命中
+    const msgs = [100, 101, 102, 103, 104].map((uid) => {
+      const m = inboxMessage(uid, 'other@test.example', 'other@test.example');
+      m.internalDate = new Date('2026-08-01T10:00:00Z');
+      return m;
+    });
+    fakeMessages = msgs;
+
+    const initialCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 10,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 预算 3：扫描前 3 封 (100, 101, 102)，0 命中
+    const page1 = await listMessagesSince(
+      'victim@test.example',
+      initialCursor,
+      10,
+      'inbox',
+      { scanBudget: 3 },
+    );
+    expect(page1.messages).toEqual([]);
+    expect(page1.nextCursor).not.toBeNull();
+    const dec1 = decodeMailForwardCursor(page1.nextCursor!, config.taskSigningSecret);
+    // scanUid 推进到本批最大 UID 102
+    expect(dec1.scanUid).toBe(102);
+    // (t_c, u_c) 绝不推进，保持原值
     expect(dec1.t).toBe(new Date('2026-08-01T09:00:00Z').getTime());
     expect(dec1.uid).toBe(10);
+    expect(dec1.uidValidity).toBe('17');
+  });
 
-    // 请求 2：以 page1.nextCursor 续扫
-    // 从 scanUid = 150 之后继续，扫描剩余候选 [600, 700]
-    // m3 (UID 600, 09:30) 的时间在 09:00 之后，必须成功送出（若像 R2 提前推进到 10:00 则会被漏掉）
-    const page2 = await listMessagesSince(
-      'victim@test.example',
-      page1.nextCursor!,
-      1,
-      'inbox',
-      { scanBudget: 2 },
+  test('回归测试 4：追平后再轮询只扫新 UID（scanUid 水位生效，不重扫历史）', async () => {
+    const m1 = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T10:00:00Z');
+
+    const m2 = inboxMessage(200, 'victim@test.example', 'victim@test.example');
+    m2.internalDate = new Date('2026-08-01T10:30:00Z');
+
+    fakeMessages = [m1, m2];
+    fetchedUidBatches = [];
+
+    // 游标已追平至 UID 200
+    const caughtUpCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 10,
+        uidValidity: 17,
+        scanUid: 200,
+      },
+      config.taskSigningSecret,
     );
-    expect(page2.messages.map((m) => m.id)).toEqual(['600']);
 
-    // 断言不重扫：检查 fake fetch 的所有批次，同一个 UID 绝不被重复 fetch
-    const allFetchedUids = fetchedUidBatches.flat();
-    expect(fetchedUidBatches).toEqual([[100, 150], [600, 700]]);
-    expect(new Set(allFetchedUids).size).toBe(allFetchedUids.length);
+    // 轮询 1：没有比 UID 200 更大的信，返回空且不发起 FETCH
+    const poll1 = await listMessagesSince('victim@test.example', caughtUpCursor, 10, 'inbox');
+    expect(poll1.messages).toEqual([]);
+    expect(poll1.nextCursor).toBeNull();
+    expect(fetchedUidBatches).toEqual([]);
+
+    // 新信件到来：UID 300
+    const m3 = inboxMessage(300, 'victim@test.example', 'victim@test.example');
+    m3.internalDate = new Date('2026-08-01T11:00:00Z');
+    fakeMessages.push(m3);
+
+    // 轮询 2：使用相同的 caughtUpCursor 轮询，只检视 UID 300，绝不重扫 100 和 200
+    const poll2 = await listMessagesSince('victim@test.example', caughtUpCursor, 10, 'inbox');
+    expect(poll2.messages.map((m) => m.id)).toEqual(['300']);
+    expect(poll2.nextCursor).toBeNull();
+    // 验证只 fetch 了 [300]
+    expect(fetchedUidBatches).toEqual([[300]]);
   });
 
   test('ZCode P2-2 回归：t=0（internalDate 与 envelope.date 皆缺）信件作为页尾时，nextCursor.t 被下限 clamp 到 cursor.t，不回退到更小时间', async () => {

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -59,7 +59,21 @@ class FakeImapFlow extends EventEmitter {
     await new Promise((resolve) => setTimeout(resolve, 20));
   }
 
-  async search() {
+  async search(query?: any) {
+    if (query?.since instanceof Date) {
+      const sinceMs = query.since.getTime();
+      return fakeMessages
+        .filter((m) => {
+          const t = m.internalDate instanceof Date
+            ? m.internalDate.getTime()
+            : m.envelope?.date instanceof Date
+              ? m.envelope.date.getTime()
+              : 0;
+          return t >= sinceMs;
+        })
+        .map((message) => message.uid)
+        .sort((a, b) => a - b);
+    }
     return fakeMessages.map((message) => message.uid).sort((a, b) => a - b);
   }
 
@@ -111,6 +125,7 @@ const {
 } = await import('../src/lib/imap.ts');
 const { config } = await import('../src/lib/config.ts');
 const {
+  decodeMailForwardCursor,
   encodeMailCursor,
   encodeMailForwardCursor,
 } = await import('../src/lib/mail-cursor.ts');
@@ -717,7 +732,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(await res.json()).toEqual({ messages: [], nextCursor: null });
   });
 
-  test('cursor 参数作为 since 的等价别名亦可正常工作', async () => {
+  test('P2-D: v1 列表路由已移除 cursor 别名，仅作为普通参数忽略，不触发前向翻页', async () => {
     const m1 = inboxMessage(20, 'victim@test.example', 'victim@test.example');
     m1.internalDate = new Date('2026-08-01T10:00:00Z');
     fakeMessages = [m1];
@@ -733,11 +748,190 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
       config.taskSigningSecret,
     );
 
+    // 传 cursor 而不传 since，不触发 since 追补，返回标准 listMessages 结果（无 nextCursor 字段）
     const res = await app.request(
       `/v1/messages?address=victim@test.example&cursor=${encodeURIComponent(cursor)}`,
     );
     expect(res.status).toBe(200);
     const json = (await res.json()) as any;
     expect(json.messages.map((m: any) => m.id)).toEqual(['20']);
+    expect(json.nextCursor).toBeUndefined();
+  });
+
+  test('P2-C: since 参数超过 2048 字符拒 → 400 invalid_request', async () => {
+    const tooLongSince = 'a'.repeat(2049);
+    const res = await app.request(
+      `/v1/messages?address=victim@test.example&since=${tooLongSince}`,
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe('invalid_request');
+  });
+
+  test('Codex P1 回归：非单调 internalDate 场景不丢信，严格按 (receivedAtMs, uid) 元组序遍历', async () => {
+    // 构造非单调场景：
+    // mCursor: UID 100, t=10:00:00
+    // m1 (UID 50,  t=11:00:00): 较小 UID 但较晚收信（如 IMAP COPY/APPEND 导致）
+    // m2 (UID 200, t=09:30:00): 较大 UID 但较早收信（元组小于游标，应被跳过）
+    // m3 (UID 150, t=12:00:00): 较晚收信
+    const mCursor = inboxMessage(100, 'victim@test.example', 'victim@test.example');
+    mCursor.internalDate = new Date('2026-08-01T10:00:00Z');
+
+    const m1 = inboxMessage(50, 'victim@test.example', 'victim@test.example');
+    m1.internalDate = new Date('2026-08-01T11:00:00Z');
+
+    const m2 = inboxMessage(200, 'victim@test.example', 'victim@test.example');
+    m2.internalDate = new Date('2026-08-01T09:30:00Z');
+
+    const m3 = inboxMessage(150, 'victim@test.example', 'victim@test.example');
+    m3.internalDate = new Date('2026-08-01T12:00:00Z');
+
+    fakeMessages = [mCursor, m1, m2, m3];
+
+    const cursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: mCursor.internalDate.getTime(),
+        uid: 100,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 逐页获取（limit=1）：严格按元组序前进，UID 50 绝不能因 50 < 100 被丢弃
+    // 第 1 页：应命中 m1 (UID 50, t=11:00)
+    const res1 = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(cursor)}&limit=1`,
+    );
+    expect(res1.status).toBe(200);
+    const body1 = (await res1.json()) as any;
+    expect(body1.messages.map((m: any) => m.id)).toEqual(['50']);
+    expect(body1.nextCursor).not.toBeNull();
+
+    // 第 2 页：应命中 m3 (UID 150, t=12:00)；所有信件均已返回完毕，nextCursor 为 null
+    const res2 = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(body1.nextCursor)}&limit=1`,
+    );
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as any;
+    expect(body2.messages.map((m: any) => m.id)).toEqual(['150']);
+    expect(body2.nextCursor).toBeNull();
+  });
+
+  test('ZCode P1 回归：扫描预算耗尽时 0 命中产出带 scanUid 续扫游标，后续分页不重扫最终可达每一封信', async () => {
+    // 构造跨越预算的大量邮件：前 6 封属于其他收件人，第 7、8 封属于 victim
+    const otherMsgs = Array.from({ length: 6 }, (_, i) => {
+      const m = inboxMessage(i + 1, 'other@test.example', 'other@test.example');
+      m.internalDate = new Date('2026-08-01T10:00:00Z');
+      return m;
+    });
+
+    const v1 = inboxMessage(7, 'victim@test.example', 'victim@test.example');
+    v1.internalDate = new Date('2026-08-01T10:15:00Z');
+
+    const v2 = inboxMessage(8, 'victim@test.example', 'victim@test.example');
+    v2.internalDate = new Date('2026-08-01T10:30:00Z');
+
+    fakeMessages = [...otherMsgs, v1, v2];
+
+    const initialCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 1, // u_c 为 1
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 采用自定义单次扫描预算 scanBudget = 3
+    // 第 1 批（扫 UID 1..3）：本身份 0 命中，预算耗尽，返回空列表 + scanUid=3 续扫游标
+    const page1 = await listMessagesSince(
+      'victim@test.example',
+      initialCursor,
+      10,
+      'inbox',
+      { scanBudget: 3 },
+    );
+    expect(page1.messages).toEqual([]);
+    expect(page1.nextCursor).not.toBeNull();
+    const decoded1 = decodeMailForwardCursor(page1.nextCursor!, config.taskSigningSecret);
+    expect(decoded1.scanUid).toBe(3);
+    expect(decoded1.uid).toBe(1); // 保持原始 u_c，不污染元组
+
+    // 第 2 批（扫 UID 4..6）：本身份仍 0 命中，从 scanUid=3 之后续扫，预算耗尽返回空列表 + scanUid=6 续扫游标
+    const page2 = await listMessagesSince(
+      'victim@test.example',
+      page1.nextCursor!,
+      10,
+      'inbox',
+      { scanBudget: 3 },
+    );
+    expect(page2.messages).toEqual([]);
+    expect(page2.nextCursor).not.toBeNull();
+    const decoded2 = decodeMailForwardCursor(page2.nextCursor!, config.taskSigningSecret);
+    expect(decoded2.scanUid).toBe(6);
+
+    // 第 3 批（扫 UID 7..8）：命中 victim 的两封邮件，且扫完全部候选集，分页结束 nextCursor 为 null
+    const page3 = await listMessagesSince(
+      'victim@test.example',
+      page2.nextCursor!,
+      10,
+      'inbox',
+      { scanBudget: 3 },
+    );
+    expect(page3.messages.map((m) => m.id)).toEqual(['7', '8']);
+    expect(page3.nextCursor).toBeNull();
+  });
+
+  test('端到端 550 封邮件在默认 500 预算下分批续扫无损到达', async () => {
+    // 构造 550 封信：前 520 封属于 other，后 30 封属于 victim
+    const msgs: any[] = [];
+    for (let i = 1; i <= 520; i++) {
+      const m = inboxMessage(i, 'other@test.example', 'other@test.example');
+      m.internalDate = new Date('2026-08-01T10:00:00Z');
+      msgs.push(m);
+    }
+    for (let i = 521; i <= 550; i++) {
+      const m = inboxMessage(i, 'victim@test.example', 'victim@test.example');
+      m.internalDate = new Date('2026-08-01T10:00:00Z');
+      msgs.push(m);
+    }
+    fakeMessages = msgs;
+
+    const startCursor = encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: 'victim@test.example',
+        t: new Date('2026-08-01T09:00:00Z').getTime(),
+        uid: 1,
+        uidValidity: 17,
+      },
+      config.taskSigningSecret,
+    );
+
+    // 请求 1（默认预算 500）：前 500 封全部为 other，返回 0 命中与 scanUid=500 续扫游标
+    const res1 = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(startCursor)}`,
+    );
+    expect(res1.status).toBe(200);
+    const body1 = (await res1.json()) as any;
+    expect(body1.messages).toEqual([]);
+    expect(body1.nextCursor).not.toBeNull();
+    const dec1 = decodeMailForwardCursor(body1.nextCursor, config.taskSigningSecret);
+    expect(dec1.scanUid).toBe(500);
+
+    // 请求 2：从 scanUid=500 继续，扫描剩余 50 封（UID 501..550），返回属于 victim 的 30 封信，全部完成 nextCursor 为 null
+    const res2 = await app.request(
+      `/v1/messages?address=victim@test.example&since=${encodeURIComponent(body1.nextCursor)}`,
+    );
+    expect(res2.status).toBe(200);
+    const body2 = (await res2.json()) as any;
+    expect(body2.messages.length).toBe(30);
+    expect(body2.messages[0].id).toBe('521');
+    expect(body2.messages[29].id).toBe('550');
+    expect(body2.nextCursor).toBeNull();
   });
 });

--- a/packages/api/test/mail-cursor.test.ts
+++ b/packages/api/test/mail-cursor.test.ts
@@ -140,7 +140,42 @@ describe('mail-cursor', () => {
       expect(() => decodeMailForwardCursor(forgedWithBadV('17'), KEY)).toThrow(
         InvalidMailCursorError,
       );
-      expect(() => decodeMailForwardCursor(forgedWithBadV(undefined), KEY)).toThrow(
+      // 非法 scanUid 格式（即使签名有效也要拒）
+      const forgedWithBadS = (s: unknown) => {
+        const body = Buffer.from(
+          JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: 17, s }),
+        ).toString('base64url');
+        return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.invalidmac`;
+      };
+      expect(() => decodeMailForwardCursor(forgedWithBadS(0), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(forgedWithBadS(-1), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(forgedWithBadS('500'), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+    });
+
+    test('带 scanUid 续扫游标往返编码与防篡改', () => {
+      const payload = {
+        folder: 'inbox' as const,
+        address: 'fox@test.example',
+        t: 1_752_000_000_000,
+        uid: 42,
+        uidValidity: 17,
+        scanUid: 500,
+      };
+      const token = encodeMailForwardCursor(payload, KEY);
+      expect(token.startsWith(`${MAIL_FORWARD_CURSOR_PREFIX}.`)).toBe(true);
+      expect(decodeMailForwardCursor(token, KEY)).toEqual(payload);
+
+      // 篡改 scanUid 签名失效拒
+      const parts = token.split('.');
+      const bodyObj = { f: 'inbox', a: 'fox@test.example', t: 1_752_000_000_000, u: 42, v: 17, s: 501 };
+      const tamperedBody = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
+      expect(() => decodeMailForwardCursor(`${parts[0]}.${tamperedBody}.${parts[2]}`, KEY)).toThrow(
         InvalidMailCursorError,
       );
     });

--- a/packages/api/test/mail-cursor.test.ts
+++ b/packages/api/test/mail-cursor.test.ts
@@ -206,5 +206,51 @@ describe('mail-cursor', () => {
       expect(decoded.t).toBe(payload.t);
       expect(decoded.uid).toBe(payload.uid);
     });
+
+    test('R5 CR Minor (Item C): encodeMailForwardCursor 签名前将 address 归一为小写，避免大小写混合 token 自毁', () => {
+      const payload = {
+        folder: 'inbox' as const,
+        address: 'Fox.Agent+Tag@Test.EXAMPLE',
+        t: 1_752_000_000_000,
+        uid: 42,
+        uidValidity: '17',
+        scanUid: 88,
+      };
+
+      const token = encodeMailForwardCursor(payload, KEY);
+      const decoded = decodeMailForwardCursor(token, KEY);
+
+      expect(decoded.address).toBe('fox.agent+tag@test.example');
+      expect(decoded.scanUid).toBe(88);
+      expect(decoded.uidValidity).toBe('17');
+    });
+
+    test('R5 ZCode P2-2 (Item E): decodeMailForwardCursor 严格校验 t 为非负整数（>=0 且 isInteger）', () => {
+      const basePayload = {
+        folder: 'inbox' as const,
+        address: 'fox@test.example',
+        t: 1_752_000_000_000,
+        uid: 42,
+        uidValidity: '17',
+      };
+      const validToken = encodeMailForwardCursor(basePayload, KEY);
+      const [prefix, , sig] = validToken.split('.');
+
+      // t = 0 合法
+      const tZeroToken = encodeMailForwardCursor({ ...basePayload, t: 0 }, KEY);
+      expect(decodeMailForwardCursor(tZeroToken, KEY).t).toBe(0);
+
+      // t 为小数（非整数）拒
+      const floatBody = Buffer.from(JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 1234.56, u: 42, v: '17' })).toString('base64url');
+      expect(() => decodeMailForwardCursor(`${prefix}.${floatBody}.${sig}`, KEY)).toThrow(InvalidMailCursorError);
+
+      // t 为负数拒
+      const negBody = Buffer.from(JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: -1, u: 42, v: '17' })).toString('base64url');
+      expect(() => decodeMailForwardCursor(`${prefix}.${negBody}.${sig}`, KEY)).toThrow(InvalidMailCursorError);
+
+      // t 为非数值拒
+      const strBody = Buffer.from(JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: '1752000000000', u: 42, v: '17' })).toString('base64url');
+      expect(() => decodeMailForwardCursor(`${prefix}.${strBody}.${sig}`, KEY)).toThrow(InvalidMailCursorError);
+    });
   });
 });

--- a/packages/api/test/mail-cursor.test.ts
+++ b/packages/api/test/mail-cursor.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from 'bun:test';
 import {
   MAIL_CURSOR_PREFIX,
+  MAIL_FORWARD_CURSOR_PREFIX,
   InvalidMailCursorError,
   decodeMailCursor,
+  decodeMailForwardCursor,
   encodeMailCursor,
+  encodeMailForwardCursor,
   isMailFolder,
 } from '../src/lib/mail-cursor.ts';
 
@@ -41,5 +44,105 @@ describe('mail-cursor', () => {
     expect(isMailFolder('all')).toBe(true);
     expect(isMailFolder('trash')).toBe(false);
     expect(isMailFolder('scheduled')).toBe(false);
+  });
+
+  describe('forward cursor (mail-fcursor-v1)', () => {
+    test('往返编码保持 folder/address/t/uid/uidValidity', () => {
+      const payload = {
+        folder: 'inbox' as const,
+        address: 'fox@test.example',
+        t: 1_752_000_000_000,
+        uid: 42,
+        uidValidity: 17,
+      };
+      const token = encodeMailForwardCursor(payload, KEY);
+      expect(token.startsWith(`${MAIL_FORWARD_CURSOR_PREFIX}.`)).toBe(true);
+      expect(decodeMailForwardCursor(token, KEY)).toEqual(payload);
+    });
+
+    test('后向与前向游标互不通用（域隔离）', () => {
+      const backwardToken = encodeMailCursor(
+        { folder: 'inbox', address: 'fox@test.example', t: 1000, uid: 10 },
+        KEY,
+      );
+      const forwardToken = encodeMailForwardCursor(
+        { folder: 'inbox', address: 'fox@test.example', t: 1000, uid: 10, uidValidity: 17 },
+        KEY,
+      );
+
+      // 前向解码器拒后向游标
+      expect(() => decodeMailForwardCursor(backwardToken, KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      // 后向解码器拒前向游标
+      expect(() => decodeMailCursor(forwardToken, KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+    });
+
+    test('前向游标篡改 HMAC、载荷或 key 一律失败', () => {
+      const payload = {
+        folder: 'inbox' as const,
+        address: 'fox@test.example',
+        t: 1_752_000_000_000,
+        uid: 42,
+        uidValidity: 17,
+      };
+      const token = encodeMailForwardCursor(payload, KEY);
+      const parts = token.split('.');
+
+      // 坏 MAC
+      expect(() => decodeMailForwardCursor(`${parts[0]}.${parts[1]}.aaaa`, KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      // 坏 key
+      expect(() => decodeMailForwardCursor(token, 'wrong-key')).toThrow(
+        InvalidMailCursorError,
+      );
+      // 非法 token
+      expect(() => decodeMailForwardCursor('not-a-token', KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(`${parts[0]}.badjson.${parts[2]}`, KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+
+      // 篡改载荷字段（HMAC 未重签必挂）
+      const tamperPayload = (mod: Record<string, unknown>) => {
+        const bodyObj = { f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: 17, ...mod };
+        const body = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
+        return `${parts[0]}.${body}.${parts[2]}`;
+      };
+      expect(() => decodeMailForwardCursor(tamperPayload({ v: 18 }), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(tamperPayload({ a: 'owl@test.example' }), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(tamperPayload({ f: 'sent' }), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+
+      // 非法 uidValidity 格式（即使签名有效也要拒）
+      const forgedWithBadV = (v: unknown) => {
+        const body = Buffer.from(
+          JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v }),
+        ).toString('base64url');
+        // 构造带有该 body 的 token
+        return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.invalidmac`;
+      };
+      expect(() => decodeMailForwardCursor(forgedWithBadV(0), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(forgedWithBadV(-1), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(forgedWithBadV('17'), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(forgedWithBadV(undefined), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+    });
   });
 });

--- a/packages/api/test/mail-cursor.test.ts
+++ b/packages/api/test/mail-cursor.test.ts
@@ -57,7 +57,10 @@ describe('mail-cursor', () => {
       };
       const token = encodeMailForwardCursor(payload, KEY);
       expect(token.startsWith(`${MAIL_FORWARD_CURSOR_PREFIX}.`)).toBe(true);
-      expect(decodeMailForwardCursor(token, KEY)).toEqual(payload);
+      expect(decodeMailForwardCursor(token, KEY)).toEqual({
+        ...payload,
+        uidValidity: '17',
+      });
     });
 
     test('后向与前向游标互不通用（域隔离）', () => {
@@ -109,11 +112,11 @@ describe('mail-cursor', () => {
 
       // 篡改载荷字段（HMAC 未重签必挂）
       const tamperPayload = (mod: Record<string, unknown>) => {
-        const bodyObj = { f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: 17, ...mod };
+        const bodyObj = { f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: '17', ...mod };
         const body = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
         return `${parts[0]}.${body}.${parts[2]}`;
       };
-      expect(() => decodeMailForwardCursor(tamperPayload({ v: 18 }), KEY)).toThrow(
+      expect(() => decodeMailForwardCursor(tamperPayload({ v: '18' }), KEY)).toThrow(
         InvalidMailCursorError,
       );
       expect(() => decodeMailForwardCursor(tamperPayload({ a: 'owl@test.example' }), KEY)).toThrow(
@@ -128,7 +131,6 @@ describe('mail-cursor', () => {
         const body = Buffer.from(
           JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v }),
         ).toString('base64url');
-        // 构造带有该 body 的 token
         return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.invalidmac`;
       };
       expect(() => decodeMailForwardCursor(forgedWithBadV(0), KEY)).toThrow(
@@ -137,19 +139,19 @@ describe('mail-cursor', () => {
       expect(() => decodeMailForwardCursor(forgedWithBadV(-1), KEY)).toThrow(
         InvalidMailCursorError,
       );
-      expect(() => decodeMailForwardCursor(forgedWithBadV('17'), KEY)).toThrow(
+      expect(() => decodeMailForwardCursor(forgedWithBadV('abc'), KEY)).toThrow(
+        InvalidMailCursorError,
+      );
+      expect(() => decodeMailForwardCursor(forgedWithBadV('0'), KEY)).toThrow(
         InvalidMailCursorError,
       );
       // 非法 scanUid 格式（即使签名有效也要拒）
       const forgedWithBadS = (s: unknown) => {
         const body = Buffer.from(
-          JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: 17, s }),
+          JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: '17', s }),
         ).toString('base64url');
         return `${MAIL_FORWARD_CURSOR_PREFIX}.${body}.invalidmac`;
       };
-      expect(() => decodeMailForwardCursor(forgedWithBadS(0), KEY)).toThrow(
-        InvalidMailCursorError,
-      );
       expect(() => decodeMailForwardCursor(forgedWithBadS(-1), KEY)).toThrow(
         InvalidMailCursorError,
       );
@@ -169,15 +171,40 @@ describe('mail-cursor', () => {
       };
       const token = encodeMailForwardCursor(payload, KEY);
       expect(token.startsWith(`${MAIL_FORWARD_CURSOR_PREFIX}.`)).toBe(true);
-      expect(decodeMailForwardCursor(token, KEY)).toEqual(payload);
+      expect(decodeMailForwardCursor(token, KEY)).toEqual({
+        ...payload,
+        uidValidity: '17',
+      });
 
       // 篡改 scanUid 签名失效拒
       const parts = token.split('.');
-      const bodyObj = { f: 'inbox', a: 'fox@test.example', t: 1_752_000_000_000, u: 42, v: 17, s: 501 };
+      const bodyObj = { f: 'inbox', a: 'fox@test.example', t: 1_752_000_000_000, u: 42, v: '17', s: 501 };
       const tamperedBody = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
       expect(() => decodeMailForwardCursor(`${parts[0]}.${tamperedBody}.${parts[2]}`, KEY)).toThrow(
         InvalidMailCursorError,
       );
+    });
+
+    test('回归测试 5 (ZCode P2-1): uidValidity > 2^53 的编解码往返一致，无 Number 精度损失', () => {
+      // 9007199254740993n 是 2^53 + 1；若用 Number(9007199254740993n) 会截断为 9007199254740992
+      const hugeUidValidity = 9007199254740993n;
+      const payload = {
+        folder: 'inbox' as const,
+        address: 'fox@test.example',
+        t: 1_752_000_000_000,
+        uid: 42,
+        uidValidity: hugeUidValidity,
+        scanUid: 123,
+      };
+
+      const token = encodeMailForwardCursor(payload, KEY);
+      const decoded = decodeMailForwardCursor(token, KEY);
+
+      expect(decoded.uidValidity).toBe('9007199254740993');
+      expect(BigInt(decoded.uidValidity)).toBe(hugeUidValidity);
+      expect(decoded.scanUid).toBe(123);
+      expect(decoded.t).toBe(payload.t);
+      expect(decoded.uid).toBe(payload.uid);
     });
   });
 });


### PR DESCRIPTION
## Summary
Implements RFC-0001 §15 PR 3 requirements:
- Adds forward `since` query capability to `GET /v1/messages` with signed forward cursor (`mail-fcursor-v1`).
- Binds `uidValidity` to forward cursor payload with cryptographic HMAC domain separation against backward cursor (`mail-cursor-v1`).
- Provides oldest-first lossless forward catch-up multi-page traversal.
- Fails closed on cursor mismatch (tampering, address mismatch, folder mismatch, direction mismatch, or stale `uidValidity`).
- Adds optional `uidValidity` integer query parameter to `GET /v1/messages/:id` (RFC-0001 §6.2, R63), returning `404 { error: 'stale_message_generation' }` on mismatch.
- Updates RFC-0001 Appendix A fetch summary line to include `?uidValidity=<data.uidValidity>`.

Part of #128

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added forward, cursor-based pagination for fetching messages since a specified point.
  * Added scan-budget support for large mailbox catch-up operations.
  * Added message-generation validation using the optional `uidValidity` parameter.
  * Added clear errors for invalid cursors and stale message generations.

* **Documentation**
  * Updated webhook guidance to include `uidValidity` when refetching message content.
  * Documented forward pagination ordering, cross-page delivery guarantees, cursor generation protection, and consumer-side sorting requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->