### PR TITLE
feat(api): outbound webhook subsystem (#128 PR4)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -22,6 +22,10 @@ The website docs are canonical — edit them in the [website repo](https://githu
 
 不做：DCR（`/oauth/register`）、OIDC discovery、admin 级 OAuth 票。
 
+## Outbound webhooks
+
+Pending retries are rebuilt from the delivery log on restart; events emitted while the process was down are not reconstructed (D7, the same weak-restart semantics as ntfy).
+
 ## Messages API (`GET /v1/messages`) 前向追补合同
 
 ### 排序与完整性契约

--- a/docs/rfcs/0001-outbound-webhooks.md
+++ b/docs/rfcs/0001-outbound-webhooks.md
@@ -1324,7 +1324,7 @@ be configured into a spin.
 
 Rescheduling is **bounded** — a `deferred` row still carries `nextAttemptAt` and is
 subject to the same 72-hour horizon, so backpressure delays delivery rather than creating an
-unbounded queue. This is the classification the first draft left empty.
+unbounded queue. If backpressure or pool saturation delays the attempt past the 72-hour horizon from `eventCreatedAt`, the attempt is terminated with dead-letter row `outcome: "permanent"` and `reason: "retry_horizon_exceeded"`. This is the classification the first draft left empty.
 
 `429` honours a consumer's `Retry-After` header when it is a sane integer
 (1 s … 1 h), clamped into the schedule; otherwise the normal backoff applies. Honoring
@@ -1597,6 +1597,8 @@ Each row records one delivery attempt:
   "uidValidity": 17,
   "rfc822MessageId": "<20260903122639.4821@mail.openagent.email>",
   "taskId": null,
+  "taskCreatedAt": null,
+  "expiresInSec": null,
   "eventCreatedAt": "2026-09-03T12:26:40.412Z",
   "attempt": 1,
   "outcome": "pending",
@@ -1608,7 +1610,7 @@ Each row records one delivery attempt:
 }
 ```
 
-Six of those fields exist because something breaks without them:
+Eight of those fields exist because something breaks without them:
 
 - **`runId`** (`run_0` for the original sequence, `run_1`, `run_2`, … for each manual
   redelivery) separates independent attempt sequences. Redelivery deliberately preserves the
@@ -1637,8 +1639,13 @@ Six of those fields exist because something breaks without them:
   silently dropped — losing exactly the human-paging event D1 put into v1 for. Per event type:
   `mail.received` populates `messageId` + `uidValidity` and leaves `taskId` null;
   `approval.requested` populates `taskId` and leaves both mail fields null.
+- **`taskCreatedAt`** and **`expiresInSec`** are persisted for `approval.requested` rows so that
+  boot reconstruction preserves the exact task creation instant and original relative expiration
+  rather than drifting timestamps or re-evaluating remaining seconds upon restart (Item 9).
 - **`rfc822MessageId`** is the message's RFC 822 `Message-ID` header when it has one, and
   exists solely to enable the cross-generation fallback in the reconstruction rules below.
+  It is bounded to at most 512 bytes (UTF-8); overlong values are treated as null and dead-lettered
+  upon generation rolls rather than persisting unbounded identifier bytes.
   Like `messageId` it is an identifier rather than content, so it does not weaken the
   no-payload rule. Null when the message had no such header, which is why that branch
   dead-letters instead of guessing.
@@ -2088,7 +2095,7 @@ bodies.
 | `POST` | `/v1/webhooks` | admin, or identity for own address — **never OAuth** (§10.4) | Create. `201` + `secret`. Accepts the same optional `Idempotency-Key` header as `rotate` (§12.2): a retry with a seen key returns the stored `201` response with `secret: null` plus the `id`, and does **not** create a second subscription. Without this, losing the `201` — a network drop, a client crash — left an identity caller with no recoverable key *and* made its natural retry consume another slot of the per-address cap (§8.7), so two lost responses could exhaust the cap with orphaned subscriptions. Recovery of the key itself is `GET …/secret` (§12.3). |
 | `GET` | `/v1/webhooks` | admin: all; identity: own address | `{webhooks:[…]}`. Never includes `secret`. |
 | `GET` | `/v1/webhooks/:id` | as above | Bare object incl. `state`, `lastDelivery`. |
-| `POST` | `/v1/webhooks/:id` | as above | Update `url` / `events` / `contentScope` / `description`. POST, not PUT/PATCH, matching `POST /v1/tasks/:id/state`. **A `url` change re-runs the full §9.5 static validation and §9.3 resolution check before persisting**, returning `invalid_webhook_url` or `webhook_target_forbidden` — not merely failing closed later at delivery time, which would let a forbidden URL sit in `webhooks.json` until something tried to connect to it. |
+| `POST` | `/v1/webhooks/:id` | as above | Update `url` / `events` / `contentScope` / `description`. POST, not PUT/PATCH, matching `POST /v1/tasks/:id/state`. **A `url` change re-runs the full §9.5 static validation and §9.3 resolution check before persisting**, returning `invalid_webhook_url` or `webhook_target_forbidden`. When `url` changes, `consecutiveFailures` is reset to 0, `state` transitions to `unverified` (except when manually `disabled`, which remains `disabled`), and a new asynchronous creation ping probe is fired to test the new target endpoint (Item 7). |
 | `GET` | `/v1/webhooks/:id/secret` | admin, or the identity that **created** it, `metadata` scope only (§10.4 Rule D, §12.3) | Re-display the current derived signing key. Audited as `webhook.reveal`. Possible only because D6 chose derivation. **Must return `Cache-Control: no-store`** (and no `ETag`): the body is long-lived key material, and a shared cache, browser history, or intermediary log retaining it would undo the entire secret-handling model. |
 | `DELETE` | `/v1/webhooks/:id` | admin, or the identity that **created** it and only at `metadata` scope (§10.4 Rules B + D) | Delete the subscription **and cancel its pending retries**, marking any not-yet-attempted rows `permanent` with reason `subscription_deleted` so the log still accounts for them. Precedent: `routes/notify.ts:228`. Identity deletion cascades the same way (§10.5). |
 | `POST` | `/v1/webhooks/:id/rotate` | admin, or the identity that **created** it and only at `metadata` scope (§10.4 Rules B + D) | Increment the derivation `epoch`; start the overlap window (§12.2). Returns the new `secret`. `409 rotation_window_open` if a window is already open, unless `force`. |
@@ -2097,6 +2104,11 @@ bodies.
 | `POST` | `/v1/webhooks/:id/enable` | admin | Clear `disabled` state, reset the counter (§8.5). |
 | `GET` | `/v1/webhooks/:id/deliveries` | admin | `{deliveries:[…], nextCursor}` — recent attempts and dead letters, from the JSONL log. |
 | `POST` | `/v1/webhooks/deliveries/:deliveryId/redeliver` | admin | Manual replay of one recorded delivery — **dead letter or success**, per decision **D15** (§17), following Resend's "replay both `failed` and `succeeded`". Enqueues a fresh attempt with a **new** `deliveryId`, the **same** event `id`, and a `replay: true` marker in the log row. Replaying a success re-sends an event the consumer already processed, so it leans on their `id` dedupe (§8.1); the marker exists so an operator reading the log can tell a replay from an original. |
+
+Create and update request validation rules:
+- `events`: must be a non-empty array of unique event types (`events.length >= 1`, duplicate entries rejected with `invalid_request`, Item 8).
+- `description`: optional human-readable string up to 1000 characters (`<= 1000 chars`, Item 4).
+- `contentScope`: `'metadata'` (default) or `'preview'` (admin-only).
 
 Create request:
 
@@ -2310,9 +2322,10 @@ takes and then discards is worse than one it refuses, since the operator's label
 vanishes on the next restart and multiple endpoints become indistinguishable.
 
 **Deleting an identity must cascade to its subscriptions.** `deleteIdentity()` today removes
-the identity and cascades OAuth grants (`identities.ts:381-388`), and this design adds webhook
-cleanup to that cascade: deleting an address removes or permanently disables **all**
-subscriptions owned by it and cancels their pending deliveries. Without this, subscriptions
+the identity and cascades OAuth grants (`identities.ts`), and this design adds webhook
+cleanup to that cascade: deleting an address hard-deletes **all** subscriptions owned by it
+from `webhooks.json`, writes a `webhook.delete` audit event for each, and cancels their pending retry
+attempts in `deliveryQueue` with reason `subscription_deleted` (Item 6). Without this, subscriptions
 keyed by address survive the identity, and if the same address is later recreated the old
 callback silently resumes receiving the *new* identity's mail — a durable exfiltration channel
 that outlives the credential it was created under, and one nobody would think to look for.
@@ -2400,9 +2413,10 @@ because it is a security event rather than a delivery outcome, and it is rare by
 it disables the endpoint immediately (§8.5), so it cannot recur at volume for one subscription.
 
 `webhook.ssrf_refused` is the one that matters for security review: it is the signal that
-someone tried to point OAE at an internal address. It carries `address` and `ip` (the
-*client* IP, via the existing `clientIp()` single implementation) and nothing about the
-target.
+someone tried to point OAE at an internal address. When triggered in the context of an HTTP request
+(such as `POST /v1/webhooks/:id/test`), it carries `address` and `ip` (client IP via `clientIp(c)`).
+For asynchronous background deliveries where there is no HTTP client context, `ip` is omitted (`null`/undefined, Item 3),
+and target internals are never leaked.
 
 ### 10.7 MCP surface parity
 

--- a/packages/api/scripts/verify-webhook-signature-vectors.py
+++ b/packages/api/scripts/verify-webhook-signature-vectors.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Independent Python 3 verifier for the public webhook signature v1 corpus (RFC-0001 §7, §12.1, §14 item 1).
+
+This intentionally uses only Python's standard library and never imports or
+executes the JavaScript production implementation. It checks the committed
+corpus against an independent HMAC-SHA256 calculation.
+"""
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import sys
+from pathlib import Path
+
+
+def derive_webhook_key(root_secret: str, webhook_id: str, epoch: int) -> str:
+    message = f"webhook-signing-v1\n{webhook_id}\n{epoch}".encode("utf-8")
+    raw_key = hmac.new(root_secret.encode("utf-8"), message, hashlib.sha256).digest()
+    return "whs_" + raw_key.hex()
+
+
+def compute_webhook_signature(displayed_secret: str, t: int, raw_body: str) -> str:
+    # §12.1: displayedSecret (68 ASCII bytes, including 'whs_' prefix) is the signing key
+    signing_key = displayed_secret.encode("utf-8")
+    signed_payload = f"{t}.{raw_body}".encode("utf-8")
+    return hmac.new(signing_key, signed_payload, hashlib.sha256).hexdigest()
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> None:
+    fixture_path = (
+        Path(__file__).resolve().parents[1]
+        / "test/fixtures/webhook-signature-vectors.v1.json"
+    )
+    fixture = json.loads(fixture_path.read_text(encoding="utf-8"))
+
+    require(
+        fixture.get("format") == "openagentemail.webhook-signature-vectors",
+        "fixture format",
+    )
+    require(fixture.get("version") == 1, "fixture version")
+    require(fixture.get("signatureScheme") == "v1", "signatureScheme")
+
+    vectors = fixture.get("vectors")
+    require(isinstance(vectors, list) and len(vectors) == 4, "vector count must be 4")
+
+    for v in vectors:
+        vid = v["id"]
+        root = v["rootSecret"]
+        whk_id = v["webhookId"]
+        epoch = v["epoch"]
+        t = v["timestampSec"]
+        raw_body = v["rawBody"]
+
+        # 1. Test key derivation
+        derived_secret = derive_webhook_key(root, whk_id, epoch)
+        require(
+            derived_secret == v["displayedSecret"],
+            f"{vid}: derived secret mismatch: {derived_secret} != {v['displayedSecret']}",
+        )
+
+        # 2. Test primary signature
+        expected_sig = v.get("expectedSignature") or v.get("expectedPrimarySignature")
+        sig = compute_webhook_signature(derived_secret, t, raw_body)
+        require(sig == expected_sig, f"{vid}: signature mismatch: {sig} != {expected_sig}")
+
+        # 3. If overlap vector, test previous epoch signature
+        if "previousEpoch" in v:
+            prev_derived = derive_webhook_key(root, whk_id, v["previousEpoch"])
+            require(
+                prev_derived == v["previousDisplayedSecret"],
+                f"{vid}: previous derived secret mismatch",
+            )
+            prev_sig = compute_webhook_signature(prev_derived, t, raw_body)
+            require(
+                prev_sig == v["expectedPreviousSignature"],
+                f"{vid}: previous signature mismatch",
+            )
+            expected_header = f"t={t},v1={sig},v1={prev_sig}"
+            require(
+                expected_header == v["expectedHeader"],
+                f"{vid}: expected header mismatch",
+            )
+        else:
+            expected_header = f"t={t},v1={sig}"
+            require(
+                expected_header == v["expectedHeader"],
+                f"{vid}: expected header mismatch",
+            )
+
+    print(f"verified {len(vectors)} public v1 webhook signature vectors with independent Python standard-library verification")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (AssertionError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+        print(f"webhook signature vector verification failed: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -19,6 +19,7 @@ import {
 import { getMcpLoopbackBase } from './lib/mcp-loopback.ts';
 import { registerMcpHttpRoutes } from './mcp/http.ts';
 import { auditRoute } from './routes/audit.ts';
+import { webhooksRoute } from './routes/webhooks.ts';
 import { identitiesRoute } from './routes/identities.ts';
 import { delegationsRoute } from './routes/delegations.ts';
 import { messagesRoute } from './routes/messages.ts';
@@ -118,6 +119,7 @@ export function createApp(options: AppOptions = {}): Hono {
       : tasksRoute,
   );
   app.route('/v1/audit', auditRoute);
+  app.route('/v1/webhooks', webhooksRoute);
 
   if (options.uiEnabled ?? config.uiEnabled) {
     const uiSessions = new UiSessionStore({

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -52,6 +52,8 @@ export type AuditEvent = {
   ip?: string;
   /** 变更后的 scope 集合（scrubbed 字符串数组）。 */
   scopes?: string[];
+  /** 关联的 Webhook 订阅 ID（RFC-0001 §10.6）。 */
+  webhookId?: string;
 };
 
 function auditPath(): string {
@@ -140,6 +142,9 @@ export function recordAuditEvent(
     ...(partial.ip !== undefined ? { ip: scrubAuditField(partial.ip, 64) } : {}),
     ...(partial.scopes !== undefined
       ? { scopes: partial.scopes.map((s) => scrubAuditField(s, 64)) }
+      : {}),
+    ...(partial.webhookId !== undefined
+      ? { webhookId: scrubAuditField(partial.webhookId, 64) }
       : {}),
   };
 

--- a/packages/api/src/lib/config.ts
+++ b/packages/api/src/lib/config.ts
@@ -7,6 +7,7 @@
 import { createHmac } from 'node:crypto';
 import { join } from 'node:path';
 import { z } from 'zod';
+import { JSON_BODY_LIMIT_BYTES } from './limits.ts';
 
 /**
  * Compose `${VAR:-}` injects "" when the var is unset. Treat empty/whitespace
@@ -170,8 +171,29 @@ const envSchema = z.object({
   // Notification transport. Docker Compose enables ntfy by default; keeping
   // the bare-process default off preserves the lightweight API test/runtime.
   NTFY_ENABLED: z.enum(['true', 'false']).default('false'),
-  // Outbound webhooks. Off by default (§10.1).
+  // Outbound webhooks (§10.1).
   WEBHOOKS_ENABLED: z.enum(['true', 'false']).default('false'),
+  WEBHOOK_SIGNING_SECRET: z.string().min(32).optional(),
+  WEBHOOK_SIGNING_SECRET_PREVIOUS: z.string().min(32).optional(),
+  WEBHOOK_ALLOW_PRIVATE_TARGETS: z.enum(['true', 'false']).default('false'),
+  WEBHOOK_ALLOWED_PORTS: z.string().default('443'),
+  WEBHOOK_MAX_SUBSCRIPTIONS: z.coerce.number().int().min(0).default(16),
+  WEBHOOK_MAX_PER_ADDRESS: z.coerce.number().int().min(0).default(4),
+  WEBHOOK_MAX_ATTEMPTS: z.coerce.number().int().min(1).max(11).default(11),
+  WEBHOOK_DELIVERY_TIMEOUT_MS: z.coerce.number().int().min(1000).default(10000),
+  WEBHOOK_MAX_CONCURRENT: z.coerce.number().int().min(1).default(8),
+  WEBHOOK_POOL_RETRY_MS: z.coerce.number().int().min(1000).default(5000),
+  WEBHOOK_PAYLOAD_MAX_BYTES: z.coerce.number().int().min(2048).default(16384),
+  WEBHOOK_APPROVAL_ARGS_MAX_BYTES: z.coerce.number().int().min(0).default(4096),
+  WEBHOOK_APPROVAL_ARGS_MAX_DEPTH: z.coerce.number().int().min(1).default(4),
+  WEBHOOK_RESPONSE_MAX_BYTES: z.coerce.number().int().min(1).default(4096),
+  WEBHOOK_TIMESTAMP_TOLERANCE_SEC: z.coerce.number().int().min(30).default(300),
+  WEBHOOK_DISABLE_THRESHOLD: z.coerce.number().int().min(1).default(10),
+  WEBHOOK_ROTATION_OVERLAP_MS: z.coerce.number().int().min(0).default(86400000),
+  WEBHOOK_LOG_RETENTION_DAYS: z.coerce.number().int().min(4).default(30),
+  WEBHOOK_RATE_CREATE_PER_MIN: z.coerce.number().int().min(0).default(10),
+  WEBHOOK_RATE_TEST_PER_MIN: z.coerce.number().int().min(0).default(3),
+  WEBHOOK_RATE_DELIVER_PER_MIN: z.coerce.number().int().min(0).default(60),
   NTFY_INTERNAL_URL: envUrl('http://ntfy'),
   // Path as seen by the ntfy container. The API writes the same named volume
   // at /app/data, so this must not be derived from DATA_DIR.
@@ -239,6 +261,22 @@ function splitCsv(value: string): string[] {
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
+}
+
+function parseAllowedPorts(rawPorts: string): number[] {
+  const parts = splitCsv(rawPorts);
+  if (parts.length === 0) {
+    throw new Error('WEBHOOK_ALLOWED_PORTS must be non-empty');
+  }
+  const ports: number[] = [];
+  for (const p of parts) {
+    const port = Number(p);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`WEBHOOK_ALLOWED_PORTS contains invalid port: "${p}"`);
+    }
+    ports.push(port);
+  }
+  return ports;
 }
 
 /**
@@ -335,6 +373,27 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
       );
     }
   }
+
+  if (raw.WEBHOOKS_ENABLED === 'true') {
+    const explicitTaskSecret = raw.TASK_SIGNING_SECRET;
+    if (!explicitTaskSecret) {
+      throw new Error('TASK_SIGNING_SECRET is required when WEBHOOKS_ENABLED is true');
+    }
+    if (explicitTaskSecret.length < 32) {
+      throw new Error(
+        'TASK_SIGNING_SECRET must be at least 32 characters when WEBHOOKS_ENABLED is true',
+      );
+    }
+  }
+
+  if (raw.WEBHOOK_PAYLOAD_MAX_BYTES > JSON_BODY_LIMIT_BYTES) {
+    throw new Error('WEBHOOK_PAYLOAD_MAX_BYTES must be <= JSON_BODY_LIMIT_BYTES');
+  }
+
+  const webhookAllowedPorts = parseAllowedPorts(raw.WEBHOOK_ALLOWED_PORTS);
+  const webhookAllowPrivateTargets =
+    raw.OAE_PUBLIC_EDGE === 'true' ? false : raw.WEBHOOK_ALLOW_PRIVATE_TARGETS === 'true';
+
   const taskSigningSecret = raw.TASK_SIGNING_SECRET ?? raw.SMTP_PASS;
 
   return {
@@ -386,6 +445,27 @@ export function parseConfig(env: NodeJS.ProcessEnv) {
     },
     webhooks: {
       enabled: raw.WEBHOOKS_ENABLED === 'true',
+      signingSecret: raw.WEBHOOK_SIGNING_SECRET,
+      signingSecretPrevious: raw.WEBHOOK_SIGNING_SECRET_PREVIOUS,
+      allowPrivateTargets: webhookAllowPrivateTargets,
+      allowedPorts: webhookAllowedPorts,
+      maxSubscriptions: raw.WEBHOOK_MAX_SUBSCRIPTIONS,
+      maxPerAddress: raw.WEBHOOK_MAX_PER_ADDRESS,
+      maxAttempts: raw.WEBHOOK_MAX_ATTEMPTS,
+      deliveryTimeoutMs: raw.WEBHOOK_DELIVERY_TIMEOUT_MS,
+      maxConcurrent: raw.WEBHOOK_MAX_CONCURRENT,
+      poolRetryMs: raw.WEBHOOK_POOL_RETRY_MS,
+      payloadMaxBytes: raw.WEBHOOK_PAYLOAD_MAX_BYTES,
+      approvalArgsMaxBytes: raw.WEBHOOK_APPROVAL_ARGS_MAX_BYTES,
+      approvalArgsMaxDepth: raw.WEBHOOK_APPROVAL_ARGS_MAX_DEPTH,
+      responseMaxBytes: raw.WEBHOOK_RESPONSE_MAX_BYTES,
+      timestampToleranceSec: raw.WEBHOOK_TIMESTAMP_TOLERANCE_SEC,
+      disableThreshold: raw.WEBHOOK_DISABLE_THRESHOLD,
+      rotationOverlapMs: raw.WEBHOOK_ROTATION_OVERLAP_MS,
+      logRetentionDays: raw.WEBHOOK_LOG_RETENTION_DAYS,
+      rateCreatePerMin: raw.WEBHOOK_RATE_CREATE_PER_MIN,
+      rateTestPerMin: raw.WEBHOOK_RATE_TEST_PER_MIN,
+      rateDeliverPerMin: raw.WEBHOOK_RATE_DELIVER_PER_MIN,
     },
     dashboardPublicUrl: raw.DASHBOARD_PUBLIC_URL
       ? normalizeUrl(raw.DASHBOARD_PUBLIC_URL)

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -29,6 +29,9 @@ import {
   revokeDelegationsForAddress,
   revokeDelegationsOnGranteeTokenRotate,
 } from './delegations.ts';
+import { cascadeDeleteWebhooksForAddress } from './webhook-store.ts';
+import { deliveryQueue } from './webhook-delivery.ts';
+import { recordAuditEvent } from './audit.ts';
 
 /** Mail-arrival push content detail. 1 = interrupt only (default), 2 = +subject/from, 3 = +body preview/OTP. */
 export type PushContentTier = 1 | 2 | 3;
@@ -480,6 +483,16 @@ export function deleteIdentity(address: string): boolean {
   if (kept.length === identities.length) return false;
   revokeDelegationsForAddress(needle);
   revokeGrantsForAddress(needle);
+  const deletedWebhooks = cascadeDeleteWebhooksForAddress(needle);
+  for (const wh of deletedWebhooks) {
+    deliveryQueue.cancelForWebhook(wh.id, 'subscription_deleted');
+    recordAuditEvent({
+      event: 'webhook.delete',
+      outcome: 'ok',
+      address: needle,
+      webhookId: wh.id,
+    });
+  }
   save(kept);
   return true;
 }

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -30,8 +30,14 @@ import {
   revokeDelegationsOnGranteeTokenRotate,
 } from './delegations.ts';
 import { cascadeDeleteWebhooksForAddress } from './webhook-store.ts';
-import { deliveryQueue } from './webhook-delivery.ts';
 import { recordAuditEvent } from './audit.ts';
+
+export type WebhookCancelCallback = (webhookId: string, reason: string) => void;
+let webhookCancelCallback: WebhookCancelCallback | undefined;
+
+export function registerWebhookCancelCallback(cb: WebhookCancelCallback): void {
+  webhookCancelCallback = cb;
+}
 
 /** Mail-arrival push content detail. 1 = interrupt only (default), 2 = +subject/from, 3 = +body preview/OTP. */
 export type PushContentTier = 1 | 2 | 3;
@@ -485,7 +491,9 @@ export function deleteIdentity(address: string): boolean {
   revokeGrantsForAddress(needle);
   const deletedWebhooks = cascadeDeleteWebhooksForAddress(needle);
   for (const wh of deletedWebhooks) {
-    deliveryQueue.cancelForWebhook(wh.id, 'subscription_deleted');
+    if (webhookCancelCallback) {
+      webhookCancelCallback(wh.id, 'subscription_deleted');
+    }
     recordAuditEvent({
       event: 'webhook.delete',
       outcome: 'ok',

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -487,9 +487,9 @@ export function deleteIdentity(address: string): boolean {
   const needle = address.toLowerCase();
   const kept = identities.filter((i) => i.address !== needle);
   if (kept.length === identities.length) return false;
-  revokeDelegationsForAddress(needle);
-  revokeGrantsForAddress(needle);
-  save(kept);
+  // Webhook cascade first (delete + cancel in-flight + audit). Identity save
+  // after that: a failed identity write is retryable, a live subscription after
+  // the identity is gone is an exfil channel (§10.5).
   const deletedWebhooks = cascadeDeleteWebhooksForAddress(needle);
   for (const wh of deletedWebhooks) {
     if (webhookCancelCallback) {
@@ -502,6 +502,9 @@ export function deleteIdentity(address: string): boolean {
       webhookId: wh.id,
     });
   }
+  revokeDelegationsForAddress(needle);
+  revokeGrantsForAddress(needle);
+  save(kept);
   return true;
 }
 

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -489,6 +489,7 @@ export function deleteIdentity(address: string): boolean {
   if (kept.length === identities.length) return false;
   revokeDelegationsForAddress(needle);
   revokeGrantsForAddress(needle);
+  save(kept);
   const deletedWebhooks = cascadeDeleteWebhooksForAddress(needle);
   for (const wh of deletedWebhooks) {
     if (webhookCancelCallback) {
@@ -501,7 +502,6 @@ export function deleteIdentity(address: string): boolean {
       webhookId: wh.id,
     });
   }
-  save(kept);
   return true;
 }
 

--- a/packages/api/src/lib/notification-watcher.ts
+++ b/packages/api/src/lib/notification-watcher.ts
@@ -50,6 +50,7 @@ import {
   type SinkWatermark,
   type WatchedMessage,
 } from './event-dispatcher.ts';
+import { createWebhookSink } from './webhook-sink.ts';
 
 export type { WatchedMessage } from './event-dispatcher.ts';
 
@@ -1816,9 +1817,11 @@ export function startNotificationWatcher(cfg = config): () => void {
   if (!watcherAbort) {
     watcherAbort = new AbortController();
     const dispatcher = getEventDispatcher();
-    // webhook sink 随 PR 4 注册；PR 2 中 WEBHOOKS_ENABLED 仅作启动门输入
     if (!dispatcher.getSink('ntfy')) {
       dispatcher.registerSink(createNtfySink());
+    }
+    if (!dispatcher.getSink('webhook')) {
+      dispatcher.registerSink(createWebhookSink());
     }
     void runWatcher(watcherAbort.signal, dispatcher);
   }

--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -1424,7 +1424,7 @@ async function findTaskMessages(id: string): Promise<TaskLookupResult> {
 
 /** Raw durable/queued snapshot. Lock-holding writers must use this rather
  * than public getTask(), whose approval read path may itself materialize. */
-async function getTaskSnapshot(id: string): Promise<Task | null> {
+export async function getTaskSnapshot(id: string): Promise<Task | null> {
   if (!isTaskId(id)) return null;
   let raw: Task | null;
   let hadMatchingRows: boolean;
@@ -1468,7 +1468,7 @@ function validateParentChain(snapshot: Task[], parentTaskId: string, childId: st
   for (let depth = 0; current; depth += 1) {
     if (current.id === childId || seen.has(current.id)) throw new Error('parent_task_invalid_chain');
     seen.add(current.id);
-    const next = current.parentTaskId;
+    const next: string | undefined = current.parentTaskId;
     if (next === undefined) return;
     if (!isTaskId(next) || seen.size >= PARENT_CHAIN_MAX) throw new Error('parent_task_invalid_chain');
     current = byId.get(next) ?? null;

--- a/packages/api/src/lib/tool-tiers.ts
+++ b/packages/api/src/lib/tool-tiers.ts
@@ -31,15 +31,19 @@ export const TOOL_TIER_SPEC = {
   mail_read_message: 'read',
   mail_wait_for: 'read',
   mail_list_identities: 'read',
+  mail_webhook_list: 'read',
   notify_check: 'read',
   task_list: 'read',
   task_get: 'read',
   task_list_children: 'read',
   // minimal
   mail_mark_seen: 'minimal',
+  mail_webhook_delete: 'minimal',
+  mail_webhook_disable: 'minimal',
   task_create: 'minimal',
   // contained
   mail_send: 'contained',
+  mail_webhook_test: 'contained',
   task_update: 'contained',
   task_decide: 'contained',
   task_claim: 'contained',
@@ -49,6 +53,7 @@ export const TOOL_TIER_SPEC = {
   notify_user: 'contained',
   // critical：OAuth deny-by-default
   mail_new_identity: 'critical',
+  mail_webhook_create: 'critical',
   notify_verify: 'critical',
 } as const satisfies Record<string, ToolTier>;
 

--- a/packages/api/src/lib/utf8-truncate.ts
+++ b/packages/api/src/lib/utf8-truncate.ts
@@ -25,3 +25,11 @@ export function truncateUtf8Bytes(buf: Buffer, maxBytes: number): Buffer {
   }
   return buf.subarray(0, maxBytes);
 }
+
+/** Truncate to at most `maxChars` Unicode code points (`[...str]`). */
+export function truncateUtf8Codepoints(str: string, maxChars: number): string {
+  if (maxChars <= 0) return '';
+  const units = [...str];
+  if (units.length <= maxChars) return str;
+  return units.slice(0, maxChars).join('');
+}

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -466,19 +466,29 @@ export function readDeliveryLogRows(options?: {
   return { deliveries: paged, nextCursor };
 }
 
+/** Latest attempt per webhook from an already-read log (one parse per request). */
+export function latestDeliveryByWebhookId(
+  rows: WebhookDeliveryLogRow[],
+): Map<string, WebhookDeliveryLogRow> {
+  const latest = new Map<string, WebhookDeliveryLogRow>();
+  for (const row of rows) {
+    const prev = latest.get(row.webhookId);
+    if (!prev) {
+      latest.set(row.webhookId, row);
+      continue;
+    }
+    const ts = new Date(row.ts).getTime();
+    const prevTs = new Date(prev.ts).getTime();
+    if (ts > prevTs || (ts === prevTs && row.attempt > prev.attempt)) {
+      latest.set(row.webhookId, row);
+    }
+  }
+  return latest;
+}
+
 /** Returns the latest delivery attempt for an endpoint, if any. */
 export function getLatestDeliveryForWebhook(webhookId: string): WebhookDeliveryLogRow | null {
-  const rows = readAllDeliveryLogRows().filter((r) => r.webhookId === webhookId);
-  if (rows.length === 0) return null;
-
-  rows.sort((a, b) => {
-    const tA = new Date(a.ts).getTime();
-    const tB = new Date(b.ts).getTime();
-    if (tA !== tB) return tB - tA;
-    return b.attempt - a.attempt;
-  });
-
-  return rows[0] ?? null;
+  return latestDeliveryByWebhookId(readAllDeliveryLogRows()).get(webhookId) ?? null;
 }
 
 /**
@@ -535,7 +545,7 @@ export function compactDeliveryLog(
     let offset = 0;
     while (offset < buf.length) {
       const written = writeSync(fd, buf, offset, buf.length - offset);
-      if (written <= 0) break;
+      if (written <= 0) throw new Error('short_write');
       offset += written;
     }
     fsyncSync(fd);
@@ -1147,6 +1157,7 @@ class WebhookDeliveryLimiter {
   private testProbeLimiters = new Map<string, number[]>();
   private createLimiters = new Map<string, number[]>();
   private rotateLimiters = new Map<string, number[]>();
+  private readLimiters = new Map<string, number[]>();
 
   getActiveTotal(): number {
     return this.activeTotal;
@@ -1229,6 +1240,17 @@ class WebhookDeliveryLimiter {
     );
   }
 
+  /** Independent GET bucket, sized like create. */
+  checkReadRate(tokenKey: string, now = Date.now()): { allowed: boolean; retryAfterSec: number } {
+    return slidingWindowCheck(
+      this.readLimiters,
+      tokenKey,
+      config.webhooks.rateCreatePerMin,
+      60_000,
+      now,
+    );
+  }
+
   reset(): void {
     this.activePerEndpoint.clear();
     this.activeTotal = 0;
@@ -1236,6 +1258,7 @@ class WebhookDeliveryLimiter {
     this.testProbeLimiters.clear();
     this.createLimiters.clear();
     this.rotateLimiters.clear();
+    this.readLimiters.clear();
   }
 }
 

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -1,0 +1,2303 @@
+/**
+ * Outbound Webhook Delivery Engine (RFC-0001 §6, §8, §9, §10, §12).
+ *
+ * Coordinates durable JSONL logging, SSRF pinning, sliding-window rate limiting,
+ * per-endpoint and instance-wide concurrency pools, 11-attempt 72h retry backoff,
+ * circuit breaker disablement, payload bounding, derived HMAC signing,
+ * and boot reconstruction.
+ */
+
+import { randomUUID } from 'node:crypto';
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { isIP } from 'node:net';
+import { join } from 'node:path';
+import { config } from './config.ts';
+import { recordAuditEvent } from './audit.ts';
+import {
+  defaultDnsLookup,
+  pinnedFetch,
+  type DnsLookup,
+  type PinnedFetchOptions,
+} from './pinned-fetch.ts';
+import {
+  isBlockedSsrfIp,
+  isPrivateOrLoopbackHostname,
+  isSsrfBlockedResolvedIp,
+} from './net.ts';
+import { slidingWindowCheck, slidingWindowRelease } from './ratelimit.ts';
+import {
+  buildWebhookSignatureHeader,
+  deriveWebhookKey,
+} from './webhook-signing.ts';
+import {
+  getWebhookSubscription,
+  listWebhookSubscriptions,
+  updateWebhookSubscription,
+  type WebhookSubscription,
+  type WebhookState,
+} from './webhook-store.ts';
+import { encodeMailForwardCursor } from './mail-cursor.ts';
+import { truncateUtf8Bytes } from './utf8-truncate.ts';
+
+export function truncateUtf8String(str: string, maxBytes: number): string {
+  const buf = Buffer.from(str, 'utf8');
+  if (buf.byteLength <= maxBytes) return str;
+  return truncateUtf8Bytes(buf, maxBytes).toString('utf8');
+}
+
+import { getMessage, withInbox } from './imap.ts';
+import { getTaskSnapshot } from './tasks-internal.ts';
+import { notificationService } from './notify.ts';
+
+let customDnsLookupForTests: DnsLookup | undefined;
+export function setWebhookDnsLookupForTests(fn?: DnsLookup): void {
+  customDnsLookupForTests = fn;
+}
+
+// ---------------------------------------------------------------------------
+// Types and Schemas
+// ---------------------------------------------------------------------------
+
+export type WebhookEventType = 'mail.received' | 'approval.requested' | 'webhook.ping';
+
+export type WebhookDeliveryOutcome =
+  | 'pending'
+  | 'success'
+  | 'retryable'
+  | 'permanent'
+  | 'refused'
+  | 'deferred';
+
+export type WebhookDeliveryLogRow = {
+  ts: string;
+  webhookId: string;
+  eventId: string;
+  runId: string;
+  deliveryId: string;
+  type: WebhookEventType;
+  address: string | null;
+  messageId: string | null;
+  uidValidity: number | null;
+  rfc822MessageId: string | null;
+  taskId: string | null;
+  taskCreatedAt: string | null;
+  expiresInSec: number | null;
+  taskExpiresInSec?: number | null;
+  eventCreatedAt: string;
+  attempt: number;
+  outcome: WebhookDeliveryOutcome;
+  status: number | null;
+  durationMs: number | null;
+  sensitive: boolean;
+  replay: boolean;
+  nextAttemptAt: string | null;
+  reason?: string | null;
+};
+
+export type WebhookEnvelopeBase = {
+  id: string; // evt_<uuid>
+  type: WebhookEventType;
+  payloadVersion: 'v1';
+  createdAt: string; // ISO RFC 3339
+  domain: string;
+};
+
+export type MailEventInput = {
+  address: string;
+  messageId: string;
+  uid: number;
+  uidValidity: number;
+  receivedAt: string;
+  rfc822MessageId?: string | null;
+  from: { address: string; name?: string };
+  to: string[];
+  cc: string[];
+  subject: string;
+  sizeBytes: number;
+  hasAttachments: boolean;
+  unread: boolean;
+  containsSecurityCode: boolean;
+  containsLink: boolean;
+  textPreview?: string;
+  securityCodes?: string[];
+  links?: string[];
+};
+
+export type ApprovalEventInput = {
+  taskId: string;
+  taskState: 'input-required';
+  from: string;
+  to: string;
+  reviewer: string;
+  subject: string;
+  createdAt: string;
+  expiresAt: string;
+  expiresInSec: number | null;
+  digest: string;
+  actionType: string;
+  actionName: string;
+  actionArguments?: unknown;
+};
+
+// ---------------------------------------------------------------------------
+// Retry Schedule (§8.3)
+// ---------------------------------------------------------------------------
+
+export const WEBHOOK_META_FIELD_MAX_BYTES = 400;
+export const WEBHOOK_BODY_PREVIEW_CHARS = 280;
+export const WEBHOOK_MAX_CODE_ITEMS = 5;
+export const WEBHOOK_CODE_ENTRY_CHARS = 200;
+
+/** Cumulative offsets in seconds from the first attempt (11 attempts spanning 72 hours). */
+export const RETRY_SCHEDULE_OFFSETS_SEC = [
+  0,        // 1: immediate
+  5,        // 2: +5s
+  300,      // 3: +5m
+  1800,     // 4: +30m
+  7200,     // 5: +2h
+  18000,    // 6: +5h
+  36000,    // 7: +10h
+  72000,    // 8: +20h
+  122400,   // 9: +34h
+  172800,   // 10: +48h
+  259200,   // 11: +72h (pinned)
+] as const;
+
+export const MAX_RETRY_SCHEDULE_ATTEMPTS = 11;
+export const MAX_PING_ATTEMPTS = 3;
+export const RETRY_HORIZON_SEC = 259200; // 72 hours in seconds
+
+/**
+ * Calculates next attempt scheduled time with ±10% non-cumulative gap jitter (§8.3).
+ * Attempt 11 is pinned to exactly +72h.
+ * Returns null if attempts exhausted.
+ */
+export function calculateNextAttemptTime(
+  currentAttempt: number,
+  firstAttemptTimeMs: number,
+  options?: {
+    isPing?: boolean;
+    retryAfterSec?: number;
+    maxAttempts?: number;
+    randomFn?: () => number;
+  },
+): number | null {
+  const nextAttempt = currentAttempt + 1;
+  const isPing = options?.isPing ?? false;
+  const maxAttempts = Math.min(
+    options?.maxAttempts ?? config.webhooks.maxAttempts,
+    isPing ? MAX_PING_ATTEMPTS : MAX_RETRY_SCHEDULE_ATTEMPTS,
+  );
+
+  if (nextAttempt > maxAttempts) {
+    return null;
+  }
+
+  const rand = options?.randomFn ?? Math.random;
+
+  // Attempt 1 is always immediate (offset 0)
+  if (nextAttempt === 1) {
+    return firstAttemptTimeMs;
+  }
+
+  const idx = nextAttempt - 1;
+
+  // Attempt 11 is pinned to exactly +72h unjittered (§8.3)
+  if (nextAttempt === 11) {
+    return firstAttemptTimeMs + RETRY_SCHEDULE_OFFSETS_SEC[10]! * 1000;
+  }
+
+  // If a sane Retry-After header was received on 429 (1s..3600s), clamp into schedule (§8.2)
+  if (
+    options?.retryAfterSec !== undefined &&
+    Number.isInteger(options.retryAfterSec) &&
+    options.retryAfterSec >= 1 &&
+    options.retryAfterSec <= 3600
+  ) {
+    const baseOffsetSec = RETRY_SCHEDULE_OFFSETS_SEC[idx]!;
+    const scheduledOffsetSec = Math.max(
+      RETRY_SCHEDULE_OFFSETS_SEC[idx - 1]! + options.retryAfterSec,
+      baseOffsetSec,
+    );
+    return firstAttemptTimeMs + scheduledOffsetSec * 1000;
+  }
+
+  const prevOffset = RETRY_SCHEDULE_OFFSETS_SEC[idx - 1]!;
+  const currOffset = RETRY_SCHEDULE_OFFSETS_SEC[idx]!;
+  const gap = currOffset - prevOffset;
+
+  // Jitter shifts each attempt by up to ±10% of its own gap
+  const jitterFraction = rand() * 0.2 - 0.1; // [-0.1, +0.1]
+  const jitterSec = gap * jitterFraction;
+
+  let computedOffset = currOffset + jitterSec;
+  // Clamped so offsets stay strictly monotonically increasing and under 72h
+  if (computedOffset <= prevOffset) {
+    computedOffset = prevOffset + 1;
+  }
+  if (computedOffset >= RETRY_HORIZON_SEC) {
+    computedOffset = RETRY_HORIZON_SEC - 1;
+  }
+
+  return firstAttemptTimeMs + Math.round(computedOffset * 1000);
+}
+
+// ---------------------------------------------------------------------------
+// Durable Log Persistence (webhook-deliveries.jsonl)
+// ---------------------------------------------------------------------------
+
+function deliveryLogPath(): string {
+  return join(config.dataDir, 'webhook-deliveries.jsonl');
+}
+
+function ensureDataDir(): void {
+  mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(config.dataDir, 0o700);
+  } catch {
+    // best-effort
+  }
+}
+
+/** Append a single row to DATA_DIR/webhook-deliveries.jsonl (0600 mode). */
+export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
+  ensureDataDir();
+  const path = deliveryLogPath();
+
+  // Normalize row fields, ensuring forbidden keys or arbitrary payload never land in log
+  const sanitizedRow: WebhookDeliveryLogRow = {
+    ts: row.ts,
+    webhookId: row.webhookId,
+    eventId: row.eventId,
+    runId: row.runId,
+    deliveryId: row.deliveryId,
+    type: row.type,
+    address: row.address,
+    messageId: row.messageId,
+    uidValidity: row.uidValidity,
+    rfc822MessageId: row.rfc822MessageId,
+    taskId: row.taskId,
+    taskCreatedAt: row.taskCreatedAt ?? null,
+    expiresInSec: row.expiresInSec ?? row.taskExpiresInSec ?? null,
+    taskExpiresInSec: row.taskExpiresInSec ?? row.expiresInSec ?? null,
+    eventCreatedAt: row.eventCreatedAt,
+    attempt: row.attempt,
+    outcome: row.outcome,
+    status: row.status,
+    durationMs: row.durationMs,
+    sensitive: row.sensitive,
+    replay: row.replay,
+    nextAttemptAt: row.nextAttemptAt,
+    reason: row.reason ?? null,
+  };
+
+  const line = `${JSON.stringify(sanitizedRow)}\n`;
+  if (!existsSync(path)) {
+    writeFileSync(path, line, { mode: 0o600 });
+    try {
+      chmodSync(path, 0o600);
+    } catch {
+      // best effort
+    }
+  } else {
+    appendFileSync(path, line);
+  }
+}
+
+/** Reads all delivery log rows from disk, failing closed if corrupt. */
+export function readAllDeliveryLogRows(): WebhookDeliveryLogRow[] {
+  const path = deliveryLogPath();
+  if (!existsSync(path)) return [];
+
+  const content = readFileSync(path, 'utf8');
+  const lines = content.split('\n');
+  const rows: WebhookDeliveryLogRow[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    try {
+      const parsed = JSON.parse(line);
+      rows.push(parsed);
+    } catch {
+      throw new Error(`Corrupted delivery log at line ${i + 1}`);
+    }
+  }
+
+  return rows;
+}
+
+/**
+ * Filtered reader for GET /v1/webhooks/:id/deliveries.
+ * Returns newest rows first.
+ */
+export function readDeliveryLogRows(options?: {
+  webhookId?: string;
+  limit?: number;
+  cursor?: string;
+}): { deliveries: WebhookDeliveryLogRow[]; nextCursor?: string } {
+  const all = readAllDeliveryLogRows();
+  let filtered = options?.webhookId
+    ? all.filter((r) => r.webhookId === options.webhookId)
+    : all;
+
+  // Sort newest first by ts, tie-break by attempt desc
+  filtered.sort((a, b) => {
+    const tA = new Date(a.ts).getTime();
+    const tB = new Date(b.ts).getTime();
+    if (tA !== tB) return tB - tA;
+    return b.attempt - a.attempt;
+  });
+
+  const limit = Math.min(Math.max(1, options?.limit ?? 20), 100);
+  let startIndex = 0;
+
+  if (options?.cursor) {
+    const idx = filtered.findIndex((r) => r.deliveryId === options.cursor);
+    if (idx >= 0) {
+      startIndex = idx + 1;
+    }
+  }
+
+  const paged = filtered.slice(startIndex, startIndex + limit);
+  const nextItem = filtered[startIndex + limit];
+  const nextCursor = nextItem ? nextItem.deliveryId : undefined;
+
+  return { deliveries: paged, nextCursor };
+}
+
+/** Returns the latest delivery attempt for an endpoint, if any. */
+export function getLatestDeliveryForWebhook(webhookId: string): WebhookDeliveryLogRow | null {
+  const rows = readAllDeliveryLogRows().filter((r) => r.webhookId === webhookId);
+  if (rows.length === 0) return null;
+
+  rows.sort((a, b) => {
+    const tA = new Date(a.ts).getTime();
+    const tB = new Date(b.ts).getTime();
+    if (tA !== tB) return tB - tA;
+    return b.attempt - a.attempt;
+  });
+
+  return rows[0] ?? null;
+}
+
+/**
+ * Compaction: prune rows older than retention days, preserving pending sequences.
+ */
+export function compactDeliveryLog(
+  now = Date.now(),
+  retentionDays = config.webhooks.logRetentionDays,
+): void {
+  const path = deliveryLogPath();
+  if (!existsSync(path)) return;
+
+  const rows = readAllDeliveryLogRows();
+  const retentionCutoff = now - retentionDays * 86400000;
+
+  // Identify groups with pending retries so we never prune them
+  const groups = new Map<string, WebhookDeliveryLogRow[]>();
+  for (const row of rows) {
+    const key = `${row.webhookId}:${row.eventId}:${row.runId}`;
+    let list = groups.get(key);
+    if (!list) {
+      list = [];
+      groups.set(key, list);
+    }
+    list.push(row);
+  }
+
+  const activeGroupKeys = new Set<string>();
+  for (const [key, groupRows] of groups.entries()) {
+    groupRows.sort((a, b) => {
+      if (a.attempt !== b.attempt) return b.attempt - a.attempt;
+      return new Date(b.ts).getTime() - new Date(a.ts).getTime();
+    });
+    const latest = groupRows[0]!;
+    const isFinal =
+      latest.outcome === 'success' ||
+      latest.outcome === 'permanent' ||
+      latest.outcome === 'refused' ||
+      (latest.outcome === 'retryable' && latest.attempt >= MAX_RETRY_SCHEDULE_ATTEMPTS);
+    if (!isFinal) {
+      activeGroupKeys.add(key);
+    }
+  }
+
+  const retainedRows = rows.filter((row) => {
+    const key = `${row.webhookId}:${row.eventId}:${row.runId}`;
+    if (activeGroupKeys.has(key)) return true;
+    return new Date(row.ts).getTime() > retentionCutoff;
+  });
+
+  if (retainedRows.length === rows.length) return;
+
+  const tmpPath = `${path}.tmp.${Date.now()}`;
+  const lines = retainedRows.map((r) => JSON.stringify(r)).join('\n') + (retainedRows.length ? '\n' : '');
+  writeFileSync(tmpPath, lines, { mode: 0o600 });
+  renameSync(tmpPath, path);
+}
+
+// ---------------------------------------------------------------------------
+// URL Validation (§9.3, §9.5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Static validation of webhook URL before persistence (§9.5).
+ */
+export function validateWebhookUrlStatic(
+  urlStr: string,
+  opts?: {
+    allowPrivateTargets?: boolean;
+    allowedPorts?: number[];
+  },
+): { valid: true; parsedUrl: URL } | { valid: false; code: 'invalid_webhook_url'; error: string } {
+  let url: URL;
+  try {
+    url = new URL(urlStr);
+  } catch {
+    return { valid: false, code: 'invalid_webhook_url', error: 'malformed_url' };
+  }
+
+  const allowPrivate = opts?.allowPrivateTargets ?? config.webhooks.allowPrivateTargets;
+
+  // Protocol: https required; http permitted only when allowPrivateTargets is true
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+    return { valid: false, code: 'invalid_webhook_url', error: 'unsupported_protocol' };
+  }
+  if (url.protocol === 'http:' && !allowPrivate) {
+    return { valid: false, code: 'invalid_webhook_url', error: 'http_requires_private_targets' };
+  }
+
+  // No userinfo
+  if (url.username || url.password) {
+    return { valid: false, code: 'invalid_webhook_url', error: 'userinfo_forbidden' };
+  }
+
+  // No query string
+  if (url.search) {
+    return { valid: false, code: 'invalid_webhook_url', error: 'query_string_forbidden' };
+  }
+
+  // No fragment
+  if (url.hash) {
+    return { valid: false, code: 'invalid_webhook_url', error: 'fragment_forbidden' };
+  }
+
+  // Port in WEBHOOK_ALLOWED_PORTS
+  const port = url.port
+    ? Number(url.port)
+    : url.protocol === 'https:'
+      ? 443
+      : 80;
+  const configuredPorts = opts?.allowedPorts ?? config.webhooks.allowedPorts;
+  const allowedPorts =
+    opts?.allowedPorts ??
+    (allowPrivate && url.protocol === 'http:' && !configuredPorts.includes(80)
+      ? [...configuredPorts, 80]
+      : configuredPorts);
+  if (!allowedPorts.includes(port)) {
+    return { valid: false, code: 'invalid_webhook_url', error: 'port_not_allowed' };
+  }
+
+  // Hostname must be a DNS name, not an IP literal unless allowPrivateTargets
+  const literal = url.hostname.replace(/^\[(.+)\]$/, '$1');
+  if (isIP(literal) !== 0 && !allowPrivate) {
+    return { valid: false, code: 'invalid_webhook_url', error: 'ip_literal_forbidden' };
+  }
+
+  return { valid: true, parsedUrl: url };
+}
+
+/**
+ * Resolution validation of webhook URL before persistence or on update (§9.3, §9.5, §10.4 Rule C).
+ */
+export async function validateWebhookUrlResolution(
+  urlStr: string,
+  opts: {
+    allowPrivateTargets: boolean;
+    dnsLookup?: DnsLookup;
+    allowedPorts?: number[];
+  },
+): Promise<
+  | { valid: true; isPrivateTarget: boolean; parsedUrl: URL }
+  | { valid: false; code: 'invalid_webhook_url' | 'webhook_target_forbidden'; error: string }
+> {
+  const staticRes = validateWebhookUrlStatic(urlStr, {
+    allowPrivateTargets: opts.allowPrivateTargets,
+    allowedPorts: opts.allowedPorts,
+  });
+  if (!staticRes.valid) return staticRes;
+
+  const url = staticRes.parsedUrl;
+  const literal = url.hostname.replace(/^\[(.+)\]$/, '$1');
+  const isIpLiteral = isIP(literal) !== 0;
+  const dnsLookup = opts.dnsLookup ?? customDnsLookupForTests ?? defaultDnsLookup;
+
+  const publicEdge = !opts.allowPrivateTargets || config.oaePublicEdge;
+
+  let resolvedAddresses: string[] = [];
+
+  if (isIpLiteral) {
+    resolvedAddresses = [literal];
+  } else {
+    try {
+      const list = await dnsLookup(literal);
+      if (list.length === 0) {
+        return { valid: false, code: 'invalid_webhook_url', error: 'dns_empty' };
+      }
+      resolvedAddresses = list.map((r) => r.address);
+    } catch {
+      return { valid: false, code: 'invalid_webhook_url', error: 'dns_lookup_failed' };
+    }
+  }
+
+  // 1. Check always-blocked SSRF
+  for (const ip of resolvedAddresses) {
+    if (isBlockedSsrfIp(ip)) {
+      return { valid: false, code: 'webhook_target_forbidden', error: 'ssrf_blocked_ip' };
+    }
+    if (isSsrfBlockedResolvedIp(ip, { publicEdge })) {
+      return { valid: false, code: 'webhook_target_forbidden', error: 'ssrf_blocked_ip' };
+    }
+  }
+
+  // 2. If scheme is http, additionally require that every address resolves private (§9.3 step 5)
+  if (url.protocol === 'http:') {
+    const allPrivate = resolvedAddresses.every((ip) => isPrivateOrLoopbackHostname(ip));
+    if (!allPrivate) {
+      return {
+        valid: false,
+        code: 'webhook_target_forbidden',
+        error: 'http_target_must_be_private',
+      };
+    }
+  }
+
+  const isPrivateTarget = resolvedAddresses.some((ip) => isPrivateOrLoopbackHostname(ip));
+  return { valid: true, isPrivateTarget, parsedUrl: url };
+}
+
+// ---------------------------------------------------------------------------
+// Payload Formatting and Bounding (§6.1 – §6.6)
+// ---------------------------------------------------------------------------
+
+function getJsonDepth(val: unknown, current = 1): number {
+  if (val === null || typeof val !== 'object') return current;
+  let max = current;
+  if (Array.isArray(val)) {
+    for (const item of val) {
+      max = Math.max(max, getJsonDepth(item, current + 1));
+    }
+  } else {
+    for (const key of Object.keys(val as Record<string, unknown>)) {
+      max = Math.max(max, getJsonDepth((val as Record<string, unknown>)[key], current + 1));
+    }
+  }
+  return max;
+}
+
+export function formatMailPayload(
+  sub: WebhookSubscription,
+  envelope: WebhookEnvelopeBase,
+  input: MailEventInput,
+): { body: string; sensitive: boolean } {
+  const sensitive = sub.contentScope === 'preview';
+  const isPreview = sub.contentScope === 'preview';
+
+  // Base data object
+  const data: Record<string, unknown> = {
+    object: 'mail',
+    address: input.address,
+    messageId: input.messageId,
+    cursor: encodeMailForwardCursor(
+      {
+        folder: 'inbox',
+        address: input.address,
+        t: new Date(input.receivedAt).getTime(),
+        uid: input.uid,
+        uidValidity: String(input.uidValidity),
+      },
+      config.taskSigningSecret,
+    ),
+    uid: input.uid,
+    uidValidity: input.uidValidity,
+    receivedAt: input.receivedAt,
+    from: {
+      address: truncateUtf8String(
+        input.from.address,
+        (config.webhooks as any)?.metaFieldMaxBytes ?? WEBHOOK_META_FIELD_MAX_BYTES,
+      ),
+      ...(input.from.name
+        ? {
+            name: truncateUtf8String(
+              input.from.name,
+              (config.webhooks as any)?.metaFieldMaxBytes ?? WEBHOOK_META_FIELD_MAX_BYTES,
+            ),
+          }
+        : {}),
+    },
+    to: input.to.map((a) =>
+      truncateUtf8String(
+        a,
+        (config.webhooks as any)?.metaFieldMaxBytes ?? WEBHOOK_META_FIELD_MAX_BYTES,
+      ),
+    ),
+    cc: input.cc.map((a) =>
+      truncateUtf8String(
+        a,
+        (config.webhooks as any)?.metaFieldMaxBytes ?? WEBHOOK_META_FIELD_MAX_BYTES,
+      ),
+    ),
+    subject: truncateUtf8String(
+      input.subject,
+      (config.webhooks as any)?.metaFieldMaxBytes ?? WEBHOOK_META_FIELD_MAX_BYTES,
+    ),
+    sizeBytes: input.sizeBytes,
+    hasAttachments: input.hasAttachments,
+    unread: input.unread,
+    containsSecurityCode: input.containsSecurityCode,
+    containsLink: input.containsLink,
+  };
+
+  if (isPreview) {
+    if (input.textPreview !== undefined) {
+      data.textPreview = truncateUtf8String(
+        input.textPreview,
+        (config.webhooks as any)?.bodyPreviewChars ?? WEBHOOK_BODY_PREVIEW_CHARS,
+      );
+    }
+    if (input.securityCodes !== undefined) {
+      data.securityCodes = input.securityCodes
+        .slice(0, (config.webhooks as any)?.maxCodeItems ?? WEBHOOK_MAX_CODE_ITEMS)
+        .map((c) =>
+          truncateUtf8String(
+            c,
+            (config.webhooks as any)?.codeEntryChars ?? WEBHOOK_CODE_ENTRY_CHARS,
+          ),
+        );
+    }
+    if (input.links !== undefined) {
+      // Over-long links (> webhookCodeEntryChars) are dropped whole, never truncated (§6.2, §6.6)
+      const codeChars = (config.webhooks as any)?.codeEntryChars ?? WEBHOOK_CODE_ENTRY_CHARS;
+      data.links = input.links
+        .filter((l) => Buffer.byteLength(l, 'utf8') <= codeChars)
+        .slice(0, (config.webhooks as any)?.maxCodeItems ?? WEBHOOK_MAX_CODE_ITEMS);
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    ...envelope,
+    data,
+  };
+
+  const fits = () =>
+    Buffer.byteLength(JSON.stringify(payload), 'utf8') <= config.webhooks.payloadMaxBytes;
+  if (fits()) {
+    return { body: JSON.stringify(payload), sensitive };
+  }
+
+  // Overflow drop order (§6.6):
+  // 1. preview scope: links -> securityCodes -> textPreview
+  if (isPreview) {
+    if (data.links !== undefined) {
+      delete data.links;
+      if (fits()) return { body: JSON.stringify(payload), sensitive };
+    }
+    if (data.securityCodes !== undefined) {
+      delete data.securityCodes;
+      if (fits()) return { body: JSON.stringify(payload), sensitive };
+    }
+    if (data.textPreview !== undefined) {
+      delete data.textPreview;
+      if (fits()) return { body: JSON.stringify(payload), sensitive };
+    }
+  }
+
+  // 2. both scopes: cc -> to -> subject -> from.name
+  if (Array.isArray(data.cc) && (data.cc as unknown[]).length > 0) {
+    data.cc = [];
+    if (fits()) return { body: JSON.stringify(payload), sensitive };
+  }
+  if (Array.isArray(data.to) && (data.to as unknown[]).length > 0) {
+    data.to = [];
+    if (fits()) return { body: JSON.stringify(payload), sensitive };
+  }
+  if (typeof data.subject === 'string' && data.subject.length > 0) {
+    data.subject = '';
+    if (fits()) return { body: JSON.stringify(payload), sensitive };
+  }
+  const fromObj = data.from as { address: string; name?: string } | undefined;
+  if (fromObj && fromObj.name !== undefined) {
+    delete fromObj.name;
+    if (fits()) return { body: JSON.stringify(payload), sensitive };
+  }
+
+  // If still does not fit, delivery fails closed (§6.6)
+  throw new Error('payload_too_large');
+}
+
+export function formatApprovalPayload(
+  sub: WebhookSubscription,
+  envelope: WebhookEnvelopeBase,
+  input: ApprovalEventInput,
+): { body: string; sensitive: boolean } {
+  const sensitive = sub.contentScope === 'preview';
+  const isPreview = sub.contentScope === 'preview';
+
+  const metaFieldMaxBytes =
+    (config.webhooks as any)?.metaFieldMaxBytes ?? WEBHOOK_META_FIELD_MAX_BYTES;
+
+  const data: Record<string, unknown> = {
+    object: 'approval',
+    taskId: input.taskId,
+    taskState: 'input-required',
+    from: truncateUtf8String(input.from, metaFieldMaxBytes),
+    to: truncateUtf8String(input.to, metaFieldMaxBytes),
+    reviewer: truncateUtf8String(input.reviewer, metaFieldMaxBytes),
+    subject: truncateUtf8String(input.subject, metaFieldMaxBytes),
+    createdAt: input.createdAt,
+    expiresAt: input.expiresAt,
+    expiresInSec: input.expiresInSec,
+    digest: input.digest,
+    actionType: input.actionType,
+    actionName: truncateUtf8String(input.actionName, metaFieldMaxBytes),
+  };
+
+  if (isPreview && input.actionArguments !== undefined) {
+    const depth = getJsonDepth(input.actionArguments);
+    if (
+      depth <= config.webhooks.approvalArgsMaxDepth &&
+      config.webhooks.approvalArgsMaxBytes > 0
+    ) {
+      try {
+        const serialized = JSON.stringify(input.actionArguments);
+        if (Buffer.byteLength(serialized, 'utf8') <= config.webhooks.approvalArgsMaxBytes) {
+          data.actionArguments = input.actionArguments;
+        }
+      } catch {
+        // drop if serializing throws
+      }
+    }
+  }
+
+  const payload: Record<string, unknown> = {
+    ...envelope,
+    data,
+  };
+
+  const fits = () =>
+    Buffer.byteLength(JSON.stringify(payload), 'utf8') <= config.webhooks.payloadMaxBytes;
+  if (fits()) {
+    return { body: JSON.stringify(payload), sensitive };
+  }
+
+  // Overflow drop order (§6.6 for approval.requested):
+  // 1. preview scope: actionArguments first (dropped whole)
+  if (isPreview && data.actionArguments !== undefined) {
+    delete data.actionArguments;
+    if (fits()) return { body: JSON.stringify(payload), sensitive };
+  }
+
+  // 2. both scopes: subject
+  if (typeof data.subject === 'string' && data.subject.length > 0) {
+    data.subject = '';
+    if (fits()) return { body: JSON.stringify(payload), sensitive };
+  }
+
+  // If still does not fit, fail closed
+  throw new Error('payload_too_large');
+}
+
+export function formatPingPayload(
+  envelope: WebhookEnvelopeBase,
+  webhookId: string,
+  trigger: 'creation' | 'test',
+): { body: string; sensitive: boolean } {
+  const payload = {
+    ...envelope,
+    data: {
+      object: 'ping',
+      webhookId,
+      trigger,
+    },
+  };
+  return { body: JSON.stringify(payload), sensitive: false };
+}
+
+// ---------------------------------------------------------------------------
+// Egress & Pinned Fetch Wrapper (§9.1, §9.3)
+// ---------------------------------------------------------------------------
+
+export type WebhookFetchResult = {
+  status: number | null;
+  outcome: WebhookDeliveryOutcome;
+  durationMs: number;
+  reason: string | null;
+};
+
+/**
+ * Executes a single delivery attempt against the target URL with SSRF pinning.
+ */
+export async function executeWebhookAttempt(
+  subscription: WebhookSubscription,
+  rawBody: string,
+  eventType: WebhookEventType,
+  deliveryId: string,
+  options?: {
+    dnsLookup?: DnsLookup;
+    overrideUrl?: string;
+  },
+): Promise<WebhookFetchResult> {
+  const start = Date.now();
+  const targetUrl = options?.overrideUrl ?? subscription.url;
+  const url = new URL(targetUrl);
+
+  const t = Math.floor(Date.now() / 1000);
+  const signatureResult = buildWebhookSignatureHeader({
+    rootSecret: config.webhooks.signingSecret || config.taskSigningSecret,
+    previousRootSecret: config.webhooks.signingSecretPrevious,
+    webhookId: subscription.id,
+    epoch: subscription.epoch,
+    overlapUntil: subscription.overlapUntil,
+    timestampSec: t,
+    rawBody,
+  });
+
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+    'User-Agent': 'openagentemail-webhooks/1',
+    'X-OAE-Event': eventType,
+    'X-OAE-Delivery': deliveryId,
+    'X-OAE-Signature': signatureResult.headerValue,
+  };
+
+  // Rule C: private targets require both global escape hatch and per-subscription grant (§10.4 Rule C)
+  const isPrivateTargetAllowed =
+    config.webhooks.allowPrivateTargets &&
+    !config.oaePublicEdge &&
+    subscription.privateTargetGranted === true;
+
+  // SSRF publicEdge option: true when private targets are blocked for this delivery
+  const publicEdge = !isPrivateTargetAllowed;
+
+  // Custom DNS lookup to enforce §9.3 step 5 for http targets
+  const baseDnsLookup = options?.dnsLookup ?? customDnsLookupForTests ?? defaultDnsLookup;
+  const deliveryDnsLookup: DnsLookup = async (hostname) => {
+    const list = await baseDnsLookup(hostname);
+    if (url.protocol === 'http:') {
+      for (const r of list) {
+        if (!isPrivateOrLoopbackHostname(r.address)) {
+          throw Object.assign(new Error('ssrf_blocked_ip'), { code: 'EACCES' });
+        }
+      }
+    }
+    return list;
+  };
+
+  // Pre-check for IP literal on http targets
+  const literal = url.hostname.replace(/^\[(.+)\]$/, '$1');
+  if (isIP(literal) !== 0 && url.protocol === 'http:' && !isPrivateOrLoopbackHostname(literal)) {
+    const durationMs = Date.now() - start;
+    return { status: null, outcome: 'refused', durationMs, reason: 'ssrf_refused' };
+  }
+
+  const fetchOpts: PinnedFetchOptions = {
+    method: 'POST',
+    headers,
+    body: rawBody,
+    maxBytes: config.webhooks.responseMaxBytes,
+    timeoutMs: config.webhooks.deliveryTimeoutMs,
+    deadlineMs: config.webhooks.deliveryTimeoutMs,
+    dnsLookup: deliveryDnsLookup,
+    ssrfOptions: { publicEdge },
+  };
+
+  try {
+    const response = await pinnedFetch(targetUrl, fetchOpts);
+    const durationMs = Date.now() - start;
+    const status = response.status;
+
+    if (status >= 200 && status < 300) {
+      return { status, outcome: 'success', durationMs, reason: null };
+    }
+
+    if (status >= 300 && status < 400) {
+      // 3xx redirects are permanent failures (§8.2, §9.4)
+      return { status, outcome: 'permanent', durationMs, reason: 'redirect_forbidden' };
+    }
+
+    if (status === 408 || status === 429 || status >= 500) {
+      let retryAfter: number | undefined;
+      const retryHeader = response.headers.get('retry-after');
+      if (retryHeader) {
+        const parsedSec = Number.parseInt(retryHeader, 10);
+        if (Number.isInteger(parsedSec) && parsedSec >= 1 && parsedSec <= 3600) {
+          retryAfter = parsedSec;
+        }
+      }
+      return {
+        status,
+        outcome: 'retryable',
+        durationMs,
+        reason: status === 429 ? (retryAfter ? `rate_limited_retry_after_${retryAfter}` : 'rate_limited') : 'server_error',
+      };
+    }
+
+    // Any other 4xx is permanent
+    return { status, outcome: 'permanent', durationMs, reason: `http_${status}` };
+  } catch (err: any) {
+    const durationMs = Date.now() - start;
+    const msg = err instanceof Error ? err.message : String(err);
+
+    if (msg === 'ssrf_blocked_ip') {
+      return { status: null, outcome: 'refused', durationMs, reason: 'ssrf_refused' };
+    }
+    if (msg === 'redirect_forbidden') {
+      return { status: null, outcome: 'permanent', durationMs, reason: 'redirect_forbidden' };
+    }
+    if (msg === 'timeout' || msg === 'deadline_exceeded') {
+      return { status: null, outcome: 'retryable', durationMs, reason: 'timeout' };
+    }
+    if (msg === 'response_too_large') {
+      return { status: null, outcome: 'permanent', durationMs, reason: 'response_too_large' };
+    }
+    if (err?.code === 'ENOTFOUND' || msg === 'dns_empty') {
+      return { status: null, outcome: 'retryable', durationMs, reason: 'dns_error' };
+    }
+    if (err?.code === 'ECONNREFUSED') {
+      return { status: null, outcome: 'retryable', durationMs, reason: 'connection_refused' };
+    }
+    if (err?.code?.startsWith?.('ERR_TLS_') || msg.includes('SSL') || msg.includes('TLS')) {
+      return { status: null, outcome: 'retryable', durationMs, reason: 'tls_error' };
+    }
+
+    return { status: null, outcome: 'retryable', durationMs, reason: msg || 'network_error' };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rate Limiting & Concurrency Manager (§8.7)
+// ---------------------------------------------------------------------------
+
+class WebhookDeliveryLimiter {
+  private activePerEndpoint = new Set<string>();
+  private activeTotal = 0;
+  private deliverLimiters = new Map<string, number[]>();
+  private testProbeLimiters = new Map<string, number[]>();
+  private createLimiters = new Map<string, number[]>();
+
+  getActiveTotal(): number {
+    return this.activeTotal;
+  }
+
+  isEndpointActive(webhookId: string): boolean {
+    return this.activePerEndpoint.has(webhookId);
+  }
+
+  acquireSlot(webhookId: string): boolean {
+    if (this.activeTotal >= config.webhooks.maxConcurrent) {
+      return false;
+    }
+    if (this.activePerEndpoint.has(webhookId)) {
+      return false;
+    }
+    this.activePerEndpoint.add(webhookId);
+    this.activeTotal++;
+    return true;
+  }
+
+  releaseSlot(webhookId: string): void {
+    if (this.activePerEndpoint.delete(webhookId)) {
+      this.activeTotal = Math.max(0, this.activeTotal - 1);
+    }
+  }
+
+  checkDeliverRate(webhookId: string, now = Date.now()): { allowed: boolean; retryAfterSec: number } {
+    return slidingWindowCheck(
+      this.deliverLimiters,
+      webhookId,
+      config.webhooks.rateDeliverPerMin,
+      60_000,
+      now,
+    );
+  }
+
+  checkTestProbeRate(tokenKey: string, now = Date.now()): { allowed: boolean; retryAfterSec: number } {
+    return slidingWindowCheck(
+      this.testProbeLimiters,
+      tokenKey,
+      config.webhooks.rateTestPerMin,
+      60_000,
+      now,
+    );
+  }
+
+  checkCreateRate(tokenKey: string, now = Date.now()): { allowed: boolean; retryAfterSec: number } {
+    return slidingWindowCheck(
+      this.createLimiters,
+      tokenKey,
+      config.webhooks.rateCreatePerMin,
+      60_000,
+      now,
+    );
+  }
+
+  reset(): void {
+    this.activePerEndpoint.clear();
+    this.activeTotal = 0;
+    this.deliverLimiters.clear();
+    this.testProbeLimiters.clear();
+    this.createLimiters.clear();
+  }
+}
+
+export const deliveryLimiter = new WebhookDeliveryLimiter();
+
+// ---------------------------------------------------------------------------
+// Delivery Task & Queue Engine
+// ---------------------------------------------------------------------------
+
+export type ScheduledDeliveryJob = {
+  webhookId: string;
+  eventId: string;
+  runId: string;
+  type: WebhookEventType;
+  payloadBuilder: () => { body: string; sensitive: boolean };
+  firstAttemptAt: number;
+  attempt: number;
+  nextAttemptAt: number;
+  replay: boolean;
+  address: string | null;
+  messageId: string | null;
+  uidValidity: number | null;
+  rfc822MessageId: string | null;
+  taskId: string | null;
+  taskCreatedAt: string | null;
+  expiresInSec: number | null;
+  eventCreatedAt: string;
+};
+
+class WebhookDeliveryQueue {
+  private activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  private jobs = new Map<string, ScheduledDeliveryJob>();
+
+  private jobKey(webhookId: string, eventId: string, runId: string): string {
+    return `${webhookId}:${eventId}:${runId}`;
+  }
+
+  schedule(job: ScheduledDeliveryJob): void {
+    const key = this.jobKey(job.webhookId, job.eventId, job.runId);
+    this.clearTimer(key);
+    this.jobs.set(key, job);
+
+    const now = Date.now();
+    const delay = Math.max(0, job.nextAttemptAt - now);
+
+    const timer = setTimeout(() => {
+      this.activeTimers.delete(key);
+      void this.executeJob(key);
+    }, delay);
+
+    if (typeof timer.unref === 'function') {
+      timer.unref();
+    }
+    this.activeTimers.set(key, timer);
+  }
+
+  cancelForWebhook(webhookId: string, reason: string): void {
+    for (const [key, job] of this.jobs.entries()) {
+      if (job.webhookId === webhookId) {
+        this.clearTimer(key);
+        this.jobs.delete(key);
+
+        // Record dead-letter row in log for pending attempt
+        appendDeliveryLogRow({
+          ts: new Date().toISOString(),
+          webhookId: job.webhookId,
+          eventId: job.eventId,
+          runId: job.runId,
+          deliveryId: `dlv_${randomUUID()}`,
+          type: job.type,
+          address: job.address,
+          messageId: job.messageId,
+          uidValidity: job.uidValidity,
+          rfc822MessageId: job.rfc822MessageId,
+          taskId: job.taskId,
+          taskCreatedAt: job.taskCreatedAt,
+          expiresInSec: job.expiresInSec,
+          eventCreatedAt: job.eventCreatedAt,
+          attempt: job.attempt,
+          outcome: 'permanent',
+          status: null,
+          durationMs: null,
+          sensitive: false,
+          replay: job.replay,
+          nextAttemptAt: null,
+          reason,
+        });
+      }
+    }
+  }
+
+  cancelAll(): void {
+    for (const timer of this.activeTimers.values()) {
+      clearTimeout(timer);
+    }
+    this.activeTimers.clear();
+    this.jobs.clear();
+  }
+
+  private clearTimer(key: string): void {
+    const t = this.activeTimers.get(key);
+    if (t) {
+      clearTimeout(t);
+      this.activeTimers.delete(key);
+    }
+  }
+
+  private async executeJob(key: string): Promise<void> {
+    const job = this.jobs.get(key);
+    if (!job) return;
+
+    const sub = getWebhookSubscription(job.webhookId);
+    if (!sub || sub.state === 'disabled') {
+      this.jobs.delete(key);
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: job.webhookId,
+        eventId: job.eventId,
+        runId: job.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: job.type,
+        address: job.address,
+        messageId: job.messageId,
+        uidValidity: job.uidValidity,
+        rfc822MessageId: job.rfc822MessageId,
+        taskId: job.taskId,
+        taskCreatedAt: job.taskCreatedAt,
+        expiresInSec: job.expiresInSec,
+        eventCreatedAt: job.eventCreatedAt,
+        attempt: job.attempt,
+        outcome: 'permanent',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: job.replay,
+        nextAttemptAt: null,
+        reason: !sub ? 'subscription_deleted' : 'webhook_disabled',
+      });
+      return;
+    }
+
+    const now = Date.now();
+
+    // Check item 2: 72h horizon check for job
+    if (now > job.firstAttemptAt + RETRY_HORIZON_SEC * 1000) {
+      this.jobs.delete(key);
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: job.webhookId,
+        eventId: job.eventId,
+        runId: job.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: job.type,
+        address: job.address,
+        messageId: job.messageId,
+        uidValidity: job.uidValidity,
+        rfc822MessageId: job.rfc822MessageId,
+        taskId: job.taskId,
+        taskCreatedAt: job.taskCreatedAt,
+        expiresInSec: job.expiresInSec,
+        eventCreatedAt: job.eventCreatedAt,
+        attempt: job.attempt,
+        outcome: 'permanent',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: job.replay,
+        nextAttemptAt: null,
+        reason: 'retry_horizon_exceeded',
+      });
+      return;
+    }
+
+    // 1. Check endpoint concurrency & global concurrency pool (§8.7)
+    if (!deliveryLimiter.acquireSlot(job.webhookId)) {
+      // Pool saturated or endpoint busy: defer! (§8.2)
+      const isPoolFull = deliveryLimiter.getActiveTotal() >= config.webhooks.maxConcurrent;
+      const rescheduleAt = now + (isPoolFull ? config.webhooks.poolRetryMs : 100);
+
+      // Check item 2: deferred hitting 72h horizon -> terminal outcome=permanent + reason=retry_horizon_exceeded
+      if (rescheduleAt > job.firstAttemptAt + RETRY_HORIZON_SEC * 1000) {
+        this.jobs.delete(key);
+        appendDeliveryLogRow({
+          ts: new Date().toISOString(),
+          webhookId: job.webhookId,
+          eventId: job.eventId,
+          runId: job.runId,
+          deliveryId: `dlv_${randomUUID()}`,
+          type: job.type,
+          address: job.address,
+          messageId: job.messageId,
+          uidValidity: job.uidValidity,
+          rfc822MessageId: job.rfc822MessageId,
+          taskId: job.taskId,
+          taskCreatedAt: job.taskCreatedAt,
+          expiresInSec: job.expiresInSec,
+          eventCreatedAt: job.eventCreatedAt,
+          attempt: job.attempt,
+          outcome: 'permanent',
+          status: null,
+          durationMs: null,
+          sensitive: false,
+          replay: job.replay,
+          nextAttemptAt: null,
+          reason: 'retry_horizon_exceeded',
+        });
+        return;
+      }
+
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: job.webhookId,
+        eventId: job.eventId,
+        runId: job.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: job.type,
+        address: job.address,
+        messageId: job.messageId,
+        uidValidity: job.uidValidity,
+        rfc822MessageId: job.rfc822MessageId,
+        taskId: job.taskId,
+        taskCreatedAt: job.taskCreatedAt,
+        expiresInSec: job.expiresInSec,
+        eventCreatedAt: job.eventCreatedAt,
+        attempt: job.attempt,
+        outcome: 'deferred',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: job.replay,
+        nextAttemptAt: new Date(rescheduleAt).toISOString(),
+        reason: isPoolFull ? 'concurrency_pool_full' : 'endpoint_busy',
+      });
+
+      job.nextAttemptAt = rescheduleAt;
+      this.schedule(job);
+      return;
+    }
+
+    // 2. Check per-endpoint delivery rate limit (§8.7)
+    const rateCheck = deliveryLimiter.checkDeliverRate(job.webhookId, now);
+    if (!rateCheck.allowed) {
+      deliveryLimiter.releaseSlot(job.webhookId);
+      const limiterReschedule = now + rateCheck.retryAfterSec * 1000;
+      const scheduledOffset = calculateNextAttemptTime(job.attempt - 1, job.firstAttemptAt) ?? limiterReschedule;
+      const rescheduleAt = Math.max(limiterReschedule, scheduledOffset);
+
+      // Check item 2: deferred hitting 72h horizon
+      if (rescheduleAt > job.firstAttemptAt + RETRY_HORIZON_SEC * 1000) {
+        this.jobs.delete(key);
+        appendDeliveryLogRow({
+          ts: new Date().toISOString(),
+          webhookId: job.webhookId,
+          eventId: job.eventId,
+          runId: job.runId,
+          deliveryId: `dlv_${randomUUID()}`,
+          type: job.type,
+          address: job.address,
+          messageId: job.messageId,
+          uidValidity: job.uidValidity,
+          rfc822MessageId: job.rfc822MessageId,
+          taskId: job.taskId,
+          taskCreatedAt: job.taskCreatedAt,
+          expiresInSec: job.expiresInSec,
+          eventCreatedAt: job.eventCreatedAt,
+          attempt: job.attempt,
+          outcome: 'permanent',
+          status: null,
+          durationMs: null,
+          sensitive: false,
+          replay: job.replay,
+          nextAttemptAt: null,
+          reason: 'retry_horizon_exceeded',
+        });
+        return;
+      }
+
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: job.webhookId,
+        eventId: job.eventId,
+        runId: job.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: job.type,
+        address: job.address,
+        messageId: job.messageId,
+        uidValidity: job.uidValidity,
+        rfc822MessageId: job.rfc822MessageId,
+        taskId: job.taskId,
+        taskCreatedAt: job.taskCreatedAt,
+        expiresInSec: job.expiresInSec,
+        eventCreatedAt: job.eventCreatedAt,
+        attempt: job.attempt,
+        outcome: 'deferred',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: job.replay,
+        nextAttemptAt: new Date(rescheduleAt).toISOString(),
+        reason: 'rate_limited',
+      });
+
+      job.nextAttemptAt = rescheduleAt;
+      this.schedule(job);
+      return;
+    }
+
+    // Build payload and execute attempt
+    const deliveryId = `dlv_${randomUUID()}`;
+    let body: string;
+    let sensitive = false;
+
+    try {
+      const formatted = job.payloadBuilder();
+      body = formatted.body;
+      sensitive = formatted.sensitive;
+    } catch (err: any) {
+      deliveryLimiter.releaseSlot(job.webhookId);
+      this.jobs.delete(key);
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: job.webhookId,
+        eventId: job.eventId,
+        runId: job.runId,
+        deliveryId,
+        type: job.type,
+        address: job.address,
+        messageId: job.messageId,
+        uidValidity: job.uidValidity,
+        rfc822MessageId: job.rfc822MessageId,
+        taskId: job.taskId,
+        taskCreatedAt: job.taskCreatedAt,
+        expiresInSec: job.expiresInSec,
+        eventCreatedAt: job.eventCreatedAt,
+        attempt: job.attempt,
+        outcome: 'permanent',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: job.replay,
+        nextAttemptAt: null,
+        reason: err?.message || 'payload_too_large',
+      });
+      return;
+    }
+
+    let result: WebhookFetchResult;
+    try {
+      result = await executeWebhookAttempt(sub, body, job.type, deliveryId);
+    } finally {
+      deliveryLimiter.releaseSlot(job.webhookId);
+    }
+
+    // Process outcome & update circuit breaker (§8.5, D2a)
+    const finishedTs = new Date().toISOString();
+    let nextScheduledTime: number | null = null;
+
+    if (result.outcome === 'success') {
+      this.jobs.delete(key);
+      updateWebhookSubscription(sub.id, (s) => {
+        s.consecutiveFailures = 0;
+        if (s.state === 'unverified') {
+          s.state = 'enabled';
+        }
+      });
+    } else if (result.outcome === 'refused') {
+      this.jobs.delete(key);
+      updateWebhookSubscription(sub.id, (s) => {
+        s.state = 'disabled';
+        s.disabledReason = 'refused';
+      });
+
+      // Item 3: Background delivery webhook.ssrf_refused audit row omits ip!
+      recordAuditEvent({
+        event: 'webhook.ssrf_refused',
+        outcome: 'denied',
+        address: sub.address,
+        webhookId: sub.id,
+      });
+      recordAuditEvent({
+        event: 'webhook.disabled',
+        outcome: 'ok',
+        address: sub.address,
+        webhookId: sub.id,
+      });
+
+      // Best effort notify
+      const localpart = sub.address.split('@')[0];
+      void notificationService()
+        .publish({
+          target: localpart ? `agent:${localpart}` : 'user',
+          title: 'Webhook Disabled: SSRF Refused',
+          message: `Webhook ${sub.id} disabled due to SSRF policy violation.`,
+          level: 'urgent',
+          tags: ['webhook', 'disabled'],
+          identityAddress: sub.address,
+        })
+        .catch(() => {});
+    } else if (result.outcome === 'permanent') {
+      this.jobs.delete(key);
+      updateWebhookSubscription(sub.id, (s) => {
+        s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
+        if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
+          s.state = 'disabled';
+          s.disabledReason = 'threshold';
+        }
+      });
+
+      const updated = getWebhookSubscription(sub.id);
+      if (updated?.state === 'disabled') {
+        recordAuditEvent({
+          event: 'webhook.disabled',
+          outcome: 'ok',
+          address: sub.address,
+          webhookId: sub.id,
+        });
+        const localpart = sub.address.split('@')[0];
+        void notificationService()
+          .publish({
+            target: localpart ? `agent:${localpart}` : 'user',
+            title: 'Webhook Disabled: Threshold Reached',
+            message: `Webhook ${sub.id} disabled after ${config.webhooks.disableThreshold} consecutive failures.`,
+            level: 'urgent',
+            tags: ['webhook', 'disabled'],
+            identityAddress: sub.address,
+          })
+          .catch(() => {});
+      }
+    } else if (result.outcome === 'retryable') {
+      updateWebhookSubscription(sub.id, (s) => {
+        s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
+        if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
+          s.state = 'disabled';
+          s.disabledReason = 'threshold';
+        }
+      });
+
+      const updated = getWebhookSubscription(sub.id);
+      if (updated?.state === 'disabled') {
+        recordAuditEvent({
+          event: 'webhook.disabled',
+          outcome: 'ok',
+          address: sub.address,
+          webhookId: sub.id,
+        });
+        const localpart = sub.address.split('@')[0];
+        void notificationService()
+          .publish({
+            target: localpart ? `agent:${localpart}` : 'user',
+            title: 'Webhook Disabled: Threshold Reached',
+            message: `Webhook ${sub.id} disabled after ${config.webhooks.disableThreshold} consecutive failures.`,
+            level: 'urgent',
+            tags: ['webhook', 'disabled'],
+            identityAddress: sub.address,
+          })
+          .catch(() => {});
+      }
+
+      // Check if breaker tripped; if so, dead-letter and stop retrying
+      if (updated?.state === 'disabled') {
+        this.jobs.delete(key);
+        result.outcome = 'permanent';
+        result.reason = 'webhook_disabled';
+      } else {
+        // Calculate retry schedule
+        const retryAfterMatch = result.reason?.match(/^rate_limited_retry_after_(\d+)$/);
+        const retryAfterSec = retryAfterMatch ? Number.parseInt(retryAfterMatch[1]!, 10) : undefined;
+        nextScheduledTime = calculateNextAttemptTime(job.attempt, job.firstAttemptAt, {
+          isPing: job.type === 'webhook.ping',
+          retryAfterSec,
+        });
+
+        if (nextScheduledTime === null) {
+          // Max attempts reached: dead-letter (§8.3)
+          this.jobs.delete(key);
+        } else {
+          // Advance job to next attempt
+          job.attempt++;
+          job.nextAttemptAt = nextScheduledTime;
+          this.schedule(job);
+        }
+      }
+    }
+
+    // Append completed attempt row
+    appendDeliveryLogRow({
+      ts: finishedTs,
+      webhookId: job.webhookId,
+      eventId: job.eventId,
+      runId: job.runId,
+      deliveryId,
+      type: job.type,
+      address: job.address,
+      messageId: job.messageId,
+      uidValidity: job.uidValidity,
+      rfc822MessageId: job.rfc822MessageId,
+      taskId: job.taskId,
+      taskCreatedAt: job.taskCreatedAt,
+      expiresInSec: job.expiresInSec,
+      eventCreatedAt: job.eventCreatedAt,
+      attempt: job.attempt,
+      outcome: result.outcome,
+      status: result.status,
+      durationMs: result.durationMs,
+      sensitive,
+      replay: job.replay,
+      nextAttemptAt: nextScheduledTime ? new Date(nextScheduledTime).toISOString() : null,
+      reason: result.reason,
+    });
+  }
+}
+
+export const deliveryQueue = new WebhookDeliveryQueue();
+
+// ---------------------------------------------------------------------------
+// Public Dispatch APIs
+// ---------------------------------------------------------------------------
+
+/**
+ * Enqueues a delivery for a subscription.
+ */
+export function enqueueWebhookDelivery(params: {
+  subscription: WebhookSubscription;
+  eventId: string;
+  runId?: string;
+  type: WebhookEventType;
+  payloadBuilder: () => { body: string; sensitive: boolean };
+  replay?: boolean;
+  address?: string | null;
+  messageId?: string | null;
+  uidValidity?: number | null;
+  rfc822MessageId?: string | null;
+  taskId?: string | null;
+  taskCreatedAt?: string | null;
+  expiresInSec?: number | null;
+  eventCreatedAt?: string;
+  delayMs?: number;
+}): void {
+  const sub = params.subscription;
+  const now = Date.now();
+  const runId = params.runId ?? 'run_0';
+  const eventCreatedAt = params.eventCreatedAt ?? new Date().toISOString();
+  const nextAttemptAt = now + (params.delayMs ?? 0);
+
+  // If endpoint is disabled: dead-letter immediately rather than queuing (§8.5)
+  if (sub.state === 'disabled') {
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: params.eventId,
+      runId,
+      deliveryId: `dlv_${randomUUID()}`,
+      type: params.type,
+      address: params.address ?? sub.address ?? null,
+      messageId: params.messageId ?? null,
+      uidValidity: params.uidValidity ?? null,
+      rfc822MessageId: params.rfc822MessageId ?? null,
+      taskId: params.taskId ?? null,
+      taskCreatedAt: params.taskCreatedAt ?? null,
+      expiresInSec: params.expiresInSec ?? null,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'permanent',
+      status: null,
+      durationMs: null,
+      sensitive: sub.contentScope === 'preview',
+      replay: params.replay ?? false,
+      nextAttemptAt: null,
+      reason: 'webhook_disabled',
+    });
+    return;
+  }
+
+  // Write durable pending row before scheduling (§8.6, §11.4)
+  appendDeliveryLogRow({
+    ts: new Date().toISOString(),
+    webhookId: sub.id,
+    eventId: params.eventId,
+    runId,
+    deliveryId: `dlv_${randomUUID()}`,
+    type: params.type,
+    address: params.address ?? sub.address ?? null,
+    messageId: params.messageId ?? null,
+    uidValidity: params.uidValidity ?? null,
+    rfc822MessageId: params.rfc822MessageId ?? null,
+    taskId: params.taskId ?? null,
+    taskCreatedAt: params.taskCreatedAt ?? null,
+    expiresInSec: params.expiresInSec ?? null,
+    eventCreatedAt,
+    attempt: 1,
+    outcome: 'pending',
+    status: null,
+    durationMs: null,
+    sensitive: sub.contentScope === 'preview',
+    replay: params.replay ?? false,
+    nextAttemptAt: new Date(nextAttemptAt).toISOString(),
+    reason: null,
+  });
+
+  deliveryQueue.schedule({
+    webhookId: sub.id,
+    eventId: params.eventId,
+    runId,
+    type: params.type,
+    payloadBuilder: params.payloadBuilder,
+    firstAttemptAt: now,
+    attempt: 1,
+    nextAttemptAt,
+    replay: params.replay ?? false,
+    address: params.address ?? sub.address ?? null,
+    messageId: params.messageId ?? null,
+    uidValidity: params.uidValidity ?? null,
+    rfc822MessageId: params.rfc822MessageId ?? null,
+    taskId: params.taskId ?? null,
+    taskCreatedAt: params.taskCreatedAt ?? null,
+    expiresInSec: params.expiresInSec ?? null,
+    eventCreatedAt,
+  });
+}
+
+/**
+ * Fires an asynchronous creation ping (§5.1, D12) or URL change ping.
+ */
+export function fireCreationPing(
+  subscription: WebhookSubscription,
+  trigger: 'creation' | 'test' = 'creation',
+): void {
+  const eventId = `evt_${randomUUID()}`;
+  const envelope: WebhookEnvelopeBase = {
+    id: eventId,
+    type: 'webhook.ping',
+    payloadVersion: 'v1',
+    createdAt: new Date().toISOString(),
+    domain: config.domain,
+  };
+
+  enqueueWebhookDelivery({
+    subscription,
+    eventId,
+    type: 'webhook.ping',
+    payloadBuilder: () => formatPingPayload(envelope, subscription.id, trigger),
+    address: null,
+  });
+}
+
+/**
+ * Executes a test probe against an endpoint (POST /v1/webhooks/:id/test).
+ * Awaits attempt 1 up to WEBHOOK_DELIVERY_TIMEOUT_MS.
+ * If attempt 1 fails and is retryable, background retries continue.
+ */
+export async function executeWebhookTestProbe(
+  subscription: WebhookSubscription,
+  callerTokenKey: string,
+  options?: { dnsLookup?: DnsLookup },
+): Promise<{
+  deliveryId: string;
+  outcome: WebhookDeliveryOutcome;
+  status: number | null;
+  reason: string | null;
+}> {
+  // On a disabled endpoint, throw 409 webhook_disabled (§10.3)
+  if (subscription.state === 'disabled') {
+    const err: any = new Error('webhook_disabled');
+    err.code = 'webhook_disabled';
+    err.disabledReason = subscription.disabledReason ?? 'manual';
+    throw err;
+  }
+
+  // Rate limit: check shared test probe bucket (§8.7)
+  const probeCheck = deliveryLimiter.checkTestProbeRate(callerTokenKey);
+  if (!probeCheck.allowed) {
+    const err: any = new Error('rate_limited');
+    err.code = 'rate_limited';
+    err.retryAfterSec = probeCheck.retryAfterSec;
+    throw err;
+  }
+
+  const deliveryId = `dlv_${randomUUID()}`;
+  const eventId = `evt_${randomUUID()}`;
+  const eventCreatedAt = new Date().toISOString();
+
+  const envelope: WebhookEnvelopeBase = {
+    id: eventId,
+    type: 'webhook.ping',
+    payloadVersion: 'v1',
+    createdAt: eventCreatedAt,
+    domain: config.domain,
+  };
+
+  const payloadBuilder = () => formatPingPayload(envelope, subscription.id, 'test');
+  const { body } = payloadBuilder();
+
+  // Write pending row
+  appendDeliveryLogRow({
+    ts: new Date().toISOString(),
+    webhookId: subscription.id,
+    eventId,
+    runId: 'run_0',
+    deliveryId,
+    type: 'webhook.ping',
+    address: null,
+    messageId: null,
+    uidValidity: null,
+    rfc822MessageId: null,
+    taskId: null,
+    taskCreatedAt: null,
+    expiresInSec: null,
+    eventCreatedAt,
+    attempt: 1,
+    outcome: 'pending',
+    status: null,
+    durationMs: null,
+    sensitive: false,
+    replay: false,
+    nextAttemptAt: new Date().toISOString(),
+    reason: null,
+  });
+
+  const fetchResult = await executeWebhookAttempt(
+    subscription,
+    body,
+    'webhook.ping',
+    deliveryId,
+    options,
+  );
+
+  const finishedTs = new Date().toISOString();
+
+  // Update circuit breaker
+  if (fetchResult.outcome === 'success') {
+    updateWebhookSubscription(subscription.id, (s) => {
+      s.consecutiveFailures = 0;
+      if (s.state === 'unverified') s.state = 'enabled';
+    });
+  } else if (fetchResult.outcome === 'refused') {
+    updateWebhookSubscription(subscription.id, (s) => {
+      s.state = 'disabled';
+      s.disabledReason = 'refused';
+    });
+    recordAuditEvent({
+      event: 'webhook.ssrf_refused',
+      outcome: 'denied',
+      address: subscription.address,
+      webhookId: subscription.id,
+    });
+    recordAuditEvent({
+      event: 'webhook.disabled',
+      outcome: 'ok',
+      address: subscription.address,
+      webhookId: subscription.id,
+    });
+  } else {
+    updateWebhookSubscription(subscription.id, (s) => {
+      s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
+      if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
+        s.state = 'disabled';
+        s.disabledReason = 'threshold';
+      }
+    });
+  }
+
+  let nextScheduledTime: number | null = null;
+  if (fetchResult.outcome === 'retryable') {
+    nextScheduledTime = calculateNextAttemptTime(1, Date.now(), { isPing: true });
+    if (nextScheduledTime) {
+      deliveryQueue.schedule({
+        webhookId: subscription.id,
+        eventId,
+        runId: 'run_0',
+        type: 'webhook.ping',
+        payloadBuilder,
+        firstAttemptAt: Date.now(),
+        attempt: 2,
+        nextAttemptAt: nextScheduledTime,
+        replay: false,
+        address: null,
+        messageId: null,
+        uidValidity: null,
+        rfc822MessageId: null,
+        taskId: null,
+        taskCreatedAt: null,
+        expiresInSec: null,
+        eventCreatedAt,
+      });
+    }
+  }
+
+  appendDeliveryLogRow({
+    ts: finishedTs,
+    webhookId: subscription.id,
+    eventId,
+    runId: 'run_0',
+    deliveryId,
+    type: 'webhook.ping',
+    address: null,
+    messageId: null,
+    uidValidity: null,
+    rfc822MessageId: null,
+    taskId: null,
+    taskCreatedAt: null,
+    expiresInSec: null,
+    eventCreatedAt,
+    attempt: 1,
+    outcome: fetchResult.outcome,
+    status: fetchResult.status,
+    durationMs: fetchResult.durationMs,
+    sensitive: false,
+    replay: false,
+    nextAttemptAt: nextScheduledTime ? new Date(nextScheduledTime).toISOString() : null,
+    reason: fetchResult.reason,
+  });
+
+  return {
+    deliveryId,
+    outcome: fetchResult.outcome,
+    status: fetchResult.status,
+    reason: fetchResult.reason,
+  };
+}
+
+/**
+ * Replays an existing delivery (POST /v1/webhooks/deliveries/:deliveryId/redeliver).
+ */
+export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
+  deliveryId: string;
+  eventId: string;
+  runId: string;
+  address: string;
+  webhookId: string;
+}> {
+  const rows = readAllDeliveryLogRows();
+  const original = rows.find((r) => r.deliveryId === deliveryId);
+  if (!original) {
+    const err: any = new Error('delivery_not_found');
+    err.code = 'delivery_not_found';
+    throw err;
+  }
+
+  const sub = getWebhookSubscription(original.webhookId);
+  if (!sub) {
+    const err: any = new Error('not_found');
+    err.code = 'not_found';
+    throw err;
+  }
+  if (sub.state === 'disabled') {
+    const err: any = new Error('webhook_disabled');
+    err.code = 'webhook_disabled';
+    err.disabledReason = sub.disabledReason ?? 'manual';
+    throw err;
+  }
+
+  // Calculate new runId
+  const matchingRuns = rows.filter(
+    (r) => r.webhookId === original.webhookId && r.eventId === original.eventId,
+  );
+  let maxRunNum = 0;
+  for (const r of matchingRuns) {
+    const m = r.runId.match(/^run_(\d+)$/);
+    if (m) {
+      maxRunNum = Math.max(maxRunNum, Number.parseInt(m[1]!, 10));
+    }
+  }
+  const newRunId = `run_${maxRunNum + 1}`;
+  const newDeliveryId = `dlv_${randomUUID()}`;
+
+  // Rebuild payload based on event type
+  let payloadBuilder: () => { body: string; sensitive: boolean };
+
+  if (original.type === 'webhook.ping') {
+    const envelope: WebhookEnvelopeBase = {
+      id: original.eventId,
+      type: 'webhook.ping',
+      payloadVersion: 'v1',
+      createdAt: original.eventCreatedAt,
+      domain: config.domain,
+    };
+    payloadBuilder = () => formatPingPayload(envelope, sub.id, 'test');
+  } else if (original.type === 'approval.requested') {
+    if (!original.taskId) {
+      throw new Error('missing_task_id');
+    }
+    const task = await getTaskSnapshot(original.taskId);
+    if (!task || task.kind !== 'approval' || !task.approval) {
+      throw new Error('task_not_found');
+    }
+    const envelope: WebhookEnvelopeBase = {
+      id: original.eventId,
+      type: 'approval.requested',
+      payloadVersion: 'v1',
+      createdAt: original.eventCreatedAt,
+      domain: config.domain,
+    };
+    payloadBuilder = () =>
+      formatApprovalPayload(sub, envelope, {
+        taskId: task.id,
+        taskState: 'input-required',
+        from: task.from,
+        to: task.to,
+        reviewer: task.approval!.reviewer,
+        subject: task.subject,
+        createdAt: original.taskCreatedAt ?? task.createdAt,
+        expiresAt: task.approval!.expiresAt,
+        expiresInSec: original.expiresInSec ?? original.taskExpiresInSec ?? null,
+        digest: task.approval!.digest,
+        actionType: task.approval!.action.type,
+        actionName: task.approval!.action.name,
+        actionArguments: task.approval!.action.arguments,
+      });
+  } else if (original.type === 'mail.received') {
+    if (!original.address || !original.messageId) {
+      throw new Error('missing_mail_identifiers');
+    }
+    const detail = await getMessage(original.address, original.messageId, {
+      uidValidity: original.uidValidity ?? undefined,
+    });
+    if (!detail) {
+      throw new Error('message_not_found');
+    }
+    const envelope: WebhookEnvelopeBase = {
+      id: original.eventId,
+      type: 'mail.received',
+      payloadVersion: 'v1',
+      createdAt: original.eventCreatedAt,
+      domain: config.domain,
+    };
+    payloadBuilder = () =>
+      formatMailPayload(sub, envelope, {
+        address: original.address!,
+        messageId: detail.id,
+        uid: Number(detail.id),
+        uidValidity: original.uidValidity ?? 0,
+        receivedAt: detail.date,
+        from: { address: detail.from },
+        to: [detail.to],
+        cc: [],
+        subject: detail.subject,
+        sizeBytes: 0,
+        hasAttachments: false,
+        unread: true,
+        containsSecurityCode: detail.otp.codes.length > 0,
+        containsLink: detail.otp.links.length > 0,
+        textPreview: detail.text,
+        securityCodes: detail.otp.codes,
+        links: detail.otp.links,
+      });
+  } else {
+    throw new Error('unsupported_event_type');
+  }
+
+  enqueueWebhookDelivery({
+    subscription: sub,
+    eventId: original.eventId,
+    runId: newRunId,
+    type: original.type,
+    payloadBuilder,
+    replay: true,
+    address: original.address,
+    messageId: original.messageId,
+    uidValidity: original.uidValidity,
+    rfc822MessageId: original.rfc822MessageId,
+    taskId: original.taskId,
+    taskCreatedAt: original.taskCreatedAt,
+    expiresInSec: original.expiresInSec,
+    eventCreatedAt: original.eventCreatedAt,
+  });
+
+  return {
+    deliveryId: newDeliveryId,
+    eventId: original.eventId,
+    runId: newRunId,
+    address: sub.address,
+    webhookId: sub.id,
+  };
+}
+
+/**
+ * Boot reconstruction algorithm (§8.6).
+ * Reconstructs pending delivery attempts from webhook-deliveries.jsonl.
+ */
+export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()): Promise<{
+  reconstructed: number;
+  deadLettered: number;
+}> {
+  const rows = readAllDeliveryLogRows();
+  if (rows.length === 0) return { reconstructed: 0, deadLettered: 0 };
+
+  // 1. Group rows by (webhookId, eventId, runId)
+  const groups = new Map<string, WebhookDeliveryLogRow[]>();
+  for (const row of rows) {
+    const key = `${row.webhookId}:${row.eventId}:${row.runId}`;
+    let list = groups.get(key);
+    if (!list) {
+      list = [];
+      groups.set(key, list);
+    }
+    list.push(row);
+  }
+
+  let reconstructed = 0;
+  let deadLettered = 0;
+
+  for (const [key, groupRows] of groups.entries()) {
+    // 2. Take only the row with highest attempt, tie-broken on ts
+    groupRows.sort((a, b) => {
+      if (a.attempt !== b.attempt) return b.attempt - a.attempt;
+      return new Date(b.ts).getTime() - new Date(a.ts).getTime();
+    });
+    const latest = groupRows[0]!;
+
+    // 3. Discard group if latest row is final (§8.6 step 3)
+    const isSuccessOrRefused = latest.outcome === 'success' || latest.outcome === 'refused';
+    const isPermanent = latest.outcome === 'permanent';
+    const isCompletedMaxRetryable =
+      latest.outcome === 'retryable' && latest.attempt >= MAX_RETRY_SCHEDULE_ATTEMPTS;
+
+    if (isSuccessOrRefused || isPermanent || isCompletedMaxRetryable) {
+      continue;
+    }
+
+    // 4. Otherwise pending!
+    const sub = getWebhookSubscription(latest.webhookId);
+    if (!sub || sub.state === 'disabled') {
+      deadLettered++;
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: latest.webhookId,
+        eventId: latest.eventId,
+        runId: latest.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: latest.type,
+        address: latest.address,
+        messageId: latest.messageId,
+        uidValidity: latest.uidValidity,
+        rfc822MessageId: latest.rfc822MessageId,
+        taskId: latest.taskId,
+        taskCreatedAt: latest.taskCreatedAt,
+        expiresInSec: latest.expiresInSec,
+        eventCreatedAt: latest.eventCreatedAt,
+        attempt: latest.attempt,
+        outcome: 'permanent',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: latest.replay,
+        nextAttemptAt: null,
+        reason: !sub ? 'subscription_deleted' : 'webhook_disabled',
+      });
+      continue;
+    }
+
+    // Calculate scheduled time: max(nextAttemptAt, bootTime)
+    const nextAttemptMs = latest.nextAttemptAt
+      ? new Date(latest.nextAttemptAt).getTime()
+      : bootTime;
+    const scheduledTime = Math.max(nextAttemptMs, bootTime);
+
+    // 5. Rebuild payload (§8.6 step 5)
+    try {
+      let payloadBuilder: () => { body: string; sensitive: boolean };
+
+      if (latest.type === 'webhook.ping') {
+        const envelope: WebhookEnvelopeBase = {
+          id: latest.eventId,
+          type: 'webhook.ping',
+          payloadVersion: 'v1',
+          createdAt: latest.eventCreatedAt,
+          domain: config.domain,
+        };
+        payloadBuilder = () => formatPingPayload(envelope, sub.id, 'test');
+      } else if (latest.type === 'approval.requested') {
+        if (!latest.taskId) {
+          throw Object.assign(new Error('missing_task_id'), { reason: 'task_not_found' });
+        }
+        let task: any = null;
+        try {
+          task = await getTaskSnapshot(latest.taskId);
+        } catch {
+          throw Object.assign(new Error('task_not_found'), { reason: 'task_not_found' });
+        }
+        if (!task || task.kind !== 'approval' || !task.approval) {
+          throw Object.assign(new Error('task_not_found'), { reason: 'task_not_found' });
+        }
+        const envelope: WebhookEnvelopeBase = {
+          id: latest.eventId,
+          type: 'approval.requested',
+          payloadVersion: 'v1',
+          createdAt: latest.eventCreatedAt,
+          domain: config.domain,
+        };
+        // Item 9: restore taskCreatedAt and expiresInSec from row!
+        payloadBuilder = () =>
+          formatApprovalPayload(sub, envelope, {
+            taskId: task.id,
+            taskState: 'input-required',
+            from: task.from,
+            to: task.to,
+            reviewer: task.approval!.reviewer,
+            subject: task.subject,
+            createdAt: latest.taskCreatedAt ?? task.createdAt,
+            expiresAt: task.approval!.expiresAt,
+            expiresInSec: latest.expiresInSec ?? (latest as any).taskExpiresInSec ?? null,
+            digest: task.approval!.digest,
+            actionType: task.approval!.action.type,
+            actionName: task.approval!.action.name,
+            actionArguments: task.approval!.action.arguments,
+          });
+      } else if (latest.type === 'mail.received') {
+        if (!latest.address || !latest.messageId) {
+          throw Object.assign(new Error('missing_mail_identifiers'), { reason: 'message_not_found' });
+        }
+
+        // Mail reconstruction (§8.6): Generation check & fallback to rfc822MessageId
+        let activeUid = latest.messageId;
+        let activeUidValidity = latest.uidValidity;
+
+        let mailDetail: any = null;
+        try {
+          mailDetail = await withInbox(async (client) => {
+            const currentGen = client.mailbox ? Number(client.mailbox.uidValidity) : undefined;
+            if (
+              currentGen !== undefined &&
+              latest.uidValidity !== null &&
+              currentGen !== latest.uidValidity
+            ) {
+              // Generation differs: fall back to RFC 822 Message-ID search
+              // Item 5: overlong (>512) treated as null
+              if (!latest.rfc822MessageId) {
+                throw Object.assign(new Error('uidvalidity_changed'), {
+                  reason: 'uidvalidity_changed',
+                });
+              }
+              const foundUids = await client.search(
+                { header: { 'Message-ID': latest.rfc822MessageId } },
+                { uid: true },
+              );
+              if (!foundUids || foundUids.length !== 1) {
+                throw Object.assign(new Error('uidvalidity_changed'), {
+                  reason: 'uidvalidity_changed',
+                });
+              }
+              const newUid = foundUids[0]!;
+              activeUid = String(newUid);
+              activeUidValidity = currentGen;
+              return getMessage(latest.address!, activeUid, { uidValidity: currentGen });
+            }
+
+            return getMessage(latest.address!, latest.messageId!, {
+              uidValidity: latest.uidValidity ?? undefined,
+            });
+          });
+        } catch (err: any) {
+          if (err?.reason === 'uidvalidity_changed') throw err;
+          throw Object.assign(new Error('message_not_found'), { reason: 'message_not_found' });
+        }
+
+        if (!mailDetail) {
+          throw Object.assign(new Error('message_not_found'), { reason: 'message_not_found' });
+        }
+
+        const envelope: WebhookEnvelopeBase = {
+          id: latest.eventId,
+          type: 'mail.received',
+          payloadVersion: 'v1',
+          createdAt: latest.eventCreatedAt,
+          domain: config.domain,
+        };
+
+        payloadBuilder = () =>
+          formatMailPayload(sub, envelope, {
+            address: latest.address!,
+            messageId: activeUid,
+            uid: Number(activeUid),
+            uidValidity: activeUidValidity ?? 0,
+            receivedAt: mailDetail.date,
+            from: { address: mailDetail.from },
+            to: [mailDetail.to],
+            cc: [],
+            subject: mailDetail.subject,
+            sizeBytes: 0,
+            hasAttachments: false,
+            unread: true,
+            containsSecurityCode: mailDetail.otp.codes.length > 0,
+            containsLink: mailDetail.otp.links.length > 0,
+            textPreview: mailDetail.text,
+            securityCodes: mailDetail.otp.codes,
+            links: mailDetail.otp.links,
+          });
+      } else {
+        throw new Error('unsupported_type');
+      }
+
+      // Reconstructed successfully, enqueue to delivery queue
+      deliveryQueue.schedule({
+        webhookId: sub.id,
+        eventId: latest.eventId,
+        runId: latest.runId,
+        type: latest.type,
+        payloadBuilder,
+        firstAttemptAt: new Date(latest.eventCreatedAt).getTime(),
+        attempt: latest.outcome === 'pending' ? latest.attempt : latest.attempt + 1,
+        nextAttemptAt: scheduledTime,
+        replay: latest.replay,
+        address: latest.address,
+        messageId: latest.messageId,
+        uidValidity: latest.uidValidity,
+        rfc822MessageId: latest.rfc822MessageId,
+        taskId: latest.taskId,
+        taskCreatedAt: latest.taskCreatedAt,
+        expiresInSec: latest.expiresInSec,
+        eventCreatedAt: latest.eventCreatedAt,
+      });
+
+      reconstructed++;
+    } catch (err: any) {
+      deadLettered++;
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: latest.webhookId,
+        eventId: latest.eventId,
+        runId: latest.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: latest.type,
+        address: latest.address,
+        messageId: latest.messageId,
+        uidValidity: latest.uidValidity,
+        rfc822MessageId: latest.rfc822MessageId,
+        taskId: latest.taskId,
+        taskCreatedAt: latest.taskCreatedAt,
+        expiresInSec: latest.expiresInSec,
+        eventCreatedAt: latest.eventCreatedAt,
+        attempt: latest.attempt,
+        outcome: 'permanent',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: latest.replay,
+        nextAttemptAt: null,
+        reason: err?.reason || err?.message || 'reconstruction_failed',
+      });
+    }
+  }
+
+  return { reconstructed, deadLettered };
+}

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -617,7 +617,7 @@ export function readDeliveryLogRows(options?: {
   let startIndex = 0;
 
   if (options?.cursor) {
-    const idx = filtered.findIndex((r) => r.deliveryId === options.cursor);
+    const idx = filtered.findIndex((r) => deliveryRowCursor(r) === options.cursor || r.deliveryId === options.cursor);
     if (idx >= 0) {
       startIndex = idx + 1;
     }
@@ -625,9 +625,26 @@ export function readDeliveryLogRows(options?: {
 
   const paged = filtered.slice(startIndex, startIndex + limit);
   const hasMore = startIndex + limit < filtered.length;
-  const nextCursor = hasMore && paged.length > 0 ? paged[paged.length - 1]!.deliveryId : undefined;
+  const nextCursor =
+    hasMore && paged.length > 0 ? deliveryRowCursor(paged[paged.length - 1]!) : undefined;
 
   return { deliveries: paged, nextCursor };
+}
+
+function deliveryRowCursor(row: WebhookDeliveryLogRow): string {
+  return `${row.deliveryId}|${row.attempt}|${row.ts}`;
+}
+
+function latestRowForDeliveryId(
+  rows: WebhookDeliveryLogRow[],
+  deliveryId: string,
+): WebhookDeliveryLogRow | undefined {
+  let latest: WebhookDeliveryLogRow | undefined;
+  for (const row of rows) {
+    if (row.deliveryId !== deliveryId) continue;
+    if (!latest || isNewerDeliveryRow(row, latest)) latest = row;
+  }
+  return latest;
 }
 
 /** Latest attempt per webhook from an already-read log (one parse per request). */
@@ -2327,7 +2344,7 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
   webhookId: string;
 }> {
   const rows = readAllDeliveryLogRows();
-  const original = rows.find((r) => r.deliveryId === deliveryId);
+  const original = latestRowForDeliveryId(rows, deliveryId);
   if (!original) {
     const err: any = new Error('delivery_not_found');
     err.code = 'delivery_not_found';

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -11,12 +11,16 @@ import { randomUUID } from 'node:crypto';
 import {
   appendFileSync,
   chmodSync,
+  closeSync,
   existsSync,
+  fsyncSync,
   mkdirSync,
+  openSync,
   readFileSync,
   renameSync,
   unlinkSync,
   writeFileSync,
+  writeSync,
 } from 'node:fs';
 import { isIP } from 'node:net';
 import { join } from 'node:path';
@@ -55,7 +59,7 @@ export function truncateUtf8String(str: string, maxBytes: number): string {
   return truncateUtf8Bytes(buf, maxBytes).toString('utf8');
 }
 
-import { getMessage, withInbox } from './imap.ts';
+import { getMessage, withInbox, StaleMessageGenerationError } from './imap.ts';
 import { getTaskSnapshot } from './tasks-internal.ts';
 import { registerWebhookCancelCallback } from './identities.ts';
 import { simpleParser } from 'mailparser';
@@ -306,19 +310,39 @@ export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
   };
 
   const line = `${JSON.stringify(sanitizedRow)}\n`;
-  if (!existsSync(path)) {
-    writeFileSync(path, line, { mode: 0o600 });
+  const fd = openSync(path, 'a', 0o600);
+  try {
     try {
       chmodSync(path, 0o600);
     } catch {
       // best effort
     }
-  } else {
-    appendFileSync(path, line);
+    const buf = Buffer.from(line, 'utf8');
+    let offset = 0;
+    while (offset < buf.length) {
+      const written = writeSync(fd, buf, offset, buf.length - offset);
+      if (written <= 0) break;
+      offset += written;
+    }
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
   }
 }
 
-/** Reads all delivery log rows from disk, failing closed if corrupt. */
+/**
+ * Reads all delivery log rows from disk, with per-line fault tolerance.
+ *
+ * Semantic distinction:
+ * - Webhook configuration store (`webhooks.json`): fail-closed on read.
+ *   If the subscription store is corrupt, serving state is unsafe so we must halt
+ *   and refuse mutations to protect customer secrets and invariants.
+ * - Webhook delivery log (`webhook-deliveries.jsonl`): append-only event log.
+ *   Writes are fail-closed (atomic fsync append), but reads fail open:
+ *   corrupted or partial lines (e.g. from power loss before fsync or dirty disk writes)
+ *   are skipped and logged as errors so that a single bad line does not crash the entire
+ *   API on startup or cause 500s across read endpoints.
+ */
 export function readAllDeliveryLogRows(): WebhookDeliveryLogRow[] {
   const path = deliveryLogPath();
   if (!existsSync(path)) return [];
@@ -326,6 +350,7 @@ export function readAllDeliveryLogRows(): WebhookDeliveryLogRow[] {
   const content = readFileSync(path, 'utf8');
   const lines = content.split('\n');
   const rows: WebhookDeliveryLogRow[] = [];
+  let corruptCount = 0;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!.trim();
@@ -333,9 +358,20 @@ export function readAllDeliveryLogRows(): WebhookDeliveryLogRow[] {
     try {
       const parsed = JSON.parse(line);
       rows.push(parsed);
-    } catch {
-      throw new Error(`Corrupted delivery log at line ${i + 1}`);
+    } catch (err) {
+      corruptCount++;
+      console.error(
+        `[webhooks] corrupted delivery log line ${i + 1} skipped:`,
+        line.slice(0, 100),
+        err,
+      );
     }
+  }
+
+  if (corruptCount > 0) {
+    console.error(
+      `[webhooks] readAllDeliveryLogRows skipped ${corruptCount} corrupted line(s) in delivery log`,
+    );
   }
 
   return rows;
@@ -447,8 +483,40 @@ export function compactDeliveryLog(
 
   const tmpPath = `${path}.tmp.${Date.now()}`;
   const lines = retainedRows.map((r) => JSON.stringify(r)).join('\n') + (retainedRows.length ? '\n' : '');
-  writeFileSync(tmpPath, lines, { mode: 0o600 });
+
+  const fd = openSync(tmpPath, 'w', 0o600);
+  try {
+    const buf = Buffer.from(lines, 'utf8');
+    let offset = 0;
+    while (offset < buf.length) {
+      const written = writeSync(fd, buf, offset, buf.length - offset);
+      if (written <= 0) break;
+      offset += written;
+    }
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  try {
+    chmodSync(tmpPath, 0o600);
+  } catch {
+    // best effort
+  }
+
   renameSync(tmpPath, path);
+
+  // fsync parent directory (matching webhook-store.ts writeStore)
+  try {
+    const dirFd = openSync(config.dataDir, 'r');
+    try {
+      fsyncSync(dirFd);
+    } finally {
+      closeSync(dirFd);
+    }
+  } catch {
+    // best effort
+  }
 }
 
 export function startWebhookMaintenance(): void {
@@ -1830,10 +1898,35 @@ export async function executeWebhookTestProbe(
   while (!deliveryLimiter.acquireSlot(subscription.id)) {
     if (Date.now() - startWait >= waitTimeout) {
       const isPoolFull = deliveryLimiter.getActiveTotal() >= config.webhooks.maxConcurrent;
+      const reason = isPoolFull ? 'concurrency_pool_full' : 'endpoint_busy';
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: subscription.id,
+        eventId,
+        runId: 'run_0',
+        deliveryId,
+        type: 'webhook.ping',
+        address: null,
+        messageId: null,
+        uidValidity: null,
+        rfc822MessageId: null,
+        taskId: null,
+        taskCreatedAt: null,
+        expiresInSec: null,
+        eventCreatedAt,
+        attempt: 1,
+        outcome: 'permanent',
+        status: null,
+        durationMs: Date.now() - startWait,
+        sensitive: false,
+        replay: false,
+        nextAttemptAt: null,
+        reason,
+      });
       const err: any = new Error('rate_limited');
       err.code = 'rate_limited';
       err.retryAfterSec = 5;
-      err.reason = isPoolFull ? 'concurrency_pool_full' : 'endpoint_busy';
+      err.reason = reason;
       throw err;
     }
     await new Promise((resolve) => setTimeout(resolve, 50));
@@ -2036,13 +2129,35 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
       });
   } else if (original.type === 'mail.received') {
     if (!original.address || !original.messageId) {
-      throw new Error('missing_mail_identifiers');
+      const err: any = new Error('missing_mail_identifiers');
+      err.code = 'missing_mail_identifiers';
+      throw err;
     }
-    const detail = await getMessage(original.address, original.messageId, {
-      uidValidity: original.uidValidity ?? undefined,
-    });
+    // Fail-closed against generation drift: refuse redelivery if uidValidity is absent (P2-2)
+    if (original.uidValidity === null || original.uidValidity === undefined) {
+      const err: any = new Error('uidvalidity_required');
+      err.code = 'uidvalidity_required';
+      err.reason = 'uidvalidity_required';
+      throw err;
+    }
+    let detail: any;
+    try {
+      detail = await getMessage(original.address, original.messageId, {
+        uidValidity: original.uidValidity,
+      });
+    } catch (err: any) {
+      if (err instanceof StaleMessageGenerationError || err?.name === 'StaleMessageGenerationError') {
+        const staleErr: any = new Error('stale_message_generation');
+        staleErr.code = 'stale_message_generation';
+        staleErr.reason = 'stale_message_generation';
+        throw staleErr;
+      }
+      throw err;
+    }
     if (!detail) {
-      throw new Error('message_not_found');
+      const err: any = new Error('message_not_found');
+      err.code = 'message_not_found';
+      throw err;
     }
 
     let unread = true;
@@ -2260,7 +2375,10 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
           });
       } else if (latest.type === 'mail.received') {
         if (!latest.address || !latest.messageId) {
-          throw Object.assign(new Error('missing_mail_identifiers'), { reason: 'message_not_found' });
+          throw Object.assign(new Error('missing_mail_identifiers'), {
+            reason: 'message_not_found',
+            isPermanent: true,
+          });
         }
 
         // Mail reconstruction (§8.6): Generation check & fallback to rfc822MessageId
@@ -2284,6 +2402,7 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
               if (!latest.rfc822MessageId) {
                 throw Object.assign(new Error('uidvalidity_changed'), {
                   reason: 'uidvalidity_changed',
+                  isPermanent: true,
                 });
               }
               const foundUids = await client.search(
@@ -2293,6 +2412,7 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
               if (!foundUids || foundUids.length !== 1) {
                 throw Object.assign(new Error('uidvalidity_changed'), {
                   reason: 'uidvalidity_changed',
+                  isPermanent: true,
                 });
               }
               const newUid = foundUids[0]!;
@@ -2329,12 +2449,31 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
             });
           });
         } catch (err: any) {
-          if (err?.reason === 'uidvalidity_changed') throw err;
-          throw Object.assign(new Error('message_not_found'), { reason: 'message_not_found' });
+          if (err?.isPermanent) throw err;
+          if (
+            err instanceof StaleMessageGenerationError ||
+            err?.name === 'StaleMessageGenerationError' ||
+            err?.reason === 'uidvalidity_changed'
+          ) {
+            throw Object.assign(new Error('uidvalidity_changed'), {
+              reason: 'uidvalidity_changed',
+              isPermanent: true,
+            });
+          }
+          // Backend temporarily unreachable (e.g. Dovecot not started yet in container orchestration)
+          // P2-6: Do NOT prematurely dead-letter transient errors.
+          throw Object.assign(new Error(err?.message || 'backend_unreachable'), {
+            reason: 'transient_backend_unreachable',
+            isTransient: true,
+            cause: err,
+          });
         }
 
         if (!mailDetail) {
-          throw Object.assign(new Error('message_not_found'), { reason: 'message_not_found' });
+          throw Object.assign(new Error('message_not_found'), {
+            reason: 'message_not_found',
+            isPermanent: true,
+          });
         }
 
         const envelope: WebhookEnvelopeBase = {
@@ -2366,7 +2505,10 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
             links: mailDetail.otp.links,
           });
       } else {
-        throw new Error('unsupported_type');
+        throw Object.assign(new Error('unsupported_type'), {
+          reason: 'unsupported_type',
+          isPermanent: true,
+        });
       }
 
       // Reconstructed successfully, enqueue to delivery queue
@@ -2392,6 +2534,16 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
 
       reconstructed++;
     } catch (err: any) {
+      if (err?.isTransient) {
+        console.warn(
+          `[webhooks] boot reconstruction transient failure for delivery ${latest.eventId} / webhook ${latest.webhookId}, retaining pending state:`,
+          err?.message,
+        );
+        // Do NOT append a permanent dead-letter row!
+        // Leave the pending row intact in the delivery log for next boot/retry.
+        continue;
+      }
+
       deadLettered++;
       appendDeliveryLogRow({
         ts: new Date().toISOString(),

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -1160,7 +1160,7 @@ export function formatPingPayload(
   const payload = {
     ...envelope,
     data: {
-      object: 'ping',
+      object: 'webhook',
       webhookId,
       trigger,
     },
@@ -1438,6 +1438,7 @@ export type ScheduledDeliveryJob = {
   webhookId: string;
   eventId: string;
   runId: string;
+  deliveryId: string;
   type: WebhookEventType;
   payloadBuilder: (currentSub: WebhookSubscription) => { body: string; sensitive: boolean };
   firstAttemptAt: number;
@@ -1513,7 +1514,7 @@ class WebhookDeliveryQueue {
           webhookId: job.webhookId,
           eventId: job.eventId,
           runId: job.runId,
-          deliveryId: `dlv_${randomUUID()}`,
+          deliveryId: job.deliveryId,
           type: job.type,
           address: job.address,
           messageId: job.messageId,
@@ -1601,7 +1602,7 @@ class WebhookDeliveryQueue {
           webhookId: job.webhookId,
           eventId: job.eventId,
           runId: job.runId,
-          deliveryId: `dlv_${randomUUID()}`,
+          deliveryId: job.deliveryId,
           type: job.type,
           address: job.address,
           messageId: job.messageId,
@@ -1636,7 +1637,7 @@ class WebhookDeliveryQueue {
         webhookId: job.webhookId,
         eventId: job.eventId,
         runId: job.runId,
-        deliveryId: `dlv_${randomUUID()}`,
+        deliveryId: job.deliveryId,
         type: job.type,
         address: job.address,
         messageId: job.messageId,
@@ -1668,7 +1669,7 @@ class WebhookDeliveryQueue {
         webhookId: job.webhookId,
         eventId: job.eventId,
         runId: job.runId,
-        deliveryId: `dlv_${randomUUID()}`,
+        deliveryId: job.deliveryId,
         type: job.type,
         address: job.address,
         messageId: job.messageId,
@@ -1710,7 +1711,7 @@ class WebhookDeliveryQueue {
           webhookId: job.webhookId,
           eventId: job.eventId,
           runId: job.runId,
-          deliveryId: `dlv_${randomUUID()}`,
+          deliveryId: job.deliveryId,
           type: job.type,
           address: job.address,
           messageId: job.messageId,
@@ -1753,7 +1754,7 @@ class WebhookDeliveryQueue {
           webhookId: job.webhookId,
           eventId: job.eventId,
           runId: job.runId,
-          deliveryId: `dlv_${randomUUID()}`,
+          deliveryId: job.deliveryId,
           type: job.type,
           address: job.address,
           messageId: job.messageId,
@@ -1780,8 +1781,8 @@ class WebhookDeliveryQueue {
       return;
     }
 
-    // Build payload and execute attempt
-    const deliveryId = `dlv_${randomUUID()}`;
+    // Build payload and execute attempt — reuse the pending row's deliveryId
+    const deliveryId = job.deliveryId;
     let body: string;
     let sensitive = false;
 
@@ -2041,6 +2042,7 @@ export function enqueueWebhookDelivery(params: {
     webhookId: sub.id,
     eventId: params.eventId,
     runId,
+    deliveryId,
     type: params.type,
     payloadBuilder: params.payloadBuilder,
     firstAttemptAt: now,
@@ -2068,9 +2070,9 @@ export function fireCreationPing(
 ): void {
   const tokenKey = callerTokenKey ?? subscription.createdBy ?? subscription.address;
   const probeCheck = deliveryLimiter.checkTestProbeRate(tokenKey);
-  if (!probeCheck.allowed) {
-    return;
-  }
+  // Probe-full: still enqueue a delayed ping (deferred: no attempt consumed).
+  // Dropping here left the subscription stuck unverified.
+  const delayMs = probeCheck.allowed ? 0 : Math.max(config.webhooks.poolRetryMs, 1);
 
   const eventId = `evt_${randomUUID()}`;
   const envelope: WebhookEnvelopeBase = {
@@ -2087,6 +2089,7 @@ export function fireCreationPing(
     type: 'webhook.ping',
     payloadBuilder: (currentSub) => formatPingPayload(envelope, currentSub.id, trigger),
     address: null,
+    delayMs,
   });
 }
 
@@ -2261,6 +2264,7 @@ export async function executeWebhookTestProbe(
         webhookId: subscription.id,
         eventId,
         runId: 'run_0',
+        deliveryId,
         type: 'webhook.ping',
         payloadBuilder,
         firstAttemptAt: Date.now(),
@@ -2629,7 +2633,7 @@ export async function reconstructPendingDeliveriesAtBoot(
         webhookId: latest.webhookId,
         eventId: latest.eventId,
         runId: latest.runId,
-        deliveryId: `dlv_${randomUUID()}`,
+        deliveryId: latest.deliveryId,
         type: latest.type,
         address: latest.address,
         messageId: latest.messageId,
@@ -2660,7 +2664,7 @@ export async function reconstructPendingDeliveriesAtBoot(
         webhookId: latest.webhookId,
         eventId: latest.eventId,
         runId: latest.runId,
-        deliveryId: `dlv_${randomUUID()}`,
+        deliveryId: latest.deliveryId,
         type: latest.type,
         address: latest.address,
         messageId: latest.messageId,
@@ -2882,6 +2886,7 @@ export async function reconstructPendingDeliveriesAtBoot(
         webhookId: sub.id,
         eventId: latest.eventId,
         runId: latest.runId,
+        deliveryId: latest.deliveryId,
         type: latest.type,
         payloadBuilder,
         firstAttemptAt: new Date(latest.eventCreatedAt).getTime(),
@@ -2916,7 +2921,7 @@ export async function reconstructPendingDeliveriesAtBoot(
         webhookId: latest.webhookId,
         eventId: latest.eventId,
         runId: latest.runId,
-        deliveryId: `dlv_${randomUUID()}`,
+        deliveryId: latest.deliveryId,
         type: latest.type,
         address: latest.address,
         messageId: latest.messageId,

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -47,6 +47,7 @@ import {
   getWebhookSubscription,
   listWebhookSubscriptions,
   updateWebhookSubscription,
+  WebhookStoreCorruptError,
   type WebhookSubscription,
   type WebhookState,
 } from './webhook-store.ts';
@@ -181,6 +182,38 @@ export const RETRY_SCHEDULE_OFFSETS_SEC = [
 export const MAX_RETRY_SCHEDULE_ATTEMPTS = 11;
 export const MAX_PING_ATTEMPTS = 3;
 export const RETRY_HORIZON_SEC = 259200; // 72 hours in seconds
+
+/** Effective attempt cap for this event type: ping is 3, others follow WEBHOOK_MAX_ATTEMPTS. */
+export function maxAttemptsForEventType(type: WebhookEventType): number {
+  if (type === 'webhook.ping') return MAX_PING_ATTEMPTS;
+  return Math.min(config.webhooks.maxAttempts, MAX_RETRY_SCHEDULE_ATTEMPTS);
+}
+
+/**
+ * §8.6 step 3: a latest row is final if success/permanent/refused, or a *completed*
+ * retryable at the event type's actual cap. A pending row is never final.
+ */
+export function isTerminalDeliveryRow(
+  row: Pick<WebhookDeliveryLogRow, 'outcome' | 'attempt' | 'type'>,
+): boolean {
+  if (row.outcome === 'success' || row.outcome === 'permanent' || row.outcome === 'refused') {
+    return true;
+  }
+  return row.outcome === 'retryable' && row.attempt >= maxAttemptsForEventType(row.type);
+}
+
+/**
+ * Parse HTTP Retry-After as delay-seconds. The entire trimmed value must be a
+ * base-10 integer in 1..3600; strings like "3600junk" are rejected.
+ */
+export function parseRetryAfterSeconds(header: string | null | undefined): number | undefined {
+  if (header == null) return undefined;
+  const trimmed = header.trim();
+  if (!/^[0-9]+$/.test(trimmed)) return undefined;
+  const n = Number(trimmed);
+  if (!Number.isSafeInteger(n) || n < 1 || n > 3600) return undefined;
+  return n;
+}
 
 /**
  * Calculates next attempt scheduled time with ±10% non-cumulative gap jitter (§8.3).
@@ -588,18 +621,13 @@ export function validateWebhookUrlStatic(
     return { valid: false, code: 'invalid_webhook_url', error: 'fragment_forbidden' };
   }
 
-  // Port in WEBHOOK_ALLOWED_PORTS
+  // Port in WEBHOOK_ALLOWED_PORTS — no implicit 80 for private http (§9.5)
   const port = url.port
     ? Number(url.port)
     : url.protocol === 'https:'
       ? 443
       : 80;
-  const configuredPorts = opts?.allowedPorts ?? config.webhooks.allowedPorts;
-  const allowedPorts =
-    opts?.allowedPorts ??
-    (allowPrivate && url.protocol === 'http:' && !configuredPorts.includes(80)
-      ? [...configuredPorts, 80]
-      : configuredPorts);
+  const allowedPorts = opts?.allowedPorts ?? config.webhooks.allowedPorts;
   if (!allowedPorts.includes(port)) {
     return { valid: false, code: 'invalid_webhook_url', error: 'port_not_allowed' };
   }
@@ -1032,14 +1060,7 @@ export async function executeWebhookAttempt(
     }
 
     if (status === 408 || status === 429 || status >= 500) {
-      let retryAfter: number | undefined;
-      const retryHeader = response.headers.get('retry-after');
-      if (retryHeader) {
-        const parsedSec = Number.parseInt(retryHeader, 10);
-        if (Number.isInteger(parsedSec) && parsedSec >= 1 && parsedSec <= 3600) {
-          retryAfter = parsedSec;
-        }
-      }
+      const retryAfter = parseRetryAfterSeconds(response.headers.get('retry-after'));
       return {
         status,
         outcome: 'retryable',
@@ -1090,6 +1111,7 @@ class WebhookDeliveryLimiter {
   private deliverLimiters = new Map<string, number[]>();
   private testProbeLimiters = new Map<string, number[]>();
   private createLimiters = new Map<string, number[]>();
+  private rotateLimiters = new Map<string, number[]>();
 
   getActiveTotal(): number {
     return this.activeTotal;
@@ -1161,12 +1183,24 @@ class WebhookDeliveryLimiter {
     );
   }
 
+  /** Independent rotate bucket, sized like the test-probe limit. */
+  checkRotateRate(tokenKey: string, now = Date.now()): { allowed: boolean; retryAfterSec: number } {
+    return slidingWindowCheck(
+      this.rotateLimiters,
+      tokenKey,
+      config.webhooks.rateTestPerMin,
+      60_000,
+      now,
+    );
+  }
+
   reset(): void {
     this.activePerEndpoint.clear();
     this.activeTotal = 0;
     this.deliverLimiters.clear();
     this.testProbeLimiters.clear();
     this.createLimiters.clear();
+    this.rotateLimiters.clear();
   }
 }
 
@@ -1286,6 +1320,15 @@ class WebhookDeliveryQueue {
     this.jobs.clear();
   }
 
+  hasQueuedJob(webhookId: string, eventId?: string): boolean {
+    for (const job of this.jobs.values()) {
+      if (job.webhookId !== webhookId) continue;
+      if (eventId !== undefined && job.eventId !== eventId) continue;
+      return true;
+    }
+    return false;
+  }
+
   private clearTimer(key: string): void {
     const t = this.activeTimers.get(key);
     if (t) {
@@ -1294,9 +1337,67 @@ class WebhookDeliveryQueue {
     }
   }
 
+  private scheduleIfStillQueued(key: string, job: ScheduledDeliveryJob): void {
+    if (this.jobs.get(key) !== job) return;
+    this.schedule(job);
+  }
+
   private async executeJob(key: string): Promise<void> {
     const job = this.jobs.get(key);
     if (!job) return;
+    try {
+      await this.runExecuteJob(key, job);
+    } catch (err: unknown) {
+      this.clearTimer(key);
+      this.jobs.delete(key);
+      try {
+        deliveryLimiter.releaseSlot(job.webhookId);
+      } catch {
+        // ignore double-release
+      }
+      const storeCorrupt =
+        err instanceof WebhookStoreCorruptError ||
+        (err !== null &&
+          typeof err === 'object' &&
+          'code' in err &&
+          (err as { code?: string }).code === 'store_corrupt');
+      if (storeCorrupt) {
+        console.error('[webhooks] store corrupt during delivery:', err);
+      } else {
+        console.error('[webhooks] executeJob failed:', err);
+      }
+      try {
+        appendDeliveryLogRow({
+          ts: new Date().toISOString(),
+          webhookId: job.webhookId,
+          eventId: job.eventId,
+          runId: job.runId,
+          deliveryId: `dlv_${randomUUID()}`,
+          type: job.type,
+          address: job.address,
+          messageId: job.messageId,
+          uidValidity: job.uidValidity,
+          rfc822MessageId: job.rfc822MessageId,
+          taskId: job.taskId,
+          taskCreatedAt: job.taskCreatedAt,
+          expiresInSec: job.expiresInSec,
+          eventCreatedAt: job.eventCreatedAt,
+          attempt: job.attempt,
+          outcome: 'permanent',
+          status: null,
+          durationMs: null,
+          sensitive: false,
+          replay: job.replay,
+          nextAttemptAt: null,
+          reason: storeCorrupt ? 'store_corrupt' : 'execute_error',
+        });
+      } catch (logErr) {
+        console.error('[webhooks] failed to write executeJob dead letter:', logErr);
+      }
+    }
+  }
+
+  private async runExecuteJob(key: string, job: ScheduledDeliveryJob): Promise<void> {
 
     const sub = getWebhookSubscription(job.webhookId);
     if (!sub || sub.state === 'disabled') {
@@ -1426,7 +1527,7 @@ class WebhookDeliveryQueue {
       });
 
       job.nextAttemptAt = rescheduleAt;
-      this.schedule(job);
+      this.scheduleIfStillQueued(key, job);
       return;
     }
 
@@ -1494,7 +1595,7 @@ class WebhookDeliveryQueue {
       });
 
       job.nextAttemptAt = rescheduleAt;
-      this.schedule(job);
+      this.scheduleIfStillQueued(key, job);
       return;
     }
 
@@ -1542,6 +1643,11 @@ class WebhookDeliveryQueue {
       result = await executeWebhookAttempt(sub, body, job.type, deliveryId);
     } finally {
       deliveryLimiter.releaseSlot(job.webhookId);
+    }
+
+    // cancelForWebhook may have removed this job while the attempt was in flight.
+    if (this.jobs.get(key) !== job) {
+      return;
     }
 
     // Process outcome & update circuit breaker (§8.5, D2a)
@@ -1666,7 +1772,7 @@ class WebhookDeliveryQueue {
     if (result.outcome === 'retryable' && nextScheduledTime !== null) {
       job.attempt = currentAttempt + 1;
       job.nextAttemptAt = nextScheduledTime;
-      this.schedule(job);
+      this.scheduleIfStillQueued(key, job);
     }
   }
 }
@@ -1826,7 +1932,7 @@ export function fireCreationPing(
 export async function executeWebhookTestProbe(
   subscription: WebhookSubscription,
   callerTokenKey: string,
-  options?: { dnsLookup?: DnsLookup },
+  options?: { dnsLookup?: DnsLookup; clientIp?: string },
 ): Promise<{
   deliveryId: string;
   outcome: WebhookDeliveryOutcome;
@@ -1963,6 +2069,7 @@ export async function executeWebhookTestProbe(
       outcome: 'denied',
       address: subscription.address,
       webhookId: subscription.id,
+      ...(options?.clientIp ? { ip: options.clientIp } : {}),
     });
     recordAuditEvent({
       event: 'webhook.disabled',
@@ -2276,13 +2383,9 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
     });
     const latest = groupRows[0]!;
 
-    // 3. Discard group if latest row is final (§8.6 step 3)
-    const isSuccessOrRefused = latest.outcome === 'success' || latest.outcome === 'refused';
-    const isPermanent = latest.outcome === 'permanent';
-    const isCompletedMaxRetryable =
-      latest.outcome === 'retryable' && latest.attempt >= MAX_RETRY_SCHEDULE_ATTEMPTS;
-
-    if (isSuccessOrRefused || isPermanent || isCompletedMaxRetryable) {
+    // 3. Discard group if latest row is final (§8.6 step 3) using the
+    // event type's actual cap (ping=3, others=WEBHOOK_MAX_ATTEMPTS).
+    if (isTerminalDeliveryRow(latest)) {
       continue;
     }
 

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -371,7 +371,7 @@ export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
     let offset = 0;
     while (offset < buf.length) {
       const written = writeSync(fd, buf, offset, buf.length - offset);
-      if (written <= 0) break;
+      if (written <= 0) throw new Error('short_write');
       offset += written;
     }
     fsyncSync(fd);
@@ -656,12 +656,32 @@ export function validateWebhookUrlStatic(
 /**
  * Resolution validation of webhook URL before persistence or on update (§9.3, §9.5, §10.4 Rule C).
  */
+export const WEBHOOK_URL_DNS_TIMEOUT_MS = 5_000;
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('dns_lookup_timeout')), timeoutMs);
+    timer.unref?.();
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (err) => {
+        clearTimeout(timer);
+        reject(err);
+      },
+    );
+  });
+}
+
 export async function validateWebhookUrlResolution(
   urlStr: string,
   opts: {
     allowPrivateTargets: boolean;
     dnsLookup?: DnsLookup;
     allowedPorts?: number[];
+    dnsLookupTimeoutMs?: number;
   },
 ): Promise<
   | { valid: true; isPrivateTarget: boolean; parsedUrl: URL }
@@ -686,7 +706,10 @@ export async function validateWebhookUrlResolution(
     resolvedAddresses = [literal];
   } else {
     try {
-      const list = await dnsLookup(literal);
+      const list = await withTimeout(
+        dnsLookup(literal),
+        opts.dnsLookupTimeoutMs ?? WEBHOOK_URL_DNS_TIMEOUT_MS,
+      );
       if (list.length === 0) {
         return { valid: false, code: 'invalid_webhook_url', error: 'dns_empty' };
       }

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -56,7 +56,7 @@ export function truncateUtf8String(str: string, maxBytes: number): string {
 
 import { getMessage, withInbox } from './imap.ts';
 import { getTaskSnapshot } from './tasks-internal.ts';
-import { notificationService } from './notify.ts';
+import { registerWebhookCancelCallback } from './identities.ts';
 
 let customDnsLookupForTests: DnsLookup | undefined;
 export function setWebhookDnsLookupForTests(fn?: DnsLookup): void {
@@ -1442,19 +1442,6 @@ class WebhookDeliveryQueue {
         address: sub.address,
         webhookId: sub.id,
       });
-
-      // Best effort notify
-      const localpart = sub.address.split('@')[0];
-      void notificationService()
-        .publish({
-          target: localpart ? `agent:${localpart}` : 'user',
-          title: 'Webhook Disabled: SSRF Refused',
-          message: `Webhook ${sub.id} disabled due to SSRF policy violation.`,
-          level: 'urgent',
-          tags: ['webhook', 'disabled'],
-          identityAddress: sub.address,
-        })
-        .catch(() => {});
     } else if (result.outcome === 'permanent') {
       this.jobs.delete(key);
       updateWebhookSubscription(sub.id, (s) => {
@@ -1473,17 +1460,6 @@ class WebhookDeliveryQueue {
           address: sub.address,
           webhookId: sub.id,
         });
-        const localpart = sub.address.split('@')[0];
-        void notificationService()
-          .publish({
-            target: localpart ? `agent:${localpart}` : 'user',
-            title: 'Webhook Disabled: Threshold Reached',
-            message: `Webhook ${sub.id} disabled after ${config.webhooks.disableThreshold} consecutive failures.`,
-            level: 'urgent',
-            tags: ['webhook', 'disabled'],
-            identityAddress: sub.address,
-          })
-          .catch(() => {});
       }
     } else if (result.outcome === 'retryable') {
       updateWebhookSubscription(sub.id, (s) => {
@@ -1502,17 +1478,6 @@ class WebhookDeliveryQueue {
           address: sub.address,
           webhookId: sub.id,
         });
-        const localpart = sub.address.split('@')[0];
-        void notificationService()
-          .publish({
-            target: localpart ? `agent:${localpart}` : 'user',
-            title: 'Webhook Disabled: Threshold Reached',
-            message: `Webhook ${sub.id} disabled after ${config.webhooks.disableThreshold} consecutive failures.`,
-            level: 'urgent',
-            tags: ['webhook', 'disabled'],
-            identityAddress: sub.address,
-          })
-          .catch(() => {});
       }
 
       // Check if breaker tripped; if so, dead-letter and stop retrying
@@ -1570,6 +1535,11 @@ class WebhookDeliveryQueue {
 }
 
 export const deliveryQueue = new WebhookDeliveryQueue();
+
+// Register cascade cancellation hook for deleted identities
+registerWebhookCancelCallback((webhookId, reason) => {
+  deliveryQueue.cancelForWebhook(webhookId, reason);
+});
 
 // ---------------------------------------------------------------------------
 // Public Dispatch APIs

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -9,7 +9,6 @@
 
 import { randomUUID } from 'node:crypto';
 import {
-  appendFileSync,
   chmodSync,
   closeSync,
   existsSync,
@@ -17,7 +16,9 @@ import {
   mkdirSync,
   openSync,
   readFileSync,
+  readSync,
   renameSync,
+  statSync,
   unlinkSync,
   writeFileSync,
   writeSync,
@@ -52,7 +53,7 @@ import {
   type WebhookState,
 } from './webhook-store.ts';
 import { encodeMailForwardCursor } from './mail-cursor.ts';
-import { truncateUtf8Bytes } from './utf8-truncate.ts';
+import { truncateUtf8Bytes, truncateUtf8Codepoints } from './utf8-truncate.ts';
 
 export function truncateUtf8String(str: string, maxBytes: number): string {
   const buf = Buffer.from(str, 'utf8');
@@ -327,13 +328,201 @@ function ensureDataDir(): void {
   }
 }
 
-/** Append a single row to DATA_DIR/webhook-deliveries.jsonl (0600 mode). */
-export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
-  ensureDataDir();
-  const path = deliveryLogPath();
+type DeliveryLogIndex = {
+  path: string;
+  ino: number | null;
+  mtimeMs: number;
+  size: number;
+  rows: WebhookDeliveryLogRow[];
+  latestByWebhook: Map<string, WebhookDeliveryLogRow>;
+  latestByGroup: Map<string, WebhookDeliveryLogRow>;
+};
 
-  // Normalize row fields, ensuring forbidden keys or arbitrary payload never land in log
-  const sanitizedRow: WebhookDeliveryLogRow = {
+function emptyDeliveryLogIndex(path = ''): DeliveryLogIndex {
+  return {
+    path,
+    ino: null,
+    mtimeMs: 0,
+    size: 0,
+    rows: [],
+    latestByWebhook: new Map(),
+    latestByGroup: new Map(),
+  };
+}
+
+let deliveryLogIndex: DeliveryLogIndex = emptyDeliveryLogIndex();
+
+function groupKeyForRow(row: WebhookDeliveryLogRow): string {
+  return `${row.webhookId}:${row.eventId}:${row.runId}`;
+}
+
+function isNewerDeliveryRow(a: WebhookDeliveryLogRow, b: WebhookDeliveryLogRow): boolean {
+  const tsA = new Date(a.ts).getTime();
+  const tsB = new Date(b.ts).getTime();
+  if (tsA !== tsB) return tsA > tsB;
+  return a.attempt > b.attempt;
+}
+
+function upsertLatestRow(
+  map: Map<string, WebhookDeliveryLogRow>,
+  key: string,
+  row: WebhookDeliveryLogRow,
+): void {
+  const prev = map.get(key);
+  if (!prev || isNewerDeliveryRow(row, prev)) map.set(key, row);
+}
+
+function applyRowToIndex(index: DeliveryLogIndex, row: WebhookDeliveryLogRow): void {
+  index.rows.push(row);
+  upsertLatestRow(index.latestByWebhook, row.webhookId, row);
+  upsertLatestRow(index.latestByGroup, groupKeyForRow(row), row);
+}
+
+function parseDeliveryLogText(content: string): WebhookDeliveryLogRow[] {
+  const lines = content.split('\n');
+  const rows: WebhookDeliveryLogRow[] = [];
+  let corruptCount = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    if (!line) continue;
+    try {
+      rows.push(JSON.parse(line));
+    } catch (err) {
+      corruptCount++;
+      console.error(
+        `[webhooks] corrupted delivery log line ${i + 1} skipped:`,
+        line.slice(0, 100),
+        err,
+      );
+    }
+  }
+
+  if (corruptCount > 0) {
+    console.error(
+      `[webhooks] readAllDeliveryLogRows skipped ${corruptCount} corrupted line(s) in delivery log`,
+    );
+  }
+
+  return rows;
+}
+
+function captureIndexCursor(index: DeliveryLogIndex, path: string): void {
+  if (!existsSync(path)) {
+    index.path = path;
+    index.ino = null;
+    index.mtimeMs = 0;
+    index.size = 0;
+    return;
+  }
+  const st = statSync(path);
+  index.path = path;
+  index.ino = st.ino;
+  index.mtimeMs = st.mtimeMs;
+  index.size = st.size;
+}
+
+function adoptDeliveryLogIndex(rows: WebhookDeliveryLogRow[]): void {
+  const path = deliveryLogPath();
+  const index = emptyDeliveryLogIndex(path);
+  for (const row of rows) applyRowToIndex(index, row);
+  captureIndexCursor(index, path);
+  deliveryLogIndex = index;
+}
+
+function rebuildDeliveryLogIndexFromDisk(): DeliveryLogIndex {
+  adoptDeliveryLogIndex(readAllDeliveryLogRowsFromDisk());
+  return deliveryLogIndex;
+}
+
+function ingestIncrementalBytes(index: DeliveryLogIndex, chunk: Buffer): number {
+  if (chunk.length === 0) return 0;
+  const text = chunk.toString('utf8');
+  const lastNl = text.lastIndexOf('\n');
+  if (lastNl < 0) return 0;
+  const complete = text.slice(0, lastNl + 1);
+  for (const line of complete.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      applyRowToIndex(index, JSON.parse(trimmed));
+    } catch (err) {
+      console.error(
+        '[webhooks] corrupted delivery log line skipped during incremental read:',
+        trimmed.slice(0, 100),
+        err,
+      );
+    }
+  }
+  return Buffer.byteLength(complete, 'utf8');
+}
+
+function refreshDeliveryLogIndex(): DeliveryLogIndex {
+  const path = deliveryLogPath();
+  if (!existsSync(path)) {
+    deliveryLogIndex = emptyDeliveryLogIndex(path);
+    return deliveryLogIndex;
+  }
+  const st = statSync(path);
+  const pathChanged = deliveryLogIndex.path !== path;
+  const inodeChanged = deliveryLogIndex.ino !== st.ino;
+  const truncated = st.size < deliveryLogIndex.size;
+  const rewrittenInPlace =
+    st.size === deliveryLogIndex.size &&
+    st.mtimeMs !== deliveryLogIndex.mtimeMs &&
+    deliveryLogIndex.ino !== null;
+  if (pathChanged || inodeChanged || truncated || rewrittenInPlace || deliveryLogIndex.ino === null) {
+    return rebuildDeliveryLogIndexFromDisk();
+  }
+  if (st.size === deliveryLogIndex.size) {
+    return deliveryLogIndex;
+  }
+
+  const length = st.size - deliveryLogIndex.size;
+  const fd = openSync(path, 'r');
+  try {
+    const buf = Buffer.alloc(length);
+    const n = readSync(fd, buf, 0, length, deliveryLogIndex.size);
+    const consumed = ingestIncrementalBytes(deliveryLogIndex, buf.subarray(0, n));
+    deliveryLogIndex.size += consumed;
+    deliveryLogIndex.mtimeMs = st.mtimeMs;
+    deliveryLogIndex.ino = st.ino;
+  } finally {
+    closeSync(fd);
+  }
+  return deliveryLogIndex;
+}
+
+function syncIndexAfterAppend(row: WebhookDeliveryLogRow, lineBytes: number): void {
+  const path = deliveryLogPath();
+  if (!existsSync(path)) return;
+  const st = statSync(path);
+  if (
+    deliveryLogIndex.path === path &&
+    deliveryLogIndex.ino === st.ino &&
+    deliveryLogIndex.size + lineBytes === st.size
+  ) {
+    applyRowToIndex(deliveryLogIndex, row);
+    deliveryLogIndex.size = st.size;
+    deliveryLogIndex.mtimeMs = st.mtimeMs;
+    return;
+  }
+  deliveryLogIndex.ino = null;
+}
+
+export function resetDeliveryLogIndexForTests(): void {
+  deliveryLogIndex = emptyDeliveryLogIndex();
+}
+
+/** Full-file parse used by boot reconstruction and compaction. */
+export function readAllDeliveryLogRowsFromDisk(): WebhookDeliveryLogRow[] {
+  const path = deliveryLogPath();
+  if (!existsSync(path)) return [];
+  return parseDeliveryLogText(readFileSync(path, 'utf8'));
+}
+
+function sanitizeDeliveryLogRow(row: WebhookDeliveryLogRow): WebhookDeliveryLogRow {
+  return {
     ts: row.ts,
     webhookId: row.webhookId,
     eventId: row.eventId,
@@ -358,7 +547,13 @@ export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
     nextAttemptAt: row.nextAttemptAt,
     reason: row.reason ?? null,
   };
+}
 
+/** Append a single row to DATA_DIR/webhook-deliveries.jsonl (0600 mode). */
+export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
+  ensureDataDir();
+  const path = deliveryLogPath();
+  const sanitizedRow = sanitizeDeliveryLogRow(row);
   const line = `${JSON.stringify(sanitizedRow)}\n`;
   const fd = openSync(path, 'a', 0o600);
   try {
@@ -378,53 +573,22 @@ export function appendDeliveryLogRow(row: WebhookDeliveryLogRow): void {
   } finally {
     closeSync(fd);
   }
+  syncIndexAfterAppend(sanitizedRow, Buffer.byteLength(line, 'utf8'));
 }
 
 /**
- * Reads all delivery log rows from disk, with per-line fault tolerance.
+ * Reads all delivery log rows, parsing only bytes appended since the last
+ * cursor (offset + mtime/inode). Compaction rename rebuilds the index.
  *
  * Semantic distinction:
  * - Webhook configuration store (`webhooks.json`): fail-closed on read.
- *   If the subscription store is corrupt, serving state is unsafe so we must halt
- *   and refuse mutations to protect customer secrets and invariants.
  * - Webhook delivery log (`webhook-deliveries.jsonl`): append-only event log.
  *   Writes are fail-closed (atomic fsync append), but reads fail open:
- *   corrupted or partial lines (e.g. from power loss before fsync or dirty disk writes)
- *   are skipped and logged as errors so that a single bad line does not crash the entire
- *   API on startup or cause 500s across read endpoints.
+ *   corrupted or partial lines are skipped so a single bad line does not crash
+ *   the API on startup or cause 500s across read endpoints.
  */
 export function readAllDeliveryLogRows(): WebhookDeliveryLogRow[] {
-  const path = deliveryLogPath();
-  if (!existsSync(path)) return [];
-
-  const content = readFileSync(path, 'utf8');
-  const lines = content.split('\n');
-  const rows: WebhookDeliveryLogRow[] = [];
-  let corruptCount = 0;
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!.trim();
-    if (!line) continue;
-    try {
-      const parsed = JSON.parse(line);
-      rows.push(parsed);
-    } catch (err) {
-      corruptCount++;
-      console.error(
-        `[webhooks] corrupted delivery log line ${i + 1} skipped:`,
-        line.slice(0, 100),
-        err,
-      );
-    }
-  }
-
-  if (corruptCount > 0) {
-    console.error(
-      `[webhooks] readAllDeliveryLogRows skipped ${corruptCount} corrupted line(s) in delivery log`,
-    );
-  }
-
-  return rows;
+  return refreshDeliveryLogIndex().rows.slice();
 }
 
 /**
@@ -488,7 +652,7 @@ export function latestDeliveryByWebhookId(
 
 /** Returns the latest delivery attempt for an endpoint, if any. */
 export function getLatestDeliveryForWebhook(webhookId: string): WebhookDeliveryLogRow | null {
-  return latestDeliveryByWebhookId(readAllDeliveryLogRows()).get(webhookId) ?? null;
+  return refreshDeliveryLogIndex().latestByWebhook.get(webhookId) ?? null;
 }
 
 /**
@@ -501,7 +665,7 @@ export function compactDeliveryLog(
   const path = deliveryLogPath();
   if (!existsSync(path)) return;
 
-  const rows = readAllDeliveryLogRows();
+  const rows = readAllDeliveryLogRowsFromDisk();
   const retentionCutoff = now - retentionDays * 86400000;
 
   // Identify groups with pending retries so we never prune them
@@ -572,6 +736,8 @@ export function compactDeliveryLog(
   } catch {
     // best effort
   }
+
+  adoptDeliveryLogIndex(retainedRows);
 }
 
 export function startWebhookMaintenance(): void {
@@ -839,7 +1005,7 @@ export function formatMailPayload(
 
   if (isPreview) {
     if (input.textPreview !== undefined) {
-      data.textPreview = truncateUtf8String(
+      data.textPreview = truncateUtf8Codepoints(
         input.textPreview,
         (config.webhooks as any)?.bodyPreviewChars ?? WEBHOOK_BODY_PREVIEW_CHARS,
       );
@@ -848,7 +1014,7 @@ export function formatMailPayload(
       data.securityCodes = input.securityCodes
         .slice(0, (config.webhooks as any)?.maxCodeItems ?? WEBHOOK_MAX_CODE_ITEMS)
         .map((c) =>
-          truncateUtf8String(
+          truncateUtf8Codepoints(
             c,
             (config.webhooks as any)?.codeEntryChars ?? WEBHOOK_CODE_ENTRY_CHARS,
           ),
@@ -858,7 +1024,7 @@ export function formatMailPayload(
       // Over-long links (> webhookCodeEntryChars) are dropped whole, never truncated (§6.2, §6.6)
       const codeChars = (config.webhooks as any)?.codeEntryChars ?? WEBHOOK_CODE_ENTRY_CHARS;
       data.links = input.links
-        .filter((l) => Buffer.byteLength(l, 'utf8') <= codeChars)
+        .filter((l) => [...l].length <= codeChars)
         .slice(0, (config.webhooks as any)?.maxCodeItems ?? WEBHOOK_MAX_CODE_ITEMS);
     }
   }
@@ -2163,6 +2329,11 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
     err.code = 'delivery_not_found';
     throw err;
   }
+  if (!isTerminalDeliveryRow(original)) {
+    const err: any = new Error('delivery_not_replayable');
+    err.code = 'delivery_not_replayable';
+    throw err;
+  }
 
   const sub = getWebhookSubscription(original.webhookId);
   if (!sub) {
@@ -2408,7 +2579,8 @@ export async function reconstructPendingDeliveriesAtBoot(
   reconstructed: number;
   deadLettered: number;
 }> {
-  const rows = readAllDeliveryLogRows();
+  const rows = readAllDeliveryLogRowsFromDisk();
+  adoptDeliveryLogIndex(rows);
   if (rows.length === 0) return { reconstructed: 0, deadLettered: 0 };
 
   // 1. Group rows by (webhookId, eventId, runId)

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -1471,6 +1471,8 @@ export type ScheduledDeliveryJob = {
   expiresInSec: number | null;
   eventCreatedAt: string;
   deferredCount?: number;
+  /** When set, executeJob re-checks the shared probe bucket before sending. */
+  probeTokenKey?: string;
 };
 
 class WebhookDeliveryQueue {
@@ -1677,6 +1679,44 @@ class WebhookDeliveryQueue {
     }
 
     const now = Date.now();
+
+    if (job.probeTokenKey) {
+      const probeCheck = deliveryLimiter.checkTestProbeRate(job.probeTokenKey, now);
+      if (!probeCheck.allowed) {
+        this.jobs.delete(key);
+        recordAuditEvent({
+          event: 'webhook.probe_rate_limited',
+          outcome: 'rate_limited',
+          address: sub.address,
+          webhookId: sub.id,
+        });
+        appendDeliveryLogRow({
+          ts: new Date().toISOString(),
+          webhookId: job.webhookId,
+          eventId: job.eventId,
+          runId: job.runId,
+          deliveryId: job.deliveryId,
+          type: job.type,
+          address: job.address,
+          messageId: job.messageId,
+          uidValidity: job.uidValidity,
+          rfc822MessageId: job.rfc822MessageId,
+          taskId: job.taskId,
+          taskCreatedAt: job.taskCreatedAt,
+          expiresInSec: job.expiresInSec,
+          eventCreatedAt: job.eventCreatedAt,
+          attempt: job.attempt,
+          outcome: 'permanent',
+          status: null,
+          durationMs: null,
+          sensitive: false,
+          replay: job.replay,
+          nextAttemptAt: null,
+          reason: 'probe_rate_limited',
+        });
+        return;
+      }
+    }
 
     // Check item 2: 72h horizon check for job
     if (now > job.firstAttemptAt + RETRY_HORIZON_SEC * 1000) {
@@ -1992,6 +2032,7 @@ export function enqueueWebhookDelivery(params: {
   expiresInSec?: number | null;
   eventCreatedAt?: string;
   delayMs?: number;
+  probeTokenKey?: string;
 }): void {
   const sub = params.subscription;
   const now = Date.now();
@@ -2074,6 +2115,7 @@ export function enqueueWebhookDelivery(params: {
     taskCreatedAt: params.taskCreatedAt ?? null,
     expiresInSec: params.expiresInSec ?? null,
     eventCreatedAt,
+    probeTokenKey: params.probeTokenKey,
   });
 }
 
@@ -2087,8 +2129,8 @@ export function fireCreationPing(
 ): void {
   const tokenKey = callerTokenKey ?? subscription.createdBy ?? subscription.address;
   const probeCheck = deliveryLimiter.checkTestProbeRate(tokenKey);
-  // Probe-full: still enqueue a delayed ping (deferred: no attempt consumed).
-  // Dropping here left the subscription stuck unverified.
+  // Probe-full: enqueue delayed; executeJob re-checks the shared bucket and
+  // audits+drops if still full (create+retarget must not bypass the quota).
   const delayMs = probeCheck.allowed ? 0 : Math.max(config.webhooks.poolRetryMs, 1);
 
   const eventId = `evt_${randomUUID()}`;
@@ -2107,6 +2149,7 @@ export function fireCreationPing(
     payloadBuilder: (currentSub) => formatPingPayload(envelope, currentSub.id, trigger),
     address: null,
     delayMs,
+    probeTokenKey: probeCheck.allowed ? undefined : tokenKey,
   });
 }
 
@@ -2730,8 +2773,12 @@ export async function reconstructPendingDeliveriesAtBoot(
         let task: any = null;
         try {
           task = await getTaskSnapshot(latest.taskId);
-        } catch {
-          throw Object.assign(new Error('task_not_found'), { reason: 'task_not_found' });
+        } catch (err: any) {
+          throw Object.assign(new Error(err?.message || 'backend_unreachable'), {
+            reason: 'transient_backend_unreachable',
+            isTransient: true,
+            cause: err,
+          });
         }
         if (!task || task.kind !== 'approval' || !task.approval) {
           throw Object.assign(new Error('task_not_found'), { reason: 'task_not_found' });

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -1526,7 +1526,9 @@ class WebhookDeliveryQueue {
 
     // 1. Check endpoint concurrency & global concurrency pool (§8.7)
     if (!deliveryLimiter.acquireSlot(job.webhookId)) {
-      // Pool saturated or endpoint busy: defer! (§8.2)
+      // Pool saturated or endpoint busy: memory-only reschedule (§8.2).
+      // The durable pending row already carries nextAttemptAt; do not append
+      // a deferred row per tick (that unbounded the JSONL log).
       const isPoolFull = deliveryLimiter.getActiveTotal() >= config.webhooks.maxConcurrent;
       job.deferredCount = (job.deferredCount ?? 0) + 1;
       const delay = isPoolFull
@@ -1563,31 +1565,6 @@ class WebhookDeliveryQueue {
         });
         return;
       }
-
-      appendDeliveryLogRow({
-        ts: new Date().toISOString(),
-        webhookId: job.webhookId,
-        eventId: job.eventId,
-        runId: job.runId,
-        deliveryId: `dlv_${randomUUID()}`,
-        type: job.type,
-        address: job.address,
-        messageId: job.messageId,
-        uidValidity: job.uidValidity,
-        rfc822MessageId: job.rfc822MessageId,
-        taskId: job.taskId,
-        taskCreatedAt: job.taskCreatedAt,
-        expiresInSec: job.expiresInSec,
-        eventCreatedAt: job.eventCreatedAt,
-        attempt: job.attempt,
-        outcome: 'deferred',
-        status: null,
-        durationMs: null,
-        sensitive: false,
-        replay: job.replay,
-        nextAttemptAt: new Date(rescheduleAt).toISOString(),
-        reason: isPoolFull ? 'concurrency_pool_full' : 'endpoint_busy',
-      });
 
       job.nextAttemptAt = rescheduleAt;
       this.scheduleIfStillQueued(key, job);
@@ -1631,31 +1608,6 @@ class WebhookDeliveryQueue {
         });
         return;
       }
-
-      appendDeliveryLogRow({
-        ts: new Date().toISOString(),
-        webhookId: job.webhookId,
-        eventId: job.eventId,
-        runId: job.runId,
-        deliveryId: `dlv_${randomUUID()}`,
-        type: job.type,
-        address: job.address,
-        messageId: job.messageId,
-        uidValidity: job.uidValidity,
-        rfc822MessageId: job.rfc822MessageId,
-        taskId: job.taskId,
-        taskCreatedAt: job.taskCreatedAt,
-        expiresInSec: job.expiresInSec,
-        eventCreatedAt: job.eventCreatedAt,
-        attempt: job.attempt,
-        outcome: 'deferred',
-        status: null,
-        durationMs: null,
-        sensitive: false,
-        replay: job.replay,
-        nextAttemptAt: new Date(rescheduleAt).toISOString(),
-        reason: 'rate_limited',
-      });
 
       job.nextAttemptAt = rescheduleAt;
       this.scheduleIfStillQueued(key, job);

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -203,6 +203,23 @@ export function isTerminalDeliveryRow(
 }
 
 /**
+ * §5.1 / §8.5: creation-ping (and any ping while unverified) is the setup race.
+ * A permanent ping (typically 400/401 signature reject) is never counted.
+ */
+export function countsTowardCircuitBreaker(
+  type: WebhookEventType,
+  outcome: WebhookDeliveryOutcome,
+  sub: Pick<WebhookSubscription, 'state'>,
+): boolean {
+  if (outcome !== 'retryable' && outcome !== 'permanent') return false;
+  if (type === 'webhook.ping') {
+    if (sub.state === 'unverified') return false;
+    if (outcome === 'permanent') return false;
+  }
+  return true;
+}
+
+/**
  * Parse HTTP Retry-After as delay-seconds. The entire trimmed value must be a
  * base-10 integer in 1..3600; strings like "3600junk" are rejected.
  */
@@ -496,12 +513,7 @@ export function compactDeliveryLog(
       return new Date(b.ts).getTime() - new Date(a.ts).getTime();
     });
     const latest = groupRows[0]!;
-    const isFinal =
-      latest.outcome === 'success' ||
-      latest.outcome === 'permanent' ||
-      latest.outcome === 'refused' ||
-      (latest.outcome === 'retryable' && latest.attempt >= MAX_RETRY_SCHEDULE_ATTEMPTS);
-    if (!isFinal) {
+    if (!isTerminalDeliveryRow(latest)) {
       activeGroupKeys.add(key);
     }
   }
@@ -1318,6 +1330,11 @@ class WebhookDeliveryQueue {
     }
     this.activeTimers.clear();
     this.jobs.clear();
+    cancelReconstructionRetries();
+  }
+
+  isJobQueued(webhookId: string, eventId: string, runId: string): boolean {
+    return this.jobs.has(`${webhookId}:${eventId}:${runId}`);
   }
 
   hasQueuedJob(webhookId: string, eventId?: string): boolean {
@@ -1683,51 +1700,37 @@ class WebhookDeliveryQueue {
         address: sub.address,
         webhookId: sub.id,
       });
-    } else if (result.outcome === 'permanent') {
-      this.jobs.delete(key);
-      updateWebhookSubscription(sub.id, (s) => {
-        s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
-        if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
-          s.state = 'disabled';
-          s.disabledReason = 'threshold';
-        }
-      });
-
-      const updated = getWebhookSubscription(sub.id);
-      if (updated?.state === 'disabled') {
-        recordAuditEvent({
-          event: 'webhook.disabled',
-          outcome: 'ok',
-          address: sub.address,
-          webhookId: sub.id,
-        });
-      }
-    } else if (result.outcome === 'retryable') {
-      updateWebhookSubscription(sub.id, (s) => {
-        s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
-        if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
-          s.state = 'disabled';
-          s.disabledReason = 'threshold';
-        }
-      });
-
-      const updated = getWebhookSubscription(sub.id);
-      if (updated?.state === 'disabled') {
-        recordAuditEvent({
-          event: 'webhook.disabled',
-          outcome: 'ok',
-          address: sub.address,
-          webhookId: sub.id,
-        });
-      }
-
-      // Check if breaker tripped; if so, dead-letter and stop retrying
-      if (updated?.state === 'disabled') {
+    } else if (result.outcome === 'permanent' || result.outcome === 'retryable') {
+      if (result.outcome === 'permanent') {
         this.jobs.delete(key);
-        result.outcome = 'permanent';
-        result.reason = 'webhook_disabled';
-      } else {
-        // Calculate retry schedule
+      }
+
+      if (countsTowardCircuitBreaker(job.type, result.outcome, sub)) {
+        updateWebhookSubscription(sub.id, (s) => {
+          s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
+          if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
+            s.state = 'disabled';
+            s.disabledReason = 'threshold';
+          }
+        });
+
+        const updated = getWebhookSubscription(sub.id);
+        if (updated?.state === 'disabled') {
+          recordAuditEvent({
+            event: 'webhook.disabled',
+            outcome: 'ok',
+            address: sub.address,
+            webhookId: sub.id,
+          });
+          if (result.outcome === 'retryable') {
+            this.jobs.delete(key);
+            result.outcome = 'permanent';
+            result.reason = 'webhook_disabled';
+          }
+        }
+      }
+
+      if (result.outcome === 'retryable') {
         const retryAfterMatch = result.reason?.match(/^rate_limited_retry_after_(\d+)$/);
         const retryAfterSec = retryAfterMatch ? Number.parseInt(retryAfterMatch[1]!, 10) : undefined;
         nextScheduledTime = calculateNextAttemptTime(currentAttempt, job.firstAttemptAt, {
@@ -1737,7 +1740,6 @@ class WebhookDeliveryQueue {
         });
 
         if (nextScheduledTime === null) {
-          // Max attempts reached: dead-letter (§8.3)
           this.jobs.delete(key);
         }
       }
@@ -2077,7 +2079,7 @@ export async function executeWebhookTestProbe(
       address: subscription.address,
       webhookId: subscription.id,
     });
-  } else {
+  } else if (countsTowardCircuitBreaker('webhook.ping', fetchResult.outcome, subscription)) {
     updateWebhookSubscription(subscription.id, (s) => {
       s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
       if (s.consecutiveFailures >= config.webhooks.disableThreshold && s.state !== 'disabled') {
@@ -2349,11 +2351,62 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
   };
 }
 
+export const RECONSTRUCT_RETRY_INITIAL_MS = 30_000;
+export const RECONSTRUCT_RETRY_MAX_MS = 600_000;
+
+let reconstructRetryInitialMs = RECONSTRUCT_RETRY_INITIAL_MS;
+let reconstructRetryMaxMs = RECONSTRUCT_RETRY_MAX_MS;
+const reconstructRetryTimers = new Map<string, ReturnType<typeof setTimeout>>();
+const reconstructRetryDelays = new Map<string, number>();
+
+export function setReconstructRetryDelaysForTests(initialMs?: number, maxMs?: number): void {
+  cancelReconstructionRetries();
+  reconstructRetryInitialMs = initialMs ?? RECONSTRUCT_RETRY_INITIAL_MS;
+  reconstructRetryMaxMs = maxMs ?? RECONSTRUCT_RETRY_MAX_MS;
+}
+
+export function pendingReconstructionRetryCount(): number {
+  return reconstructRetryTimers.size;
+}
+
+function cancelReconstructionRetries(): void {
+  for (const timer of reconstructRetryTimers.values()) {
+    clearTimeout(timer);
+  }
+  reconstructRetryTimers.clear();
+  reconstructRetryDelays.clear();
+}
+
+function nextReconstructRetryDelay(key: string): number {
+  const prev = reconstructRetryDelays.get(key);
+  const next =
+    prev === undefined
+      ? reconstructRetryInitialMs
+      : Math.min(prev * 2, reconstructRetryMaxMs);
+  reconstructRetryDelays.set(key, next);
+  return next;
+}
+
+function scheduleReconstructionRetry(key: string): void {
+  const existing = reconstructRetryTimers.get(key);
+  if (existing) clearTimeout(existing);
+  const delay = nextReconstructRetryDelay(key);
+  const timer = setTimeout(() => {
+    reconstructRetryTimers.delete(key);
+    void reconstructPendingDeliveriesAtBoot(Date.now(), { onlyKeys: new Set([key]) });
+  }, delay);
+  timer.unref?.();
+  reconstructRetryTimers.set(key, timer);
+}
+
 /**
  * Boot reconstruction algorithm (§8.6).
  * Reconstructs pending delivery attempts from webhook-deliveries.jsonl.
  */
-export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()): Promise<{
+export async function reconstructPendingDeliveriesAtBoot(
+  bootTime = Date.now(),
+  options?: { onlyKeys?: Set<string> },
+): Promise<{
   reconstructed: number;
   deadLettered: number;
 }> {
@@ -2376,6 +2429,8 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
   let deadLettered = 0;
 
   for (const [key, groupRows] of groups.entries()) {
+    if (options?.onlyKeys && !options.onlyKeys.has(key)) continue;
+
     // 2. Take only the row with highest attempt, tie-broken on ts
     groupRows.sort((a, b) => {
       if (a.attempt !== b.attempt) return b.attempt - a.attempt;
@@ -2386,6 +2441,43 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
     // 3. Discard group if latest row is final (§8.6 step 3) using the
     // event type's actual cap (ping=3, others=WEBHOOK_MAX_ATTEMPTS).
     if (isTerminalDeliveryRow(latest)) {
+      reconstructRetryDelays.delete(key);
+      continue;
+    }
+
+    if (deliveryQueue.isJobQueued(latest.webhookId, latest.eventId, latest.runId)) {
+      reconstructRetryDelays.delete(key);
+      continue;
+    }
+
+    const createdMs = Date.parse(latest.eventCreatedAt);
+    if (Number.isFinite(createdMs) && bootTime > createdMs + RETRY_HORIZON_SEC * 1000) {
+      deadLettered++;
+      reconstructRetryDelays.delete(key);
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: latest.webhookId,
+        eventId: latest.eventId,
+        runId: latest.runId,
+        deliveryId: `dlv_${randomUUID()}`,
+        type: latest.type,
+        address: latest.address,
+        messageId: latest.messageId,
+        uidValidity: latest.uidValidity,
+        rfc822MessageId: latest.rfc822MessageId,
+        taskId: latest.taskId,
+        taskCreatedAt: latest.taskCreatedAt,
+        expiresInSec: latest.expiresInSec,
+        eventCreatedAt: latest.eventCreatedAt,
+        attempt: latest.attempt,
+        outcome: 'permanent',
+        status: null,
+        durationMs: null,
+        sensitive: false,
+        replay: latest.replay,
+        nextAttemptAt: null,
+        reason: 'retry_horizon_exceeded',
+      });
       continue;
     }
 
@@ -2417,6 +2509,7 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
         nextAttemptAt: null,
         reason: !sub ? 'subscription_deleted' : 'webhook_disabled',
       });
+      reconstructRetryDelays.delete(key);
       continue;
     }
 
@@ -2636,14 +2729,14 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
       });
 
       reconstructed++;
+      reconstructRetryDelays.delete(key);
     } catch (err: any) {
       if (err?.isTransient) {
         console.warn(
-          `[webhooks] boot reconstruction transient failure for delivery ${latest.eventId} / webhook ${latest.webhookId}, retaining pending state:`,
+          `[webhooks] boot reconstruction transient failure for delivery ${latest.eventId} / webhook ${latest.webhookId}, retrying with bounded backoff:`,
           err?.message,
         );
-        // Do NOT append a permanent dead-letter row!
-        // Leave the pending row intact in the delivery log for next boot/retry.
+        scheduleReconstructionRetry(key);
         continue;
       }
 
@@ -2672,6 +2765,7 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
         nextAttemptAt: null,
         reason: err?.reason || err?.message || 'reconstruction_failed',
       });
+      reconstructRetryDelays.delete(key);
     }
   }
 

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -39,6 +39,7 @@ import {
   deriveWebhookKey,
 } from './webhook-signing.ts';
 import {
+  compactIdempotencyKeys,
   getWebhookSubscription,
   listWebhookSubscriptions,
   updateWebhookSubscription,
@@ -57,6 +58,7 @@ export function truncateUtf8String(str: string, maxBytes: number): string {
 import { getMessage, withInbox } from './imap.ts';
 import { getTaskSnapshot } from './tasks-internal.ts';
 import { registerWebhookCancelCallback } from './identities.ts';
+import { simpleParser } from 'mailparser';
 
 let customDnsLookupForTests: DnsLookup | undefined;
 export function setWebhookDnsLookupForTests(fn?: DnsLookup): void {
@@ -115,7 +117,7 @@ export type MailEventInput = {
   address: string;
   messageId: string;
   uid: number;
-  uidValidity: number;
+  uidValidity: number | null;
   receivedAt: string;
   rfc822MessageId?: string | null;
   from: { address: string; name?: string };
@@ -187,6 +189,7 @@ export function calculateNextAttemptTime(
   options?: {
     isPing?: boolean;
     retryAfterSec?: number;
+    receivedAtMs?: number;
     maxAttempts?: number;
     randomFn?: () => number;
   },
@@ -223,12 +226,14 @@ export function calculateNextAttemptTime(
     options.retryAfterSec >= 1 &&
     options.retryAfterSec <= 3600
   ) {
+    const arrivalTimeMs =
+      options.receivedAtMs ??
+      firstAttemptTimeMs + (RETRY_SCHEDULE_OFFSETS_SEC[currentAttempt - 1] ?? 0) * 1000;
+    const scheduledByArrival = arrivalTimeMs + options.retryAfterSec * 1000;
     const baseOffsetSec = RETRY_SCHEDULE_OFFSETS_SEC[idx]!;
-    const scheduledOffsetSec = Math.max(
-      RETRY_SCHEDULE_OFFSETS_SEC[idx - 1]! + options.retryAfterSec,
-      baseOffsetSec,
-    );
-    return firstAttemptTimeMs + scheduledOffsetSec * 1000;
+    const scheduledByOffset = firstAttemptTimeMs + baseOffsetSec * 1000;
+    const nextTime = Math.max(scheduledByArrival, scheduledByOffset);
+    return Math.min(nextTime, firstAttemptTimeMs + (RETRY_HORIZON_SEC - 1) * 1000);
   }
 
   const prevOffset = RETRY_SCHEDULE_OFFSETS_SEC[idx - 1]!;
@@ -369,8 +374,8 @@ export function readDeliveryLogRows(options?: {
   }
 
   const paged = filtered.slice(startIndex, startIndex + limit);
-  const nextItem = filtered[startIndex + limit];
-  const nextCursor = nextItem ? nextItem.deliveryId : undefined;
+  const hasMore = startIndex + limit < filtered.length;
+  const nextCursor = hasMore && paged.length > 0 ? paged[paged.length - 1]!.deliveryId : undefined;
 
   return { deliveries: paged, nextCursor };
 }
@@ -444,6 +449,29 @@ export function compactDeliveryLog(
   const lines = retainedRows.map((r) => JSON.stringify(r)).join('\n') + (retainedRows.length ? '\n' : '');
   writeFileSync(tmpPath, lines, { mode: 0o600 });
   renameSync(tmpPath, path);
+}
+
+export function startWebhookMaintenance(): void {
+  const tick = () => {
+    try {
+      compactDeliveryLog();
+      compactIdempotencyKeys(config.webhooks.logRetentionDays);
+    } catch (err) {
+      console.error('[webhooks] maintenance failed:', err);
+    }
+  };
+  tick();
+  const schedule = () => {
+    const d = new Date();
+    const next = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
+    const delay = Math.max(1_000, next - Date.now());
+    const timer = setTimeout(() => {
+      tick();
+      schedule();
+    }, delay);
+    timer.unref?.();
+  };
+  schedule();
 }
 
 // ---------------------------------------------------------------------------
@@ -624,7 +652,7 @@ export function formatMailPayload(
         address: input.address,
         t: new Date(input.receivedAt).getTime(),
         uid: input.uid,
-        uidValidity: String(input.uidValidity),
+        uidValidity: input.uidValidity !== null ? String(input.uidValidity) : '0',
       },
       config.taskSigningSecret,
     ),
@@ -768,7 +796,7 @@ export function formatApprovalPayload(
     expiresAt: input.expiresAt,
     expiresInSec: input.expiresInSec,
     digest: input.digest,
-    actionType: input.actionType,
+    actionType: truncateUtf8String(input.actionType, metaFieldMaxBytes),
     actionName: truncateUtf8String(input.actionName, metaFieldMaxBytes),
   };
 
@@ -1015,9 +1043,23 @@ class WebhookDeliveryLimiter {
     return true;
   }
 
+  private slotReleaseListeners = new Set<(webhookId: string) => void>();
+
+  onSlotRelease(listener: (webhookId: string) => void): () => void {
+    this.slotReleaseListeners.add(listener);
+    return () => this.slotReleaseListeners.delete(listener);
+  }
+
   releaseSlot(webhookId: string): void {
     if (this.activePerEndpoint.delete(webhookId)) {
       this.activeTotal = Math.max(0, this.activeTotal - 1);
+      for (const listener of this.slotReleaseListeners) {
+        try {
+          listener(webhookId);
+        } catch {
+          // ignore listener errors
+        }
+      }
     }
   }
 
@@ -1071,7 +1113,7 @@ export type ScheduledDeliveryJob = {
   eventId: string;
   runId: string;
   type: WebhookEventType;
-  payloadBuilder: () => { body: string; sensitive: boolean };
+  payloadBuilder: (currentSub: WebhookSubscription) => { body: string; sensitive: boolean };
   firstAttemptAt: number;
   attempt: number;
   nextAttemptAt: number;
@@ -1084,11 +1126,31 @@ export type ScheduledDeliveryJob = {
   taskCreatedAt: string | null;
   expiresInSec: number | null;
   eventCreatedAt: string;
+  deferredCount?: number;
 };
 
 class WebhookDeliveryQueue {
   private activeTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private jobs = new Map<string, ScheduledDeliveryJob>();
+
+  constructor() {
+    deliveryLimiter.onSlotRelease((releasedWebhookId) => {
+      this.wakeUpDeferred(releasedWebhookId);
+    });
+  }
+
+  wakeUpDeferred(webhookId: string): void {
+    for (const [key, job] of this.jobs.entries()) {
+      if (job.webhookId === webhookId || deliveryLimiter.getActiveTotal() < config.webhooks.maxConcurrent) {
+        if ((job.deferredCount ?? 0) > 0) {
+          job.deferredCount = 0;
+          this.clearTimer(key);
+          job.nextAttemptAt = Date.now();
+          void this.executeJob(key);
+        }
+      }
+    }
+  }
 
   private jobKey(webhookId: string, eventId: string, runId: string): string {
     return `${webhookId}:${eventId}:${runId}`;
@@ -1234,7 +1296,11 @@ class WebhookDeliveryQueue {
     if (!deliveryLimiter.acquireSlot(job.webhookId)) {
       // Pool saturated or endpoint busy: defer! (§8.2)
       const isPoolFull = deliveryLimiter.getActiveTotal() >= config.webhooks.maxConcurrent;
-      const rescheduleAt = now + (isPoolFull ? config.webhooks.poolRetryMs : 100);
+      job.deferredCount = (job.deferredCount ?? 0) + 1;
+      const delay = isPoolFull
+        ? config.webhooks.poolRetryMs
+        : Math.min(5000, 500 * Math.pow(1.5, Math.min(job.deferredCount - 1, 6)));
+      const rescheduleAt = now + delay;
 
       // Check item 2: deferred hitting 72h horizon -> terminal outcome=permanent + reason=retry_horizon_exceeded
       if (rescheduleAt > job.firstAttemptAt + RETRY_HORIZON_SEC * 1000) {
@@ -1370,7 +1436,7 @@ class WebhookDeliveryQueue {
     let sensitive = false;
 
     try {
-      const formatted = job.payloadBuilder();
+      const formatted = job.payloadBuilder(sub);
       body = formatted.body;
       sensitive = formatted.sensitive;
     } catch (err: any) {
@@ -1412,6 +1478,7 @@ class WebhookDeliveryQueue {
 
     // Process outcome & update circuit breaker (§8.5, D2a)
     const finishedTs = new Date().toISOString();
+    const currentAttempt = job.attempt;
     let nextScheduledTime: number | null = null;
 
     if (result.outcome === 'success') {
@@ -1489,19 +1556,15 @@ class WebhookDeliveryQueue {
         // Calculate retry schedule
         const retryAfterMatch = result.reason?.match(/^rate_limited_retry_after_(\d+)$/);
         const retryAfterSec = retryAfterMatch ? Number.parseInt(retryAfterMatch[1]!, 10) : undefined;
-        nextScheduledTime = calculateNextAttemptTime(job.attempt, job.firstAttemptAt, {
+        nextScheduledTime = calculateNextAttemptTime(currentAttempt, job.firstAttemptAt, {
           isPing: job.type === 'webhook.ping',
           retryAfterSec,
+          receivedAtMs: Date.now(),
         });
 
         if (nextScheduledTime === null) {
           // Max attempts reached: dead-letter (§8.3)
           this.jobs.delete(key);
-        } else {
-          // Advance job to next attempt
-          job.attempt++;
-          job.nextAttemptAt = nextScheduledTime;
-          this.schedule(job);
         }
       }
     }
@@ -1522,7 +1585,7 @@ class WebhookDeliveryQueue {
       taskCreatedAt: job.taskCreatedAt,
       expiresInSec: job.expiresInSec,
       eventCreatedAt: job.eventCreatedAt,
-      attempt: job.attempt,
+      attempt: currentAttempt,
       outcome: result.outcome,
       status: result.status,
       durationMs: result.durationMs,
@@ -1531,6 +1594,12 @@ class WebhookDeliveryQueue {
       nextAttemptAt: nextScheduledTime ? new Date(nextScheduledTime).toISOString() : null,
       reason: result.reason,
     });
+
+    if (result.outcome === 'retryable' && nextScheduledTime !== null) {
+      job.attempt = currentAttempt + 1;
+      job.nextAttemptAt = nextScheduledTime;
+      this.schedule(job);
+    }
   }
 }
 
@@ -1552,8 +1621,9 @@ export function enqueueWebhookDelivery(params: {
   subscription: WebhookSubscription;
   eventId: string;
   runId?: string;
+  deliveryId?: string;
   type: WebhookEventType;
-  payloadBuilder: () => { body: string; sensitive: boolean };
+  payloadBuilder: (currentSub: WebhookSubscription) => { body: string; sensitive: boolean };
   replay?: boolean;
   address?: string | null;
   messageId?: string | null;
@@ -1570,6 +1640,7 @@ export function enqueueWebhookDelivery(params: {
   const runId = params.runId ?? 'run_0';
   const eventCreatedAt = params.eventCreatedAt ?? new Date().toISOString();
   const nextAttemptAt = now + (params.delayMs ?? 0);
+  const deliveryId = params.deliveryId ?? `dlv_${randomUUID()}`;
 
   // If endpoint is disabled: dead-letter immediately rather than queuing (§8.5)
   if (sub.state === 'disabled') {
@@ -1578,7 +1649,7 @@ export function enqueueWebhookDelivery(params: {
       webhookId: sub.id,
       eventId: params.eventId,
       runId,
-      deliveryId: `dlv_${randomUUID()}`,
+      deliveryId,
       type: params.type,
       address: params.address ?? sub.address ?? null,
       messageId: params.messageId ?? null,
@@ -1606,7 +1677,7 @@ export function enqueueWebhookDelivery(params: {
     webhookId: sub.id,
     eventId: params.eventId,
     runId,
-    deliveryId: `dlv_${randomUUID()}`,
+    deliveryId,
     type: params.type,
     address: params.address ?? sub.address ?? null,
     messageId: params.messageId ?? null,
@@ -1653,7 +1724,14 @@ export function enqueueWebhookDelivery(params: {
 export function fireCreationPing(
   subscription: WebhookSubscription,
   trigger: 'creation' | 'test' = 'creation',
+  callerTokenKey?: string,
 ): void {
+  const tokenKey = callerTokenKey ?? subscription.createdBy ?? subscription.address;
+  const probeCheck = deliveryLimiter.checkTestProbeRate(tokenKey);
+  if (!probeCheck.allowed) {
+    return;
+  }
+
   const eventId = `evt_${randomUUID()}`;
   const envelope: WebhookEnvelopeBase = {
     id: eventId,
@@ -1667,7 +1745,7 @@ export function fireCreationPing(
     subscription,
     eventId,
     type: 'webhook.ping',
-    payloadBuilder: () => formatPingPayload(envelope, subscription.id, trigger),
+    payloadBuilder: (currentSub) => formatPingPayload(envelope, currentSub.id, trigger),
     address: null,
   });
 }
@@ -1716,8 +1794,9 @@ export async function executeWebhookTestProbe(
     domain: config.domain,
   };
 
-  const payloadBuilder = () => formatPingPayload(envelope, subscription.id, 'test');
-  const { body } = payloadBuilder();
+  const payloadBuilder = (currentSub: WebhookSubscription) =>
+    formatPingPayload(envelope, currentSub.id, 'test');
+  const { body } = payloadBuilder(subscription);
 
   // Write pending row
   appendDeliveryLogRow({
@@ -1745,13 +1824,33 @@ export async function executeWebhookTestProbe(
     reason: null,
   });
 
-  const fetchResult = await executeWebhookAttempt(
-    subscription,
-    body,
-    'webhook.ping',
-    deliveryId,
-    options,
-  );
+  // Acquire concurrency slot (Item 21)
+  const waitTimeout = config.webhooks.deliveryTimeoutMs || 10_000;
+  const startWait = Date.now();
+  while (!deliveryLimiter.acquireSlot(subscription.id)) {
+    if (Date.now() - startWait >= waitTimeout) {
+      const isPoolFull = deliveryLimiter.getActiveTotal() >= config.webhooks.maxConcurrent;
+      const err: any = new Error('rate_limited');
+      err.code = 'rate_limited';
+      err.retryAfterSec = 5;
+      err.reason = isPoolFull ? 'concurrency_pool_full' : 'endpoint_busy';
+      throw err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+
+  let fetchResult: WebhookFetchResult;
+  try {
+    fetchResult = await executeWebhookAttempt(
+      subscription,
+      body,
+      'webhook.ping',
+      deliveryId,
+      options,
+    );
+  } finally {
+    deliveryLimiter.releaseSlot(subscription.id);
+  }
 
   const finishedTs = new Date().toISOString();
 
@@ -1893,7 +1992,7 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
   const newDeliveryId = `dlv_${randomUUID()}`;
 
   // Rebuild payload based on event type
-  let payloadBuilder: () => { body: string; sensitive: boolean };
+  let payloadBuilder: (currentSub: WebhookSubscription) => { body: string; sensitive: boolean };
 
   if (original.type === 'webhook.ping') {
     const envelope: WebhookEnvelopeBase = {
@@ -1903,7 +2002,7 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
       createdAt: original.eventCreatedAt,
       domain: config.domain,
     };
-    payloadBuilder = () => formatPingPayload(envelope, sub.id, 'test');
+    payloadBuilder = (currentSub) => formatPingPayload(envelope, currentSub.id, 'test');
   } else if (original.type === 'approval.requested') {
     if (!original.taskId) {
       throw new Error('missing_task_id');
@@ -1919,8 +2018,8 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
       createdAt: original.eventCreatedAt,
       domain: config.domain,
     };
-    payloadBuilder = () =>
-      formatApprovalPayload(sub, envelope, {
+    payloadBuilder = (currentSub) =>
+      formatApprovalPayload(currentSub, envelope, {
         taskId: task.id,
         taskState: 'input-required',
         from: task.from,
@@ -1945,6 +2044,31 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
     if (!detail) {
       throw new Error('message_not_found');
     }
+
+    let unread = true;
+    let sizeBytes = 0;
+    let hasAttachments = false;
+    try {
+      await withInbox(async (client) => {
+        const uid = Number(detail.id);
+        const msg = await client.fetchOne(uid, { source: true, flags: true }, { uid: true });
+        if (msg) {
+          unread = !msg.flags?.has('\\Seen');
+          if (msg.source) {
+            sizeBytes = msg.source.length;
+            try {
+              const parsed = await simpleParser(msg.source);
+              hasAttachments = (parsed.attachments?.length ?? 0) > 0;
+            } catch {
+              // ignore parse failure
+            }
+          }
+        }
+      });
+    } catch {
+      // fallback to defaults
+    }
+
     const envelope: WebhookEnvelopeBase = {
       id: original.eventId,
       type: 'mail.received',
@@ -1952,20 +2076,20 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
       createdAt: original.eventCreatedAt,
       domain: config.domain,
     };
-    payloadBuilder = () =>
-      formatMailPayload(sub, envelope, {
+    payloadBuilder = (currentSub) =>
+      formatMailPayload(currentSub, envelope, {
         address: original.address!,
         messageId: detail.id,
         uid: Number(detail.id),
-        uidValidity: original.uidValidity ?? 0,
+        uidValidity: original.uidValidity ?? null,
         receivedAt: detail.date,
         from: { address: detail.from },
         to: [detail.to],
         cc: [],
         subject: detail.subject,
-        sizeBytes: 0,
-        hasAttachments: false,
-        unread: true,
+        sizeBytes,
+        hasAttachments,
+        unread,
         containsSecurityCode: detail.otp.codes.length > 0,
         containsLink: detail.otp.links.length > 0,
         textPreview: detail.text,
@@ -1980,6 +2104,7 @@ export async function redeliverWebhookDelivery(deliveryId: string): Promise<{
     subscription: sub,
     eventId: original.eventId,
     runId: newRunId,
+    deliveryId: newDeliveryId,
     type: original.type,
     payloadBuilder,
     replay: true,
@@ -2085,7 +2210,7 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
 
     // 5. Rebuild payload (§8.6 step 5)
     try {
-      let payloadBuilder: () => { body: string; sensitive: boolean };
+      let payloadBuilder: (currentSub: WebhookSubscription) => { body: string; sensitive: boolean };
 
       if (latest.type === 'webhook.ping') {
         const envelope: WebhookEnvelopeBase = {
@@ -2095,7 +2220,7 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
           createdAt: latest.eventCreatedAt,
           domain: config.domain,
         };
-        payloadBuilder = () => formatPingPayload(envelope, sub.id, 'test');
+        payloadBuilder = (currentSub) => formatPingPayload(envelope, currentSub.id, 'test');
       } else if (latest.type === 'approval.requested') {
         if (!latest.taskId) {
           throw Object.assign(new Error('missing_task_id'), { reason: 'task_not_found' });
@@ -2117,8 +2242,8 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
           domain: config.domain,
         };
         // Item 9: restore taskCreatedAt and expiresInSec from row!
-        payloadBuilder = () =>
-          formatApprovalPayload(sub, envelope, {
+        payloadBuilder = (currentSub) =>
+          formatApprovalPayload(currentSub, envelope, {
             taskId: task.id,
             taskState: 'input-required',
             from: task.from,
@@ -2143,6 +2268,9 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
         let activeUidValidity = latest.uidValidity;
 
         let mailDetail: any = null;
+        let unread = true;
+        let sizeBytes = 0;
+        let hasAttachments = false;
         try {
           mailDetail = await withInbox(async (client) => {
             const currentGen = client.mailbox ? Number(client.mailbox.uidValidity) : undefined;
@@ -2170,9 +2298,32 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
               const newUid = foundUids[0]!;
               activeUid = String(newUid);
               activeUidValidity = currentGen;
+              const msg = await client.fetchOne(newUid, { source: true, flags: true }, { uid: true });
+              if (msg) {
+                unread = !msg.flags?.has('\\Seen');
+                if (msg.source) {
+                  sizeBytes = msg.source.length;
+                  try {
+                    const parsed = await simpleParser(msg.source);
+                    hasAttachments = (parsed.attachments?.length ?? 0) > 0;
+                  } catch {}
+                }
+              }
               return getMessage(latest.address!, activeUid, { uidValidity: currentGen });
             }
 
+            const uidNum = Number(latest.messageId);
+            const msg = await client.fetchOne(uidNum, { source: true, flags: true }, { uid: true });
+            if (msg) {
+              unread = !msg.flags?.has('\\Seen');
+              if (msg.source) {
+                sizeBytes = msg.source.length;
+                try {
+                  const parsed = await simpleParser(msg.source);
+                  hasAttachments = (parsed.attachments?.length ?? 0) > 0;
+                } catch {}
+              }
+            }
             return getMessage(latest.address!, latest.messageId!, {
               uidValidity: latest.uidValidity ?? undefined,
             });
@@ -2194,20 +2345,20 @@ export async function reconstructPendingDeliveriesAtBoot(bootTime = Date.now()):
           domain: config.domain,
         };
 
-        payloadBuilder = () =>
-          formatMailPayload(sub, envelope, {
+        payloadBuilder = (currentSub) =>
+          formatMailPayload(currentSub, envelope, {
             address: latest.address!,
             messageId: activeUid,
             uid: Number(activeUid),
-            uidValidity: activeUidValidity ?? 0,
+            uidValidity: activeUidValidity ?? null,
             receivedAt: mailDetail.date,
             from: { address: mailDetail.from },
             to: [mailDetail.to],
             cc: [],
             subject: mailDetail.subject,
-            sizeBytes: 0,
-            hasAttachments: false,
-            unread: true,
+            sizeBytes,
+            hasAttachments,
+            unread,
             containsSecurityCode: mailDetail.otp.codes.length > 0,
             containsLink: mailDetail.otp.links.length > 0,
             textPreview: mailDetail.text,

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -1716,6 +1716,9 @@ class WebhookDeliveryQueue {
         });
         return;
       }
+      // Once admitted, clear probeTokenKey so background retries never re-deduct
+      // or re-check the caller's probe rate bucket (§8.7).
+      delete job.probeTokenKey;
     }
 
     // Check item 2: 72h horizon check for job

--- a/packages/api/src/lib/webhook-signing.ts
+++ b/packages/api/src/lib/webhook-signing.ts
@@ -1,0 +1,212 @@
+/**
+ * Webhook 签名与密钥派生机制 (RFC-0001 §7, §12.1, §12.2)
+ *
+ * 规范：
+ * - 派生密钥：HMAC-SHA256(rootSecret, "webhook-signing-v1\n" + webhookId + "\n" + epoch) (32 字节)
+ * - 展示密钥：displayedSecret = "whs_" + lowerCaseHex(endpointKey) (68 字符)
+ * - 签名密钥：signingKey = utf8Bytes(displayedSecret) (68 字节，whs_ 为密钥本体一部分)
+ * - 签名串：signedPayload = t + "." + rawRequestBody
+ * - 签名计算：lower-case hex HMAC-SHA256(signingKey, signedPayload)
+ * - 头部格式：X-OAE-Signature: t=<unix-seconds>,v1=<hex>[,v1=<hex>]
+ * - 轮换重叠：overlapUntil 内发射 (epoch, epoch - 1) 双签
+ * - 根密钥重叠：WEBHOOK_SIGNING_SECRET_PREVIOUS 配置时发射旧根签名
+ */
+
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { config } from './config.ts';
+
+export type DerivedWebhookKey = {
+  rawKey: Buffer;
+  displayedSecret: string;
+  signingKey: Buffer;
+  secretPrefix: string;
+};
+
+/**
+ * 依据 rootSecret + webhookId + epoch 确定性派生端点签名密钥（§12.1）。
+ * 显示形式 whs_<64-hex> 本身即为 HMAC 签名的 ASCII 密钥。
+ */
+export function deriveWebhookKey(
+  rootSecret: string,
+  webhookId: string,
+  epoch: number,
+): DerivedWebhookKey {
+  if (!rootSecret || rootSecret.length < 32) {
+    throw new Error('webhook signing root secret must be at least 32 characters');
+  }
+  const derivationMessage = `webhook-signing-v1\n${webhookId}\n${epoch}`;
+  const rawKey = createHmac('sha256', rootSecret)
+    .update(derivationMessage, 'utf8')
+    .digest();
+  const hex = rawKey.toString('hex');
+  const displayedSecret = `whs_${hex}`;
+  const signingKey = Buffer.from(displayedSecret, 'utf8');
+  const secretPrefix = `${displayedSecret.slice(0, 8)}…`;
+
+  return {
+    rawKey,
+    displayedSecret,
+    signingKey,
+    secretPrefix,
+  };
+}
+
+export function getWebhookSigningRoot(cfg = config): string {
+  return cfg.webhooks.signingSecret ?? cfg.taskSigningSecret;
+}
+
+export type BuildSignatureOptions = {
+  rootSecret?: string;
+  webhookId: string;
+  epoch: number;
+  rawBody: string | Buffer;
+  timestampSec?: number;
+  overlapUntil?: string | null;
+  previousRootSecret?: string;
+  nowMs?: number;
+};
+
+export type BuildSignatureResult = {
+  headerValue: string;
+  timestampSec: number;
+  primarySignature: string;
+  signatures: string[];
+};
+
+/**
+ * 构造 X-OAE-Signature 头部值（含轮换重叠双签支持，§7.2, §12.2）。
+ */
+export function buildWebhookSignatureHeader(
+  options: BuildSignatureOptions,
+): BuildSignatureResult {
+  const root = options.rootSecret ?? getWebhookSigningRoot();
+  const nowMs = options.nowMs ?? Date.now();
+  const t = options.timestampSec ?? Math.floor(nowMs / 1000);
+  const rawBodyStr =
+    typeof options.rawBody === 'string'
+      ? options.rawBody
+      : options.rawBody.toString('utf8');
+  const signedPayload = `${t}.${rawBodyStr}`;
+
+  // 1. 主签名 (当前 epoch)
+  const primaryDerived = deriveWebhookKey(root, options.webhookId, options.epoch);
+  const primarySig = createHmac('sha256', primaryDerived.signingKey)
+    .update(signedPayload, 'utf8')
+    .digest('hex');
+
+  const signatures: string[] = [primarySig];
+
+  // 2. Epoch 轮换重叠签名 (§12.2)
+  if (
+    options.overlapUntil &&
+    options.epoch > 0 &&
+    nowMs < new Date(options.overlapUntil).getTime()
+  ) {
+    const prevDerived = deriveWebhookKey(root, options.webhookId, options.epoch - 1);
+    const prevSig = createHmac('sha256', prevDerived.signingKey)
+      .update(signedPayload, 'utf8')
+      .digest('hex');
+    signatures.push(prevSig);
+  }
+
+  // 3. 根密钥轮换重叠签名 (§12.2)
+  const prevRoot = options.previousRootSecret ?? config.webhooks.signingSecretPrevious;
+  if (prevRoot) {
+    const prevRootDerived = deriveWebhookKey(prevRoot, options.webhookId, options.epoch);
+    const prevRootSig = createHmac('sha256', prevRootDerived.signingKey)
+      .update(signedPayload, 'utf8')
+      .digest('hex');
+    signatures.push(prevRootSig);
+  }
+
+  const headerValue = `t=${t},${signatures.map((s) => `v1=${s}`).join(',')}`;
+
+  return {
+    headerValue,
+    timestampSec: t,
+    primarySignature: primarySig,
+    signatures,
+  };
+}
+
+export type VerifySignatureOptions = {
+  signatureHeader: string | null | undefined;
+  rawBody: string | Buffer;
+  secret: string; // "whs_<64hex>"
+  nowMs?: number;
+  toleranceSec?: number;
+};
+
+export type VerifySignatureResult = {
+  valid: boolean;
+  reason?:
+    | 'missing_header'
+    | 'invalid_header'
+    | 'timestamp_out_of_range'
+    | 'signature_mismatch';
+};
+
+/**
+ * 校验 X-OAE-Signature 头部（标准实现，供测试与消费方对照，§7.3）。
+ */
+export function verifyWebhookSignature(
+  options: VerifySignatureOptions,
+): VerifySignatureResult {
+  const { signatureHeader, rawBody, secret } = options;
+  if (!signatureHeader || !signatureHeader.trim()) {
+    return { valid: false, reason: 'missing_header' };
+  }
+
+  const parts = signatureHeader.split(',');
+  let t: number | undefined;
+  const v1Sigs: string[] = [];
+
+  for (const part of parts) {
+    const trimmed = part.trim();
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    const k = trimmed.slice(0, eqIdx);
+    const v = trimmed.slice(eqIdx + 1);
+    if (k === 't') {
+      const parsedT = Number.parseInt(v, 10);
+      if (Number.isFinite(parsedT) && parsedT >= 0) {
+        t = parsedT;
+      }
+    } else if (k === 'v1') {
+      v1Sigs.push(v);
+    }
+    // 未知键忽略（向后兼容，例如未来 v2=）
+  }
+
+  if (t === undefined || v1Sigs.length === 0) {
+    return { valid: false, reason: 'invalid_header' };
+  }
+
+  const nowMs = options.nowMs ?? Date.now();
+  const toleranceSec = options.toleranceSec ?? config.webhooks.timestampToleranceSec;
+  const nowSec = Math.floor(nowMs / 1000);
+
+  if (Math.abs(nowSec - t) > toleranceSec) {
+    return { valid: false, reason: 'timestamp_out_of_range' };
+  }
+
+  const rawBodyStr = typeof rawBody === 'string' ? rawBody : rawBody.toString('utf8');
+  const signedPayload = `${t}.${rawBodyStr}`;
+  const signingKeyBuf = Buffer.from(secret, 'utf8');
+  const expectedSigHex = createHmac('sha256', signingKeyBuf)
+    .update(signedPayload, 'utf8')
+    .digest('hex');
+  const expectedSigBuf = Buffer.from(expectedSigHex, 'utf8');
+
+  for (const sig of v1Sigs) {
+    const candidateBuf = Buffer.from(sig, 'utf8');
+    if (
+      candidateBuf.length === expectedSigBuf.length &&
+      timingSafeEqual(candidateBuf, expectedSigBuf)
+    ) {
+      return { valid: true };
+    }
+  }
+
+  return { valid: false, reason: 'signature_mismatch' };
+}

--- a/packages/api/src/lib/webhook-signing.ts
+++ b/packages/api/src/lib/webhook-signing.ts
@@ -110,7 +110,12 @@ export function buildWebhookSignatureHeader(
   }
 
   // 3. 根密钥轮换重叠签名 (§12.2)
-  const prevRoot = options.previousRootSecret ?? config.webhooks.signingSecretPrevious;
+  const prevRoot =
+    options.previousRootSecret !== undefined
+      ? options.previousRootSecret
+      : options.rootSecret !== undefined
+        ? undefined
+        : config.webhooks.signingSecretPrevious;
   if (prevRoot) {
     const prevRootDerived = deriveWebhookKey(prevRoot, options.webhookId, options.epoch);
     const prevRootSig = createHmac('sha256', prevRootDerived.signingKey)

--- a/packages/api/src/lib/webhook-sink.ts
+++ b/packages/api/src/lib/webhook-sink.ts
@@ -1,0 +1,268 @@
+/**
+ * Webhook Event Sink (§11.4, §6.2, §6.3).
+ *
+ * Implements the process-wide EventSink interface for outbound webhooks:
+ * 1. handleMail: matches recipient addresses to active webhooks and enqueues mail.received deliveries.
+ * 2. handleApproval: matches reviewer address to active webhooks and enqueues approval.requested deliveries (with §6.3 trimmed fields).
+ */
+
+import { randomUUID } from 'node:crypto';
+import { simpleParser } from 'mailparser';
+import type { FetchMessageObject } from 'imapflow';
+import { config } from './config.ts';
+import type {
+  ApprovalRequestedEvent,
+  EventSink,
+  MailDispatchContext,
+  MailReceivedEvent,
+  SinkWatermark,
+} from './event-dispatcher.ts';
+import { messageRecipients } from './imap.ts';
+import { extractOtp, htmlToText } from './otp.ts';
+import {
+  enqueueWebhookDelivery,
+  formatApprovalPayload,
+  formatMailPayload,
+  type ApprovalEventInput,
+  type MailEventInput,
+  type WebhookEnvelopeBase,
+} from './webhook-delivery.ts';
+import { listWebhookSubscriptions, type WebhookSubscription } from './webhook-store.ts';
+
+export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
+  return {
+    id: 'webhook',
+    isEnabled: () => config.webhooks.enabled,
+    watermark,
+
+    async handleApproval(event: ApprovalRequestedEvent): Promise<void> {
+      if (!config.webhooks.enabled) return;
+
+      const task = event.task;
+      if (!task || task.kind !== 'approval' || !task.approval) return;
+
+      const reviewer = task.approval.reviewer;
+      if (!reviewer) return;
+
+      const allSubs = listWebhookSubscriptions();
+      const matchedSubs = allSubs.filter(
+        (sub) =>
+          sub.state !== 'disabled' &&
+          sub.events.includes('approval.requested') &&
+          sub.address === reviewer,
+      );
+
+      if (matchedSubs.length === 0) return;
+
+      const eventCreatedAt = new Date().toISOString();
+      const createdAtMs = new Date(task.createdAt).getTime();
+      const expiresAtMs = new Date(task.approval.expiresAt).getTime();
+      const expiresInSec = Math.max(0, Math.floor((expiresAtMs - createdAtMs) / 1000));
+
+      const input: ApprovalEventInput = {
+        taskId: task.id,
+        taskState: 'input-required',
+        from: task.from,
+        to: task.to,
+        reviewer,
+        subject: task.subject,
+        createdAt: task.createdAt,
+        expiresAt: task.approval.expiresAt,
+        expiresInSec,
+        digest: task.approval.digest,
+        actionType: task.approval.action.type,
+        actionName: task.approval.action.name,
+        actionArguments: task.approval.action.arguments,
+      };
+
+      for (const sub of matchedSubs) {
+        const eventId = `evt_${randomUUID()}`;
+        const envelope: WebhookEnvelopeBase = {
+          id: eventId,
+          type: 'approval.requested',
+          payloadVersion: 'v1',
+          createdAt: eventCreatedAt,
+          domain: config.domain,
+        };
+
+        enqueueWebhookDelivery({
+          subscription: sub,
+          eventId,
+          type: 'approval.requested',
+          payloadBuilder: () => formatApprovalPayload(sub, envelope, input),
+          address: sub.address,
+          taskId: task.id,
+          taskCreatedAt: task.createdAt,
+          expiresInSec,
+          eventCreatedAt,
+        });
+      }
+    },
+
+    async handleMail(event: MailReceivedEvent, context?: MailDispatchContext): Promise<void> {
+      if (!config.webhooks.enabled) return;
+
+      const message = event.message;
+      const uid = message.uid;
+      const uidValidity = event.uidValidity !== undefined ? Number(event.uidValidity) : 0;
+      const recipients = messageRecipients(message as FetchMessageObject);
+      if (recipients.size === 0) return;
+
+      const allSubs = listWebhookSubscriptions();
+      const activeMailSubs = allSubs.filter(
+        (s) => s.state !== 'disabled' && s.events.includes('mail.received'),
+      );
+      if (activeMailSubs.length === 0) return;
+
+      // Group active subscriptions by matching recipient address
+      const matchedByRecipient = new Map<string, WebhookSubscription[]>();
+      for (const recipient of recipients) {
+        const subsForRecipient = activeMailSubs.filter((s) => s.address === recipient);
+        if (subsForRecipient.length > 0) {
+          matchedByRecipient.set(recipient, subsForRecipient);
+        }
+      }
+
+      if (matchedByRecipient.size === 0) return;
+
+      // Parse message content once for all recipient deliveries
+      const envelopeDate = message.envelope?.date;
+      const receivedAt = (
+        message.internalDate instanceof Date
+          ? message.internalDate
+          : message.internalDate
+            ? new Date(message.internalDate)
+            : envelopeDate instanceof Date
+              ? envelopeDate
+              : new Date()
+      ).toISOString();
+
+      const unread = !message.flags?.has('\\Seen');
+      const sizeBytes = message.source ? message.source.length : 0;
+
+      let subject = typeof message.envelope?.subject === 'string' ? message.envelope.subject : '';
+      let fromAddress =
+        (message.envelope?.from as Array<{ address?: string | null }> | undefined)?.[0]?.address ??
+        'unknown@domain';
+      let fromName =
+        (message.envelope?.from as Array<{ name?: string | null }> | undefined)?.[0]?.name ??
+        undefined;
+      let toAddresses: string[] = (
+        message.envelope?.to as Array<{ address?: string | null }> | undefined
+      )
+        ?.map((t) => t.address ?? '')
+        .filter(Boolean) ?? [];
+      let ccAddresses: string[] = (
+        message.envelope?.cc as Array<{ address?: string | null }> | undefined
+      )
+        ?.map((c) => c.address ?? '')
+        .filter(Boolean) ?? [];
+      let rfc822MessageId: string | null = null;
+      if (message.envelope?.messageId) {
+        rfc822MessageId = Array.isArray(message.envelope.messageId)
+          ? message.envelope.messageId[0] ?? null
+          : String(message.envelope.messageId);
+      }
+
+      let text = '';
+      let securityCodes: string[] = [];
+      let links: string[] = [];
+      let hasAttachments = false;
+
+      if (message.source) {
+        try {
+          const parsed = await simpleParser(message.source);
+          if (typeof parsed.subject === 'string') subject = parsed.subject;
+          if (parsed.from?.value?.[0]?.address) {
+            fromAddress = parsed.from.value[0].address;
+            fromName = parsed.from.value[0].name || undefined;
+          }
+          if (parsed.to) {
+            const list = Array.isArray(parsed.to) ? parsed.to : [parsed.to];
+            const addrs = list.flatMap((t) => t.value.map((v) => v.address || '')).filter(Boolean);
+            if (addrs.length > 0) toAddresses = addrs;
+          }
+          if (parsed.cc) {
+            const list = Array.isArray(parsed.cc) ? parsed.cc : [parsed.cc];
+            const addrs = list.flatMap((c) => c.value.map((v) => v.address || '')).filter(Boolean);
+            if (addrs.length > 0) ccAddresses = addrs;
+          }
+          if (parsed.messageId) {
+            rfc822MessageId = parsed.messageId;
+          }
+
+          const parsedText = (parsed.text ?? '').trim();
+          const htmlText = parsed.html ? htmlToText(parsed.html) : '';
+          text = parsedText || htmlText;
+
+          const otp = extractOtp(text, parsed.html || undefined);
+          securityCodes = otp.codes;
+          links = otp.links;
+
+          hasAttachments = (parsed.attachments?.length ?? 0) > 0;
+        } catch {
+          // Parsing failure: proceed with envelope metadata
+        }
+      }
+
+      // Item 5: rfc822MessageId <= 512 bytes, overlong treated as null
+      let boundedRfc822MessageId: string | null = null;
+      if (rfc822MessageId) {
+        const trimmed = String(rfc822MessageId).trim();
+        if (Buffer.byteLength(trimmed, 'utf8') <= 512) {
+          boundedRfc822MessageId = trimmed;
+        }
+      }
+
+      const eventCreatedAt = new Date().toISOString();
+
+      for (const [recipient, subs] of matchedByRecipient.entries()) {
+        const input: MailEventInput = {
+          address: recipient,
+          messageId: String(uid),
+          uid,
+          uidValidity,
+          receivedAt,
+          from: {
+            address: fromAddress,
+            name: fromName,
+          },
+          to: toAddresses.length > 0 ? toAddresses : [recipient],
+          cc: ccAddresses,
+          subject,
+          sizeBytes,
+          hasAttachments,
+          unread,
+          containsSecurityCode: securityCodes.length > 0,
+          containsLink: links.length > 0,
+          textPreview: text,
+          securityCodes,
+          links,
+        };
+
+        for (const sub of subs) {
+          const eventId = `evt_${randomUUID()}`;
+          const envelope: WebhookEnvelopeBase = {
+            id: eventId,
+            type: 'mail.received',
+            payloadVersion: 'v1',
+            createdAt: eventCreatedAt,
+            domain: config.domain,
+          };
+
+          enqueueWebhookDelivery({
+            subscription: sub,
+            eventId,
+            type: 'mail.received',
+            payloadBuilder: () => formatMailPayload(sub, envelope, input),
+            address: recipient,
+            messageId: String(uid),
+            uidValidity,
+            rfc822MessageId: boundedRfc822MessageId,
+            eventCreatedAt,
+          });
+        }
+      }
+    },
+  };
+}

--- a/packages/api/src/lib/webhook-sink.ts
+++ b/packages/api/src/lib/webhook-sink.ts
@@ -57,7 +57,8 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
       const eventCreatedAt = new Date().toISOString();
       const createdAtMs = new Date(task.createdAt).getTime();
       const expiresAtMs = new Date(task.approval.expiresAt).getTime();
-      const expiresInSec = Math.max(0, Math.floor((expiresAtMs - createdAtMs) / 1000));
+      const rawExpiresInSec = Math.floor((expiresAtMs - createdAtMs) / 1000);
+      const expiresInSec = rawExpiresInSec > 0 ? rawExpiresInSec : null;
 
       const input: ApprovalEventInput = {
         taskId: task.id,
@@ -75,8 +76,8 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
         actionArguments: task.approval.action.arguments,
       };
 
+      const eventId = `evt_${randomUUID()}`;
       for (const sub of matchedSubs) {
-        const eventId = `evt_${randomUUID()}`;
         const envelope: WebhookEnvelopeBase = {
           id: eventId,
           type: 'approval.requested',
@@ -89,7 +90,7 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
           subscription: sub,
           eventId,
           type: 'approval.requested',
-          payloadBuilder: () => formatApprovalPayload(sub, envelope, input),
+          payloadBuilder: (currentSub) => formatApprovalPayload(currentSub, envelope, input),
           address: sub.address,
           taskId: task.id,
           taskCreatedAt: task.createdAt,
@@ -104,7 +105,10 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
 
       const message = event.message;
       const uid = message.uid;
-      const uidValidity = event.uidValidity !== undefined ? Number(event.uidValidity) : 0;
+      const uidValidity =
+        event.uidValidity !== undefined && event.uidValidity !== null
+          ? Number(event.uidValidity)
+          : null;
       const recipients = messageRecipients(message as FetchMessageObject);
       if (recipients.size === 0) return;
 
@@ -240,8 +244,8 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
           links,
         };
 
+        const eventId = `evt_${randomUUID()}`;
         for (const sub of subs) {
-          const eventId = `evt_${randomUUID()}`;
           const envelope: WebhookEnvelopeBase = {
             id: eventId,
             type: 'mail.received',
@@ -254,7 +258,7 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
             subscription: sub,
             eventId,
             type: 'mail.received',
-            payloadBuilder: () => formatMailPayload(sub, envelope, input),
+            payloadBuilder: (currentSub) => formatMailPayload(currentSub, envelope, input),
             address: recipient,
             messageId: String(uid),
             uidValidity,

--- a/packages/api/src/lib/webhook-sink.ts
+++ b/packages/api/src/lib/webhook-sink.ts
@@ -27,7 +27,18 @@ import {
   type MailEventInput,
   type WebhookEnvelopeBase,
 } from './webhook-delivery.ts';
-import { listWebhookSubscriptions, type WebhookSubscription } from './webhook-store.ts';
+import {
+  listWebhookSubscriptions,
+  WebhookStoreCorruptError,
+  type WebhookSubscription,
+} from './webhook-store.ts';
+
+function rethrowStoreCorrupt(err: unknown): never {
+  if (err instanceof WebhookStoreCorruptError) {
+    throw Object.assign(err, { failureKind: 'service' as const });
+  }
+  throw err;
+}
 
 export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
   return {
@@ -44,7 +55,12 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
       const reviewer = task.approval.reviewer;
       if (!reviewer) return;
 
-      const allSubs = listWebhookSubscriptions();
+      let allSubs: WebhookSubscription[];
+      try {
+        allSubs = listWebhookSubscriptions();
+      } catch (err) {
+        rethrowStoreCorrupt(err);
+      }
       const matchedSubs = allSubs.filter(
         (sub) =>
           sub.state !== 'disabled' &&
@@ -112,7 +128,12 @@ export function createWebhookSink(watermark: SinkWatermark = {}): EventSink {
       const recipients = messageRecipients(message as FetchMessageObject);
       if (recipients.size === 0) return;
 
-      const allSubs = listWebhookSubscriptions();
+      let allSubs: WebhookSubscription[];
+      try {
+        allSubs = listWebhookSubscriptions();
+      } catch (err) {
+        rethrowStoreCorrupt(err);
+      }
       const activeMailSubs = allSubs.filter(
         (s) => s.state !== 'disabled' && s.events.includes('mail.received'),
       );

--- a/packages/api/src/lib/webhook-store.ts
+++ b/packages/api/src/lib/webhook-store.ts
@@ -82,6 +82,7 @@ export type WebhooksFile = {
 
 export class WebhookStoreCorruptError extends Error {
   readonly code = 'store_corrupt';
+  readonly failureKind = 'service' as const;
   constructor(message = 'webhooks store is corrupt') {
     super(message);
     this.name = 'WebhookStoreCorruptError';

--- a/packages/api/src/lib/webhook-store.ts
+++ b/packages/api/src/lib/webhook-store.ts
@@ -318,6 +318,14 @@ export function deleteWebhook(id: string): WebhookRecord | undefined {
   const idx = file.webhooks.findIndex((w) => w.id === id);
   if (idx < 0) return undefined;
   const [removed] = file.webhooks.splice(idx, 1);
+  if (file.createIdempotency) {
+    file.createIdempotency = file.createIdempotency.filter(
+      (c) => c.webhookId !== id && c.responseBody?.id !== id,
+    );
+  }
+  if (file.rotateIdempotency) {
+    file.rotateIdempotency = file.rotateIdempotency.filter((r) => r.webhookId !== id);
+  }
   writeStore(file);
   return removed;
 }
@@ -384,15 +392,28 @@ export function cascadeDeleteWebhooksForAddress(address: string): WebhookRecord[
   const file = readStore();
   const removed: WebhookRecord[] = [];
   const kept: WebhookRecord[] = [];
+  const removedIds = new Set<string>();
   for (const w of file.webhooks) {
     if (w.address.toLowerCase() === needle) {
       removed.push(w);
+      removedIds.add(w.id);
     } else {
       kept.push(w);
     }
   }
   if (removed.length === 0) return [];
   file.webhooks = kept;
+  if (file.createIdempotency) {
+    file.createIdempotency = file.createIdempotency.filter(
+      (c) =>
+        c.address.toLowerCase() !== needle &&
+        (!c.webhookId || !removedIds.has(c.webhookId)) &&
+        (!c.responseBody?.id || !removedIds.has(c.responseBody.id as string)),
+    );
+  }
+  if (file.rotateIdempotency) {
+    file.rotateIdempotency = file.rotateIdempotency.filter((r) => !removedIds.has(r.webhookId));
+  }
   writeStore(file);
   return removed;
 }
@@ -465,7 +486,9 @@ export function saveRotateIdempotency(record: RotateIdempotencyRecord): void {
   writeStore(file);
 }
 
-export function compactIdempotencyKeys(retentionDays: number): void {
+export function compactIdempotencyKeys(
+  retentionDays: number = config.webhooks.logRetentionDays,
+): void {
   const file = readStore();
   const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
   if (file.createIdempotency) {

--- a/packages/api/src/lib/webhook-store.ts
+++ b/packages/api/src/lib/webhook-store.ts
@@ -1,0 +1,505 @@
+/**
+ * Webhook 订阅注册表存储：DATA_DIR/webhooks.json (RFC-0001 §10.5)
+ *
+ * 规范约定：
+ * - 0600 文件，0700 目录
+ * - 单写者，原子 .tmp + rename，fsync 文件与目录
+ * - 损坏文件 fail-closed（抛错并标记拒绝读写）
+ * - FORBIDDEN_SECRET_KEYS 门闩：拒绝持久化 secret, signingSecret, previousSecret
+ * - 幂等键表持久化（create 与 rotate 幂等），留存至 WEBHOOK_LOG_RETENTION_DAYS
+ * - 身份删除级联硬删除订阅
+ */
+
+import {
+  chmodSync,
+  closeSync,
+  existsSync,
+  fsyncSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+  writeSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { config } from './config.ts';
+import { deriveWebhookKey } from './webhook-signing.ts';
+
+export const WEBHOOK_STORE_SCHEMA_VERSION = 1;
+export const WEBHOOK_STORE_FILE = 'webhooks.json';
+
+export type WebhookContentScope = 'metadata' | 'preview';
+export type WebhookState = 'unverified' | 'enabled' | 'disabled';
+export type WebhookDisabledReason = 'manual' | 'threshold' | 'refused' | null;
+
+export type WebhookRecord = {
+  id: string; // 'whk_' + UUIDv4
+  url: string;
+  address: string; // lower-cased
+  events: string[];
+  contentScope: WebhookContentScope;
+  description: string;
+  state: WebhookState;
+  disabledReason: WebhookDisabledReason;
+  secretPrefix: string;
+  epoch: number;
+  overlapUntil: string | null;
+  createdAt: string;
+  updatedAt: string;
+  rotatedAt: string | null;
+  consecutiveFailures: number;
+  privateTargetGranted: boolean;
+  createdBy: string; // 'admin' or address
+};
+
+export type CreateIdempotencyRecord = {
+  key: string;
+  address: string;
+  webhookId: string;
+  responseBody: Record<string, unknown>; // secret: null
+  createdAt: string;
+};
+
+export type RotateIdempotencyRecord = {
+  key: string;
+  webhookId: string;
+  epoch: number;
+  responseBody: Record<string, unknown>; // secret: null
+  createdAt: string;
+};
+
+export type WebhooksFile = {
+  schemaVersion: typeof WEBHOOK_STORE_SCHEMA_VERSION;
+  webhooks: WebhookRecord[];
+  createIdempotency?: CreateIdempotencyRecord[];
+  rotateIdempotency?: RotateIdempotencyRecord[];
+};
+
+export class WebhookStoreCorruptError extends Error {
+  readonly code = 'store_corrupt';
+  constructor(message = 'webhooks store is corrupt') {
+    super(message);
+    this.name = 'WebhookStoreCorruptError';
+  }
+}
+
+export class WebhookForbiddenSecretError extends Error {
+  readonly code = 'forbidden_secret_key';
+  constructor(key: string) {
+    super(`Cannot persist forbidden secret key: "${key}"`);
+    this.name = 'WebhookForbiddenSecretError';
+  }
+}
+
+/** 禁止落盘的键名（大小写不敏感）；只看 key，不扫字符串值。 */
+export const FORBIDDEN_SECRET_KEYS = new Set([
+  'password',
+  'token',
+  'secret',
+  'signingsecret',
+  'previoussecret',
+]);
+
+/** 内存 failClosed 闸。一旦检测到文件损坏，拒绝后续读写。 */
+let failClosed = false;
+
+function storePath(): string {
+  return join(config.dataDir, WEBHOOK_STORE_FILE);
+}
+
+function tmpPath(): string {
+  return `${storePath()}.tmp`;
+}
+
+function failClosedPath(): string {
+  return `${storePath()}.failclosed`;
+}
+
+export function webhookStoreHasForbiddenSecretKey(value: unknown): boolean {
+  if (value === null || typeof value !== 'object') return false;
+  if (Array.isArray(value)) {
+    return value.some((item) => webhookStoreHasForbiddenSecretKey(item));
+  }
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    if (FORBIDDEN_SECRET_KEYS.has(key.toLowerCase())) {
+      if (child !== null && child !== undefined) return true;
+    }
+    if (webhookStoreHasForbiddenSecretKey(child)) return true;
+  }
+  return false;
+}
+
+function ensureDataDir(): void {
+  mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
+  try {
+    chmodSync(config.dataDir, 0o700);
+  } catch {
+    // bind mount 属主可能不同；文件 mode 仍会设置
+  }
+}
+
+function writeAllSync(fd: number, text: string): void {
+  const buf = Buffer.from(text, 'utf8');
+  let offset = 0;
+  while (offset < buf.length) {
+    const n = writeSync(fd, buf, offset, buf.length - offset);
+    if (n <= 0) throw new Error('short_write');
+    offset += n;
+  }
+}
+
+function markStoreFailClosed(kind: string): void {
+  failClosed = true;
+  try {
+    writeFileSync(failClosedPath(), `${kind}\n`, { mode: 0o600 });
+  } catch {
+    // 内存闸仍拦住本进程
+  }
+  console.error(`[webhook-store] HIGH: fail-closed due to ${kind}`);
+}
+
+function checkFailClosed(): void {
+  if (failClosed || existsSync(failClosedPath())) {
+    failClosed = true;
+    throw new WebhookStoreCorruptError('webhooks store is in fail-closed state');
+  }
+}
+
+function parseFile(content: string): WebhooksFile {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    markStoreFailClosed('json_parse_error');
+    throw new WebhookStoreCorruptError(
+      `webhooks.json is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    markStoreFailClosed('root_not_object');
+    throw new WebhookStoreCorruptError('webhooks.json root must be an object');
+  }
+
+  const root = parsed as Record<string, unknown>;
+  if (root.schemaVersion !== WEBHOOK_STORE_SCHEMA_VERSION) {
+    markStoreFailClosed('unsupported_schema_version');
+    throw new WebhookStoreCorruptError(
+      `webhooks.json unsupported schemaVersion: ${root.schemaVersion}`,
+    );
+  }
+
+  if (!Array.isArray(root.webhooks)) {
+    markStoreFailClosed('webhooks_not_array');
+    throw new WebhookStoreCorruptError('webhooks.json webhooks must be an array');
+  }
+
+  // 基础校验每个记录的完整性
+  for (const item of root.webhooks) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      markStoreFailClosed('invalid_webhook_item');
+      throw new WebhookStoreCorruptError('webhooks.json item is not an object');
+    }
+    const r = item as Record<string, unknown>;
+    if (
+      typeof r.id !== 'string' ||
+      !r.id.startsWith('whk_') ||
+      typeof r.url !== 'string' ||
+      typeof r.address !== 'string' ||
+      !Array.isArray(r.events) ||
+      typeof r.contentScope !== 'string' ||
+      typeof r.state !== 'string' ||
+      typeof r.epoch !== 'number'
+    ) {
+      markStoreFailClosed('invalid_webhook_record_fields');
+      throw new WebhookStoreCorruptError('webhooks.json invalid record fields');
+    }
+  }
+
+  return root as WebhooksFile;
+}
+
+export function readStore(): WebhooksFile {
+  checkFailClosed();
+  ensureDataDir();
+  const file = storePath();
+  if (!existsSync(file)) {
+    return {
+      schemaVersion: WEBHOOK_STORE_SCHEMA_VERSION,
+      webhooks: [],
+      createIdempotency: [],
+      rotateIdempotency: [],
+    };
+  }
+
+  const text = readFileSync(file, 'utf8');
+  if (!text.trim()) {
+    return {
+      schemaVersion: WEBHOOK_STORE_SCHEMA_VERSION,
+      webhooks: [],
+      createIdempotency: [],
+      rotateIdempotency: [],
+    };
+  }
+
+  return parseFile(text);
+}
+
+export function writeStore(data: WebhooksFile): void {
+  checkFailClosed();
+  ensureDataDir();
+
+  // FORBIDDEN_SECRET_KEYS 门闩：绝不落盘密钥明文
+  if (webhookStoreHasForbiddenSecretKey(data)) {
+    throw new WebhookForbiddenSecretError('forbidden secret key detected in store payload');
+  }
+
+  const tmp = tmpPath();
+  const target = storePath();
+  const text = JSON.stringify(data, null, 2);
+
+  const fd = openSync(tmp, 'w', 0o600);
+  try {
+    writeAllSync(fd, text);
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+
+  try {
+    chmodSync(tmp, 0o600);
+  } catch {
+    // best-effort
+  }
+
+  renameSync(tmp, target);
+
+  // fsync 所在目录
+  try {
+    const dirFd = openSync(config.dataDir, 'r');
+    try {
+      fsyncSync(dirFd);
+    } finally {
+      closeSync(dirFd);
+    }
+  } catch {
+    // 目录 fsync 尽力而为（非 POSIX 兼容系统可能不支持）
+  }
+}
+
+export function listWebhooks(address?: string): WebhookRecord[] {
+  const file = readStore();
+  if (!address) return file.webhooks;
+  const needle = address.toLowerCase();
+  return file.webhooks.filter((w) => w.address.toLowerCase() === needle);
+}
+
+export function getWebhook(id: string): WebhookRecord | undefined {
+  const file = readStore();
+  return file.webhooks.find((w) => w.id === id);
+}
+
+export function saveWebhook(record: WebhookRecord): void {
+  const file = readStore();
+  const idx = file.webhooks.findIndex((w) => w.id === record.id);
+  if (idx >= 0) {
+    file.webhooks[idx] = record;
+  } else {
+    file.webhooks.push(record);
+  }
+  writeStore(file);
+}
+
+export function deleteWebhook(id: string): WebhookRecord | undefined {
+  const file = readStore();
+  const idx = file.webhooks.findIndex((w) => w.id === id);
+  if (idx < 0) return undefined;
+  const [removed] = file.webhooks.splice(idx, 1);
+  writeStore(file);
+  return removed;
+}
+
+export type WebhookSubscription = WebhookRecord;
+export const getWebhookSubscription = getWebhook;
+export const listWebhookSubscriptions = listWebhooks;
+export const deleteWebhookSubscription = deleteWebhook;
+
+export function updateWebhookSubscription(
+  id: string,
+  updater: (record: WebhookRecord) => void,
+): WebhookRecord | undefined {
+  const file = readStore();
+  const idx = file.webhooks.findIndex((w) => w.id === id);
+  if (idx < 0) return undefined;
+  updater(file.webhooks[idx]!);
+  file.webhooks[idx]!.updatedAt = new Date().toISOString();
+  writeStore(file);
+  return file.webhooks[idx];
+}
+
+export function createWebhookSubscription(params: {
+  url: string;
+  address: string;
+  events: string[];
+  contentScope?: WebhookContentScope;
+  description?: string;
+  privateTargetGranted?: boolean;
+  createdBy?: string;
+}): WebhookRecord {
+  const id = `whk_${randomUUID()}`;
+  const now = new Date().toISOString();
+  const derived = deriveWebhookKey(
+    config.webhooks.signingSecret || config.taskSigningSecret,
+    id,
+    0,
+  );
+  const record: WebhookRecord = {
+    id,
+    url: params.url,
+    address: params.address.toLowerCase(),
+    events: params.events,
+    contentScope: params.contentScope ?? 'metadata',
+    description: params.description ?? '',
+    state: 'unverified',
+    disabledReason: null,
+    secretPrefix: derived.secretPrefix,
+    epoch: 0,
+    overlapUntil: null,
+    createdAt: now,
+    updatedAt: now,
+    rotatedAt: null,
+    consecutiveFailures: 0,
+    privateTargetGranted: params.privateTargetGranted ?? false,
+    createdBy: params.createdBy ?? 'admin',
+  };
+  saveWebhook(record);
+  return record;
+}
+
+export function cascadeDeleteWebhooksForAddress(address: string): WebhookRecord[] {
+  const needle = address.toLowerCase();
+  const file = readStore();
+  const removed: WebhookRecord[] = [];
+  const kept: WebhookRecord[] = [];
+  for (const w of file.webhooks) {
+    if (w.address.toLowerCase() === needle) {
+      removed.push(w);
+    } else {
+      kept.push(w);
+    }
+  }
+  if (removed.length === 0) return [];
+  file.webhooks = kept;
+  writeStore(file);
+  return removed;
+}
+
+export function checkSubscriptionLimits(
+  address: string,
+  maxTotal: number = config.webhooks.maxSubscriptions,
+  maxPerAddress: number = config.webhooks.maxPerAddress,
+): { allowed: boolean; reason?: 'instance_limit' | 'address_limit' } {
+  const file = readStore();
+  if (maxTotal > 0 && file.webhooks.length >= maxTotal) {
+    return { allowed: false, reason: 'instance_limit' };
+  }
+  if (maxPerAddress > 0) {
+    const needle = address.toLowerCase();
+    const count = file.webhooks.filter((w) => w.address.toLowerCase() === needle).length;
+    if (count >= maxPerAddress) {
+      return { allowed: false, reason: 'address_limit' };
+    }
+  }
+  return { allowed: true };
+}
+
+export function findCreateIdempotency(
+  key: string,
+  address: string,
+): CreateIdempotencyRecord | undefined {
+  const file = readStore();
+  const needle = address.toLowerCase();
+  return file.createIdempotency?.find(
+    (c) => c.key === key && c.address.toLowerCase() === needle,
+  );
+}
+
+export function saveCreateIdempotency(record: CreateIdempotencyRecord): void {
+  const file = readStore();
+  file.createIdempotency = file.createIdempotency ?? [];
+  const idx = file.createIdempotency.findIndex(
+    (c) => c.key === record.key && c.address.toLowerCase() === record.address.toLowerCase(),
+  );
+  if (idx >= 0) {
+    file.createIdempotency[idx] = record;
+  } else {
+    file.createIdempotency.push(record);
+  }
+  writeStore(file);
+}
+
+export function findRotateIdempotency(
+  webhookId: string,
+  key: string,
+): RotateIdempotencyRecord | undefined {
+  const file = readStore();
+  return file.rotateIdempotency?.find(
+    (r) => r.webhookId === webhookId && r.key === key,
+  );
+}
+
+export function saveRotateIdempotency(record: RotateIdempotencyRecord): void {
+  const file = readStore();
+  file.rotateIdempotency = file.rotateIdempotency ?? [];
+  const idx = file.rotateIdempotency.findIndex(
+    (r) => r.webhookId === record.webhookId && r.key === record.key,
+  );
+  if (idx >= 0) {
+    file.rotateIdempotency[idx] = record;
+  } else {
+    file.rotateIdempotency.push(record);
+  }
+  writeStore(file);
+}
+
+export function compactIdempotencyKeys(retentionDays: number): void {
+  const file = readStore();
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  if (file.createIdempotency) {
+    file.createIdempotency = file.createIdempotency.filter(
+      (c) => new Date(c.createdAt).getTime() >= cutoff,
+    );
+  }
+  if (file.rotateIdempotency) {
+    file.rotateIdempotency = file.rotateIdempotency.filter(
+      (r) => new Date(r.createdAt).getTime() >= cutoff,
+    );
+  }
+  writeStore(file);
+}
+
+export function resetWebhooksStoreForTests(): void {
+  failClosed = false;
+  try {
+    if (existsSync(failClosedPath())) unlinkSync(failClosedPath());
+  } catch {
+    // ignore
+  }
+  try {
+    if (existsSync(tmpPath())) unlinkSync(tmpPath());
+  } catch {
+    // ignore
+  }
+  try {
+    if (existsSync(storePath())) unlinkSync(storePath());
+  } catch {
+    // ignore
+  }
+}
+
+export function setWebhooksFailClosedForTests(value: boolean): void {
+  failClosed = value;
+}

--- a/packages/api/src/lib/webhook-store.ts
+++ b/packages/api/src/lib/webhook-store.ts
@@ -30,6 +30,8 @@ import { deriveWebhookKey } from './webhook-signing.ts';
 
 export const WEBHOOK_STORE_SCHEMA_VERSION = 1;
 export const WEBHOOK_STORE_FILE = 'webhooks.json';
+/** Cap on persisted create/rotate idempotency records per list (newest kept). */
+export const WEBHOOK_IDEMPOTENCY_MAX_RECORDS = 256;
 
 export type WebhookContentScope = 'metadata' | 'preview';
 export type WebhookState = 'unverified' | 'enabled' | 'disabled';
@@ -448,6 +450,30 @@ export function findCreateIdempotency(
   );
 }
 
+function createdAtMs(value: string): number {
+  const t = Date.parse(value);
+  return Number.isFinite(t) ? t : 0;
+}
+
+function trimIdempotencyList<T extends { createdAt: string }>(
+  list: T[] | undefined,
+  retentionDays: number,
+  maxRecords: number,
+): T[] {
+  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
+  const kept = (list ?? []).filter((r) => createdAtMs(r.createdAt) >= cutoff);
+  if (kept.length <= maxRecords) return kept;
+  kept.sort((a, b) => createdAtMs(b.createdAt) - createdAtMs(a.createdAt));
+  return kept.slice(0, maxRecords);
+}
+
+function capIdempotencyList<T extends { createdAt: string }>(list: T[], maxRecords: number): T[] {
+  if (list.length <= maxRecords) return list;
+  return [...list]
+    .sort((a, b) => createdAtMs(b.createdAt) - createdAtMs(a.createdAt))
+    .slice(0, maxRecords);
+}
+
 export function saveCreateIdempotency(record: CreateIdempotencyRecord): void {
   const file = readStore();
   file.createIdempotency = file.createIdempotency ?? [];
@@ -459,6 +485,10 @@ export function saveCreateIdempotency(record: CreateIdempotencyRecord): void {
   } else {
     file.createIdempotency.push(record);
   }
+  file.createIdempotency = capIdempotencyList(
+    file.createIdempotency,
+    WEBHOOK_IDEMPOTENCY_MAX_RECORDS,
+  );
   writeStore(file);
 }
 
@@ -483,24 +513,28 @@ export function saveRotateIdempotency(record: RotateIdempotencyRecord): void {
   } else {
     file.rotateIdempotency.push(record);
   }
+  file.rotateIdempotency = capIdempotencyList(
+    file.rotateIdempotency,
+    WEBHOOK_IDEMPOTENCY_MAX_RECORDS,
+  );
   writeStore(file);
 }
 
 export function compactIdempotencyKeys(
   retentionDays: number = config.webhooks.logRetentionDays,
+  maxRecords: number = WEBHOOK_IDEMPOTENCY_MAX_RECORDS,
 ): void {
   const file = readStore();
-  const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
-  if (file.createIdempotency) {
-    file.createIdempotency = file.createIdempotency.filter(
-      (c) => new Date(c.createdAt).getTime() >= cutoff,
-    );
-  }
-  if (file.rotateIdempotency) {
-    file.rotateIdempotency = file.rotateIdempotency.filter(
-      (r) => new Date(r.createdAt).getTime() >= cutoff,
-    );
-  }
+  file.createIdempotency = trimIdempotencyList(
+    file.createIdempotency,
+    retentionDays,
+    maxRecords,
+  );
+  file.rotateIdempotency = trimIdempotencyList(
+    file.rotateIdempotency,
+    retentionDays,
+    maxRecords,
+  );
   writeStore(file);
 }
 

--- a/packages/api/src/lib/webhook-store.ts
+++ b/packages/api/src/lib/webhook-store.ts
@@ -240,12 +240,8 @@ export function readStore(): WebhooksFile {
 
   const text = readFileSync(file, 'utf8');
   if (!text.trim()) {
-    return {
-      schemaVersion: WEBHOOK_STORE_SCHEMA_VERSION,
-      webhooks: [],
-      createIdempotency: [],
-      rotateIdempotency: [],
-    };
+    markStoreFailClosed('empty_file');
+    throw new WebhookStoreCorruptError('webhooks.json exists but is empty');
   }
 
   return parseFile(text);

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -28,6 +28,10 @@ import { startNotificationLogMaintenance } from './lib/notification-log.ts';
 import { startSendLogMaintenance } from './lib/send-log.ts';
 import { startRetentionLoop } from './lib/retention.ts';
 import { startTaskLeaseReaper } from './lib/task-lease-reaper.ts';
+import {
+  reconstructPendingDeliveriesAtBoot,
+  startWebhookMaintenance,
+} from './lib/webhook-delivery.ts';
 import { createApp } from './app.ts';
 
 const app = createApp();
@@ -42,6 +46,10 @@ if (config.ntfy.enabled) {
 }
 if ((config.ntfy.enabled && config.ntfy.pushPolicy !== 'none') || config.webhooks.enabled) {
   startNotificationWatcher();
+}
+if (config.webhooks.enabled) {
+  startWebhookMaintenance();
+  await reconstructPendingDeliveriesAtBoot();
 }
 
 console.log(`[api] listening on :${config.port} (domain ${config.domain})`);

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -49,7 +49,11 @@ if ((config.ntfy.enabled && config.ntfy.pushPolicy !== 'none') || config.webhook
 }
 if (config.webhooks.enabled) {
   startWebhookMaintenance();
-  await reconstructPendingDeliveriesAtBoot();
+  try {
+    await reconstructPendingDeliveriesAtBoot();
+  } catch (err) {
+    console.error('[webhooks] boot reconstruction failed, proceeding with startup:', err);
+  }
 }
 
 console.log(`[api] listening on :${config.port} (domain ${config.domain})`);

--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -49,11 +49,9 @@ if ((config.ntfy.enabled && config.ntfy.pushPolicy !== 'none') || config.webhook
 }
 if (config.webhooks.enabled) {
   startWebhookMaintenance();
-  try {
-    await reconstructPendingDeliveriesAtBoot();
-  } catch (err) {
-    console.error('[webhooks] boot reconstruction failed, proceeding with startup:', err);
-  }
+  void reconstructPendingDeliveriesAtBoot().catch((err) => {
+    console.error('[webhooks] boot reconstruction failed:', err);
+  });
 }
 
 console.log(`[api] listening on :${config.port} (domain ${config.domain})`);

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -503,4 +503,74 @@ export class OpenAgentEmailClient {
       ...(reason === undefined ? {} : { reason }),
     });
   }
+
+  async listWebhooks(address?: string): Promise<WebhookSubscriptionDetail[]> {
+    const params = new URLSearchParams();
+    if (address) params.set('address', address);
+    const suffix = params.size ? `?${params.toString()}` : '';
+    const res = await this.request<{ webhooks: WebhookSubscriptionDetail[] }>('GET', `/v1/webhooks${suffix}`);
+    return res.webhooks;
+  }
+
+  createWebhook(params: {
+    url: string;
+    address: string;
+    events: string[];
+    contentScope?: 'metadata' | 'preview';
+    description?: string;
+  }): Promise<WebhookCreateResult> {
+    return this.request<WebhookCreateResult>('POST', '/v1/webhooks', params);
+  }
+
+  deleteWebhook(id: string): Promise<{ ok: boolean }> {
+    return this.request<{ ok: boolean }>('DELETE', `/v1/webhooks/${encodeURIComponent(id)}`);
+  }
+
+  testWebhook(id: string): Promise<WebhookTestResult> {
+    return this.request<WebhookTestResult>('POST', `/v1/webhooks/${encodeURIComponent(id)}/test`);
+  }
+
+  disableWebhook(id: string): Promise<WebhookSubscriptionDetail> {
+    return this.request<WebhookSubscriptionDetail>('POST', `/v1/webhooks/${encodeURIComponent(id)}/disable`);
+  }
 }
+
+export interface WebhookSubscriptionDetail {
+  id: string;
+  url: string;
+  address: string;
+  events: string[];
+  contentScope: 'metadata' | 'preview';
+  description: string;
+  state: 'unverified' | 'active' | 'failing' | 'disabled';
+  disabledReason: string | null;
+  secretPrefix: string;
+  signatureScheme: string;
+  timestampToleranceSec: number;
+  createdAt: string;
+  updatedAt: string;
+  rotatedAt: string | null;
+  consecutiveFailures: number;
+  privateTargetGranted: boolean;
+  lastDelivery: {
+    deliveryId: string;
+    ts: string;
+    attempt: number;
+    outcome: string;
+    status: number | null;
+    durationMs: number | null;
+    reason: string | null;
+  } | null;
+}
+
+export interface WebhookCreateResult extends WebhookSubscriptionDetail {
+  secret: string | null;
+}
+
+export interface WebhookTestResult {
+  ok: boolean;
+  status: number | null;
+  durationMs: number;
+  reason: string | null;
+}
+

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -542,7 +542,7 @@ export interface WebhookSubscriptionDetail {
   events: string[];
   contentScope: 'metadata' | 'preview';
   description: string;
-  state: 'unverified' | 'active' | 'failing' | 'disabled';
+  state: 'unverified' | 'enabled' | 'disabled';
   disabledReason: string | null;
   secretPrefix: string;
   signatureScheme: string;

--- a/packages/api/src/mcp/client.ts
+++ b/packages/api/src/mcp/client.ts
@@ -530,8 +530,8 @@ export class OpenAgentEmailClient {
     return this.request<WebhookTestResult>('POST', `/v1/webhooks/${encodeURIComponent(id)}/test`);
   }
 
-  disableWebhook(id: string): Promise<WebhookSubscriptionDetail> {
-    return this.request<WebhookSubscriptionDetail>('POST', `/v1/webhooks/${encodeURIComponent(id)}/disable`);
+  disableWebhook(id: string): Promise<{ ok: boolean; state: string; disabledReason: string }> {
+    return this.request<{ ok: boolean; state: string; disabledReason: string }>('POST', `/v1/webhooks/${encodeURIComponent(id)}/disable`);
   }
 }
 

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -235,6 +235,73 @@ export function registerOpenAgentEmailTools(
     leaseGeneration: z.number().int(),
   };
 
+  const webhookListItemSchema = {
+    id: z.string(),
+    url: z.string(),
+    address: z.string(),
+    events: z.array(z.string()),
+    contentScope: z.string().optional(),
+    description: z.string().optional(),
+    state: z.string(),
+    disabledReason: z.string().nullable().optional(),
+    secretPrefix: z.string().optional(),
+    signatureScheme: z.string().optional(),
+    timestampToleranceSec: z.number().optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+    rotatedAt: z.string().nullable().optional(),
+    consecutiveFailures: z.number().optional(),
+    privateTargetGranted: z.boolean().optional(),
+    lastDelivery: z
+      .object({
+        deliveryId: z.string(),
+        ts: z.string(),
+        attempt: z.number(),
+        outcome: z.string(),
+        status: z.number().nullable().optional(),
+        durationMs: z.number().nullable().optional(),
+        reason: z.string().nullable().optional(),
+      })
+      .nullable()
+      .optional(),
+  };
+
+  const webhookListOutputSchema = {
+    webhooks: z.array(z.object(webhookListItemSchema)),
+  };
+
+  const webhookCreateOutputSchema = {
+    id: z.string(),
+    url: z.string(),
+    address: z.string(),
+    events: z.array(z.string()),
+    contentScope: z.string().optional(),
+    description: z.string().optional(),
+    state: z.string(),
+    secret: z.string().nullable().optional(),
+    secretPrefix: z.string().optional(),
+    signatureScheme: z.string().optional(),
+    timestampToleranceSec: z.number().optional(),
+    createdAt: z.string().optional(),
+  };
+
+  const webhookDeleteOutputSchema = {
+    ok: z.boolean(),
+  };
+
+  const webhookTestOutputSchema = {
+    deliveryId: z.string().optional(),
+    outcome: z.string().optional(),
+    status: z.number().nullable().optional(),
+    reason: z.string().nullable().optional(),
+  };
+
+  const webhookDisableOutputSchema = {
+    ok: z.boolean(),
+    state: z.string(),
+    disabledReason: z.string().nullable().optional(),
+  };
+
   function ok(data: unknown): CallToolResult {
     if (typeof data !== "object" || data === null || Array.isArray(data)) {
       throw new TypeError("Tool output must be a JSON object");
@@ -729,6 +796,7 @@ export function registerOpenAgentEmailTools(
       inputSchema: {
         address: z.string().regex(IDENTITY_ADDRESS_PATTERN).optional().describe("Optional identity email address to filter by (admin only)"),
       },
+      outputSchema: webhookListOutputSchema,
       annotations: readOnlyAnnotations,
     },
     ({ address }) => callApi(async () => ({ webhooks: await client.listWebhooks(address) })),
@@ -760,6 +828,7 @@ export function registerOpenAgentEmailTools(
           .optional()
           .describe("Optional human-readable description (max 1000 characters)"),
       },
+      outputSchema: webhookCreateOutputSchema,
       annotations: mutatingAnnotations,
     },
     (params) => callApi(() => client.createWebhook(params)),
@@ -774,6 +843,7 @@ export function registerOpenAgentEmailTools(
       inputSchema: {
         id: z.string().min(1).describe("Webhook subscription ID (whk_...)"),
       },
+      outputSchema: webhookDeleteOutputSchema,
       annotations: { ...mutatingAnnotations, destructiveHint: true },
     },
     ({ id }) => callApi(() => client.deleteWebhook(id)),
@@ -788,6 +858,7 @@ export function registerOpenAgentEmailTools(
       inputSchema: {
         id: z.string().min(1).describe("Webhook subscription ID (whk_...)"),
       },
+      outputSchema: webhookTestOutputSchema,
       annotations: mutatingAnnotations,
     },
     ({ id }) => callApi(() => client.testWebhook(id)),
@@ -802,6 +873,7 @@ export function registerOpenAgentEmailTools(
       inputSchema: {
         id: z.string().min(1).describe("Webhook subscription ID (whk_...)"),
       },
+      outputSchema: webhookDisableOutputSchema,
       annotations: mutatingAnnotations,
     },
     ({ id }) => callApi(() => client.disableWebhook(id)),

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -720,6 +720,93 @@ export function registerOpenAgentEmailTools(
     ({ id, leaseToken, reason }) => callApi(() => client.releaseTask(id, leaseToken, reason)),
   );
 
-  // 收尾：规格表内全部 19 工具均须已在本次注册中 declare。
+  tier("mail_webhook_list", "read");
+  server.registerTool(
+    "mail_webhook_list",
+    {
+      title: "List Webhook Subscriptions",
+      description: "List outbound webhook subscriptions. Identity callers see only their own subscriptions; admin callers may see all or filter by address.",
+      inputSchema: {
+        address: z.string().regex(IDENTITY_ADDRESS_PATTERN).optional().describe("Optional identity email address to filter by (admin only)"),
+      },
+      annotations: readOnlyAnnotations,
+    },
+    ({ address }) => callApi(async () => ({ webhooks: await client.listWebhooks(address) })),
+  );
+
+  tier("mail_webhook_create", "critical");
+  server.registerTool(
+    "mail_webhook_create",
+    {
+      title: "Create Webhook Subscription",
+      description: "Create an outbound webhook subscription. Returns subscription metadata and the displayed signing secret (whs_...). Deny-by-default for OAuth tokens.",
+      inputSchema: {
+        url: z.string().url().describe("Webhook target URL (https:// required unless private target granted)"),
+        address: z.string().regex(IDENTITY_ADDRESS_PATTERN).describe("Identity email address to receive events for"),
+        events: z
+          .array(z.enum(['mail.received', 'approval.requested']))
+          .min(1)
+          .refine((items) => new Set(items).size === items.length, {
+            message: 'events must be unique',
+          })
+          .describe("Events to subscribe to ('mail.received', 'approval.requested')"),
+        contentScope: z
+          .enum(['metadata', 'preview'])
+          .optional()
+          .describe("Payload content scope: 'metadata' (default) or 'preview' (admin only)"),
+        description: z
+          .string()
+          .max(1000)
+          .optional()
+          .describe("Optional human-readable description (max 1000 characters)"),
+      },
+      annotations: mutatingAnnotations,
+    },
+    (params) => callApi(() => client.createWebhook(params)),
+  );
+
+  tier("mail_webhook_delete", "minimal");
+  server.registerTool(
+    "mail_webhook_delete",
+    {
+      title: "Delete Webhook Subscription",
+      description: "Permanently delete an outbound webhook subscription and cancel any pending retries.",
+      inputSchema: {
+        id: z.string().min(1).describe("Webhook subscription ID (whk_...)"),
+      },
+      annotations: { ...mutatingAnnotations, destructiveHint: true },
+    },
+    ({ id }) => callApi(() => client.deleteWebhook(id)),
+  );
+
+  tier("mail_webhook_test", "contained");
+  server.registerTool(
+    "mail_webhook_test",
+    {
+      title: "Test Webhook Subscription",
+      description: "Send an immediate probe ping to test webhook connectivity.",
+      inputSchema: {
+        id: z.string().min(1).describe("Webhook subscription ID (whk_...)"),
+      },
+      annotations: mutatingAnnotations,
+    },
+    ({ id }) => callApi(() => client.testWebhook(id)),
+  );
+
+  tier("mail_webhook_disable", "minimal");
+  server.registerTool(
+    "mail_webhook_disable",
+    {
+      title: "Disable Webhook Subscription",
+      description: "Pause an active webhook subscription by marking it disabled.",
+      inputSchema: {
+        id: z.string().min(1).describe("Webhook subscription ID (whk_...)"),
+      },
+      annotations: mutatingAnnotations,
+    },
+    ({ id }) => callApi(() => client.disableWebhook(id)),
+  );
+
+  // 收尾：规格表内全部 25 工具均须已在本次注册中 declare。
   assertAllSpecTiersDeclared();
 }

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -809,7 +809,7 @@ export function registerOpenAgentEmailTools(
       title: "Create Webhook Subscription",
       description: "Create an outbound webhook subscription. Returns subscription metadata and the displayed signing secret (whs_...). Deny-by-default for OAuth tokens.",
       inputSchema: {
-        url: z.string().url().describe("Webhook target URL (https:// required unless private target granted)"),
+        url: z.string().url().max(2048).describe("Webhook target URL (https:// required unless private target granted)"),
         address: z.string().regex(IDENTITY_ADDRESS_PATTERN).describe("Identity email address to receive events for"),
         events: z
           .array(z.enum(['mail.received', 'approval.requested']))

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -108,6 +108,8 @@ const updateSchema = z
   })
   .strict();
 
+const rotateSchema = z.object({ force: z.boolean().optional() }).strict();
+
 const IDEMPOTENCY_KEY_MAX = 128;
 
 function callerRateKey(c: Context): string {
@@ -212,15 +214,8 @@ export const webhooksRoute = new Hono()
       return c.json({ error: 'content_scope_requires_admin' }, 403);
     }
 
-    // Rate limiting
-    const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
-    const rateRes = deliveryLimiter.checkCreateRate(tokenKey);
-    if (!rateRes.allowed) {
-      c.header('Retry-After', String(rateRes.retryAfterSec));
-      return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
-    }
-
-    // Idempotency check
+    // Idempotency hits must skip the create limiter: a lost 201 retry
+    // with a seen key would otherwise 429 and never recover the cache.
     const idempotency = parseIdempotencyKey(c);
     if (!idempotency.ok) return idempotency.response;
     const idempotencyKey = idempotency.key;
@@ -239,6 +234,13 @@ export const webhooksRoute = new Hono()
       if (found) {
         return c.json(found.responseBody, 201);
       }
+    }
+
+    const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
+    const rateRes = deliveryLimiter.checkCreateRate(tokenKey);
+    if (!rateRes.allowed) {
+      c.header('Retry-After', String(rateRes.retryAfterSec));
+      return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
     }
 
     const executeCreate = async (): Promise<InFlightCreateResult> => {
@@ -421,6 +423,9 @@ export const webhooksRoute = new Hono()
       if (err.code === 'webhook_disabled') {
         return c.json({ error: 'webhook_disabled', disabledReason: err.disabledReason }, 409);
       }
+      if (err.code === 'delivery_not_replayable') {
+        return c.json({ error: 'delivery_not_replayable' }, 409);
+      }
       throw err;
     }
   })
@@ -519,8 +524,10 @@ export const webhooksRoute = new Hono()
       if (parsed.data.description !== undefined) s.description = parsed.data.description;
       if (urlChanged) {
         s.consecutiveFailures = 0;
-        if (s.state !== 'disabled') {
+        const keepManualDisabled = s.state === 'disabled' && s.disabledReason === 'manual';
+        if (!keepManualDisabled) {
           s.state = 'unverified';
+          s.disabledReason = null;
         }
         s.privateTargetGranted = isPrivateTarget;
       }
@@ -530,7 +537,7 @@ export const webhooksRoute = new Hono()
       return c.json({ error: 'not_found' }, 404);
     }
 
-    if (urlChanged) {
+    if (urlChanged && updated.state !== 'disabled') {
       const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
       fireCreationPing(updated, 'creation', tokenKey);
     }
@@ -669,8 +676,22 @@ export const webhooksRoute = new Hono()
       }
     }
 
-    // Overlap window check
-    const force = c.req.query('force') === 'true';
+    let force = false;
+    const rotateText = await c.req.text();
+    if (rotateText.trim().length > 0) {
+      let rotateBody: unknown;
+      try {
+        rotateBody = JSON.parse(rotateText);
+      } catch {
+        return c.json({ error: 'invalid_json' }, 400);
+      }
+      const parsedForce = rotateSchema.safeParse(rotateBody);
+      if (!parsedForce.success) {
+        return c.json({ error: 'invalid_request', details: parsedForce.error.issues }, 400);
+      }
+      force = parsedForce.data.force === true;
+    }
+
     if (
       sub.overlapUntil &&
       new Date(sub.overlapUntil).getTime() > Date.now() &&

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -34,9 +34,12 @@ import {
   executeWebhookTestProbe,
   fireCreationPing,
   getLatestDeliveryForWebhook,
+  latestDeliveryByWebhookId,
+  readAllDeliveryLogRows,
   readDeliveryLogRows,
   redeliverWebhookDelivery,
   validateWebhookUrlResolution,
+  type WebhookDeliveryLogRow,
 } from '../lib/webhook-delivery.ts';
 
 function requireAdmin(c: Context) {
@@ -105,8 +108,38 @@ const updateSchema = z
   })
   .strict();
 
-function formatSubscriptionDetail(sub: WebhookRecord) {
-  const lastDelivery = getLatestDeliveryForWebhook(sub.id);
+const IDEMPOTENCY_KEY_MAX = 128;
+
+function callerRateKey(c: Context): string {
+  const auth = getAuth(c);
+  return auth.kind === 'admin' ? 'admin' : auth.address;
+}
+
+function rejectIfReadRateLimited(c: Context) {
+  const rateRes = deliveryLimiter.checkReadRate(callerRateKey(c));
+  if (!rateRes.allowed) {
+    c.header('Retry-After', String(rateRes.retryAfterSec));
+    return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
+  }
+  return null;
+}
+
+function parseIdempotencyKey(c: Context): { ok: true; key?: string } | { ok: false; response: Response } {
+  const raw = c.req.header('idempotency-key');
+  if (raw === undefined) return { ok: true };
+  const key = raw.trim();
+  if (!key) return { ok: true };
+  if (key.length > IDEMPOTENCY_KEY_MAX) {
+    return { ok: false, response: c.json({ error: 'invalid_request' }, 400) };
+  }
+  return { ok: true, key };
+}
+
+function formatSubscriptionDetail(
+  sub: WebhookRecord,
+  lastDelivery: WebhookDeliveryLogRow | null | undefined = undefined,
+) {
+  const latest = lastDelivery !== undefined ? lastDelivery : getLatestDeliveryForWebhook(sub.id);
   return {
     id: sub.id,
     url: sub.url,
@@ -124,15 +157,15 @@ function formatSubscriptionDetail(sub: WebhookRecord) {
     rotatedAt: sub.rotatedAt,
     consecutiveFailures: sub.consecutiveFailures,
     privateTargetGranted: sub.privateTargetGranted,
-    lastDelivery: lastDelivery
+    lastDelivery: latest
       ? {
-          deliveryId: lastDelivery.deliveryId,
-          ts: lastDelivery.ts,
-          attempt: lastDelivery.attempt,
-          outcome: lastDelivery.outcome,
-          status: lastDelivery.status,
-          durationMs: lastDelivery.durationMs,
-          reason: lastDelivery.reason,
+          deliveryId: latest.deliveryId,
+          ts: latest.ts,
+          attempt: latest.attempt,
+          outcome: latest.outcome,
+          status: latest.status,
+          durationMs: latest.durationMs,
+          reason: latest.reason,
         }
       : null,
   };
@@ -188,7 +221,9 @@ export const webhooksRoute = new Hono()
     }
 
     // Idempotency check
-    const idempotencyKey = c.req.header('idempotency-key')?.trim();
+    const idempotency = parseIdempotencyKey(c);
+    if (!idempotency.ok) return idempotency.response;
+    const idempotencyKey = idempotency.key;
     const compositeKey = idempotencyKey ? `${idempotencyKey}:${targetAddress}` : null;
     if (idempotencyKey && compositeKey) {
       const pending = inFlightCreateIdempotency.get(compositeKey);
@@ -313,6 +348,9 @@ export const webhooksRoute = new Hono()
 
   // GET /v1/webhooks - List subscriptions
   .get('/', async (c) => {
+    const deniedRead = rejectIfReadRateLimited(c);
+    if (deniedRead) return deniedRead;
+
     const auth = getAuth(c);
     const addressParam = c.req.query('address')?.trim()?.toLowerCase();
     if (addressParam && auth.kind !== 'admin') {
@@ -327,8 +365,11 @@ export const webhooksRoute = new Hono()
       filtered = all.filter((s) => s.address === auth.address);
     }
 
+    const latestByWebhook = latestDeliveryByWebhookId(readAllDeliveryLogRows());
     return c.json({
-      webhooks: filtered.map((sub) => formatSubscriptionDetail(sub)),
+      webhooks: filtered.map((sub) =>
+        formatSubscriptionDetail(sub, latestByWebhook.get(sub.id) ?? null),
+      ),
     });
   })
 
@@ -386,6 +427,9 @@ export const webhooksRoute = new Hono()
 
   // GET /v1/webhooks/:id - Get subscription detail
   .get('/:id', async (c) => {
+    const deniedRead = rejectIfReadRateLimited(c);
+    if (deniedRead) return deniedRead;
+
     const sub = getWebhookSubscription(c.req.param('id'));
     if (!sub) {
       return c.json({ error: 'not_found' }, 404);
@@ -394,7 +438,8 @@ export const webhooksRoute = new Hono()
     const denied = forbidUnlessAddress(c, sub.address);
     if (denied) return denied;
 
-    return c.json(formatSubscriptionDetail(sub));
+    const latestByWebhook = latestDeliveryByWebhookId(readAllDeliveryLogRows());
+    return c.json(formatSubscriptionDetail(sub, latestByWebhook.get(sub.id) ?? null));
   })
 
   // POST /v1/webhooks/:id - Update subscription
@@ -497,7 +542,8 @@ export const webhooksRoute = new Hono()
       webhookId: sub.id,
     });
 
-    return c.json(formatSubscriptionDetail(updated));
+    const latestByWebhook = latestDeliveryByWebhookId(readAllDeliveryLogRows());
+    return c.json(formatSubscriptionDetail(updated, latestByWebhook.get(updated.id) ?? null));
   })
 
   // GET /v1/webhooks/:id/secret - Reveal signing secret
@@ -613,7 +659,9 @@ export const webhooksRoute = new Hono()
     }
 
     // Idempotency check (cached hits skip the write-amplification limiter)
-    const idempotencyKey = c.req.header('idempotency-key')?.trim();
+    const idempotency = parseIdempotencyKey(c);
+    if (!idempotency.ok) return idempotency.response;
+    const idempotencyKey = idempotency.key;
     if (idempotencyKey) {
       const found = findRotateIdempotency(sub.id, idempotencyKey);
       if (found) {

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -6,6 +6,7 @@ import { Hono } from 'hono';
 import type { Context } from 'hono';
 import { z } from 'zod';
 import { config } from '../lib/config.ts';
+import { StaleMessageGenerationError } from '../lib/imap.ts';
 import {
   forbidUnlessAddress,
   getAttribution,
@@ -344,8 +345,25 @@ export const webhooksRoute = new Hono()
       if (err.code === 'delivery_not_found') {
         return c.json({ error: 'delivery_not_found' }, 404);
       }
-      if (err.code === 'not_found') {
+      if (err.code === 'not_found' || err.code === 'webhook_not_found') {
         return c.json({ error: 'webhook_not_found' }, 404);
+      }
+      if (err.code === 'message_not_found' || err.reason === 'message_not_found') {
+        return c.json({ error: 'message_not_found' }, 404);
+      }
+      if (err.code === 'task_not_found' || err.reason === 'task_not_found') {
+        return c.json({ error: 'task_not_found' }, 404);
+      }
+      if (
+        err instanceof StaleMessageGenerationError ||
+        err?.name === 'StaleMessageGenerationError' ||
+        err.code === 'stale_message_generation' ||
+        err.reason === 'stale_message_generation'
+      ) {
+        return c.json({ error: 'stale_message_generation' }, 409);
+      }
+      if (err.code === 'uidvalidity_required' || err.reason === 'uidvalidity_required') {
+        return c.json({ error: 'uidvalidity_required' }, 409);
       }
       if (err.code === 'webhook_disabled') {
         return c.json({ error: 'webhook_disabled', disabledReason: err.disabledReason }, 409);
@@ -678,9 +696,16 @@ export const webhooksRoute = new Hono()
     try {
       const probeRes = await executeWebhookTestProbe(sub, tokenKey);
 
+      let auditOutcome: 'ok' | 'denied' | 'error' = 'ok';
+      if (probeRes.outcome === 'refused') {
+        auditOutcome = 'denied';
+      } else if (probeRes.outcome !== 'success') {
+        auditOutcome = 'error';
+      }
+
       recordAuditEvent({
         event: 'webhook.test',
-        outcome: probeRes.outcome === 'success' ? 'ok' : 'denied',
+        outcome: auditOutcome,
         address: sub.address,
         webhookId: sub.id,
       });
@@ -783,7 +808,18 @@ export const webhooksRoute = new Hono()
       return c.json({ error: 'not_found' }, 404);
     }
 
-    const limit = c.req.query('limit') ? Number(c.req.query('limit')) : 20;
+    const rawLimit = c.req.query('limit');
+    let limit = 20;
+    if (rawLimit !== undefined && rawLimit !== '') {
+      const n = Number(rawLimit);
+      if (!Number.isFinite(n) || !Number.isInteger(n) || n <= 0) {
+        return c.json(
+          { error: 'invalid_request', error_description: 'limit must be a positive integer' },
+          400,
+        );
+      }
+      limit = Math.min(n, 100);
+    }
     const cursor = c.req.query('cursor');
 
     const res = readDeliveryLogRows({

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -1,0 +1,717 @@
+/**
+ * Webhooks REST API Routes (RFC-0001 §10.3, §10.4, §10.6, §12).
+ */
+
+import { Hono } from 'hono';
+import type { Context } from 'hono';
+import { z } from 'zod';
+import { config } from '../lib/config.ts';
+import {
+  forbidUnlessAddress,
+  getAttribution,
+  getAuth,
+} from '../lib/auth.ts';
+import { recordAuditEvent } from '../lib/audit.ts';
+import {
+  checkSubscriptionLimits,
+  createWebhookSubscription,
+  deleteWebhookSubscription,
+  findCreateIdempotency,
+  findRotateIdempotency,
+  getWebhookSubscription,
+  listWebhookSubscriptions,
+  saveCreateIdempotency,
+  saveRotateIdempotency,
+  updateWebhookSubscription,
+  type WebhookRecord,
+} from '../lib/webhook-store.ts';
+import { deriveWebhookKey } from '../lib/webhook-signing.ts';
+import {
+  deliveryLimiter,
+  deliveryQueue,
+  executeWebhookTestProbe,
+  fireCreationPing,
+  getLatestDeliveryForWebhook,
+  readDeliveryLogRows,
+  redeliverWebhookDelivery,
+  validateWebhookUrlResolution,
+} from '../lib/webhook-delivery.ts';
+
+function requireAdmin(c: Context) {
+  const auth = getAuth(c);
+  if (auth.kind !== 'admin') {
+    return c.json({ error: 'forbidden: admin key required' }, 403);
+  }
+  return null;
+}
+
+function forbidOAuthMutation(c: Context) {
+  const attr = getAttribution(c);
+  if (attr?.kind === 'oauth') {
+    return c.json(
+      { error: 'forbidden: oauth tokens may not mutate webhook subscriptions' },
+      403,
+    );
+  }
+  return null;
+}
+
+const createSchema = z
+  .object({
+    url: z.string().url(),
+    address: z.string().email(),
+    events: z
+      .array(z.enum(['mail.received', 'approval.requested']))
+      .min(1, 'events must be non-empty')
+      .refine((arr) => new Set(arr).size === arr.length, 'events must be unique'),
+    contentScope: z.enum(['metadata', 'preview']).optional().default('metadata'),
+    description: z.string().max(1000).optional().default(''),
+  })
+  .strict();
+
+const updateSchema = z
+  .object({
+    url: z.string().url().optional(),
+    events: z
+      .array(z.enum(['mail.received', 'approval.requested']))
+      .min(1, 'events must be non-empty')
+      .refine((arr) => new Set(arr).size === arr.length, 'events must be unique')
+      .optional(),
+    contentScope: z.enum(['metadata', 'preview']).optional(),
+    description: z.string().max(1000).optional(),
+  })
+  .strict();
+
+function formatSubscriptionDetail(sub: WebhookRecord) {
+  const lastDelivery = getLatestDeliveryForWebhook(sub.id);
+  return {
+    id: sub.id,
+    url: sub.url,
+    address: sub.address,
+    events: sub.events,
+    contentScope: sub.contentScope,
+    description: sub.description,
+    state: sub.state,
+    disabledReason: sub.disabledReason,
+    secretPrefix: sub.secretPrefix,
+    signatureScheme: 'v1',
+    timestampToleranceSec: config.webhooks.timestampToleranceSec,
+    createdAt: sub.createdAt,
+    updatedAt: sub.updatedAt,
+    rotatedAt: sub.rotatedAt,
+    consecutiveFailures: sub.consecutiveFailures,
+    privateTargetGranted: sub.privateTargetGranted,
+    lastDelivery: lastDelivery
+      ? {
+          deliveryId: lastDelivery.deliveryId,
+          ts: lastDelivery.ts,
+          attempt: lastDelivery.attempt,
+          outcome: lastDelivery.outcome,
+          status: lastDelivery.status,
+          durationMs: lastDelivery.durationMs,
+          reason: lastDelivery.reason,
+        }
+      : null,
+  };
+}
+
+export const webhooksRoute = new Hono()
+  .use('*', async (c, next) => {
+    if (!config.webhooks.enabled) {
+      return c.json({ error: 'webhooks_disabled' }, 404);
+    }
+    await next();
+  })
+
+  // POST /v1/webhooks - Create subscription
+  .post('/', async (c) => {
+    const deniedOAuth = forbidOAuthMutation(c);
+    if (deniedOAuth) return deniedOAuth;
+
+    let body: unknown = {};
+    const text = await c.req.text();
+    if (text.trim().length > 0) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        return c.json({ error: 'invalid_json' }, 400);
+      }
+    }
+
+    const parsed = createSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+
+    const auth = getAuth(c);
+    const targetAddress = parsed.data.address.toLowerCase();
+
+    // Scope check: identity can only create for own address
+    if (auth.kind === 'identity' && auth.address !== targetAddress) {
+      return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    // Preview contentScope requires admin
+    if (auth.kind === 'identity' && parsed.data.contentScope === 'preview') {
+      return c.json({ error: 'content_scope_requires_admin' }, 403);
+    }
+
+    // Rate limiting
+    const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
+    const rateRes = deliveryLimiter.checkCreateRate(tokenKey);
+    if (!rateRes.allowed) {
+      c.header('Retry-After', String(rateRes.retryAfterSec));
+      return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
+    }
+
+    // Idempotency check
+    const idempotencyKey = c.req.header('idempotency-key')?.trim();
+    if (idempotencyKey) {
+      const found = findCreateIdempotency(idempotencyKey, targetAddress);
+      if (found) {
+        return c.json(found.responseBody, 201);
+      }
+    }
+
+    // URL validation (static & DNS resolution)
+    const resolution = await validateWebhookUrlResolution(parsed.data.url, {
+      allowPrivateTargets: config.webhooks.allowPrivateTargets,
+    });
+    if (!resolution.valid) {
+      return c.json(
+        {
+          error:
+            resolution.code === 'webhook_target_forbidden'
+              ? 'webhook_target_forbidden'
+              : 'invalid_webhook_url',
+        },
+        400,
+      );
+    }
+
+    // Rule C: private target requires admin
+    if (resolution.isPrivateTarget && auth.kind !== 'admin') {
+      return c.json({ error: 'webhook_target_forbidden' }, 400);
+    }
+
+    // Subscription limit check
+    const limits = checkSubscriptionLimits(targetAddress);
+    if (!limits.allowed) {
+      return c.json({ error: 'webhook_limit_reached' }, 409);
+    }
+
+    const createdBy = auth.kind === 'admin' ? 'admin' : auth.address;
+    const record = createWebhookSubscription({
+      url: parsed.data.url,
+      address: targetAddress,
+      events: parsed.data.events,
+      contentScope: parsed.data.contentScope,
+      description: parsed.data.description,
+      privateTargetGranted: resolution.isPrivateTarget && auth.kind === 'admin',
+      createdBy,
+    });
+
+    const derived = deriveWebhookKey(
+      config.webhooks.signingSecret || config.taskSigningSecret,
+      record.id,
+      record.epoch,
+    );
+
+    // Fire asynchronous ping at creation (§5.1, D12)
+    fireCreationPing(record, 'creation');
+
+    recordAuditEvent({
+      event: 'webhook.create',
+      outcome: 'ok',
+      address: record.address,
+      webhookId: record.id,
+    });
+
+    const response = {
+      id: record.id,
+      url: record.url,
+      address: record.address,
+      events: record.events,
+      contentScope: record.contentScope,
+      description: record.description,
+      state: record.state,
+      secret: derived.displayedSecret,
+      secretPrefix: record.secretPrefix,
+      signatureScheme: 'v1',
+      timestampToleranceSec: config.webhooks.timestampToleranceSec,
+      createdAt: record.createdAt,
+    };
+
+    if (idempotencyKey) {
+      saveCreateIdempotency({
+        key: idempotencyKey,
+        address: record.address,
+        webhookId: record.id,
+        responseBody: { ...response, secret: null },
+        createdAt: record.createdAt,
+      });
+    }
+
+    return c.json(response, 201);
+  })
+
+  // GET /v1/webhooks - List subscriptions
+  .get('/', async (c) => {
+    const auth = getAuth(c);
+    const all = listWebhookSubscriptions();
+    const filtered =
+      auth.kind === 'admin'
+        ? all
+        : all.filter((s) => s.address === auth.address);
+
+    return c.json({
+      webhooks: filtered.map((sub) => formatSubscriptionDetail(sub)),
+    });
+  })
+
+  // POST /v1/webhooks/deliveries/:deliveryId/redeliver - Replay delivery
+  .post('/deliveries/:deliveryId/redeliver', async (c) => {
+    const denied = requireAdmin(c);
+    if (denied) return denied;
+
+    const deliveryId = c.req.param('deliveryId');
+    try {
+      const result = await redeliverWebhookDelivery(deliveryId);
+
+      recordAuditEvent({
+        event: 'webhook.redeliver',
+        outcome: 'ok',
+        address: result.address,
+        webhookId: result.webhookId,
+      });
+
+      return c.json({
+        ok: true,
+        deliveryId: result.deliveryId,
+        eventId: result.eventId,
+      });
+    } catch (err: any) {
+      if (err.code === 'delivery_not_found') {
+        return c.json({ error: 'delivery_not_found' }, 404);
+      }
+      if (err.code === 'not_found') {
+        return c.json({ error: 'webhook_not_found' }, 404);
+      }
+      if (err.code === 'webhook_disabled') {
+        return c.json({ error: 'webhook_disabled', disabledReason: err.disabledReason }, 409);
+      }
+      throw err;
+    }
+  })
+
+  // GET /v1/webhooks/:id - Get subscription detail
+  .get('/:id', async (c) => {
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const denied = forbidUnlessAddress(c, sub.address);
+    if (denied) return denied;
+
+    return c.json(formatSubscriptionDetail(sub));
+  })
+
+  // POST /v1/webhooks/:id - Update subscription
+  .post('/:id', async (c) => {
+    const deniedOAuth = forbidOAuthMutation(c);
+    if (deniedOAuth) return deniedOAuth;
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const deniedAddress = forbidUnlessAddress(c, sub.address);
+    if (deniedAddress) return deniedAddress;
+
+    let body: unknown = {};
+    const text = await c.req.text();
+    if (text.trim().length > 0) {
+      try {
+        body = JSON.parse(text);
+      } catch {
+        return c.json({ error: 'invalid_json' }, 400);
+      }
+    }
+
+    const parsed = updateSchema.safeParse(body);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
+    }
+
+    const auth = getAuth(c);
+
+    // Rule B: preview contentScope requires admin
+    if (parsed.data.contentScope === 'preview' && auth.kind !== 'admin') {
+      return c.json({ error: 'content_scope_requires_admin' }, 403);
+    }
+
+    // Rule B: if stored contentScope is preview, identity cannot change url
+    if (
+      sub.contentScope === 'preview' &&
+      auth.kind !== 'admin' &&
+      parsed.data.url !== undefined &&
+      parsed.data.url !== sub.url
+    ) {
+      return c.json({ error: 'content_scope_requires_admin' }, 403);
+    }
+
+    let urlChanged = false;
+    let isPrivateTarget = sub.privateTargetGranted;
+
+    if (parsed.data.url && parsed.data.url !== sub.url) {
+      urlChanged = true;
+      const resolution = await validateWebhookUrlResolution(parsed.data.url, {
+        allowPrivateTargets: config.webhooks.allowPrivateTargets,
+      });
+      if (!resolution.valid) {
+        return c.json(
+          {
+            error:
+              resolution.code === 'webhook_target_forbidden'
+                ? 'webhook_target_forbidden'
+                : 'invalid_webhook_url',
+          },
+          400,
+        );
+      }
+      if (resolution.isPrivateTarget && auth.kind !== 'admin') {
+        return c.json({ error: 'webhook_target_forbidden' }, 400);
+      }
+      isPrivateTarget = resolution.isPrivateTarget && auth.kind === 'admin';
+    }
+
+    const updated = updateWebhookSubscription(sub.id, (s) => {
+      if (parsed.data.url) s.url = parsed.data.url;
+      if (parsed.data.events) s.events = parsed.data.events;
+      if (parsed.data.contentScope) s.contentScope = parsed.data.contentScope;
+      if (parsed.data.description !== undefined) s.description = parsed.data.description;
+      if (urlChanged) {
+        s.consecutiveFailures = 0;
+        if (s.state !== 'disabled') {
+          s.state = 'unverified';
+        }
+        s.privateTargetGranted = isPrivateTarget;
+      }
+    });
+
+    if (urlChanged && updated) {
+      fireCreationPing(updated, 'creation');
+    }
+
+    recordAuditEvent({
+      event: 'webhook.update',
+      outcome: 'ok',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    return c.json(formatSubscriptionDetail(updated!));
+  })
+
+  // GET /v1/webhooks/:id/secret - Reveal signing secret
+  .get('/:id/secret', async (c) => {
+    c.header('Cache-Control', 'no-store');
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const deniedAddress = forbidUnlessAddress(c, sub.address);
+    if (deniedAddress) return deniedAddress;
+
+    const auth = getAuth(c);
+
+    // Rule D: Identity caller can only reveal if created by itself
+    if (auth.kind === 'identity' && sub.createdBy !== auth.address) {
+      return c.json({ error: 'forbidden: admin key required' }, 403);
+    }
+
+    // Rule D / §12.3: Identity caller requires metadata scope
+    if (auth.kind === 'identity' && sub.contentScope !== 'metadata') {
+      return c.json({ error: 'content_scope_requires_admin' }, 403);
+    }
+
+    const derived = deriveWebhookKey(
+      config.webhooks.signingSecret || config.taskSigningSecret,
+      sub.id,
+      sub.epoch,
+    );
+
+    recordAuditEvent({
+      event: 'webhook.reveal',
+      outcome: 'ok',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    return c.json({
+      id: sub.id,
+      secret: derived.displayedSecret,
+      secretPrefix: sub.secretPrefix,
+      epoch: sub.epoch,
+      overlapUntil: sub.overlapUntil,
+    });
+  })
+
+  // DELETE /v1/webhooks/:id - Delete subscription
+  .delete('/:id', async (c) => {
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const deniedAddress = forbidUnlessAddress(c, sub.address);
+    if (deniedAddress) return deniedAddress;
+
+    const auth = getAuth(c);
+
+    // Rule D: Identity caller can only delete if created by itself
+    if (auth.kind === 'identity' && sub.createdBy !== auth.address) {
+      return c.json({ error: 'forbidden: admin key required' }, 403);
+    }
+
+    // Rule B: Identity caller requires metadata scope
+    if (auth.kind === 'identity' && sub.contentScope !== 'metadata') {
+      return c.json({ error: 'content_scope_requires_admin' }, 403);
+    }
+
+    deleteWebhookSubscription(sub.id);
+    deliveryQueue.cancelForWebhook(sub.id, 'subscription_deleted');
+
+    recordAuditEvent({
+      event: 'webhook.delete',
+      outcome: 'ok',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    return c.json({ ok: true });
+  })
+
+  // POST /v1/webhooks/:id/rotate - Rotate signing secret
+  .post('/:id/rotate', async (c) => {
+    const deniedOAuth = forbidOAuthMutation(c);
+    if (deniedOAuth) return deniedOAuth;
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const deniedAddress = forbidUnlessAddress(c, sub.address);
+    if (deniedAddress) return deniedAddress;
+
+    const auth = getAuth(c);
+
+    // Rule D: Identity caller can only rotate if created by itself
+    if (auth.kind === 'identity' && sub.createdBy !== auth.address) {
+      return c.json({ error: 'forbidden: admin key required' }, 403);
+    }
+
+    // Rule B: Identity caller requires metadata scope
+    if (auth.kind === 'identity' && sub.contentScope !== 'metadata') {
+      return c.json({ error: 'content_scope_requires_admin' }, 403);
+    }
+
+    // Idempotency check
+    const idempotencyKey = c.req.header('idempotency-key')?.trim();
+    if (idempotencyKey) {
+      const found = findRotateIdempotency(idempotencyKey, sub.id);
+      if (found) {
+        return c.json(found.responseBody, 200);
+      }
+    }
+
+    // Overlap window check
+    const force = c.req.query('force') === 'true';
+    if (
+      sub.overlapUntil &&
+      new Date(sub.overlapUntil).getTime() > Date.now() &&
+      !force
+    ) {
+      return c.json(
+        { error: 'rotation_window_open', overlapUntil: sub.overlapUntil },
+        409,
+      );
+    }
+
+    const nextEpoch = sub.epoch + 1;
+    const now = Date.now();
+    const overlapUntil =
+      config.webhooks.rotationOverlapMs > 0
+        ? new Date(now + config.webhooks.rotationOverlapMs).toISOString()
+        : null;
+
+    const derived = deriveWebhookKey(
+      config.webhooks.signingSecret || config.taskSigningSecret,
+      sub.id,
+      nextEpoch,
+    );
+
+    updateWebhookSubscription(sub.id, (s) => {
+      s.epoch = nextEpoch;
+      s.secretPrefix = derived.secretPrefix;
+      s.overlapUntil = overlapUntil;
+      s.rotatedAt = new Date(now).toISOString();
+    });
+
+    recordAuditEvent({
+      event: 'webhook.rotate',
+      outcome: 'ok',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    const response = {
+      id: sub.id,
+      epoch: nextEpoch,
+      secret: derived.displayedSecret,
+      secretPrefix: derived.secretPrefix,
+      overlapUntil,
+    };
+
+    if (idempotencyKey) {
+      saveRotateIdempotency({
+        key: idempotencyKey,
+        webhookId: sub.id,
+        epoch: nextEpoch,
+        responseBody: { ...response, secret: null },
+        createdAt: new Date(now).toISOString(),
+      });
+    }
+
+    return c.json(response, 200);
+  })
+
+  // POST /v1/webhooks/:id/test - Test probe
+  .post('/:id/test', async (c) => {
+    const deniedOAuth = forbidOAuthMutation(c);
+    if (deniedOAuth) return deniedOAuth;
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const deniedAddress = forbidUnlessAddress(c, sub.address);
+    if (deniedAddress) return deniedAddress;
+
+    if (sub.state === 'disabled') {
+      return c.json(
+        { error: 'webhook_disabled', disabledReason: sub.disabledReason },
+        409,
+      );
+    }
+
+    const auth = getAuth(c);
+    const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
+    const rateRes = deliveryLimiter.checkTestProbeRate(tokenKey);
+    if (!rateRes.allowed) {
+      c.header('Retry-After', String(rateRes.retryAfterSec));
+      return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
+    }
+
+    const probeRes = await executeWebhookTestProbe(sub, tokenKey);
+
+    recordAuditEvent({
+      event: 'webhook.test',
+      outcome: probeRes.outcome === 'success' ? 'ok' : 'denied',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    return c.json(probeRes, 200);
+  })
+
+  // POST /v1/webhooks/:id/disable - Manual pause
+  .post('/:id/disable', async (c) => {
+    const deniedOAuth = forbidOAuthMutation(c);
+    if (deniedOAuth) return deniedOAuth;
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const deniedAddress = forbidUnlessAddress(c, sub.address);
+    if (deniedAddress) return deniedAddress;
+
+    updateWebhookSubscription(sub.id, (s) => {
+      s.state = 'disabled';
+      s.disabledReason = 'manual';
+    });
+    deliveryQueue.cancelForWebhook(sub.id, 'webhook_disabled');
+
+    recordAuditEvent({
+      event: 'webhook.disabled',
+      outcome: 'ok',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    return c.json({ ok: true, state: 'disabled', disabledReason: 'manual' });
+  })
+
+  // POST /v1/webhooks/:id/enable - Resume endpoint (admin only)
+  .post('/:id/enable', async (c) => {
+    const denied = requireAdmin(c);
+    if (denied) return denied;
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    if (sub.state !== 'disabled') {
+      return c.json({ error: 'webhook_not_disabled' }, 409);
+    }
+
+    const updated = updateWebhookSubscription(sub.id, (s) => {
+      s.state = 'unverified';
+      s.disabledReason = null;
+      s.consecutiveFailures = 0;
+    });
+
+    if (updated) {
+      fireCreationPing(updated, 'creation');
+    }
+
+    recordAuditEvent({
+      event: 'webhook.enabled',
+      outcome: 'ok',
+      address: sub.address,
+      webhookId: sub.id,
+    });
+
+    return c.json({ ok: true, state: 'unverified' });
+  })
+
+  // GET /v1/webhooks/:id/deliveries - List deliveries (admin only)
+  .get('/:id/deliveries', async (c) => {
+    const denied = requireAdmin(c);
+    if (denied) return denied;
+
+    const sub = getWebhookSubscription(c.req.param('id'));
+    if (!sub) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    const limit = c.req.query('limit') ? Number(c.req.query('limit')) : 20;
+    const cursor = c.req.query('cursor');
+
+    const res = readDeliveryLogRows({
+      webhookId: sub.id,
+      limit,
+      cursor,
+    });
+
+    return c.json(res);
+  });

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -13,6 +13,7 @@ import {
   getAuth,
 } from '../lib/auth.ts';
 import { recordAuditEvent } from '../lib/audit.ts';
+import { clientIp } from '../lib/net.ts';
 import {
   checkSubscriptionLimits,
   createWebhookSubscription,
@@ -70,6 +71,13 @@ function forbidOAuthRead(c: Context) {
 
 type InFlightCreateResult = { status: number; body: any };
 const inFlightCreateIdempotency = new Map<string, Promise<InFlightCreateResult>>();
+
+function redactWebhookSecret(body: unknown): unknown {
+  if (body && typeof body === 'object' && !Array.isArray(body)) {
+    return { ...(body as Record<string, unknown>), secret: null };
+  }
+  return body;
+}
 
 const createSchema = z
   .object({
@@ -187,7 +195,7 @@ export const webhooksRoute = new Hono()
       if (pending) {
         try {
           const cached = await pending;
-          return c.json(cached.body, cached.status as any);
+          return c.json(redactWebhookSecret(cached.body), cached.status as any);
         } catch {
           // ignore failure and proceed
         }
@@ -283,12 +291,16 @@ export const webhooksRoute = new Hono()
 
     if (compositeKey) {
       let promise = inFlightCreateIdempotency.get(compositeKey);
+      const waiter = Boolean(promise);
       if (!promise) {
         promise = executeCreate();
         inFlightCreateIdempotency.set(compositeKey, promise);
       }
       try {
         const res = await promise;
+        if (waiter) {
+          return c.json(redactWebhookSecret(res.body), res.status as any);
+        }
         return c.json(res.body, res.status as any);
       } finally {
         inFlightCreateIdempotency.delete(compositeKey);
@@ -600,7 +612,7 @@ export const webhooksRoute = new Hono()
       return c.json({ error: 'content_scope_requires_admin' }, 403);
     }
 
-    // Idempotency check
+    // Idempotency check (cached hits skip the write-amplification limiter)
     const idempotencyKey = c.req.header('idempotency-key')?.trim();
     if (idempotencyKey) {
       const found = findRotateIdempotency(sub.id, idempotencyKey);
@@ -620,6 +632,13 @@ export const webhooksRoute = new Hono()
         { error: 'rotation_window_open', overlapUntil: sub.overlapUntil },
         409,
       );
+    }
+
+    const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
+    const rotateRate = deliveryLimiter.checkRotateRate(tokenKey);
+    if (!rotateRate.allowed) {
+      c.header('Retry-After', String(rotateRate.retryAfterSec));
+      return c.json({ error: 'rate_limited', retryAfterSec: rotateRate.retryAfterSec }, 429);
     }
 
     const nextEpoch = sub.epoch + 1;
@@ -694,7 +713,9 @@ export const webhooksRoute = new Hono()
     const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
 
     try {
-      const probeRes = await executeWebhookTestProbe(sub, tokenKey);
+      const probeRes = await executeWebhookTestProbe(sub, tokenKey, {
+        clientIp: clientIp(c),
+      });
 
       let auditOutcome: 'ok' | 'denied' | 'error' = 'ok';
       if (probeRes.outcome === 'refused') {

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -81,7 +81,7 @@ function redactWebhookSecret(body: unknown): unknown {
 
 const createSchema = z
   .object({
-    url: z.string().url(),
+    url: z.string().url().max(2048),
     address: z.string().email(),
     events: z
       .array(z.enum(['mail.received', 'approval.requested']))
@@ -94,7 +94,7 @@ const createSchema = z
 
 const updateSchema = z
   .object({
-    url: z.string().url().optional(),
+    url: z.string().url().max(2048).optional(),
     events: z
       .array(z.enum(['mail.received', 'approval.requested']))
       .min(1, 'events must be non-empty')

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -492,6 +492,13 @@ export const webhooksRoute = new Hono()
       return c.json({ error: 'content_scope_requires_admin' }, 403);
     }
 
+    const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
+    const rateRes = deliveryLimiter.checkCreateRate(tokenKey);
+    if (!rateRes.allowed) {
+      c.header('Retry-After', String(rateRes.retryAfterSec));
+      return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
+    }
+
     let urlChanged = false;
     let isPrivateTarget = sub.privateTargetGranted;
 
@@ -538,7 +545,6 @@ export const webhooksRoute = new Hono()
     }
 
     if (urlChanged && updated.state !== 'disabled') {
-      const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
       fireCreationPing(updated, 'creation', tokenKey);
     }
 

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -56,6 +56,20 @@ function forbidOAuthMutation(c: Context) {
   return null;
 }
 
+function forbidOAuthRead(c: Context) {
+  const attr = getAttribution(c);
+  if (attr?.kind === 'oauth') {
+    return c.json(
+      { error: 'forbidden: oauth tokens may not reveal webhook secrets' },
+      403,
+    );
+  }
+  return null;
+}
+
+type InFlightCreateResult = { status: number; body: any };
+const inFlightCreateIdempotency = new Map<string, Promise<InFlightCreateResult>>();
+
 const createSchema = z
   .object({
     url: z.string().url(),
@@ -166,103 +180,139 @@ export const webhooksRoute = new Hono()
 
     // Idempotency check
     const idempotencyKey = c.req.header('idempotency-key')?.trim();
-    if (idempotencyKey) {
+    const compositeKey = idempotencyKey ? `${idempotencyKey}:${targetAddress}` : null;
+    if (idempotencyKey && compositeKey) {
+      const pending = inFlightCreateIdempotency.get(compositeKey);
+      if (pending) {
+        try {
+          const cached = await pending;
+          return c.json(cached.body, cached.status as any);
+        } catch {
+          // ignore failure and proceed
+        }
+      }
       const found = findCreateIdempotency(idempotencyKey, targetAddress);
       if (found) {
         return c.json(found.responseBody, 201);
       }
     }
 
-    // URL validation (static & DNS resolution)
-    const resolution = await validateWebhookUrlResolution(parsed.data.url, {
-      allowPrivateTargets: config.webhooks.allowPrivateTargets,
-    });
-    if (!resolution.valid) {
-      return c.json(
-        {
-          error:
-            resolution.code === 'webhook_target_forbidden'
-              ? 'webhook_target_forbidden'
-              : 'invalid_webhook_url',
-        },
-        400,
+    const executeCreate = async (): Promise<InFlightCreateResult> => {
+      // URL validation (static & DNS resolution)
+      const resolution = await validateWebhookUrlResolution(parsed.data.url, {
+        allowPrivateTargets: config.webhooks.allowPrivateTargets,
+      });
+      if (!resolution.valid) {
+        return {
+          status: 400,
+          body: {
+            error:
+              resolution.code === 'webhook_target_forbidden'
+                ? 'webhook_target_forbidden'
+                : 'invalid_webhook_url',
+          },
+        };
+      }
+
+      // Rule C: private target requires admin
+      if (resolution.isPrivateTarget && auth.kind !== 'admin') {
+        return { status: 400, body: { error: 'webhook_target_forbidden' } };
+      }
+
+      // Subscription limit check
+      const limits = checkSubscriptionLimits(targetAddress);
+      if (!limits.allowed) {
+        return { status: 409, body: { error: 'webhook_limit_reached' } };
+      }
+
+      const createdBy = auth.kind === 'admin' ? 'admin' : auth.address;
+      const record = createWebhookSubscription({
+        url: parsed.data.url,
+        address: targetAddress,
+        events: parsed.data.events,
+        contentScope: parsed.data.contentScope,
+        description: parsed.data.description,
+        privateTargetGranted: resolution.isPrivateTarget && auth.kind === 'admin',
+        createdBy,
+      });
+
+      const derived = deriveWebhookKey(
+        config.webhooks.signingSecret || config.taskSigningSecret,
+        record.id,
+        record.epoch,
       );
-    }
 
-    // Rule C: private target requires admin
-    if (resolution.isPrivateTarget && auth.kind !== 'admin') {
-      return c.json({ error: 'webhook_target_forbidden' }, 400);
-    }
+      // Fire asynchronous ping at creation (§5.1, D12, Item 19)
+      fireCreationPing(record, 'creation', tokenKey);
 
-    // Subscription limit check
-    const limits = checkSubscriptionLimits(targetAddress);
-    if (!limits.allowed) {
-      return c.json({ error: 'webhook_limit_reached' }, 409);
-    }
-
-    const createdBy = auth.kind === 'admin' ? 'admin' : auth.address;
-    const record = createWebhookSubscription({
-      url: parsed.data.url,
-      address: targetAddress,
-      events: parsed.data.events,
-      contentScope: parsed.data.contentScope,
-      description: parsed.data.description,
-      privateTargetGranted: resolution.isPrivateTarget && auth.kind === 'admin',
-      createdBy,
-    });
-
-    const derived = deriveWebhookKey(
-      config.webhooks.signingSecret || config.taskSigningSecret,
-      record.id,
-      record.epoch,
-    );
-
-    // Fire asynchronous ping at creation (§5.1, D12)
-    fireCreationPing(record, 'creation');
-
-    recordAuditEvent({
-      event: 'webhook.create',
-      outcome: 'ok',
-      address: record.address,
-      webhookId: record.id,
-    });
-
-    const response = {
-      id: record.id,
-      url: record.url,
-      address: record.address,
-      events: record.events,
-      contentScope: record.contentScope,
-      description: record.description,
-      state: record.state,
-      secret: derived.displayedSecret,
-      secretPrefix: record.secretPrefix,
-      signatureScheme: 'v1',
-      timestampToleranceSec: config.webhooks.timestampToleranceSec,
-      createdAt: record.createdAt,
-    };
-
-    if (idempotencyKey) {
-      saveCreateIdempotency({
-        key: idempotencyKey,
+      recordAuditEvent({
+        event: 'webhook.create',
+        outcome: 'ok',
         address: record.address,
         webhookId: record.id,
-        responseBody: { ...response, secret: null },
-        createdAt: record.createdAt,
       });
-    }
 
-    return c.json(response, 201);
+      const response = {
+        id: record.id,
+        url: record.url,
+        address: record.address,
+        events: record.events,
+        contentScope: record.contentScope,
+        description: record.description,
+        state: record.state,
+        secret: derived.displayedSecret,
+        secretPrefix: record.secretPrefix,
+        signatureScheme: 'v1',
+        timestampToleranceSec: config.webhooks.timestampToleranceSec,
+        createdAt: record.createdAt,
+      };
+
+      if (idempotencyKey) {
+        saveCreateIdempotency({
+          key: idempotencyKey,
+          address: record.address,
+          webhookId: record.id,
+          responseBody: { ...response, secret: null },
+          createdAt: record.createdAt,
+        });
+      }
+
+      return { status: 201, body: response };
+    };
+
+    if (compositeKey) {
+      let promise = inFlightCreateIdempotency.get(compositeKey);
+      if (!promise) {
+        promise = executeCreate();
+        inFlightCreateIdempotency.set(compositeKey, promise);
+      }
+      try {
+        const res = await promise;
+        return c.json(res.body, res.status as any);
+      } finally {
+        inFlightCreateIdempotency.delete(compositeKey);
+      }
+    } else {
+      const res = await executeCreate();
+      return c.json(res.body, res.status as any);
+    }
   })
 
   // GET /v1/webhooks - List subscriptions
   .get('/', async (c) => {
     const auth = getAuth(c);
+    const addressParam = c.req.query('address')?.trim()?.toLowerCase();
+    if (addressParam && auth.kind !== 'admin') {
+      return c.json({ error: 'forbidden: admin key required' }, 403);
+    }
+
     const all = listWebhookSubscriptions();
-    const filtered =
-      auth.kind === 'admin'
-        ? all
-        : all.filter((s) => s.address === auth.address);
+    let filtered: WebhookRecord[];
+    if (auth.kind === 'admin') {
+      filtered = addressParam ? all.filter((s) => s.address === addressParam) : all;
+    } else {
+      filtered = all.filter((s) => s.address === auth.address);
+    }
 
     return c.json({
       webhooks: filtered.map((sub) => formatSubscriptionDetail(sub)),
@@ -401,8 +451,13 @@ export const webhooksRoute = new Hono()
       }
     });
 
-    if (urlChanged && updated) {
-      fireCreationPing(updated, 'creation');
+    if (!updated) {
+      return c.json({ error: 'not_found' }, 404);
+    }
+
+    if (urlChanged) {
+      const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
+      fireCreationPing(updated, 'creation', tokenKey);
     }
 
     recordAuditEvent({
@@ -412,11 +467,14 @@ export const webhooksRoute = new Hono()
       webhookId: sub.id,
     });
 
-    return c.json(formatSubscriptionDetail(updated!));
+    return c.json(formatSubscriptionDetail(updated));
   })
 
   // GET /v1/webhooks/:id/secret - Reveal signing secret
   .get('/:id/secret', async (c) => {
+    const deniedOAuth = forbidOAuthRead(c);
+    if (deniedOAuth) return deniedOAuth;
+
     c.header('Cache-Control', 'no-store');
 
     const sub = getWebhookSubscription(c.req.param('id'));
@@ -463,6 +521,9 @@ export const webhooksRoute = new Hono()
 
   // DELETE /v1/webhooks/:id - Delete subscription
   .delete('/:id', async (c) => {
+    const deniedOAuth = forbidOAuthMutation(c);
+    if (deniedOAuth) return deniedOAuth;
+
     const sub = getWebhookSubscription(c.req.param('id'));
     if (!sub) {
       return c.json({ error: 'not_found' }, 404);
@@ -524,7 +585,7 @@ export const webhooksRoute = new Hono()
     // Idempotency check
     const idempotencyKey = c.req.header('idempotency-key')?.trim();
     if (idempotencyKey) {
-      const found = findRotateIdempotency(idempotencyKey, sub.id);
+      const found = findRotateIdempotency(sub.id, idempotencyKey);
       if (found) {
         return c.json(found.responseBody, 200);
       }
@@ -613,22 +674,33 @@ export const webhooksRoute = new Hono()
 
     const auth = getAuth(c);
     const tokenKey = auth.kind === 'admin' ? 'admin' : auth.address;
-    const rateRes = deliveryLimiter.checkTestProbeRate(tokenKey);
-    if (!rateRes.allowed) {
-      c.header('Retry-After', String(rateRes.retryAfterSec));
-      return c.json({ error: 'rate_limited', retryAfterSec: rateRes.retryAfterSec }, 429);
+
+    try {
+      const probeRes = await executeWebhookTestProbe(sub, tokenKey);
+
+      recordAuditEvent({
+        event: 'webhook.test',
+        outcome: probeRes.outcome === 'success' ? 'ok' : 'denied',
+        address: sub.address,
+        webhookId: sub.id,
+      });
+
+      return c.json(probeRes, 200);
+    } catch (err: any) {
+      if (err.code === 'rate_limited') {
+        if (err.retryAfterSec) {
+          c.header('Retry-After', String(err.retryAfterSec));
+        }
+        return c.json({ error: 'rate_limited', retryAfterSec: err.retryAfterSec }, 429);
+      }
+      if (err.code === 'webhook_disabled') {
+        return c.json(
+          { error: 'webhook_disabled', disabledReason: err.disabledReason },
+          409,
+        );
+      }
+      throw err;
     }
-
-    const probeRes = await executeWebhookTestProbe(sub, tokenKey);
-
-    recordAuditEvent({
-      event: 'webhook.test',
-      outcome: probeRes.outcome === 'success' ? 'ok' : 'denied',
-      address: sub.address,
-      webhookId: sub.id,
-    });
-
-    return c.json(probeRes, 200);
   })
 
   // POST /v1/webhooks/:id/disable - Manual pause
@@ -643,6 +715,13 @@ export const webhooksRoute = new Hono()
 
     const deniedAddress = forbidUnlessAddress(c, sub.address);
     if (deniedAddress) return deniedAddress;
+
+    const auth = getAuth(c);
+
+    // Rule D: Identity caller can only disable if created by itself
+    if (auth.kind === 'identity' && sub.createdBy !== auth.address) {
+      return c.json({ error: 'forbidden: admin key required' }, 403);
+    }
 
     updateWebhookSubscription(sub.id, (s) => {
       s.state = 'disabled';
@@ -681,7 +760,7 @@ export const webhooksRoute = new Hono()
     });
 
     if (updated) {
-      fireCreationPing(updated, 'creation');
+      fireCreationPing(updated, 'creation', 'admin');
     }
 
     recordAuditEvent({

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -578,11 +578,23 @@ export const webhooksRoute = new Hono()
 
     // Rule D: Identity caller can only reveal if created by itself
     if (auth.kind === 'identity' && sub.createdBy !== auth.address) {
+      recordAuditEvent({
+        event: 'webhook.reveal',
+        outcome: 'denied',
+        address: sub.address,
+        webhookId: sub.id,
+      });
       return c.json({ error: 'forbidden: admin key required' }, 403);
     }
 
     // Rule D / §12.3: Identity caller requires metadata scope
     if (auth.kind === 'identity' && sub.contentScope !== 'metadata') {
+      recordAuditEvent({
+        event: 'webhook.reveal',
+        outcome: 'denied',
+        address: sub.address,
+        webhookId: sub.id,
+      });
       return c.json({ error: 'content_scope_requires_admin' }, 403);
     }
 

--- a/packages/api/test/audit-tiering.test.ts
+++ b/packages/api/test/audit-tiering.test.ts
@@ -245,8 +245,8 @@ describe('attribution：三种 caller 落三种行', () => {
 });
 
 describe('工具分层', () => {
-  test('规格表 20 工具均有 tier；注册冲突会 throw', () => {
-    expect(Object.keys(TOOL_TIER_SPEC).length).toBe(20);
+  test('规格表 25 工具均有 tier；注册冲突会 throw', () => {
+    expect(Object.keys(TOOL_TIER_SPEC).length).toBe(25);
     // SPEC 回落：即使 declared 空也能预检
     resetToolTiersForTests();
     expect(isToolTierDeclared('mail_new_identity')).toBe(false);

--- a/packages/api/test/config.test.ts
+++ b/packages/api/test/config.test.ts
@@ -646,12 +646,85 @@ describe('WEBHOOKS_ENABLED configuration (#128 PR2)', () => {
     expect(config.webhooks.enabled).toBe(false);
   });
 
-  test('enables webhooks when set to true', () => {
+  test('enables webhooks when set to true and TASK_SIGNING_SECRET is valid', () => {
     const config = parseConfig({
       ...requiredEnv,
+      TASK_SIGNING_SECRET: '12345678901234567890123456789012',
       WEBHOOKS_ENABLED: 'true',
     });
     expect(config.webhooks.enabled).toBe(true);
+  });
+
+  test('R1: refuses boot when WEBHOOKS_ENABLED=true without explicit TASK_SIGNING_SECRET >= 32 chars', () => {
+    // Unset TASK_SIGNING_SECRET
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOKS_ENABLED: 'true',
+      }),
+    ).toThrow('TASK_SIGNING_SECRET is required when WEBHOOKS_ENABLED is true');
+
+    // Too short TASK_SIGNING_SECRET (< 32 chars)
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        TASK_SIGNING_SECRET: 'a'.repeat(20),
+        WEBHOOKS_ENABLED: 'true',
+      }),
+    ).toThrow('TASK_SIGNING_SECRET must be at least 32 characters when WEBHOOKS_ENABLED is true');
+
+    // Even when WEBHOOK_SIGNING_SECRET is set, TASK_SIGNING_SECRET is unconditionally required
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOK_SIGNING_SECRET: '12345678901234567890123456789012',
+        WEBHOOKS_ENABLED: 'true',
+      }),
+    ).toThrow('TASK_SIGNING_SECRET is required when WEBHOOKS_ENABLED is true');
+  });
+
+  test('forces WEBHOOK_ALLOW_PRIVATE_TARGETS to false when OAE_PUBLIC_EDGE=true', () => {
+    const config = parseConfig({
+      ...requiredEnv,
+      TASK_SIGNING_SECRET: '12345678901234567890123456789012',
+      WEBHOOKS_ENABLED: 'true',
+      WEBHOOK_ALLOW_PRIVATE_TARGETS: 'true',
+      OAE_PUBLIC_EDGE: 'true',
+    });
+    expect(config.webhooks.allowPrivateTargets).toBe(false);
+  });
+
+  test('parses and validates WEBHOOK_ALLOWED_PORTS', () => {
+    const config = parseConfig({
+      ...requiredEnv,
+      TASK_SIGNING_SECRET: '12345678901234567890123456789012',
+      WEBHOOKS_ENABLED: 'true',
+      WEBHOOK_ALLOWED_PORTS: '443, 8443',
+    });
+    expect(config.webhooks.allowedPorts).toEqual([443, 8443]);
+
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOK_ALLOWED_PORTS: '',
+      }),
+    ).toThrow('WEBHOOK_ALLOWED_PORTS must be non-empty');
+
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOK_ALLOWED_PORTS: '443, not-a-port',
+      }),
+    ).toThrow('WEBHOOK_ALLOWED_PORTS contains invalid port');
+  });
+
+  test('rejects WEBHOOK_PAYLOAD_MAX_BYTES greater than JSON_BODY_LIMIT_BYTES', () => {
+    expect(() =>
+      parseConfig({
+        ...requiredEnv,
+        WEBHOOK_PAYLOAD_MAX_BYTES: '20000000', // > 16MiB
+      }),
+    ).toThrow('WEBHOOK_PAYLOAD_MAX_BYTES must be <= JSON_BODY_LIMIT_BYTES');
   });
 
   test('rejects non-boolean string values', () => {

--- a/packages/api/test/event-dispatcher.test.ts
+++ b/packages/api/test/event-dispatcher.test.ts
@@ -67,7 +67,7 @@ describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
       isNotificationWatcherEnabled({
         ...config,
         ntfy: { ...config.ntfy, enabled: false, pushPolicy: 'otp' },
-        webhooks: { enabled: true },
+        webhooks: { ...config.webhooks, enabled: true },
       }),
     ).toBe(true);
 
@@ -76,7 +76,7 @@ describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
       isNotificationWatcherEnabled({
         ...config,
         ntfy: { ...config.ntfy, enabled: true, pushPolicy: 'otp' },
-        webhooks: { enabled: false },
+        webhooks: { ...config.webhooks, enabled: false },
       }),
     ).toBe(true);
 
@@ -85,7 +85,7 @@ describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
       isNotificationWatcherEnabled({
         ...config,
         ntfy: { ...config.ntfy, enabled: true, pushPolicy: 'none' },
-        webhooks: { enabled: false },
+        webhooks: { ...config.webhooks, enabled: false },
       }),
     ).toBe(false);
 
@@ -94,7 +94,7 @@ describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
       isNotificationWatcherEnabled({
         ...config,
         ntfy: { ...config.ntfy, enabled: true, pushPolicy: 'none' },
-        webhooks: { enabled: true },
+        webhooks: { ...config.webhooks, enabled: true },
       }),
     ).toBe(true);
 
@@ -103,7 +103,7 @@ describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
       isNotificationWatcherEnabled({
         ...config,
         ntfy: { ...config.ntfy, enabled: false, pushPolicy: 'none' },
-        webhooks: { enabled: false },
+        webhooks: { ...config.webhooks, enabled: false },
       }),
     ).toBe(false);
   });
@@ -112,7 +112,7 @@ describe('Startup gate widening (§11.4 item 1 & §14 item 4)', () => {
     const stopper = startNotificationWatcher({
       ...config,
       ntfy: { ...config.ntfy, enabled: false },
-      webhooks: { enabled: false },
+      webhooks: { ...config.webhooks, enabled: false },
     });
     expect(stopper).toBeFunction();
     stopper();
@@ -242,7 +242,7 @@ describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
       watermark: webhookWatermark,
       handleMail: async (event) => {
         // Webhook sink fails with service outage on message 41
-        throw new NotifyError('webhook_unavailable', undefined, { failureKind: 'service' });
+        throw new NotifyError('webhook_unavailable' as any, undefined, { failureKind: 'service' });
       },
     });
 
@@ -299,7 +299,7 @@ describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
       isEnabled: () => true,
       watermark: ntfyWatermark,
       handleMail: async () => {
-        throw new NotifyError('ntfy_503_service_down', undefined, { failureKind: 'service' });
+        throw new NotifyError('ntfy_503_service_down' as any, undefined, { failureKind: 'service' });
       },
     });
 
@@ -363,7 +363,7 @@ describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
       isEnabled: () => true,
       watermark: webhookWatermark,
       handleMail: async () => {
-        throw new NotifyError('endpoint_down', undefined, { failureKind: 'service' });
+        throw new NotifyError('endpoint_down' as any, undefined, { failureKind: 'service' });
       },
     });
 
@@ -421,7 +421,7 @@ describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
       isEnabled: () => true,
       watermark: { uid: 40, uidValidity: 1n },
       handleMail: async () => {
-        throw new NotifyError('outage_a', undefined, { failureKind: 'service' });
+        throw new NotifyError('outage_a' as any, undefined, { failureKind: 'service' });
       },
     });
 
@@ -430,7 +430,7 @@ describe('Per-sink watermark isolation (§11.4 item 3 & §14 item 4)', () => {
       isEnabled: () => true,
       watermark: { uid: 40, uidValidity: 1n },
       handleMail: async () => {
-        throw new NotifyError('outage_b', undefined, { failureKind: 'service' });
+        throw new NotifyError('outage_b' as any, undefined, { failureKind: 'service' });
       },
     });
 
@@ -660,7 +660,7 @@ describe('Second producer hand-off (§11.4 item 4 & §14 item 10)', () => {
     const dispatcher = new EventDispatcher();
     setEventDispatcherForTests(dispatcher);
 
-    let resolveTarpit: (() => void) | null = null;
+    let resolveTarpit!: () => void;
     const tarpitPromise = new Promise<void>((r) => {
       resolveTarpit = r;
     });
@@ -695,7 +695,7 @@ describe('Second producer hand-off (§11.4 item 4 & §14 item 10)', () => {
     expect(task.state).toBe('input-required');
 
     // Clean up tarpit to avoid lingering promises
-    resolveTarpit?.();
+    resolveTarpit();
     setEventDispatcherForTests(null);
   });
 

--- a/packages/api/test/fixtures/webhook-signature-vectors.v1.json
+++ b/packages/api/test/fixtures/webhook-signature-vectors.v1.json
@@ -1,0 +1,58 @@
+{
+  "format": "openagentemail.webhook-signature-vectors",
+  "version": 1,
+  "signatureScheme": "v1",
+  "vectors": [
+    {
+      "id": "simple-mail-v1",
+      "description": "Standard mail.received delivery with epoch 0 key",
+      "rootSecret": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "webhookId": "whk_4a1b8c2d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+      "epoch": 0,
+      "displayedSecret": "whs_2b0932ba2d72c1d53d07da69a8ad7843c70f09d24800e3b3828dca20b594127b",
+      "timestampSec": 1725366000,
+      "rawBody": "{\"id\":\"evt_11111111-2222-3333-4444-555555555555\",\"type\":\"mail.received\",\"payloadVersion\":\"v1\",\"createdAt\":\"2026-09-03T12:20:00.000Z\",\"domain\":\"openagent.email\",\"data\":{\"object\":\"mail\",\"address\":\"alice@openagent.email\",\"messageId\":\"123\",\"uid\":123,\"uidValidity\":1,\"receivedAt\":\"2026-09-03T12:20:00.000Z\"}}",
+      "expectedSignature": "6420c5b360e8c7b62d2d55ef34d43a9fd55d37349b6e42e26c8bfdca8c0f7f6d",
+      "expectedHeader": "t=1725366000,v1=6420c5b360e8c7b62d2d55ef34d43a9fd55d37349b6e42e26c8bfdca8c0f7f6d"
+    },
+    {
+      "id": "unicode-cjk-v1",
+      "description": "Payload containing multi-byte UTF-8 CJK text and emoji",
+      "rootSecret": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "webhookId": "whk_4a1b8c2d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+      "epoch": 0,
+      "displayedSecret": "whs_2b0932ba2d72c1d53d07da69a8ad7843c70f09d24800e3b3828dca20b594127b",
+      "timestampSec": 1725366300,
+      "rawBody": "{\"id\":\"evt_22222222-3333-4444-5555-666666666666\",\"type\":\"mail.received\",\"payloadVersion\":\"v1\",\"createdAt\":\"2026-09-03T12:25:00.000Z\",\"domain\":\"openagent.email\",\"data\":{\"object\":\"mail\",\"address\":\"bob@openagent.email\",\"messageId\":\"456\",\"subject\":\"你好，世界！🚀 Verify code: 849201\",\"from\":{\"address\":\"sender@example.com\",\"name\":\"张三 (Zhang San)\"}}}",
+      "expectedSignature": "6fcd141f33452357269bdcd3dffe85a5ac1e4053874c6f186e073f87b08dda3c",
+      "expectedHeader": "t=1725366300,v1=6fcd141f33452357269bdcd3dffe85a5ac1e4053874c6f186e073f87b08dda3c"
+    },
+    {
+      "id": "approval-requested-v1",
+      "description": "approval.requested delivery with epoch 1 rotated key",
+      "rootSecret": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "webhookId": "whk_4a1b8c2d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+      "epoch": 1,
+      "displayedSecret": "whs_22d6bef2a2b2c1d3b7af6646f2896c5eaf790dde79740f293eba5d8eb82437f9",
+      "timestampSec": 1725366600,
+      "rawBody": "{\"id\":\"evt_33333333-4444-5555-6666-777777777777\",\"type\":\"approval.requested\",\"payloadVersion\":\"v1\",\"createdAt\":\"2026-09-03T12:30:00.000Z\",\"domain\":\"openagent.email\",\"data\":{\"object\":\"approval\",\"taskId\":\"task_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"taskState\":\"input-required\",\"from\":\"agent@openagent.email\",\"to\":\"owner@openagent.email\",\"reviewer\":\"owner@openagent.email\",\"subject\":\"Approve deployment to production\",\"digest\":\"a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90\",\"actionType\":\"tool_call\",\"actionName\":\"deploy_service\"}}",
+      "expectedSignature": "9ce0dbe1a9db845de7ca2553073e0de0fb77c4830c1018516ea064ceaaf16930",
+      "expectedHeader": "t=1725366600,v1=9ce0dbe1a9db845de7ca2553073e0de0fb77c4830c1018516ea064ceaaf16930"
+    },
+    {
+      "id": "overlap-rotation-v1",
+      "description": "Dual v1 signatures emitted during overlap window between epoch 1 and epoch 0",
+      "rootSecret": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      "webhookId": "whk_4a1b8c2d-5e6f-4a7b-8c9d-0e1f2a3b4c5d",
+      "epoch": 1,
+      "previousEpoch": 0,
+      "displayedSecret": "whs_22d6bef2a2b2c1d3b7af6646f2896c5eaf790dde79740f293eba5d8eb82437f9",
+      "previousDisplayedSecret": "whs_2b0932ba2d72c1d53d07da69a8ad7843c70f09d24800e3b3828dca20b594127b",
+      "timestampSec": 1725366600,
+      "rawBody": "{\"id\":\"evt_33333333-4444-5555-6666-777777777777\",\"type\":\"approval.requested\",\"payloadVersion\":\"v1\",\"createdAt\":\"2026-09-03T12:30:00.000Z\",\"domain\":\"openagent.email\",\"data\":{\"object\":\"approval\",\"taskId\":\"task_aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\",\"taskState\":\"input-required\",\"from\":\"agent@openagent.email\",\"to\":\"owner@openagent.email\",\"reviewer\":\"owner@openagent.email\",\"subject\":\"Approve deployment to production\",\"digest\":\"a1b2c3d4e5f60718293a4b5c6d7e8f90a1b2c3d4e5f60718293a4b5c6d7e8f90\",\"actionType\":\"tool_call\",\"actionName\":\"deploy_service\"}}",
+      "expectedPrimarySignature": "9ce0dbe1a9db845de7ca2553073e0de0fb77c4830c1018516ea064ceaaf16930",
+      "expectedPreviousSignature": "4b87fe580cd9394a4b91a106a902e7a457ef65e2746d11b73e2a21af730a4afa",
+      "expectedHeader": "t=1725366600,v1=9ce0dbe1a9db845de7ca2553073e0de0fb77c4830c1018516ea064ceaaf16930,v1=4b87fe580cd9394a4b91a106a902e7a457ef65e2746d11b73e2a21af730a4afa"
+    }
+  ]
+}

--- a/packages/api/test/mcp-http.test.ts
+++ b/packages/api/test/mcp-http.test.ts
@@ -249,6 +249,11 @@ describe('MCP HTTP 工具', () => {
       'mail_read_message',
       'mail_send',
       'mail_wait_for',
+      'mail_webhook_create',
+      'mail_webhook_delete',
+      'mail_webhook_disable',
+      'mail_webhook_list',
+      'mail_webhook_test',
       'notify_agent',
       'notify_check',
       'notify_user',
@@ -315,7 +320,7 @@ describe('MCP HTTP 工具', () => {
     const body = (await readMcpJson(res)) as {
       result?: { tools?: unknown[] };
     };
-    expect(body.result?.tools?.length).toBe(20);
+    expect(body.result?.tools?.length).toBe(25);
   });
 
   test('mail_list_identities 无状态直连：连续两请求无 session 头各自成功', async () => {

--- a/packages/api/test/utf8-truncate.test.ts
+++ b/packages/api/test/utf8-truncate.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { truncateUtf8Bytes } from '../src/lib/utf8-truncate.ts';
+import { truncateUtf8Bytes, truncateUtf8Codepoints } from '../src/lib/utf8-truncate.ts';
 
 describe('truncateUtf8Bytes', () => {
   test('短于上限原样返回', () => {
@@ -31,5 +31,17 @@ describe('truncateUtf8Bytes', () => {
     const buf = Buffer.from('A😀B', 'utf8');
     const cut = truncateUtf8Bytes(buf, 3);
     expect(cut.toString('utf8')).toBe('A');
+  });
+});
+
+describe('truncateUtf8Codepoints', () => {
+  test('counts Unicode code points, not UTF-8 bytes', () => {
+    const han = '字'.repeat(10);
+    expect(truncateUtf8Codepoints(han, 3)).toBe('字字字');
+    expect([...truncateUtf8Codepoints(han, 3)].length).toBe(3);
+  });
+
+  test('leaves a short string unchanged', () => {
+    expect(truncateUtf8Codepoints('abc', 10)).toBe('abc');
   });
 });

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -24,10 +24,13 @@ const {
   formatApprovalPayload,
   formatMailPayload,
   formatPingPayload,
+  isTerminalDeliveryRow,
+  parseRetryAfterSeconds,
   readAllDeliveryLogRows,
   readDeliveryLogRows,
   reconstructPendingDeliveriesAtBoot,
   redeliverWebhookDelivery,
+  setWebhookDnsLookupForTests,
   validateWebhookUrlResolution,
   validateWebhookUrlStatic,
 } = await import('../src/lib/webhook-delivery.ts');
@@ -37,8 +40,10 @@ const {
   createWebhookSubscription,
   deleteWebhookSubscription,
   getWebhookSubscription,
+  setWebhooksFailClosedForTests,
   updateWebhookSubscription,
 } = await import('../src/lib/webhook-store.ts');
+const { readAuditEvents } = await import('../src/lib/audit.ts');
 type WebhookSubscription = import('../src/lib/webhook-store.ts').WebhookSubscription;
 
 const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhook-delivery');
@@ -57,8 +62,17 @@ function setupTestDir(): void {
   (config.webhooks as any).payloadMaxBytes = 16384;
   (config.webhooks as any).codeEntryChars = 200;
   (config as any).oaePublicEdge = false;
+  setWebhooksFailClosedForTests(false);
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) throw new Error('waitUntil timed out');
+    await new Promise((r) => setTimeout(r, 5));
+  }
 }
 
 describe('webhook-delivery: Retry Schedule & Jitter (§8.3)', () => {
@@ -114,6 +128,20 @@ describe('webhook-delivery: Retry Schedule & Jitter (§8.3)', () => {
     const next = calculateNextAttemptTime(1, start, { retryAfterSec: 60 });
     // Offset 2 was 5s; with Retry-After 60s from attempt 1 (0s), it schedules at >= 60s
     expect(next).toBe(start + 60000);
+  });
+
+  test('R4: parseRetryAfterSeconds requires the whole string to be a 1..3600 integer', () => {
+    expect(parseRetryAfterSeconds('60')).toBe(60);
+    expect(parseRetryAfterSeconds('3600')).toBe(3600);
+    expect(parseRetryAfterSeconds('1')).toBe(1);
+    expect(parseRetryAfterSeconds('3600junk')).toBeUndefined();
+    expect(parseRetryAfterSeconds('60.0')).toBeUndefined();
+    expect(parseRetryAfterSeconds(' 60')).toBe(60);
+    expect(parseRetryAfterSeconds('0')).toBeUndefined();
+    expect(parseRetryAfterSeconds('3601')).toBeUndefined();
+    expect(parseRetryAfterSeconds('-1')).toBeUndefined();
+    expect(parseRetryAfterSeconds('')).toBeUndefined();
+    expect(parseRetryAfterSeconds(null)).toBeUndefined();
   });
 });
 
@@ -276,6 +304,7 @@ describe('webhook-delivery: URL Validation & SSRF Safety (§9.1, §9.3, §9.5, �
     // HTTP target resolving to public IP must fail §9.3 step 5
     const httpPublicRes = await validateWebhookUrlResolution('http://public.example.com/hook', {
       allowPrivateTargets: true,
+      allowedPorts: [80, 443],
       dnsLookup: async () => [{ address: '93.184.216.34', family: 4 }],
     });
     expect(httpPublicRes.valid).toBe(false);
@@ -283,15 +312,33 @@ describe('webhook-delivery: URL Validation & SSRF Safety (§9.1, §9.3, §9.5, �
       expect(httpPublicRes.error).toBe('http_target_must_be_private');
     }
 
-    // HTTP target resolving to private IP succeeds with isPrivateTarget=true
+    // HTTP target resolving to private IP succeeds only when 80 is on the port whitelist
     const httpPrivateRes = await validateWebhookUrlResolution('http://local.internal/hook', {
       allowPrivateTargets: true,
+      allowedPorts: [80, 443],
       dnsLookup: async () => [{ address: '192.168.1.50', family: 4 }],
     });
     expect(httpPrivateRes.valid).toBe(true);
     if (httpPrivateRes.valid) {
       expect(httpPrivateRes.isPrivateTarget).toBe(true);
     }
+  });
+
+  test('R4: private http targets do not implicitly allow port 80', () => {
+    const implicit = validateWebhookUrlStatic('http://192.168.1.50/hook', {
+      allowPrivateTargets: true,
+      allowedPorts: [443],
+    });
+    expect(implicit.valid).toBe(false);
+    if (!implicit.valid) {
+      expect(implicit.error).toBe('port_not_allowed');
+    }
+
+    const explicit = validateWebhookUrlStatic('http://192.168.1.50/hook', {
+      allowPrivateTargets: true,
+      allowedPorts: [80, 443],
+    });
+    expect(explicit.valid).toBe(true);
   });
 });
 
@@ -778,6 +825,237 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     // Boot reconstruction must see terminal state and NOT reconstruct it
     const bootRes = await reconstructPendingDeliveriesAtBoot();
     expect(bootRes.reconstructed).toBe(0);
+  });
+
+  test('R4: isTerminalDeliveryRow uses ping=3 and WEBHOOK_MAX_ATTEMPTS, never pending', () => {
+    expect(
+      isTerminalDeliveryRow({ type: 'webhook.ping', outcome: 'retryable', attempt: 3 }),
+    ).toBe(true);
+    expect(
+      isTerminalDeliveryRow({ type: 'webhook.ping', outcome: 'retryable', attempt: 2 }),
+    ).toBe(false);
+    expect(
+      isTerminalDeliveryRow({ type: 'webhook.ping', outcome: 'pending', attempt: 3 }),
+    ).toBe(false);
+
+    const prev = config.webhooks.maxAttempts;
+    (config.webhooks as any).maxAttempts = 4;
+    try {
+      expect(
+        isTerminalDeliveryRow({ type: 'mail.received', outcome: 'retryable', attempt: 4 }),
+      ).toBe(true);
+      expect(
+        isTerminalDeliveryRow({ type: 'mail.received', outcome: 'retryable', attempt: 3 }),
+      ).toBe(false);
+      expect(
+        isTerminalDeliveryRow({ type: 'mail.received', outcome: 'pending', attempt: 4 }),
+      ).toBe(false);
+    } finally {
+      (config.webhooks as any).maxAttempts = prev;
+    }
+  });
+
+  test('R4: boot reconstruction does not resurrect a completed last ping retryable', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://recon-ping.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 10_000).toISOString();
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 9_000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_ping_cap',
+      runId: 'run_0',
+      deliveryId: 'dlv_ping_cap',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt,
+      attempt: 3,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 20,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 5_000).toISOString(),
+      reason: 'server_error',
+    });
+
+    const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+    expect(result.reconstructed).toBe(0);
+    expect(result.deadLettered).toBe(0);
+    expect(deliveryQueue.hasQueuedJob(sub.id, 'evt_ping_cap')).toBe(false);
+  });
+
+  test('R4: boot reconstruction does not resurrect retryable at WEBHOOK_MAX_ATTEMPTS', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://recon-max.example/hook',
+      address: 'owner@openagent.email',
+      events: ['approval.requested'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const prev = config.webhooks.maxAttempts;
+    (config.webhooks as any).maxAttempts = 4;
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 3_600_000).toISOString();
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 1_000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_max_cap',
+      runId: 'run_0',
+      deliveryId: 'dlv_max_cap',
+      type: 'approval.requested',
+      address: 'owner@openagent.email',
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: '3f8a1c62-9d4e-4b07-a5f1-6c2e8d904b73',
+      taskCreatedAt: eventCreatedAt,
+      expiresInSec: 86400,
+      eventCreatedAt,
+      attempt: 4,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 20,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 5_000).toISOString(),
+      reason: 'server_error',
+    });
+
+    try {
+      const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+      expect(result.reconstructed).toBe(0);
+      expect(result.deadLettered).toBe(0);
+    } finally {
+      (config.webhooks as any).maxAttempts = prev;
+      deliveryQueue.cancelAll();
+    }
+  });
+
+  test('R4: store-corrupt executeJob writes store_corrupt dead letter without rejecting', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://corrupt-job.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const rejections: unknown[] = [];
+    const onRej = (reason: unknown) => {
+      rejections.push(reason);
+    };
+    process.on('unhandledRejection', onRej);
+    setWebhooksFailClosedForTests(true);
+    try {
+      enqueueWebhookDelivery({
+        subscription: sub,
+        eventId: 'evt_store_corrupt_job',
+        type: 'webhook.ping',
+        payloadBuilder: () => ({ body: '{}', sensitive: false }),
+      });
+      await waitUntil(
+        () =>
+          readAllDeliveryLogRows().some(
+            (r) => r.eventId === 'evt_store_corrupt_job' && r.reason === 'store_corrupt',
+          ),
+        1500,
+      );
+      const row = readAllDeliveryLogRows().find(
+        (r) => r.eventId === 'evt_store_corrupt_job' && r.reason === 'store_corrupt',
+      );
+      expect(row?.outcome).toBe('permanent');
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off('unhandledRejection', onRej);
+      setWebhooksFailClosedForTests(false);
+      deliveryQueue.cancelAll();
+    }
+  });
+
+  test('R4: cancelForWebhook during in-flight executeJob does not reschedule', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://cancel-inflight.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    let rejectDns!: (err: unknown) => void;
+    setWebhookDnsLookupForTests(
+      () =>
+        new Promise((_, reject) => {
+          rejectDns = reject;
+        }),
+    );
+    const eventId = 'evt_cancel_inflight';
+    try {
+      enqueueWebhookDelivery({
+        subscription: sub,
+        eventId,
+        type: 'webhook.ping',
+        payloadBuilder: () => ({ body: '{}', sensitive: false }),
+      });
+      await waitUntil(() => deliveryLimiter.isEndpointActive(sub.id), 1500);
+      deliveryQueue.cancelForWebhook(sub.id, 'subscription_deleted');
+      expect(deliveryQueue.hasQueuedJob(sub.id, eventId)).toBe(false);
+
+      const err: any = new Error('getaddrinfo ENOTFOUND');
+      err.code = 'ENOTFOUND';
+      rejectDns(err);
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(deliveryQueue.hasQueuedJob(sub.id, eventId)).toBe(false);
+      const rows = readAllDeliveryLogRows().filter((r) => r.eventId === eventId);
+      expect(rows.some((r) => r.outcome === 'permanent' && r.reason === 'subscription_deleted')).toBe(
+        true,
+      );
+      expect(rows.some((r) => r.outcome === 'retryable')).toBe(false);
+    } finally {
+      setWebhookDnsLookupForTests(undefined);
+      deliveryQueue.cancelAll();
+    }
+  });
+
+  test('R4: background SSRF refusal audit omits ip', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://ssrf-bg.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    setWebhookDnsLookupForTests(async () => [{ address: '169.254.169.254', family: 4 }]);
+    try {
+      enqueueWebhookDelivery({
+        subscription: sub,
+        eventId: 'evt_ssrf_bg',
+        type: 'webhook.ping',
+        payloadBuilder: () => ({ body: '{}', sensitive: false }),
+      });
+      await waitUntil(
+        () => readAuditEvents({ event: 'webhook.ssrf_refused' }).some((e) => e.webhookId === sub.id),
+        1500,
+      );
+      const row = readAuditEvents({ event: 'webhook.ssrf_refused' }).find(
+        (e) => e.webhookId === sub.id,
+      );
+      expect(row).toBeDefined();
+      expect(row?.ip).toBeUndefined();
+    } finally {
+      setWebhookDnsLookupForTests(undefined);
+      deliveryQueue.cancelAll();
+    }
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -30,7 +30,10 @@ const {
   readDeliveryLogRows,
   reconstructPendingDeliveriesAtBoot,
   redeliverWebhookDelivery,
+  setReconstructRetryDelaysForTests,
   setWebhookDnsLookupForTests,
+  pendingReconstructionRetryCount,
+  countsTowardCircuitBreaker,
   validateWebhookUrlResolution,
   validateWebhookUrlStatic,
 } = await import('../src/lib/webhook-delivery.ts');
@@ -63,6 +66,7 @@ function setupTestDir(): void {
   (config.webhooks as any).codeEntryChars = 200;
   (config as any).oaePublicEdge = false;
   setWebhooksFailClosedForTests(false);
+  setReconstructRetryDelaysForTests();
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
 }
@@ -254,6 +258,90 @@ describe('webhook-delivery: Durable Logging & Compaction (§8.6, §14 item 5)', 
     const remaining = readAllDeliveryLogRows();
     expect(remaining.length).toBe(1);
     expect(remaining[0].eventId).toBe('evt_active');
+  });
+
+  test('R5: compactDeliveryLog prunes per-type terminal retryable sequences', () => {
+    const now = Date.now();
+    const oldTs = new Date(now - 40 * 86400000).toISOString();
+    const prev = config.webhooks.maxAttempts;
+    (config.webhooks as any).maxAttempts = 4;
+    try {
+      appendDeliveryLogRow({
+        ts: oldTs,
+        webhookId: 'whk_ping_done',
+        eventId: 'evt_ping_done',
+        runId: 'run_0',
+        deliveryId: 'dlv_ping_done',
+        type: 'webhook.ping',
+        address: null,
+        messageId: null,
+        uidValidity: null,
+        rfc822MessageId: null,
+        taskId: null,
+        taskCreatedAt: null,
+        expiresInSec: null,
+        eventCreatedAt: oldTs,
+        attempt: 3,
+        outcome: 'retryable',
+        status: 500,
+        durationMs: 20,
+        sensitive: false,
+        replay: false,
+        nextAttemptAt: null,
+      });
+      appendDeliveryLogRow({
+        ts: oldTs,
+        webhookId: 'whk_mail_done',
+        eventId: 'evt_mail_done',
+        runId: 'run_0',
+        deliveryId: 'dlv_mail_done',
+        type: 'mail.received',
+        address: 'alice@example.com',
+        messageId: '9',
+        uidValidity: 1,
+        rfc822MessageId: null,
+        taskId: null,
+        taskCreatedAt: null,
+        expiresInSec: null,
+        eventCreatedAt: oldTs,
+        attempt: 4,
+        outcome: 'retryable',
+        status: 500,
+        durationMs: 20,
+        sensitive: false,
+        replay: false,
+        nextAttemptAt: null,
+      });
+      appendDeliveryLogRow({
+        ts: oldTs,
+        webhookId: 'whk_mail_live',
+        eventId: 'evt_mail_live',
+        runId: 'run_0',
+        deliveryId: 'dlv_mail_live',
+        type: 'mail.received',
+        address: 'alice@example.com',
+        messageId: '10',
+        uidValidity: 1,
+        rfc822MessageId: null,
+        taskId: null,
+        taskCreatedAt: null,
+        expiresInSec: null,
+        eventCreatedAt: oldTs,
+        attempt: 3,
+        outcome: 'retryable',
+        status: 500,
+        durationMs: 20,
+        sensitive: false,
+        replay: false,
+        nextAttemptAt: new Date(now + 1000).toISOString(),
+      });
+
+      compactDeliveryLog(now, 30);
+      const remaining = readAllDeliveryLogRows();
+      expect(remaining.map((r) => r.eventId)).toEqual(['evt_mail_live']);
+    } finally {
+      (config.webhooks as any).maxAttempts = prev;
+    }
   });
 });
 
@@ -530,6 +618,57 @@ describe('webhook-delivery: Circuit Breaker & SSRF Immediate Disable (§8.5, D2a
     expect(disabledSub?.disabledReason).toBe('threshold');
   });
 
+  test('R5: unverified ping failures are exempt from the circuit breaker (§5.1)', () => {
+    const unverified = { state: 'unverified' as const };
+    const enabled = { state: 'enabled' as const };
+    expect(countsTowardCircuitBreaker('webhook.ping', 'permanent', unverified)).toBe(false);
+    expect(countsTowardCircuitBreaker('webhook.ping', 'retryable', unverified)).toBe(false);
+    expect(countsTowardCircuitBreaker('webhook.ping', 'permanent', enabled)).toBe(false);
+    expect(countsTowardCircuitBreaker('webhook.ping', 'retryable', enabled)).toBe(true);
+    expect(countsTowardCircuitBreaker('mail.received', 'permanent', unverified)).toBe(true);
+    expect(countsTowardCircuitBreaker('mail.received', 'retryable', unverified)).toBe(true);
+    expect(countsTowardCircuitBreaker('webhook.ping', 'refused', unverified)).toBe(false);
+  });
+
+  test('R5: creation ping retryable failure does not increment consecutiveFailures', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://setup-race.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    expect(sub.state).toBe('unverified');
+    (config.webhooks as any).disableThreshold = 1;
+    setWebhookDnsLookupForTests(async () => {
+      const err: any = new Error('getaddrinfo ENOTFOUND');
+      err.code = 'ENOTFOUND';
+      throw err;
+    });
+    try {
+      enqueueWebhookDelivery({
+        subscription: sub,
+        eventId: 'evt_setup_ping',
+        type: 'webhook.ping',
+        payloadBuilder: () => ({ body: '{}', sensitive: false }),
+      });
+      await waitUntil(
+        () =>
+          readAllDeliveryLogRows().some(
+            (r) => r.eventId === 'evt_setup_ping' && r.outcome === 'retryable',
+          ),
+        1500,
+      );
+      const after = getWebhookSubscription(sub.id);
+      expect(after?.consecutiveFailures).toBe(0);
+      expect(after?.state).toBe('unverified');
+    } finally {
+      setWebhookDnsLookupForTests(undefined);
+      (config.webhooks as any).disableThreshold = 10;
+      deliveryQueue.cancelAll();
+    }
+  });
+
   test('SSRF refusal disables endpoint immediately without waiting for threshold', async () => {
     const sub = createWebhookSubscription({
       url: 'https://ssrf.consumer.example/hook',
@@ -784,6 +923,58 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
       (r) => r.eventId === 'evt_transient_mail' && r.outcome === 'pending',
     );
     expect(pendingRows.length).toBe(1);
+    expect(pendingReconstructionRetryCount()).toBe(1);
+  });
+
+  test('R5: transient reconstruction retries with bounded backoff and does not dead-letter', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://transient-retry.example/hook',
+      address: 'bob@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 10_000).toISOString();
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 9_000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_transient_retry',
+      runId: 'run_0',
+      deliveryId: 'dlv_transient_retry',
+      type: 'mail.received',
+      address: 'bob@test.example',
+      messageId: '1002',
+      uidValidity: 99999,
+      rfc822MessageId: '<retry-msg@example.com>',
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 10_000).toISOString(),
+      reason: null,
+    });
+
+    setReconstructRetryDelaysForTests(20, 80);
+    const first = await reconstructPendingDeliveriesAtBoot(bootTime);
+    expect(first.deadLettered).toBe(0);
+    expect(first.reconstructed).toBe(0);
+    expect(pendingReconstructionRetryCount()).toBe(1);
+
+    await new Promise((r) => setTimeout(r, 90));
+    expect(pendingReconstructionRetryCount()).toBe(1);
+    const dead = readAllDeliveryLogRows().filter(
+      (r) => r.eventId === 'evt_transient_retry' && r.outcome === 'permanent',
+    );
+    expect(dead.length).toBe(0);
+    deliveryQueue.cancelAll();
+    expect(pendingReconstructionRetryCount()).toBe(0);
   });
 
   test('P2-1: test probe slot acquisition timeout writes terminal row preventing orphan pending', async () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -21,6 +21,7 @@ const {
   enqueueWebhookDelivery,
   executeWebhookAttempt,
   executeWebhookTestProbe,
+  fireCreationPing,
   formatApprovalPayload,
   formatMailPayload,
   formatPingPayload,
@@ -690,6 +691,150 @@ describe('webhook-delivery: Payload Bounding & Drop Order (§6.6, §14 item 8)',
     expect(parsed.data.actionArguments).toBeUndefined(); // dropped whole
     expect(parsed.data.digest).toBeDefined(); // never dropped
     expect(Buffer.byteLength(formatted.body, 'utf8')).toBeLessThanOrEqual(700);
+  });
+});
+
+describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('R10: webhook.ping data.object is webhook and carries trigger', () => {
+    const envelope = {
+      id: 'evt_ping_schema',
+      type: 'webhook.ping' as const,
+      payloadVersion: 'v1' as const,
+      createdAt: '2026-09-05T12:00:00.000Z',
+      domain: 'test.example',
+    };
+    const creation = JSON.parse(formatPingPayload(envelope, 'whk_schema', 'creation').body);
+    expect(creation).toEqual({
+      id: 'evt_ping_schema',
+      type: 'webhook.ping',
+      payloadVersion: 'v1',
+      createdAt: '2026-09-05T12:00:00.000Z',
+      domain: 'test.example',
+      data: { object: 'webhook', webhookId: 'whk_schema', trigger: 'creation' },
+    });
+    const testPing = JSON.parse(formatPingPayload(envelope, 'whk_schema', 'test').body);
+    expect(testPing.data.trigger).toBe('test');
+    expect(testPing.data.object).toBe('webhook');
+  });
+
+  test('R10: pending, attempt row, and X-OAE-Delivery share one deliveryId', async () => {
+    const seen: { deliveryId: string | null; body: any } = { deliveryId: null, body: null };
+    const server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: async (req) => {
+        seen.deliveryId = req.headers.get('X-OAE-Delivery');
+        seen.body = await req.json();
+        return new Response('ok', { status: 200 });
+      },
+    });
+    const prevAllow = config.webhooks.allowPrivateTargets;
+    (config.webhooks as any).allowPrivateTargets = true;
+    (config as any).oaePublicEdge = false;
+    try {
+      const sub = createWebhookSubscription({
+        url: `http://127.0.0.1:${server.port}/hook`,
+        address: 'owner@openagent.email',
+        events: ['mail.received'],
+        contentScope: 'metadata',
+        privateTargetGranted: true,
+        createdBy: 'admin',
+      });
+      enqueueWebhookDelivery({
+        subscription: sub,
+        eventId: 'evt_r10_dlv',
+        type: 'webhook.ping',
+        payloadBuilder: (current) =>
+          formatPingPayload(
+            {
+              id: 'evt_r10_dlv',
+              type: 'webhook.ping',
+              payloadVersion: 'v1',
+              createdAt: new Date().toISOString(),
+              domain: 'test.example',
+            },
+            current.id,
+            'test',
+          ),
+      });
+      const pending = readAllDeliveryLogRows().find((r) => r.eventId === 'evt_r10_dlv');
+      expect(pending?.outcome).toBe('pending');
+      await waitUntil(
+        () =>
+          readAllDeliveryLogRows().some(
+            (r) => r.eventId === 'evt_r10_dlv' && r.outcome === 'success',
+          ),
+        2000,
+      );
+      const success = readAllDeliveryLogRows().find(
+        (r) => r.eventId === 'evt_r10_dlv' && r.outcome === 'success',
+      );
+      expect(success?.deliveryId).toBe(pending?.deliveryId);
+      expect(seen.deliveryId).toBe(pending?.deliveryId);
+      expect(seen.body?.data?.object).toBe('webhook');
+    } finally {
+      (config.webhooks as any).allowPrivateTargets = prevAllow;
+      server.stop(true);
+      deliveryQueue.cancelAll();
+    }
+  });
+
+  test('R10: probe-full creation ping is delayed, not dropped, and can verify', async () => {
+    const server = Bun.serve({
+      hostname: '127.0.0.1',
+      port: 0,
+      fetch: () => new Response('ok', { status: 200 }),
+    });
+    const prevAllow = config.webhooks.allowPrivateTargets;
+    const prevProbe = config.webhooks.rateTestPerMin;
+    const prevPool = config.webhooks.poolRetryMs;
+    (config.webhooks as any).allowPrivateTargets = true;
+    (config as any).oaePublicEdge = false;
+    (config.webhooks as any).rateTestPerMin = 1;
+    (config.webhooks as any).poolRetryMs = 25;
+    deliveryLimiter.reset();
+    try {
+      const mk = (label: string) =>
+        createWebhookSubscription({
+          url: `http://127.0.0.1:${server.port}/hook`,
+          address: 'owner@openagent.email',
+          events: ['mail.received'],
+          contentScope: 'metadata',
+          privateTargetGranted: true,
+          createdBy: 'admin',
+        });
+      const first = mk('a');
+      fireCreationPing(first, 'creation', 'r10-probe');
+      await waitUntil(() => getWebhookSubscription(first.id)?.state === 'enabled', 2000);
+
+      const second = mk('b');
+      fireCreationPing(second, 'creation', 'r10-probe');
+      const pending = readAllDeliveryLogRows().find(
+        (r) => r.webhookId === second.id && r.outcome === 'pending',
+      );
+      expect(pending).toBeDefined();
+      expect(new Date(pending!.nextAttemptAt!).getTime()).toBeGreaterThan(Date.now() - 50);
+      expect(getWebhookSubscription(second.id)?.state).toBe('unverified');
+      await waitUntil(() => getWebhookSubscription(second.id)?.state === 'enabled', 2000);
+      expect(
+        readAllDeliveryLogRows().some(
+          (r) => r.webhookId === second.id && r.outcome === 'success',
+        ),
+      ).toBe(true);
+    } finally {
+      (config.webhooks as any).allowPrivateTargets = prevAllow;
+      (config.webhooks as any).rateTestPerMin = prevProbe;
+      (config.webhooks as any).poolRetryMs = prevPool;
+      deliveryLimiter.reset();
+      server.stop(true);
+      deliveryQueue.cancelAll();
+    }
   });
 });
 

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -8,7 +8,7 @@ process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const { config } = await import('../src/lib/config.ts');
@@ -25,10 +25,13 @@ const {
   formatMailPayload,
   formatPingPayload,
   isTerminalDeliveryRow,
+  getLatestDeliveryForWebhook,
   latestDeliveryByWebhookId,
   parseRetryAfterSeconds,
   readAllDeliveryLogRows,
+  readAllDeliveryLogRowsFromDisk,
   readDeliveryLogRows,
+  resetDeliveryLogIndexForTests,
   reconstructPendingDeliveriesAtBoot,
   redeliverWebhookDelivery,
   setReconstructRetryDelaysForTests,
@@ -68,6 +71,7 @@ function setupTestDir(): void {
   (config as any).oaePublicEdge = false;
   setWebhooksFailClosedForTests(false);
   setReconstructRetryDelaysForTests();
+  resetDeliveryLogIndexForTests();
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
 }
@@ -267,6 +271,63 @@ describe('webhook-delivery: Durable Logging & Compaction (§8.6, §14 item 5)', 
     const remaining = readAllDeliveryLogRows();
     expect(remaining.length).toBe(1);
     expect(remaining[0].eventId).toBe('evt_active');
+    expect(readAllDeliveryLogRowsFromDisk().map((r) => r.deliveryId)).toEqual(
+      remaining.map((r) => r.deliveryId),
+    );
+  });
+
+  test('R9: delivery log index matches full scan, sees appended lines, rebuilds after compact', () => {
+    const row = (id: string, webhookId: string, ts: string, outcome: 'success' | 'pending' = 'success') => ({
+      ts,
+      webhookId,
+      eventId: `evt_${id}`,
+      runId: 'run_0',
+      deliveryId: `dlv_${id}`,
+      type: 'webhook.ping' as const,
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: ts,
+      attempt: 1,
+      outcome,
+      status: outcome === 'success' ? 200 : null,
+      durationMs: outcome === 'success' ? 10 : null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    });
+
+    const now = Date.now();
+    const t1 = new Date(now - 2000).toISOString();
+    const t2 = new Date(now - 1000).toISOString();
+    appendDeliveryLogRow(row('a', 'whk_idx_a', t1));
+    appendDeliveryLogRow(row('b', 'whk_idx_b', t1));
+    const first = readAllDeliveryLogRows();
+    expect(first.map((r) => r.deliveryId)).toEqual(['dlv_a', 'dlv_b']);
+    expect(readAllDeliveryLogRowsFromDisk()).toEqual(first);
+    expect(getLatestDeliveryForWebhook('whk_idx_a')?.deliveryId).toBe('dlv_a');
+
+    const extra = row('c', 'whk_idx_a', t2);
+    appendFileSync(join(TEST_DATA_DIR, 'webhook-deliveries.jsonl'), `${JSON.stringify(extra)}\n`);
+    const afterAppend = readAllDeliveryLogRows();
+    expect(afterAppend.map((r) => r.deliveryId)).toEqual(['dlv_a', 'dlv_b', 'dlv_c']);
+    expect(readAllDeliveryLogRowsFromDisk()).toEqual(afterAppend);
+    expect(getLatestDeliveryForWebhook('whk_idx_a')?.deliveryId).toBe('dlv_c');
+
+    const oldTs = new Date(now - 40 * 86400000).toISOString();
+    appendDeliveryLogRow(row('old', 'whk_idx_old', oldTs));
+    compactDeliveryLog(now, 30);
+    const afterCompact = readAllDeliveryLogRows();
+    expect(afterCompact.some((r) => r.deliveryId === 'dlv_old')).toBe(false);
+    expect(afterCompact.map((r) => r.deliveryId).sort()).toEqual(['dlv_a', 'dlv_b', 'dlv_c']);
+    expect(readAllDeliveryLogRowsFromDisk().map((r) => r.deliveryId).sort()).toEqual(
+      afterCompact.map((r) => r.deliveryId).sort(),
+    );
   });
 
   test('R5: compactDeliveryLog prunes per-type terminal retryable sequences', () => {
@@ -512,6 +573,53 @@ describe('webhook-delivery: Payload Bounding & Drop Order (§6.6, §14 item 8)',
     expect(parsed.data.containsLink).toBe(true);
     expect(parsed.data.links).toEqual([]); // dropped whole!
     expect(parsed.data.securityCodes).toEqual(['123456']);
+  });
+
+  test('R9: preview fields truncate by character count, not UTF-8 bytes', () => {
+    const prevPayload = config.webhooks.payloadMaxBytes;
+    const prevPreview = (config.webhooks as any).bodyPreviewChars;
+    const prevCode = (config.webhooks as any).codeEntryChars;
+    (config.webhooks as any).payloadMaxBytes = 64_000;
+    (config.webhooks as any).bodyPreviewChars = 280;
+    (config.webhooks as any).codeEntryChars = 200;
+
+    const subPreview: WebhookSubscription = { ...dummySub, contentScope: 'preview' };
+    const envelope = {
+      id: 'evt_chars',
+      type: 'mail.received' as const,
+      payloadVersion: 'v1' as const,
+      createdAt: new Date().toISOString(),
+      domain: 'openagent.email',
+    };
+
+    const formatted = formatMailPayload(subPreview, envelope, {
+      address: 'postmaster@openagent.email',
+      messageId: '100',
+      uid: 100,
+      uidValidity: 1,
+      receivedAt: new Date().toISOString(),
+      from: { address: 'sender@example.com' },
+      to: ['postmaster@openagent.email'],
+      cc: [],
+      subject: '预览',
+      sizeBytes: 1024,
+      hasAttachments: false,
+      unread: true,
+      containsSecurityCode: true,
+      containsLink: true,
+      textPreview: '字'.repeat(300),
+      securityCodes: ['码'.repeat(250)],
+      links: ['链'.repeat(200), '链'.repeat(201)],
+    });
+
+    const parsed = JSON.parse(formatted.body);
+    expect([...parsed.data.textPreview].length).toBe(280);
+    expect(parsed.data.textPreview).toBe('字'.repeat(280));
+    expect([...parsed.data.securityCodes[0]].length).toBe(200);
+    expect(parsed.data.links).toEqual(['链'.repeat(200)]);
+    (config.webhooks as any).payloadMaxBytes = prevPayload;
+    (config.webhooks as any).bodyPreviewChars = prevPreview;
+    (config.webhooks as any).codeEntryChars = prevCode;
   });
 
   test('mail.received overflow drop order: cc -> to -> subject -> from.name', () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -778,6 +778,13 @@ describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
       expect(success?.deliveryId).toBe(pending?.deliveryId);
       expect(seen.deliveryId).toBe(pending?.deliveryId);
       expect(seen.body?.data?.object).toBe('webhook');
+
+      const replay = await redeliverWebhookDelivery(pending!.deliveryId);
+      expect(replay.deliveryId).not.toBe(pending!.deliveryId);
+      expect(replay.eventId).toBe('evt_r10_dlv');
+      expect(
+        readAllDeliveryLogRows().some((r) => r.deliveryId === replay.deliveryId && r.replay),
+      ).toBe(true);
     } finally {
       (config.webhooks as any).allowPrivateTargets = prevAllow;
       server.stop(true);
@@ -819,7 +826,7 @@ describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
         (r) => r.webhookId === second.id && r.outcome === 'pending',
       );
       expect(pending).toBeDefined();
-      expect(new Date(pending!.nextAttemptAt!).getTime()).toBeGreaterThan(Date.now() - 50);
+      expect(new Date(pending!.nextAttemptAt!).getTime()).toBeGreaterThanOrEqual(Date.now());
       expect(getWebhookSubscription(second.id)?.state).toBe('unverified');
       await waitUntil(() => getWebhookSubscription(second.id)?.state === 'enabled', 2000);
       expect(

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -428,6 +428,20 @@ describe('webhook-delivery: URL Validation & SSRF Safety (§9.1, §9.3, §9.5, �
     });
     expect(explicit.valid).toBe(true);
   });
+
+  test('R6: DNS resolution lookup times out instead of hanging', async () => {
+    const started = Date.now();
+    const res = await validateWebhookUrlResolution('https://slow-dns.example/hook', {
+      allowPrivateTargets: false,
+      dnsLookupTimeoutMs: 50,
+      dnsLookup: () => new Promise(() => {}),
+    });
+    expect(Date.now() - started).toBeLessThan(1000);
+    expect(res.valid).toBe(false);
+    if (!res.valid) {
+      expect(res.error).toBe('dns_lookup_failed');
+    }
+  });
 });
 
 describe('webhook-delivery: Payload Bounding & Drop Order (§6.6, §14 item 8)', () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -594,6 +594,192 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     expect(deadLetterRow?.expiresInSec).toBe(86400);
   });
 
+  test('P1: readAllDeliveryLogRows and boot reconstruction tolerate corrupted log lines', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://corrupt-test.example/hook',
+      address: 'owner@openagent.email',
+      events: ['webhook.ping'],
+      contentScope: 'metadata',
+      description: 'corrupt log test',
+      createdBy: 'admin',
+    });
+
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 10000).toISOString();
+
+    // 1. Valid pending row
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 9000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_corrupt_valid_1',
+      runId: 'run_0',
+      deliveryId: 'dlv_c1',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 10000).toISOString(),
+      reason: null,
+    });
+
+    // 2. Corrupted lines directly appended to JSONL file
+    const logPath = join(TEST_DATA_DIR, 'webhook-deliveries.jsonl');
+    const corruptSnippet =
+      '{"ts":"2026-09-05T00:00:00Z","corrupted_unclosed_json\n' +
+      'INVALID TRUNCATED GARBAGE BYTES <<>>\n' +
+      '{"ts":"2026-09-05T00:00:00Z","deliveryId":"dlv_bad", incomplete\n';
+    const { appendFileSync } = await import('node:fs');
+    appendFileSync(logPath, corruptSnippet);
+
+    // 3. Second valid pending row
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 8000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_corrupt_valid_2',
+      runId: 'run_0',
+      deliveryId: 'dlv_c2',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 20000).toISOString(),
+      reason: null,
+    });
+
+    // readAllDeliveryLogRows must fail open: skip corrupt lines, return the 2 valid rows
+    const rows = readAllDeliveryLogRows();
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.deliveryId).toBe('dlv_c1');
+    expect(rows[1]?.deliveryId).toBe('dlv_c2');
+
+    // reconstructPendingDeliveriesAtBoot must succeed without throwing
+    const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+    expect(result.reconstructed).toBe(2);
+    expect(result.deadLettered).toBe(0);
+  });
+
+  test('P2-6: boot reconstruction does NOT dead-letter pending deliveries on transient IMAP errors', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://transient-test.example/hook',
+      address: 'bob@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      description: 'transient error test',
+      createdBy: 'admin',
+    });
+
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 10000).toISOString();
+
+    // Append a pending mail delivery row
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 9000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_transient_mail',
+      runId: 'run_0',
+      deliveryId: 'dlv_transient_1',
+      type: 'mail.received',
+      address: 'bob@test.example',
+      messageId: '1001',
+      uidValidity: 99999,
+      rfc822MessageId: '<test-msg-id@example.com>',
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 10000).toISOString(),
+      reason: null,
+    });
+
+    // Boot reconstruction runs while IMAP server is not reachable (transient backend failure)
+    const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+
+    // It must NOT increment deadLettered
+    expect(result.deadLettered).toBe(0);
+
+    // It must NOT have written an outcome: 'permanent' row to the delivery log
+    const rows = readAllDeliveryLogRows();
+    const deadLetterRows = rows.filter(
+      (r) => r.eventId === 'evt_transient_mail' && r.outcome === 'permanent',
+    );
+    expect(deadLetterRows.length).toBe(0);
+
+    // The original pending row remains intact for subsequent retry/boot
+    const pendingRows = rows.filter(
+      (r) => r.eventId === 'evt_transient_mail' && r.outcome === 'pending',
+    );
+    expect(pendingRows.length).toBe(1);
+  });
+
+  test('P2-1: test probe slot acquisition timeout writes terminal row preventing orphan pending', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://probe-timeout.example/hook',
+      address: 'alice@test.example',
+      events: ['webhook.ping'],
+      contentScope: 'metadata',
+      description: 'probe timeout test',
+      createdBy: 'admin',
+    });
+
+    // Fill concurrency limiter to capacity
+    const oldMax = config.webhooks.maxConcurrent;
+    const oldTimeout = config.webhooks.deliveryTimeoutMs;
+    (config.webhooks as any).maxConcurrent = 1;
+    (config.webhooks as any).deliveryTimeoutMs = 100; // fast timeout for test
+
+    expect(deliveryLimiter.acquireSlot('blocking_slot')).toBe(true);
+
+    try {
+      await executeWebhookTestProbe(sub, 'test-caller');
+      expect().fail('should have thrown rate_limited');
+    } catch (err: any) {
+      expect(err.code).toBe('rate_limited');
+    } finally {
+      deliveryLimiter.releaseSlot('blocking_slot');
+      (config.webhooks as any).maxConcurrent = oldMax;
+      (config.webhooks as any).deliveryTimeoutMs = oldTimeout;
+    }
+
+    // Check delivery log: a terminal permanent row was written, preventing orphan pending
+    const rows = readAllDeliveryLogRows().filter((r) => r.webhookId === sub.id);
+    expect(rows.length).toBe(2);
+    expect(rows[0]?.outcome).toBe('pending');
+    expect(rows[1]?.outcome).toBe('permanent');
+    expect(rows[1]?.reason).toBe('concurrency_pool_full');
+
+    // Boot reconstruction must see terminal state and NOT reconstruct it
+    const bootRes = await reconstructPendingDeliveriesAtBoot();
+    expect(bootRes.reconstructed).toBe(0);
+  });
+
   afterAll(async () => {
     (config as any).dataDir = originalDataDir;
     (config.webhooks as any).enabled = false;

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -1241,6 +1241,108 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     }
   });
 
+  test('R8: pool-full reschedule does not append deferred log rows', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://r8-pool.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const oldMax = config.webhooks.maxConcurrent;
+    const oldPoolRetry = config.webhooks.poolRetryMs;
+    (config.webhooks as any).maxConcurrent = 1;
+    (config.webhooks as any).poolRetryMs = 25;
+    expect(deliveryLimiter.acquireSlot('r8_blocker')).toBe(true);
+    const eventId = 'evt_r8_pool_defer';
+    try {
+      enqueueWebhookDelivery({
+        subscription: sub,
+        eventId,
+        type: 'webhook.ping',
+        payloadBuilder: () => ({ body: '{}', sensitive: false }),
+      });
+      const afterEnqueue = readAllDeliveryLogRows().filter((r) => r.eventId === eventId);
+      expect(afterEnqueue).toHaveLength(1);
+      expect(afterEnqueue[0]?.outcome).toBe('pending');
+
+      await waitUntil(() => deliveryQueue.hasQueuedJob(sub.id, eventId), 1000);
+      await new Promise((r) => setTimeout(r, 5 * 25 + 80));
+
+      const afterWait = readAllDeliveryLogRows().filter((r) => r.eventId === eventId);
+      expect(afterWait).toHaveLength(1);
+      expect(afterWait[0]?.outcome).toBe('pending');
+      expect(afterWait.some((r) => r.outcome === 'deferred')).toBe(false);
+      expect(deliveryQueue.hasQueuedJob(sub.id, eventId)).toBe(true);
+    } finally {
+      deliveryQueue.cancelAll();
+      deliveryLimiter.releaseSlot('r8_blocker');
+      (config.webhooks as any).maxConcurrent = oldMax;
+      (config.webhooks as any).poolRetryMs = oldPoolRetry;
+    }
+  });
+
+  test('R8: boot reconstructs expired pending and delivers without a deferred witness', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://r8-boot.example/hook',
+      address: 'owner@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 10_000).toISOString();
+    const eventId = 'evt_r8_expired_pending';
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 9_000).toISOString(),
+      webhookId: sub.id,
+      eventId,
+      runId: 'run_0',
+      deliveryId: 'dlv_r8_expired',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime - 1_000).toISOString(),
+      reason: null,
+    });
+
+    setWebhookDnsLookupForTests(async () => {
+      const err: any = new Error('getaddrinfo ENOTFOUND');
+      err.code = 'ENOTFOUND';
+      throw err;
+    });
+    try {
+      const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+      expect(result.reconstructed).toBe(1);
+      expect(result.deadLettered).toBe(0);
+      expect(deliveryQueue.hasQueuedJob(sub.id, eventId)).toBe(true);
+
+      await waitUntil(
+        () =>
+          readAllDeliveryLogRows().some((r) => r.eventId === eventId && r.outcome === 'retryable'),
+        1500,
+      );
+      const rows = readAllDeliveryLogRows().filter((r) => r.eventId === eventId);
+      expect(rows.some((r) => r.outcome === 'pending')).toBe(true);
+      expect(rows.some((r) => r.outcome === 'deferred')).toBe(false);
+    } finally {
+      setWebhookDnsLookupForTests(undefined);
+      deliveryQueue.cancelAll();
+    }
+  });
+
   test('R4: background SSRF refusal audit omits ip', async () => {
     const sub = createWebhookSubscription({
       url: 'https://ssrf-bg.example/hook',

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -52,6 +52,7 @@ const {
   updateWebhookSubscription,
 } = await import('../src/lib/webhook-store.ts');
 const { readAuditEvents } = await import('../src/lib/audit.ts');
+const { setTaskGetForTests } = await import('../src/lib/tasks-internal.ts');
 type WebhookSubscription = import('../src/lib/webhook-store.ts').WebhookSubscription;
 
 const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhook-delivery');
@@ -828,6 +829,8 @@ describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
       expect(pending).toBeDefined();
       expect(new Date(pending!.nextAttemptAt!).getTime()).toBeGreaterThanOrEqual(Date.now());
       expect(getWebhookSubscription(second.id)?.state).toBe('unverified');
+      // Quota has room again before the delayed fire (window not required to stay full).
+      deliveryLimiter.reset();
       await waitUntil(() => getWebhookSubscription(second.id)?.state === 'enabled', 2000);
       expect(
         readAllDeliveryLogRows().some(
@@ -840,6 +843,58 @@ describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
       (config.webhooks as any).poolRetryMs = prevPool;
       deliveryLimiter.reset();
       server.stop(true);
+      deliveryQueue.cancelAll();
+    }
+  });
+
+  test('final: delayed ping still full at fire is audited and dropped', async () => {
+    const prevProbe = config.webhooks.rateTestPerMin;
+    const prevPool = config.webhooks.poolRetryMs;
+    (config.webhooks as any).rateTestPerMin = 1;
+    (config.webhooks as any).poolRetryMs = 25;
+    deliveryLimiter.reset();
+    try {
+      const first = createWebhookSubscription({
+        url: 'https://probe-drop-a.example/hook',
+        address: 'owner@openagent.email',
+        events: ['mail.received'],
+        contentScope: 'metadata',
+        createdBy: 'admin',
+      });
+      fireCreationPing(first, 'creation', 'final-probe');
+      await waitUntil(
+        () =>
+          readAllDeliveryLogRows().some(
+            (r) => r.webhookId === first.id && r.outcome !== 'pending',
+          ),
+        1500,
+      );
+
+      const second = createWebhookSubscription({
+        url: 'https://probe-drop-b.example/hook',
+        address: 'owner@openagent.email',
+        events: ['mail.received'],
+        contentScope: 'metadata',
+        createdBy: 'admin',
+      });
+      fireCreationPing(second, 'creation', 'final-probe');
+      await waitUntil(
+        () =>
+          readAllDeliveryLogRows().some(
+            (r) => r.webhookId === second.id && r.reason === 'probe_rate_limited',
+          ),
+        1500,
+      );
+      expect(getWebhookSubscription(second.id)?.state).toBe('unverified');
+      const audit = readAuditEvents({ event: 'webhook.probe_rate_limited' }).find(
+        (e) => e.webhookId === second.id,
+      );
+      expect(audit?.outcome).toBe('rate_limited');
+      expect(deliveryQueue.hasQueuedJob(second.id)).toBe(false);
+    } finally {
+      (config.webhooks as any).rateTestPerMin = prevProbe;
+      (config.webhooks as any).poolRetryMs = prevPool;
+      deliveryLimiter.reset();
       deliveryQueue.cancelAll();
     }
   });
@@ -982,6 +1037,7 @@ describe('webhook-delivery: Circuit Breaker & SSRF Immediate Disable (§8.5, D2a
 describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', () => {
   beforeEach(setupTestDir);
   afterEach(() => {
+    setTaskGetForTests(null);
     deliveryQueue.cancelAll();
     rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   });
@@ -1051,16 +1107,21 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
       nextAttemptAt: new Date(bootTime + 60000).toISOString(),
     });
 
-    const result = await reconstructPendingDeliveriesAtBoot(bootTime);
-    // Task does not exist in mock storage so it dead-letters gracefully with task_not_found
-    expect(result.deadLettered).toBe(1);
+    setTaskGetForTests(async () => null);
+    try {
+      const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+      // Task does not exist so it dead-letters gracefully with task_not_found
+      expect(result.deadLettered).toBe(1);
 
-    const rows = readAllDeliveryLogRows();
-    const deadLetterRow = rows.find((r) => r.outcome === 'permanent');
-    expect(deadLetterRow).toBeDefined();
-    expect(deadLetterRow?.reason).toBe('task_not_found');
-    expect(deadLetterRow?.taskCreatedAt).toBe(taskCreatedAt);
-    expect(deadLetterRow?.expiresInSec).toBe(86400);
+      const rows = readAllDeliveryLogRows();
+      const deadLetterRow = rows.find((r) => r.outcome === 'permanent');
+      expect(deadLetterRow).toBeDefined();
+      expect(deadLetterRow?.reason).toBe('task_not_found');
+      expect(deadLetterRow?.taskCreatedAt).toBe(taskCreatedAt);
+      expect(deadLetterRow?.expiresInSec).toBe(86400);
+    } finally {
+      setTaskGetForTests(null);
+    }
   });
 
   test('P1: readAllDeliveryLogRows and boot reconstruction tolerate corrupted log lines', async () => {
@@ -1258,6 +1319,60 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     expect(dead.length).toBe(0);
     deliveryQueue.cancelAll();
     expect(pendingReconstructionRetryCount()).toBe(0);
+  });
+
+  test('final: approval reconstruction retries transient getTaskSnapshot like mail', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://approval-transient.example/hook',
+      address: 'owner@openagent.email',
+      events: ['approval.requested'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 10_000).toISOString();
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 9_000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_approval_transient',
+      runId: 'run_0',
+      deliveryId: 'dlv_approval_transient',
+      type: 'approval.requested',
+      address: 'owner@openagent.email',
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: '3f8a1c62-9d4e-4b07-a5f1-6c2e8d904b73',
+      taskCreatedAt: eventCreatedAt,
+      expiresInSec: 86400,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 10_000).toISOString(),
+      reason: null,
+    });
+
+    setTaskGetForTests(async () => {
+      throw new Error('imap temporarily unavailable');
+    });
+    setReconstructRetryDelaysForTests(20, 80);
+    try {
+      const first = await reconstructPendingDeliveriesAtBoot(bootTime);
+      expect(first.deadLettered).toBe(0);
+      expect(first.reconstructed).toBe(0);
+      expect(pendingReconstructionRetryCount()).toBe(1);
+      const dead = readAllDeliveryLogRows().filter(
+        (r) => r.eventId === 'evt_approval_transient' && r.outcome === 'permanent',
+      );
+      expect(dead.length).toBe(0);
+    } finally {
+      setTaskGetForTests(null);
+      deliveryQueue.cancelAll();
+    }
   });
 
   test('P2-1: test probe slot acquisition timeout writes terminal row preventing orphan pending', async () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -5,7 +5,6 @@ process.env.IMAP_PASS = 'test-only';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'test-only';
 process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
-process.env.WEBHOOKS_ENABLED = 'true';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -597,6 +596,8 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
 
   afterAll(async () => {
     (config as any).dataDir = originalDataDir;
+    (config.webhooks as any).enabled = false;
+    delete process.env.WEBHOOKS_ENABLED;
     deliveryQueue.cancelAll();
     await new Promise((r) => setTimeout(r, 50));
     deliveryQueue.cancelAll();

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -25,6 +25,7 @@ const {
   formatMailPayload,
   formatPingPayload,
   isTerminalDeliveryRow,
+  latestDeliveryByWebhookId,
   parseRetryAfterSeconds,
   readAllDeliveryLogRows,
   readDeliveryLogRows,
@@ -191,6 +192,14 @@ describe('webhook-delivery: Durable Logging & Compaction (§8.6, §14 item 5)', 
     expect(rows.length).toBe(1);
     expect(rows[0].webhookId).toBe('whk_test_1');
     expect(rows[0].status).toBe(200);
+
+    const latest = latestDeliveryByWebhookId([
+      { ...row, webhookId: 'whk_a', deliveryId: 'dlv_old', ts: '2026-01-01T00:00:00.000Z', attempt: 2 },
+      { ...row, webhookId: 'whk_a', deliveryId: 'dlv_new', ts: '2026-01-02T00:00:00.000Z', attempt: 1 },
+      { ...row, webhookId: 'whk_b', deliveryId: 'dlv_b', ts: '2026-01-01T00:00:00.000Z', attempt: 1 },
+    ]);
+    expect(latest.get('whk_a')?.deliveryId).toBe('dlv_new');
+    expect(latest.get('whk_b')?.deliveryId).toBe('dlv_b');
 
     // Asserts no forbidden payload fields
     const raw = readFileSync(logFile, 'utf8');

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -1,0 +1,605 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'test-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
+process.env.WEBHOOKS_ENABLED = 'true';
+process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { config } = await import('../src/lib/config.ts');
+const {
+  appendDeliveryLogRow,
+  calculateNextAttemptTime,
+  compactDeliveryLog,
+  deliveryLimiter,
+  deliveryQueue,
+  enqueueWebhookDelivery,
+  executeWebhookAttempt,
+  executeWebhookTestProbe,
+  formatApprovalPayload,
+  formatMailPayload,
+  formatPingPayload,
+  readAllDeliveryLogRows,
+  readDeliveryLogRows,
+  reconstructPendingDeliveriesAtBoot,
+  redeliverWebhookDelivery,
+  validateWebhookUrlResolution,
+  validateWebhookUrlStatic,
+} = await import('../src/lib/webhook-delivery.ts');
+type WebhookDeliveryLogRow = import('../src/lib/webhook-delivery.ts').WebhookDeliveryLogRow;
+
+const {
+  createWebhookSubscription,
+  deleteWebhookSubscription,
+  getWebhookSubscription,
+  updateWebhookSubscription,
+} = await import('../src/lib/webhook-store.ts');
+type WebhookSubscription = import('../src/lib/webhook-store.ts').WebhookSubscription;
+
+const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhook-delivery');
+const originalDataDir = config.dataDir;
+
+function setupTestDir(): void {
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DATA_DIR, { recursive: true, mode: 0o700 });
+  (config as any).dataDir = TEST_DATA_DIR;
+  (config.webhooks as any).enabled = true;
+  (config as any).taskSigningSecret = '01234567890123456789012345678901';
+  (config.webhooks as any).signingSecret = '01234567890123456789012345678901';
+  (config.webhooks as any).disableThreshold = 10;
+  (config.webhooks as any).maxAttempts = 11;
+  (config.webhooks as any).allowPrivateTargets = false;
+  (config.webhooks as any).payloadMaxBytes = 16384;
+  (config.webhooks as any).codeEntryChars = 200;
+  (config as any).oaePublicEdge = false;
+  deliveryLimiter.reset();
+  deliveryQueue.cancelAll();
+}
+
+describe('webhook-delivery: Retry Schedule & Jitter (§8.3)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('attempt 1 is always immediate; attempt 11 is pinned to exactly +72h unjittered', () => {
+    const start = 1000000;
+    // Attempt 1
+    const t1 = calculateNextAttemptTime(0, start);
+    expect(t1).toBe(start);
+
+    // Attempt 11 (pinned to exactly 72h = 259200s)
+    const t11 = calculateNextAttemptTime(10, start, { randomFn: () => 0.99 });
+    expect(t11).toBe(start + 259200 * 1000);
+
+    const t11Zero = calculateNextAttemptTime(10, start, { randomFn: () => 0.01 });
+    expect(t11Zero).toBe(start + 259200 * 1000);
+
+    // Beyond attempt 11 returns null
+    const t12 = calculateNextAttemptTime(11, start);
+    expect(t12).toBeNull();
+  });
+
+  test('jitter bounds each intermediate attempt to ±10% of its own gap', () => {
+    const start = 1000000;
+    // Attempt 2: gap is 5s. ±10% is ±0.5s. Offset 5s -> [4.5s, 5.5s]
+    const minT2 = calculateNextAttemptTime(1, start, { randomFn: () => 0.0 }); // -10%
+    const maxT2 = calculateNextAttemptTime(1, start, { randomFn: () => 1.0 }); // +10%
+    expect(minT2).toBe(start + 4500);
+    expect(maxT2).toBe(start + 5500);
+
+    // Attempt 3: gap is 295s (offset 300s, prev 5s). ±10% is ±29.5s.
+    const minT3 = calculateNextAttemptTime(2, start, { randomFn: () => 0.0 });
+    const maxT3 = calculateNextAttemptTime(2, start, { randomFn: () => 1.0 });
+    expect(minT3).toBe(start + Math.round((300 - 29.5) * 1000));
+    expect(maxT3).toBe(start + Math.round((300 + 29.5) * 1000));
+  });
+
+  test('webhook.ping uses attempts 1–3 only', () => {
+    const start = 1000000;
+    expect(calculateNextAttemptTime(0, start, { isPing: true })).toBe(start);
+    expect(calculateNextAttemptTime(1, start, { isPing: true })).not.toBeNull();
+    expect(calculateNextAttemptTime(2, start, { isPing: true })).not.toBeNull();
+    expect(calculateNextAttemptTime(3, start, { isPing: true })).toBeNull();
+  });
+
+  test('honors Retry-After on 429 when integer 1s..3600s', () => {
+    const start = 1000000;
+    const next = calculateNextAttemptTime(1, start, { retryAfterSec: 60 });
+    // Offset 2 was 5s; with Retry-After 60s from attempt 1 (0s), it schedules at >= 60s
+    expect(next).toBe(start + 60000);
+  });
+});
+
+describe('webhook-delivery: Durable Logging & Compaction (§8.6, §14 item 5)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('appends rows to 0600 file; does not store payload content', () => {
+    const row: WebhookDeliveryLogRow = {
+      ts: new Date().toISOString(),
+      webhookId: 'whk_test_1',
+      eventId: 'evt_1',
+      runId: 'run_0',
+      deliveryId: 'dlv_1',
+      type: 'mail.received',
+      address: 'alice@example.com',
+      messageId: '101',
+      uidValidity: 1,
+      rfc822MessageId: '<msg1@example.com>',
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 1,
+      outcome: 'success',
+      status: 200,
+      durationMs: 45,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    };
+
+    appendDeliveryLogRow(row);
+
+    const logFile = join(TEST_DATA_DIR, 'webhook-deliveries.jsonl');
+    expect(existsSync(logFile)).toBe(true);
+
+    const rows = readAllDeliveryLogRows();
+    expect(rows.length).toBe(1);
+    expect(rows[0].webhookId).toBe('whk_test_1');
+    expect(rows[0].status).toBe(200);
+
+    // Asserts no forbidden payload fields
+    const raw = readFileSync(logFile, 'utf8');
+    expect(raw).not.toContain('subject');
+    expect(raw).not.toContain('body');
+    expect(raw).not.toContain('secret');
+  });
+
+  test('compactDeliveryLog prunes aged rows but preserves active pending sequences', () => {
+    const now = Date.now();
+    const oldTs = new Date(now - 40 * 86400000).toISOString();
+
+    // 1. Old final row -> should be pruned
+    appendDeliveryLogRow({
+      ts: oldTs,
+      webhookId: 'whk_final',
+      eventId: 'evt_old_final',
+      runId: 'run_0',
+      deliveryId: 'dlv_old_final',
+      type: 'mail.received',
+      address: 'alice@example.com',
+      messageId: '1',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: oldTs,
+      attempt: 1,
+      outcome: 'success',
+      status: 200,
+      durationMs: 20,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+    });
+
+    // 2. Old pending row -> MUST be preserved
+    appendDeliveryLogRow({
+      ts: oldTs,
+      webhookId: 'whk_active',
+      eventId: 'evt_active',
+      runId: 'run_0',
+      deliveryId: 'dlv_active_1',
+      type: 'mail.received',
+      address: 'alice@example.com',
+      messageId: '2',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: oldTs,
+      attempt: 1,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 30,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(now + 10000).toISOString(),
+    });
+
+    compactDeliveryLog(now, 30);
+
+    const remaining = readAllDeliveryLogRows();
+    expect(remaining.length).toBe(1);
+    expect(remaining[0].eventId).toBe('evt_active');
+  });
+});
+
+describe('webhook-delivery: URL Validation & SSRF Safety (§9.1, §9.3, §9.5, §10.4 Rule C)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('validateWebhookUrlStatic rejects query, fragment, userinfo, and non-allowed ports', () => {
+    // Malformed
+    expect(validateWebhookUrlStatic('not-a-url').valid).toBe(false);
+
+    // Query string forbidden
+    expect(validateWebhookUrlStatic('https://example.com/hook?key=val').valid).toBe(false);
+
+    // Fragment forbidden
+    expect(validateWebhookUrlStatic('https://example.com/hook#sec').valid).toBe(false);
+
+    // Userinfo forbidden
+    expect(validateWebhookUrlStatic('https://user:pass@example.com/hook').valid).toBe(false);
+
+    // HTTP rejected when allowPrivateTargets is false
+    expect(validateWebhookUrlStatic('http://example.com/hook', { allowPrivateTargets: false }).valid).toBe(false);
+
+    // Non-allowed port
+    expect(validateWebhookUrlStatic('https://example.com:8443/hook', { allowedPorts: [443] }).valid).toBe(false);
+
+    // IP literal rejected when allowPrivateTargets is false
+    expect(validateWebhookUrlStatic('https://1.1.1.1/hook', { allowPrivateTargets: false }).valid).toBe(false);
+
+    // Valid HTTPS URL
+    expect(validateWebhookUrlStatic('https://example.com/hook').valid).toBe(true);
+  });
+
+  test('validateWebhookUrlResolution enforces SSRF and §9.3 step 5 for http targets', async () => {
+    // SSRF blocked address (169.254.169.254)
+    const ssrfRes = await validateWebhookUrlResolution('https://metadata.internal/hook', {
+      allowPrivateTargets: true,
+      dnsLookup: async () => [{ address: '169.254.169.254', family: 4 }],
+    });
+    expect(ssrfRes.valid).toBe(false);
+    if (!ssrfRes.valid) {
+      expect(ssrfRes.code).toBe('webhook_target_forbidden');
+    }
+
+    // HTTP target resolving to public IP must fail §9.3 step 5
+    const httpPublicRes = await validateWebhookUrlResolution('http://public.example.com/hook', {
+      allowPrivateTargets: true,
+      dnsLookup: async () => [{ address: '93.184.216.34', family: 4 }],
+    });
+    expect(httpPublicRes.valid).toBe(false);
+    if (!httpPublicRes.valid) {
+      expect(httpPublicRes.error).toBe('http_target_must_be_private');
+    }
+
+    // HTTP target resolving to private IP succeeds with isPrivateTarget=true
+    const httpPrivateRes = await validateWebhookUrlResolution('http://local.internal/hook', {
+      allowPrivateTargets: true,
+      dnsLookup: async () => [{ address: '192.168.1.50', family: 4 }],
+    });
+    expect(httpPrivateRes.valid).toBe(true);
+    if (httpPrivateRes.valid) {
+      expect(httpPrivateRes.isPrivateTarget).toBe(true);
+    }
+  });
+});
+
+describe('webhook-delivery: Payload Bounding & Drop Order (§6.6, §14 item 8)', () => {
+  const dummySub: WebhookSubscription = {
+    id: 'whk_sub_1',
+    url: 'https://consumer.example/hook',
+    address: 'postmaster@openagent.email',
+    events: ['mail.received', 'approval.requested'],
+    contentScope: 'metadata',
+    description: 'test sub',
+    state: 'enabled',
+    disabledReason: null,
+    secretPrefix: 'whs_test…',
+    epoch: 0,
+    overlapUntil: null,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    rotatedAt: null,
+    consecutiveFailures: 0,
+    privateTargetGranted: false,
+    createdBy: 'admin',
+  };
+
+  test('mail.received: drops long links whole while retaining containsLink boolean', () => {
+    (config.webhooks as any).payloadMaxBytes = 16384;
+    (config.webhooks as any).codeEntryChars = 20;
+
+    const subPreview: WebhookSubscription = { ...dummySub, contentScope: 'preview' };
+    const envelope = {
+      id: 'evt_1',
+      type: 'mail.received' as const,
+      payloadVersion: 'v1' as const,
+      createdAt: new Date().toISOString(),
+      domain: 'openagent.email',
+    };
+
+    const formatted = formatMailPayload(subPreview, envelope, {
+      address: 'postmaster@openagent.email',
+      messageId: '100',
+      uid: 100,
+      uidValidity: 1,
+      receivedAt: new Date().toISOString(),
+      from: { address: 'sender@example.com', name: 'Sender' },
+      to: ['postmaster@openagent.email'],
+      cc: [],
+      subject: 'Verification Code',
+      sizeBytes: 1024,
+      hasAttachments: false,
+      unread: true,
+      containsSecurityCode: true,
+      containsLink: true,
+      textPreview: 'Your code is 123456',
+      securityCodes: ['123456'],
+      // 25 chars exceeds webhookCodeEntryChars (20)
+      links: ['https://example.com/verify-code'],
+    });
+
+    const parsed = JSON.parse(formatted.body);
+    expect(parsed.data.containsLink).toBe(true);
+    expect(parsed.data.links).toEqual([]); // dropped whole!
+    expect(parsed.data.securityCodes).toEqual(['123456']);
+  });
+
+  test('mail.received overflow drop order: cc -> to -> subject -> from.name', () => {
+    // Set a small payload cap to force drops (cc and to dropped: 734 bytes)
+    (config.webhooks as any).payloadMaxBytes = 740;
+
+    const envelope = {
+      id: 'evt_drop',
+      type: 'mail.received' as const,
+      payloadVersion: 'v1' as const,
+      createdAt: new Date().toISOString(),
+      domain: 'openagent.email',
+    };
+
+    const formatted = formatMailPayload(dummySub, envelope, {
+      address: 'postmaster@openagent.email',
+      messageId: '100',
+      uid: 100,
+      uidValidity: 1,
+      receivedAt: new Date().toISOString(),
+      from: { address: 'sender@example.com', name: 'A Very Long Sender Display Name' },
+      to: ['recipient1@example.com', 'recipient2@example.com'],
+      cc: ['cc1@example.com', 'cc2@example.com'],
+      subject: 'This is a somewhat long subject intended to trigger field shedding',
+      sizeBytes: 100,
+      hasAttachments: false,
+      unread: true,
+      containsSecurityCode: false,
+      containsLink: false,
+    });
+
+    const parsed = JSON.parse(formatted.body);
+    // cc and to should have been dropped to empty arrays to fit
+    expect(parsed.data.cc).toEqual([]);
+    expect(parsed.data.to).toEqual([]);
+    expect(Buffer.byteLength(formatted.body, 'utf8')).toBeLessThanOrEqual(740);
+  });
+
+  test('approval.requested overflow drop order: actionArguments dropped first whole', () => {
+    (config.webhooks as any).payloadMaxBytes = 700;
+    const subPreview: WebhookSubscription = { ...dummySub, contentScope: 'preview' };
+
+    const envelope = {
+      id: 'evt_appr',
+      type: 'approval.requested' as const,
+      payloadVersion: 'v1' as const,
+      createdAt: new Date().toISOString(),
+      domain: 'openagent.email',
+    };
+
+    const formatted = formatApprovalPayload(subPreview, envelope, {
+      taskId: '3f8a1c62-9d4e-4b07-a5f1-6c2e8d904b73',
+      taskState: 'input-required',
+      from: 'researcher@openagent.email',
+      to: 'owner@openagent.email',
+      reviewer: 'owner@openagent.email',
+      subject: 'Approve outbound action',
+      createdAt: new Date().toISOString(),
+      expiresAt: new Date(Date.now() + 86400000).toISOString(),
+      expiresInSec: 86400,
+      digest: '9f2c4a71b8e03d56f1a9c24e7b03d8f6a1c94e27b05d83f6a1c49e27b0d83f6a',
+      actionType: 'tool_call',
+      actionName: 'send_email',
+      actionArguments: { bigArray: new Array(50).fill('large data string') },
+    });
+
+    const parsed = JSON.parse(formatted.body);
+    expect(parsed.data.actionArguments).toBeUndefined(); // dropped whole
+    expect(parsed.data.digest).toBeDefined(); // never dropped
+    expect(Buffer.byteLength(formatted.body, 'utf8')).toBeLessThanOrEqual(700);
+  });
+});
+
+describe('webhook-delivery: Circuit Breaker & SSRF Immediate Disable (§8.5, D2a, §14 item 9)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('10 consecutive failures trip the breaker; success resets counter to 0', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://flaky.consumer.example/hook',
+      address: 'postmaster@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      description: 'breaker test',
+      privateTargetGranted: false,
+      createdBy: 'admin',
+    });
+
+    expect(sub.consecutiveFailures).toBe(0);
+
+    // Simulate 9 failures
+    for (let i = 1; i <= 9; i++) {
+      updateWebhookSubscription(sub.id, (s) => {
+        s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
+        if (s.consecutiveFailures >= 10) {
+          s.state = 'disabled';
+          s.disabledReason = 'threshold';
+        }
+      });
+    }
+    expect(getWebhookSubscription(sub.id)?.state).toBe('unverified');
+    expect(getWebhookSubscription(sub.id)?.consecutiveFailures).toBe(9);
+
+    // A success resets to 0 and transitions unverified -> enabled
+    updateWebhookSubscription(sub.id, (s) => {
+      s.consecutiveFailures = 0;
+      if (s.state === 'unverified') s.state = 'enabled';
+    });
+    expect(getWebhookSubscription(sub.id)?.consecutiveFailures).toBe(0);
+    expect(getWebhookSubscription(sub.id)?.state).toBe('enabled');
+
+    // 10 failures trips to disabled
+    for (let i = 1; i <= 10; i++) {
+      updateWebhookSubscription(sub.id, (s) => {
+        s.consecutiveFailures = (s.consecutiveFailures ?? 0) + 1;
+        if (s.consecutiveFailures >= 10) {
+          s.state = 'disabled';
+          s.disabledReason = 'threshold';
+        }
+      });
+    }
+    const disabledSub = getWebhookSubscription(sub.id);
+    expect(disabledSub?.state).toBe('disabled');
+    expect(disabledSub?.disabledReason).toBe('threshold');
+  });
+
+  test('SSRF refusal disables endpoint immediately without waiting for threshold', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://ssrf.consumer.example/hook',
+      address: 'postmaster@openagent.email',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      description: 'ssrf test',
+      privateTargetGranted: false,
+      createdBy: 'admin',
+    });
+
+    // Mock attempt that resolves to blocked SSRF
+    const res = await executeWebhookAttempt(
+      sub,
+      '{}',
+      'mail.received',
+      'dlv_ssrf',
+      {
+        dnsLookup: async () => [{ address: '169.254.169.254', family: 4 }],
+      },
+    );
+
+    expect(res.outcome).toBe('refused');
+    expect(res.reason).toBe('ssrf_refused');
+  });
+});
+
+describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('reconstructPendingDeliveriesAtBoot picks highest attempt and preserves Item 9 fields', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://recon.example/hook',
+      address: 'owner@openagent.email',
+      events: ['approval.requested'],
+      contentScope: 'metadata',
+      description: 'reconstruction test',
+      privateTargetGranted: false,
+      createdBy: 'admin',
+    });
+
+    const bootTime = Date.now();
+    const eventCreatedAt = new Date(bootTime - 3600000).toISOString();
+    const taskCreatedAt = new Date(bootTime - 3600000).toISOString();
+
+    // Past attempt 1 failed
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 3500000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_recon_1',
+      runId: 'run_0',
+      deliveryId: 'dlv_r1',
+      type: 'approval.requested',
+      address: 'owner@openagent.email',
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: '3f8a1c62-9d4e-4b07-a5f1-6c2e8d904b73',
+      taskCreatedAt,
+      expiresInSec: 86400,
+      eventCreatedAt,
+      attempt: 1,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 50,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 60000).toISOString(),
+    });
+
+    // Attempt 2 scheduled as pending
+    appendDeliveryLogRow({
+      ts: new Date(bootTime - 3499000).toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_recon_1',
+      runId: 'run_0',
+      deliveryId: 'dlv_r2',
+      type: 'approval.requested',
+      address: 'owner@openagent.email',
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: '3f8a1c62-9d4e-4b07-a5f1-6c2e8d904b73',
+      taskCreatedAt,
+      expiresInSec: 86400,
+      eventCreatedAt,
+      attempt: 2,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(bootTime + 60000).toISOString(),
+    });
+
+    const result = await reconstructPendingDeliveriesAtBoot(bootTime);
+    // Task does not exist in mock storage so it dead-letters gracefully with task_not_found
+    expect(result.deadLettered).toBe(1);
+
+    const rows = readAllDeliveryLogRows();
+    const deadLetterRow = rows.find((r) => r.outcome === 'permanent');
+    expect(deadLetterRow).toBeDefined();
+    expect(deadLetterRow?.reason).toBe('task_not_found');
+    expect(deadLetterRow?.taskCreatedAt).toBe(taskCreatedAt);
+    expect(deadLetterRow?.expiresInSec).toBe(86400);
+  });
+
+  afterAll(async () => {
+    (config as any).dataDir = originalDataDir;
+    deliveryQueue.cancelAll();
+    await new Promise((r) => setTimeout(r, 50));
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+});

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -822,12 +822,13 @@ describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
       await waitUntil(() => getWebhookSubscription(first.id)?.state === 'enabled', 2000);
 
       const second = mk('b');
+      const beforeSecond = Date.now();
       fireCreationPing(second, 'creation', 'r10-probe');
       const pending = readAllDeliveryLogRows().find(
         (r) => r.webhookId === second.id && r.outcome === 'pending',
       );
       expect(pending).toBeDefined();
-      expect(new Date(pending!.nextAttemptAt!).getTime()).toBeGreaterThanOrEqual(Date.now());
+      expect(new Date(pending!.nextAttemptAt!).getTime()).toBeGreaterThanOrEqual(beforeSecond);
       expect(getWebhookSubscription(second.id)?.state).toBe('unverified');
       // Quota has room again before the delayed fire (window not required to stay full).
       deliveryLimiter.reset();
@@ -898,6 +899,79 @@ describe('webhook-delivery: R10 ping schema, deliveryId, probe defer', () => {
       deliveryQueue.cancelAll();
     }
   });
+
+  test(
+    'final2: delayed ping admitted to execution does not re-deduct probe bucket on retries',
+    async () => {
+    let callCount = 0;
+    const server = Bun.serve({
+      port: 0,
+      fetch: (req) => {
+        const url = new URL(req.url);
+        if (url.pathname === '/first') {
+          return new Response('ok', { status: 200 });
+        }
+        callCount++;
+        if (callCount === 1) {
+          // First attempt of second ping fails with retryable 429 (Retry-After: 1s)
+          return new Response('rate limited', { status: 429, headers: { 'Retry-After': '1' } });
+        }
+        // Retry attempt succeeds
+        return new Response('ok', { status: 200 });
+      },
+    });
+    const prevAllow = config.webhooks.allowPrivateTargets;
+    const prevProbe = config.webhooks.rateTestPerMin;
+    const prevPool = config.webhooks.poolRetryMs;
+    (config.webhooks as any).allowPrivateTargets = true;
+    (config as any).oaePublicEdge = false;
+    (config.webhooks as any).rateTestPerMin = 1;
+    (config.webhooks as any).poolRetryMs = 25;
+    deliveryLimiter.reset();
+    try {
+      const mk = (path: string) =>
+        createWebhookSubscription({
+          url: `http://127.0.0.1:${server.port}${path}`,
+          address: 'owner@openagent.email',
+          events: ['mail.received'],
+          contentScope: 'metadata',
+          privateTargetGranted: true,
+          createdBy: 'admin',
+        });
+      // First ping consumes the 1 probe slot
+      const first = mk('/first');
+      fireCreationPing(first, 'creation', 'final2-probe');
+      await waitUntil(() => getWebhookSubscription(first.id)?.state === 'enabled', 2000);
+
+      // Second ping delayed due to full bucket
+      const second = mk('/second');
+      fireCreationPing(second, 'creation', 'final2-probe');
+      const pending = readAllDeliveryLogRows().find(
+        (r) => r.webhookId === second.id && r.outcome === 'pending',
+      );
+      expect(pending).toBeDefined();
+
+      // Clear quota once so delayed ping can pass initial admission
+      deliveryLimiter.reset();
+
+      // Wait until attempt 1 runs and retry (attempt 2) runs and succeeds (200)
+      // If probeTokenKey were not cleared, attempt 2 would check the probe bucket
+      // (which was filled by attempt 1) and be killed with probe_rate_limited!
+      await waitUntil(() => getWebhookSubscription(second.id)?.state === 'enabled', 7000);
+
+      expect(callCount).toBeGreaterThanOrEqual(2);
+      const rows = readAllDeliveryLogRows().filter((r) => r.webhookId === second.id);
+      expect(rows.some((r) => r.reason === 'probe_rate_limited')).toBe(false);
+      expect(rows.some((r) => r.outcome === 'success')).toBe(true);
+    } finally {
+      (config.webhooks as any).allowPrivateTargets = prevAllow;
+      (config.webhooks as any).rateTestPerMin = prevProbe;
+      (config.webhooks as any).poolRetryMs = prevPool;
+      deliveryLimiter.reset();
+      server.stop(true);
+      deliveryQueue.cancelAll();
+    }
+  }, 12000);
 });
 
 describe('webhook-delivery: Circuit Breaker & SSRF Immediate Disable (§8.5, D2a, §14 item 9)', () => {

--- a/packages/api/test/webhook-mcp.test.ts
+++ b/packages/api/test/webhook-mcp.test.ts
@@ -5,7 +5,6 @@ process.env.IMAP_PASS = 'test-only';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'test-only';
 process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
-process.env.WEBHOOKS_ENABLED = 'true';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 process.env.UI_ENABLED = 'false';
 
@@ -223,6 +222,8 @@ describe('Webhook MCP Tools & Tool Tiers (§10.7, D17)', () => {
 
   afterAll(async () => {
     (config as any).dataDir = originalDataDir;
+    (config.webhooks as any).enabled = false;
+    delete process.env.WEBHOOKS_ENABLED;
     deliveryQueue.cancelAll();
     await new Promise((r) => setTimeout(r, 50));
     deliveryQueue.cancelAll();

--- a/packages/api/test/webhook-mcp.test.ts
+++ b/packages/api/test/webhook-mcp.test.ts
@@ -218,6 +218,15 @@ describe('Webhook MCP Tools & Tool Tiers (§10.7, D17)', () => {
     expect(longDescRes.status).toBe(200);
     const longDescBody = await readMcpJson(longDescRes);
     expect(longDescBody.error || longDescBody.result?.isError).toBeTruthy();
+
+    const longUrlRes = await mcpCall(aliceToken, 'mail_webhook_create', {
+      url: `https://consumer.example/${'a'.repeat(2048)}`,
+      address: aliceAddress,
+      events: ['mail.received'],
+    });
+    expect(longUrlRes.status).toBe(200);
+    const longUrlBody = await readMcpJson(longUrlRes);
+    expect(longUrlBody.error || longUrlBody.result?.isError).toBeTruthy();
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhook-mcp.test.ts
+++ b/packages/api/test/webhook-mcp.test.ts
@@ -1,0 +1,231 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'test-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
+process.env.WEBHOOKS_ENABLED = 'true';
+process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
+process.env.UI_ENABLED = 'false';
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { createApp } = await import('../src/app.ts');
+const { config } = await import('../src/lib/config.ts');
+const {
+  deliveryLimiter,
+  deliveryQueue,
+  setWebhookDnsLookupForTests,
+} = await import('../src/lib/webhook-delivery.ts');
+const {
+  createIdentity,
+  deleteIdentity,
+} = await import('../src/lib/identities.ts');
+const {
+  putAccessTokenForTests,
+  resetOAuthStoreCacheForTests,
+} = await import('../src/lib/oauth-store.ts');
+const {
+  TOOL_TIER_SPEC,
+  getToolTier,
+} = await import('../src/lib/tool-tiers.ts');
+const { resolveResourceUri } = await import('../src/lib/oauth-url.ts');
+
+const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhook-mcp');
+const originalDataDir = config.dataDir;
+const MCP_ACCEPT = 'application/json, text/event-stream';
+
+let app: ReturnType<typeof createApp>;
+let aliceToken: string;
+let aliceAddress: string;
+let oauthToken: string;
+const adminKey = [...config.apiKeys][0] || 'test-key';
+
+function setupTestDir(): void {
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DATA_DIR, { recursive: true, mode: 0o700 });
+  (config as any).dataDir = TEST_DATA_DIR;
+  (config.webhooks as any).enabled = true;
+  (config as any).taskSigningSecret = '01234567890123456789012345678901';
+  (config.webhooks as any).signingSecret = '01234567890123456789012345678901';
+  config.apiKeys.add('test-key');
+  (config.webhooks as any).allowPrivateTargets = false;
+  (config.webhooks as any).rateCreatePerMin = 10;
+  (config.webhooks as any).rateTestPerMin = 3;
+  deliveryLimiter.reset();
+  deliveryQueue.cancelAll();
+  setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+
+  const alice = createIdentity({ localpart: 'alice', domain: 'test.example' });
+  aliceToken = alice?.token ?? '';
+  aliceAddress = alice?.identity.address ?? 'alice@test.example';
+
+  resetOAuthStoreCacheForTests();
+  oauthToken = 'oa_access_test_oauth_32bytes_pad!';
+  putAccessTokenForTests({
+    token: oauthToken,
+    grantId: 'g-test-oauth',
+    address: aliceAddress,
+    aud: resolveResourceUri('http://localhost'),
+    expiresAt: Date.now() + 3600_000,
+    ensureGrant: { clientId: 'https://client.example/cb', clientName: 'Test Client' },
+  });
+
+  app = createApp({ uiEnabled: false });
+}
+
+function mcpCall(
+  token: string,
+  name: string,
+  args: Record<string, unknown> = {},
+  id = 1,
+) {
+  return app.request('/mcp', {
+    method: 'POST',
+    headers: {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      accept: MCP_ACCEPT,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    }),
+  });
+}
+
+async function readMcpJson(res: Response): Promise<any> {
+  const text = await res.text();
+  const dataLine = text.split('\n').find((line) => line.startsWith('data: '));
+  if (dataLine) return JSON.parse(dataLine.slice('data: '.length));
+  return JSON.parse(text);
+}
+
+describe('Webhook MCP Tools & Tool Tiers (§10.7, D17)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    setWebhookDnsLookupForTests(undefined);
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('TOOL_TIER_SPEC has all 5 webhook tools with ratified tiers', () => {
+    expect(TOOL_TIER_SPEC.mail_webhook_list).toBe('read');
+    expect(TOOL_TIER_SPEC.mail_webhook_create).toBe('critical');
+    expect(TOOL_TIER_SPEC.mail_webhook_delete).toBe('minimal');
+    expect(TOOL_TIER_SPEC.mail_webhook_test).toBe('contained');
+    expect(TOOL_TIER_SPEC.mail_webhook_disable).toBe('minimal');
+
+    expect(getToolTier('mail_webhook_create')).toBe('critical');
+    expect(getToolTier('mail_webhook_list')).toBe('read');
+  });
+
+  test('mail_webhook_create tier critical: OAuth ticket rejected by WriteGuard (403 forbidden_tier)', async () => {
+    const res = await mcpCall(oauthToken, 'mail_webhook_create', {
+      url: 'https://consumer.example/hook',
+      address: aliceAddress,
+      events: ['mail.received'],
+    });
+    expect(res.status).toBe(403);
+    const body: any = await res.json();
+    expect(body.error).toBe('forbidden_tier');
+    expect(body.tier).toBe('critical');
+  });
+
+  test('mail_webhook_create, list, test, disable, delete complete lifecycle via MCP', async () => {
+    // 1. Create webhook subscription as Alice
+    const createRes = await mcpCall(aliceToken, 'mail_webhook_create', {
+      url: 'https://consumer.example/hook',
+      address: aliceAddress,
+      events: ['mail.received'],
+      description: 'Alice mail hook',
+    });
+    expect(createRes.status).toBe(200);
+    const createBody = await readMcpJson(createRes);
+    expect(createBody.result?.isError).toBeFalsy();
+    const createdData = JSON.parse(createBody.result.content[0].text);
+    expect(createdData.id).toMatch(/^whk_/);
+    expect(createdData.address).toBe(aliceAddress);
+    expect(createdData.events).toEqual(['mail.received']);
+    expect(createdData.secret).toMatch(/^whs_[a-f0-9]{64}$/);
+    const webhookId = createdData.id;
+
+    // 2. List webhooks as Alice
+    const listRes = await mcpCall(aliceToken, 'mail_webhook_list', {});
+    expect(listRes.status).toBe(200);
+    const listBody = await readMcpJson(listRes);
+    expect(listBody.result?.isError).toBeFalsy();
+    const listData = JSON.parse(listBody.result.content[0].text);
+    expect(Array.isArray(listData.webhooks)).toBe(true);
+    expect(listData.webhooks.length).toBe(1);
+    expect(listData.webhooks[0].id).toBe(webhookId);
+    expect(listData.webhooks[0].secret).toBeUndefined(); // list never leaks secret
+
+    // 3. Disable webhook
+    const disableRes = await mcpCall(aliceToken, 'mail_webhook_disable', { id: webhookId });
+    expect(disableRes.status).toBe(200);
+    const disableBody = await readMcpJson(disableRes);
+    expect(disableBody.result?.isError).toBeFalsy();
+    const disableData = JSON.parse(disableBody.result.content[0].text);
+    expect(disableData.state).toBe('disabled');
+    expect(disableData.disabledReason).toBe('manual');
+
+    // 4. Test webhook probe ping (disabled endpoint returns error cleanly without network call)
+    const testRes = await mcpCall(aliceToken, 'mail_webhook_test', { id: webhookId });
+    expect(testRes.status).toBe(200);
+    const testBody = await readMcpJson(testRes);
+    expect(testBody.result?.isError).toBe(true);
+    expect(testBody.result?.content?.[0]?.text).toMatch(/webhook_disabled/);
+
+    // 5. Delete webhook
+    const deleteRes = await mcpCall(aliceToken, 'mail_webhook_delete', { id: webhookId });
+    expect(deleteRes.status).toBe(200);
+    const deleteBody = await readMcpJson(deleteRes);
+    expect(deleteBody.result?.isError).toBeFalsy();
+    const deleteData = JSON.parse(deleteBody.result.content[0].text);
+    expect(deleteData.ok).toBe(true);
+
+    // 6. Verify list is now empty
+    const listAfterRes = await mcpCall(aliceToken, 'mail_webhook_list', {});
+    const listAfterBody = await readMcpJson(listAfterRes);
+    const listAfterData = JSON.parse(listAfterBody.result.content[0].text);
+    expect(listAfterData.webhooks.length).toBe(0);
+  }, 20000);
+
+  test('mail_webhook_create schema validation: rejects duplicate events and overlong description', async () => {
+    // Duplicate events
+    const dupRes = await mcpCall(aliceToken, 'mail_webhook_create', {
+      url: 'https://consumer.example/hook',
+      address: aliceAddress,
+      events: ['mail.received', 'mail.received'],
+    });
+    expect(dupRes.status).toBe(200);
+    const dupBody = await readMcpJson(dupRes);
+    // MCP tool schema validation failure returns isError: true
+    expect(dupBody.error || dupBody.result?.isError).toBeTruthy();
+
+    // Overlong description
+    const longDescRes = await mcpCall(aliceToken, 'mail_webhook_create', {
+      url: 'https://consumer.example/hook',
+      address: aliceAddress,
+      events: ['mail.received'],
+      description: 'x'.repeat(1001),
+    });
+    expect(longDescRes.status).toBe(200);
+    const longDescBody = await readMcpJson(longDescRes);
+    expect(longDescBody.error || longDescBody.result?.isError).toBeTruthy();
+  });
+
+  afterAll(async () => {
+    (config as any).dataDir = originalDataDir;
+    deliveryQueue.cancelAll();
+    await new Promise((r) => setTimeout(r, 50));
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+});

--- a/packages/api/test/webhook-signature-python.test.ts
+++ b/packages/api/test/webhook-signature-python.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from 'bun:test';
+import { fileURLToPath } from 'node:url';
+
+test('webhook signature vectors pass the independent Python verifier (§14 item 1)', () => {
+  const python3 = Bun.which('python3');
+  if (!python3) {
+    throw new Error('Python 3 is required for the webhook signature vector verifier');
+  }
+  const verification = Bun.spawnSync({
+    cmd: [
+      python3,
+      fileURLToPath(new URL('../scripts/verify-webhook-signature-vectors.py', import.meta.url)),
+    ],
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  expect(verification.exitCode).toBe(0);
+  expect(new TextDecoder().decode(verification.stdout)).toContain(
+    'verified 4 public v1 webhook signature vectors',
+  );
+});

--- a/packages/api/test/webhook-signing.test.ts
+++ b/packages/api/test/webhook-signing.test.ts
@@ -1,0 +1,197 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'test-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+
+import { describe, expect, test } from 'bun:test';
+import fixture from './fixtures/webhook-signature-vectors.v1.json';
+
+const {
+  buildWebhookSignatureHeader,
+  deriveWebhookKey,
+  verifyWebhookSignature,
+} = await import('../src/lib/webhook-signing.ts');
+
+describe('webhook signing and verification (§7, §12.1, §12.2, §14 item 1)', () => {
+  test('matches public v1 vectors fixture with JS production implementation', () => {
+    expect(fixture.format).toBe('openagentemail.webhook-signature-vectors');
+    expect(fixture.version).toBe(1);
+    expect(fixture.vectors.length).toBe(4);
+
+    for (const v of fixture.vectors) {
+      const derived = deriveWebhookKey(v.rootSecret, v.webhookId, v.epoch);
+      expect(derived.displayedSecret).toBe(v.displayedSecret);
+
+      const headerResult = buildWebhookSignatureHeader({
+        rootSecret: v.rootSecret,
+        webhookId: v.webhookId,
+        epoch: v.epoch,
+        rawBody: v.rawBody,
+        timestampSec: v.timestampSec,
+        overlapUntil: 'previousEpoch' in v ? '2026-09-04T12:30:00.000Z' : null,
+        nowMs: v.timestampSec * 1000,
+      });
+
+      expect(headerResult.headerValue).toBe(v.expectedHeader);
+
+      // Verify with verifyWebhookSignature
+      const verifyRes = verifyWebhookSignature({
+        signatureHeader: headerResult.headerValue,
+        rawBody: v.rawBody,
+        secret: v.displayedSecret,
+        nowMs: v.timestampSec * 1000,
+        toleranceSec: 300,
+      });
+      expect(verifyRes.valid).toBe(true);
+
+      // If overlap vector, previous displayedSecret should also verify
+      if ('previousDisplayedSecret' in v) {
+        const verifyPrev = verifyWebhookSignature({
+          signatureHeader: headerResult.headerValue,
+          rawBody: v.rawBody,
+          secret: v.previousDisplayedSecret as string,
+          nowMs: v.timestampSec * 1000,
+          toleranceSec: 300,
+        });
+        expect(verifyPrev.valid).toBe(true);
+      }
+    }
+  });
+
+  test('key derivation: distinct webhookId produces distinct keys, distinct epoch produces distinct keys', () => {
+    const root = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const whk1 = 'whk_11111111-1111-1111-1111-111111111111';
+    const whk2 = 'whk_22222222-2222-2222-2222-222222222222';
+
+    const k1_e0 = deriveWebhookKey(root, whk1, 0);
+    const k1_e1 = deriveWebhookKey(root, whk1, 1);
+    const k2_e0 = deriveWebhookKey(root, whk2, 0);
+
+    expect(k1_e0.displayedSecret).toStartWith('whs_');
+    expect(k1_e0.displayedSecret.length).toBe(68);
+    expect(k1_e0.secretPrefix).toBe(k1_e0.displayedSecret.slice(0, 8) + '…');
+
+    expect(k1_e0.displayedSecret).not.toBe(k1_e1.displayedSecret);
+    expect(k1_e0.displayedSecret).not.toBe(k2_e0.displayedSecret);
+  });
+
+  test('verification rejects tampered body, wrong secret, and expired timestamp', () => {
+    const root = '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+    const whk = 'whk_11111111-1111-1111-1111-111111111111';
+    const derived = deriveWebhookKey(root, whk, 0);
+    const body = '{"hello":"world"}';
+    const nowSec = 1725366000;
+
+    const { headerValue } = buildWebhookSignatureHeader({
+      rootSecret: root,
+      webhookId: whk,
+      epoch: 0,
+      rawBody: body,
+      timestampSec: nowSec,
+      nowMs: nowSec * 1000,
+    });
+
+    // 1. Tampered body
+    const badBodyRes = verifyWebhookSignature({
+      signatureHeader: headerValue,
+      rawBody: '{"hello":"tampered"}',
+      secret: derived.displayedSecret,
+      nowMs: nowSec * 1000,
+      toleranceSec: 300,
+    });
+    expect(badBodyRes.valid).toBe(false);
+    expect(badBodyRes.reason).toBe('signature_mismatch');
+
+    // 2. Wrong secret
+    const wrongSecret = deriveWebhookKey(root, 'whk_other', 0).displayedSecret;
+    const badSecretRes = verifyWebhookSignature({
+      signatureHeader: headerValue,
+      rawBody: body,
+      secret: wrongSecret,
+      nowMs: nowSec * 1000,
+      toleranceSec: 300,
+    });
+    expect(badSecretRes.valid).toBe(false);
+    expect(badSecretRes.reason).toBe('signature_mismatch');
+
+    // 3. Expired timestamp (> 300s)
+    const expiredRes = verifyWebhookSignature({
+      signatureHeader: headerValue,
+      rawBody: body,
+      secret: derived.displayedSecret,
+      nowMs: (nowSec + 301) * 1000,
+      toleranceSec: 300,
+    });
+    expect(expiredRes.valid).toBe(false);
+    expect(expiredRes.reason).toBe('timestamp_out_of_range');
+
+    // Within tolerance (exact boundary: 300s)
+    const exactBoundaryRes = verifyWebhookSignature({
+      signatureHeader: headerValue,
+      rawBody: body,
+      secret: derived.displayedSecret,
+      nowMs: (nowSec + 300) * 1000,
+      toleranceSec: 300,
+    });
+    expect(exactBoundaryRes.valid).toBe(true);
+
+    // 4. Missing / malformed header
+    expect(
+      verifyWebhookSignature({
+        signatureHeader: '',
+        rawBody: body,
+        secret: derived.displayedSecret,
+      }).valid,
+    ).toBe(false);
+    expect(
+      verifyWebhookSignature({
+        signatureHeader: 'invalid-header',
+        rawBody: body,
+        secret: derived.displayedSecret,
+      }).valid,
+    ).toBe(false);
+  });
+
+  test('root rotation overlap emits both new and previous root signatures', () => {
+    const newRoot = 'newrootsecret012345678901234567890123456789012345';
+    const oldRoot = 'oldrootsecret012345678901234567890123456789012345';
+    const whk = 'whk_rot_test';
+    const body = '{"event":"root_rotation"}';
+    const t = 1725366000;
+
+    const newKey = deriveWebhookKey(newRoot, whk, 0);
+    const oldKey = deriveWebhookKey(oldRoot, whk, 0);
+
+    const { headerValue, signatures } = buildWebhookSignatureHeader({
+      rootSecret: newRoot,
+      webhookId: whk,
+      epoch: 0,
+      rawBody: body,
+      timestampSec: t,
+      previousRootSecret: oldRoot,
+      nowMs: t * 1000,
+    });
+
+    expect(signatures.length).toBe(2);
+    // Both new and old root keys verify
+    expect(
+      verifyWebhookSignature({
+        signatureHeader: headerValue,
+        rawBody: body,
+        secret: newKey.displayedSecret,
+        nowMs: t * 1000,
+      }).valid,
+    ).toBe(true);
+
+    expect(
+      verifyWebhookSignature({
+        signatureHeader: headerValue,
+        rawBody: body,
+        secret: oldKey.displayedSecret,
+        nowMs: t * 1000,
+      }).valid,
+    ).toBe(true);
+  });
+});

--- a/packages/api/test/webhook-sink.test.ts
+++ b/packages/api/test/webhook-sink.test.ts
@@ -1,0 +1,190 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'test-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
+process.env.WEBHOOKS_ENABLED = 'true';
+process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { config } = await import('../src/lib/config.ts');
+const { createWebhookSink } = await import('../src/lib/webhook-sink.ts');
+const {
+  deliveryQueue,
+  readAllDeliveryLogRows,
+} = await import('../src/lib/webhook-delivery.ts');
+const {
+  createWebhookSubscription,
+} = await import('../src/lib/webhook-store.ts');
+import type { ApprovalTask } from '../src/lib/tasks-internal.ts';
+import type { MailReceivedEvent } from '../src/lib/event-dispatcher.ts';
+
+const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhook-sink');
+const originalDataDir = config.dataDir;
+
+function setupTestDir(): void {
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DATA_DIR, { recursive: true, mode: 0o700 });
+  (config as any).dataDir = TEST_DATA_DIR;
+  (config.webhooks as any).enabled = true;
+  (config as any).taskSigningSecret = '01234567890123456789012345678901';
+  (config.webhooks as any).signingSecret = '01234567890123456789012345678901';
+  deliveryQueue.cancelAll();
+}
+
+describe('webhook-sink: Dispatcher Sink Wiring (§11.4, §6.2, §6.3, Item 9)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('handleApproval enqueues delivery for matching reviewer and trims task to §6.3 schema', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      events: ['approval.requested'],
+      contentScope: 'preview',
+      address: 'reviewer@test.example',
+    });
+
+    const sink = createWebhookSink();
+    expect(sink.isEnabled()).toBe(true);
+
+    const taskCreatedAt = '2026-09-05T00:00:00.000Z';
+    const expiresAt = '2026-09-06T00:00:00.000Z'; // 86400s later
+    const task: ApprovalTask = {
+      id: '3f8a1c62-9d4e-4b07-a5f1-6c2e8d904b73',
+      kind: 'approval',
+      state: 'input-required',
+      from: 'initiator@test.example',
+      to: 'reviewer@test.example',
+      subject: 'Please approve wire transfer',
+      messages: [],
+      createdAt: taskCreatedAt,
+      updatedAt: taskCreatedAt,
+      approval: {
+        reviewer: 'reviewer@test.example',
+        expiresAt,
+        digest: '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef',
+        action: {
+          type: 'wire',
+          name: 'send_funds',
+          arguments: { amount: 1000, recipient: 'vendor' },
+        },
+      },
+    };
+
+    await sink.handleApproval!({
+      type: 'approval.requested',
+      task,
+    });
+
+    const rows = readAllDeliveryLogRows();
+    expect(rows.length).toBe(1);
+    const row = rows[0]!;
+    expect(row.webhookId).toBe(sub.id);
+    expect(row.type).toBe('approval.requested');
+    expect(row.taskId).toBe(task.id);
+    expect(row.taskCreatedAt).toBe(taskCreatedAt);
+    expect(row.expiresInSec).toBe(86400);
+    expect(row.outcome).toBe('pending');
+  });
+
+  test('handleMail matches recipient and enqueues delivery with flags and internalDate', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      events: ['mail.received'],
+      contentScope: 'preview',
+      address: 'agent@test.example',
+    });
+
+    const sink = createWebhookSink();
+    const internalDate = new Date('2026-09-05T01:23:45.000Z');
+
+    const rawMime =
+      'From: Sender <sender@external.example>\r\n' +
+      'To: agent@test.example\r\n' +
+      'Subject: Verify your login\r\n' +
+      'Message-ID: <msg-123@external.example>\r\n' +
+      'Content-Type: text/plain\r\n' +
+      '\r\n' +
+      'Your OTP code is: 987654. Click: https://external.example/verify\r\n';
+
+    const mailEvent: MailReceivedEvent = {
+      type: 'mail.received',
+      message: {
+        uid: 101,
+        internalDate,
+        flags: new Set(), // unread
+        envelope: {
+          from: [{ name: 'Sender', address: 'sender@external.example' }],
+          to: [{ address: 'agent@test.example' }],
+          subject: 'Verify your login',
+          messageId: '<msg-123@external.example>',
+        },
+        source: Buffer.from(rawMime, 'utf8'),
+      },
+      uidValidity: 42n,
+    };
+
+    await sink.handleMail!(mailEvent);
+
+    const rows = readAllDeliveryLogRows();
+    expect(rows.length).toBe(1);
+    const row = rows[0]!;
+    expect(row.webhookId).toBe(sub.id);
+    expect(row.type).toBe('mail.received');
+    expect(row.messageId).toBe('101');
+    expect(row.uidValidity).toBe(42);
+    expect(row.rfc822MessageId).toBe('<msg-123@external.example>');
+    expect(row.outcome).toBe('pending');
+  });
+
+  test('handleMail treats overlong rfc822MessageId (>512 bytes) as null (Item 5)', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      address: 'agent@test.example',
+    });
+
+    const sink = createWebhookSink();
+    const overlongId = '<' + 'x'.repeat(600) + '@example.com>';
+
+    const mailEvent: MailReceivedEvent = {
+      type: 'mail.received',
+      message: {
+        uid: 102,
+        internalDate: new Date(),
+        flags: new Set(['\\Seen']),
+        envelope: {
+          from: [{ address: 'sender@example.com' }],
+          to: [{ address: 'agent@test.example' }],
+          subject: 'Overlong test',
+          messageId: overlongId,
+        },
+      },
+      uidValidity: 1n,
+    };
+
+    await sink.handleMail!(mailEvent);
+
+    const rows = readAllDeliveryLogRows();
+    expect(rows.length).toBe(1);
+    const row = rows[0]!;
+    expect(row.rfc822MessageId).toBeNull();
+  });
+
+  afterAll(async () => {
+    (config as any).dataDir = originalDataDir;
+    deliveryQueue.cancelAll();
+    await new Promise((r) => setTimeout(r, 50));
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+});

--- a/packages/api/test/webhook-sink.test.ts
+++ b/packages/api/test/webhook-sink.test.ts
@@ -19,7 +19,9 @@ const {
 } = await import('../src/lib/webhook-delivery.ts');
 const {
   createWebhookSubscription,
+  setWebhooksFailClosedForTests,
 } = await import('../src/lib/webhook-store.ts');
+const { isSinkServiceFailure } = await import('../src/lib/event-dispatcher.ts');
 import type { ApprovalTask } from '../src/lib/tasks-internal.ts';
 import type { MailReceivedEvent } from '../src/lib/event-dispatcher.ts';
 
@@ -33,6 +35,7 @@ function setupTestDir(): void {
   (config.webhooks as any).enabled = true;
   (config as any).taskSigningSecret = '01234567890123456789012345678901';
   (config.webhooks as any).signingSecret = '01234567890123456789012345678901';
+  setWebhooksFailClosedForTests(false);
   deliveryQueue.cancelAll();
 }
 
@@ -142,6 +145,34 @@ describe('webhook-sink: Dispatcher Sink Wiring (§11.4, §6.2, §6.3, Item 9)', 
     expect(row.uidValidity).toBe(42);
     expect(row.rfc822MessageId).toBe('<msg-123@external.example>');
     expect(row.outcome).toBe('pending');
+  });
+
+  test('R7: handleMail wraps store-corrupt as a service failure', async () => {
+    const sink = createWebhookSink();
+    setWebhooksFailClosedForTests(true);
+    const mailEvent: MailReceivedEvent = {
+      type: 'mail.received',
+      message: {
+        uid: 202,
+        internalDate: new Date(),
+        flags: new Set(),
+        envelope: {
+          from: [{ address: 'sender@external.example' }],
+          to: [{ address: 'agent@test.example' }],
+          subject: 'x',
+        },
+        source: Buffer.from('From: sender@external.example\r\nTo: agent@test.example\r\n\r\nbody\r\n'),
+      },
+    };
+    try {
+      await sink.handleMail!(mailEvent);
+      expect().fail('should have thrown');
+    } catch (err) {
+      expect(isSinkServiceFailure(err)).toBe(true);
+      expect((err as { failureKind?: string }).failureKind).toBe('service');
+    } finally {
+      setWebhooksFailClosedForTests(false);
+    }
   });
 
   test('handleMail treats overlong rfc822MessageId (>512 bytes) as null (Item 5)', async () => {

--- a/packages/api/test/webhook-sink.test.ts
+++ b/packages/api/test/webhook-sink.test.ts
@@ -5,7 +5,6 @@ process.env.IMAP_PASS = 'test-only';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'test-only';
 process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
-process.env.WEBHOOKS_ENABLED = 'true';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -182,6 +181,8 @@ describe('webhook-sink: Dispatcher Sink Wiring (§11.4, §6.2, §6.3, Item 9)', 
 
   afterAll(async () => {
     (config as any).dataDir = originalDataDir;
+    (config.webhooks as any).enabled = false;
+    delete process.env.WEBHOOKS_ENABLED;
     deliveryQueue.cancelAll();
     await new Promise((r) => setTimeout(r, 50));
     deliveryQueue.cancelAll();

--- a/packages/api/test/webhook-store.test.ts
+++ b/packages/api/test/webhook-store.test.ts
@@ -131,6 +131,18 @@ describe('webhook-store storage conventions (§10.5, §14 item 5)', () => {
     expect(() => listWebhooks()).toThrow(WebhookStoreCorruptError);
   });
 
+  test('R9: missing webhooks.json is first boot; existing empty file fail-closes', () => {
+    expect(readStore().webhooks).toEqual([]);
+    const storeFile = join(config.dataDir, WEBHOOK_STORE_FILE);
+    writeFileSync(storeFile, '', { mode: 0o600 });
+    expect(() => readStore()).toThrow(WebhookStoreCorruptError);
+    expect(() => listWebhooks()).toThrow(WebhookStoreCorruptError);
+
+    resetWebhooksStoreForTests();
+    writeFileSync(join(config.dataDir, WEBHOOK_STORE_FILE), ' \n\t', { mode: 0o600 });
+    expect(() => readStore()).toThrow(WebhookStoreCorruptError);
+  });
+
   test('cascadeDeleteWebhooksForAddress: removes all subscriptions for that address and keeps others', () => {
     saveWebhook({
       id: 'whk_alice_1',

--- a/packages/api/test/webhook-store.test.ts
+++ b/packages/api/test/webhook-store.test.ts
@@ -31,6 +31,7 @@ const {
   WebhookForbiddenSecretError,
   WebhookStoreCorruptError,
   WEBHOOK_STORE_FILE,
+  WEBHOOK_IDEMPOTENCY_MAX_RECORDS,
 } = await import('../src/lib/webhook-store.ts');
 
 describe('webhook-store storage conventions (§10.5, §14 item 5)', () => {
@@ -227,6 +228,25 @@ describe('webhook-store storage conventions (§10.5, §14 item 5)', () => {
     compactIdempotencyKeys(30);
     expect(findRotateIdempotency('whk_created_1', 'idem-rot-1')).toBeUndefined();
     expect(findCreateIdempotency('idem-create-1', 'alice@test.example')).toBeDefined();
+  });
+
+  test('R4: compactIdempotencyKeys enforces a max record count keeping newest', () => {
+    const now = Date.now();
+    for (let i = 0; i < 8; i++) {
+      saveRotateIdempotency({
+        key: `rot-cap-${i}`,
+        webhookId: 'whk_cap',
+        epoch: i,
+        responseBody: { epoch: i, secret: null },
+        createdAt: new Date(now + i * 1000).toISOString(),
+      });
+    }
+    compactIdempotencyKeys(30, 3);
+    expect(findRotateIdempotency('whk_cap', 'rot-cap-7')).toBeDefined();
+    expect(findRotateIdempotency('whk_cap', 'rot-cap-6')).toBeDefined();
+    expect(findRotateIdempotency('whk_cap', 'rot-cap-5')).toBeDefined();
+    expect(findRotateIdempotency('whk_cap', 'rot-cap-0')).toBeUndefined();
+    expect(WEBHOOK_IDEMPOTENCY_MAX_RECORDS).toBeGreaterThanOrEqual(8);
   });
 
   test('checkSubscriptionLimits: limits instance-wide and per-address subscriptions', () => {

--- a/packages/api/test/webhook-store.test.ts
+++ b/packages/api/test/webhook-store.test.ts
@@ -1,0 +1,269 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'test-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
+process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { config } = await import('../src/lib/config.ts');
+const {
+  cascadeDeleteWebhooksForAddress,
+  checkSubscriptionLimits,
+  compactIdempotencyKeys,
+  deleteWebhook,
+  findCreateIdempotency,
+  findRotateIdempotency,
+  getWebhook,
+  listWebhooks,
+  readStore,
+  resetWebhooksStoreForTests,
+  saveCreateIdempotency,
+  saveRotateIdempotency,
+  saveWebhook,
+  setWebhooksFailClosedForTests,
+  webhookStoreHasForbiddenSecretKey,
+  WebhookForbiddenSecretError,
+  WebhookStoreCorruptError,
+  WEBHOOK_STORE_FILE,
+} = await import('../src/lib/webhook-store.ts');
+
+describe('webhook-store storage conventions (§10.5, §14 item 5)', () => {
+  beforeEach(() => {
+    resetWebhooksStoreForTests();
+  });
+
+  afterEach(() => {
+    resetWebhooksStoreForTests();
+  });
+
+  test('creates 0600 file in 0700 dir, stores and retrieves subscriptions', () => {
+    const whk = {
+      id: 'whk_test_1',
+      url: 'https://example.com/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata' as const,
+      description: 'my webhook',
+      state: 'unverified' as const,
+      disabledReason: null,
+      secretPrefix: 'whs_1234…',
+      epoch: 0,
+      overlapUntil: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      rotatedAt: null,
+      consecutiveFailures: 0,
+      privateTargetGranted: false,
+      createdBy: 'alice@test.example',
+    };
+
+    saveWebhook(whk);
+
+    const storeFile = join(config.dataDir, WEBHOOK_STORE_FILE);
+    expect(existsSync(storeFile)).toBe(true);
+    const stats = statSync(storeFile);
+    expect((stats.mode & 0o777)).toBe(0o600);
+
+    const loaded = getWebhook('whk_test_1');
+    expect(loaded).toBeDefined();
+    expect(loaded?.url).toBe('https://example.com/hook');
+    expect(loaded?.address).toBe('alice@test.example');
+
+    // List by address
+    expect(listWebhooks('alice@test.example').length).toBe(1);
+    expect(listWebhooks('bob@test.example').length).toBe(0);
+    expect(listWebhooks().length).toBe(1);
+
+    // Delete
+    const deleted = deleteWebhook('whk_test_1');
+    expect(deleted?.id).toBe('whk_test_1');
+    expect(getWebhook('whk_test_1')).toBeUndefined();
+  });
+
+  test('FORBIDDEN_SECRET_KEYS guard: refuses persisting secret, signingSecret, previousSecret', () => {
+    expect(webhookStoreHasForbiddenSecretKey({ secret: 'plain' })).toBe(true);
+    expect(webhookStoreHasForbiddenSecretKey({ signingSecret: 'plain' })).toBe(true);
+    expect(webhookStoreHasForbiddenSecretKey({ previousSecret: 'plain' })).toBe(true);
+    expect(webhookStoreHasForbiddenSecretKey({ token: 'plain' })).toBe(true);
+    expect(webhookStoreHasForbiddenSecretKey({ password: 'plain' })).toBe(true);
+    // Values containing secret strings are not blocked: only keys
+    expect(webhookStoreHasForbiddenSecretKey({ description: 'contains secret keyword' })).toBe(false);
+
+    // Attempting to write a store with a forbidden key throws WebhookForbiddenSecretError
+    expect(() => {
+      const whk = {
+        id: 'whk_bad',
+        url: 'https://example.com/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+        contentScope: 'metadata' as const,
+        description: 'bad',
+        state: 'unverified' as const,
+        disabledReason: null,
+        secretPrefix: 'whs_…',
+        epoch: 0,
+        overlapUntil: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        rotatedAt: null,
+        consecutiveFailures: 0,
+        privateTargetGranted: false,
+        createdBy: 'admin',
+        secret: 'should-not-be-persisted',
+      } as any;
+      saveWebhook(whk);
+    }).toThrow(WebhookForbiddenSecretError);
+  });
+
+  test('corrupt store file fails closed', () => {
+    const storeFile = join(config.dataDir, WEBHOOK_STORE_FILE);
+    writeFileSync(storeFile, 'INVALID JSON CONTENT', { mode: 0o600 });
+
+    expect(() => readStore()).toThrow(WebhookStoreCorruptError);
+    // Subsequent calls are also blocked by the fail-closed latch
+    expect(() => listWebhooks()).toThrow(WebhookStoreCorruptError);
+  });
+
+  test('cascadeDeleteWebhooksForAddress: removes all subscriptions for that address and keeps others', () => {
+    saveWebhook({
+      id: 'whk_alice_1',
+      url: 'https://example.com/1',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      description: '',
+      state: 'enabled',
+      disabledReason: null,
+      secretPrefix: 'whs_…',
+      epoch: 0,
+      overlapUntil: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      rotatedAt: null,
+      consecutiveFailures: 0,
+      privateTargetGranted: false,
+      createdBy: 'alice@test.example',
+    });
+
+    saveWebhook({
+      id: 'whk_alice_2',
+      url: 'https://example.com/2',
+      address: 'alice@test.example',
+      events: ['approval.requested'],
+      contentScope: 'metadata',
+      description: '',
+      state: 'enabled',
+      disabledReason: null,
+      secretPrefix: 'whs_…',
+      epoch: 0,
+      overlapUntil: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      rotatedAt: null,
+      consecutiveFailures: 0,
+      privateTargetGranted: false,
+      createdBy: 'alice@test.example',
+    });
+
+    saveWebhook({
+      id: 'whk_bob_1',
+      url: 'https://example.com/bob',
+      address: 'bob@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      description: '',
+      state: 'enabled',
+      disabledReason: null,
+      secretPrefix: 'whs_…',
+      epoch: 0,
+      overlapUntil: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      rotatedAt: null,
+      consecutiveFailures: 0,
+      privateTargetGranted: false,
+      createdBy: 'bob@test.example',
+    });
+
+    expect(listWebhooks().length).toBe(3);
+
+    const removed = cascadeDeleteWebhooksForAddress('alice@test.example');
+    expect(removed.length).toBe(2);
+    expect(removed.map((r) => r.id).sort()).toEqual(['whk_alice_1', 'whk_alice_2']);
+
+    const remaining = listWebhooks();
+    expect(remaining.length).toBe(1);
+    expect(remaining[0].id).toBe('whk_bob_1');
+  });
+
+  test('idempotency keys: saving, lookup, and retention compaction', () => {
+    saveCreateIdempotency({
+      key: 'idem-create-1',
+      address: 'alice@test.example',
+      webhookId: 'whk_created_1',
+      responseBody: { id: 'whk_created_1', secret: null },
+      createdAt: new Date().toISOString(),
+    });
+
+    const found = findCreateIdempotency('idem-create-1', 'alice@test.example');
+    expect(found).toBeDefined();
+    expect(found?.webhookId).toBe('whk_created_1');
+
+    saveRotateIdempotency({
+      key: 'idem-rot-1',
+      webhookId: 'whk_created_1',
+      epoch: 1,
+      responseBody: { epoch: 1, secret: null },
+      createdAt: new Date(Date.now() - 35 * 24 * 60 * 60 * 1000).toISOString(), // 35 days ago
+    });
+
+    // Compacting with 30-day retention drops the 35-day-old rotate record
+    compactIdempotencyKeys(30);
+    expect(findRotateIdempotency('whk_created_1', 'idem-rot-1')).toBeUndefined();
+    expect(findCreateIdempotency('idem-create-1', 'alice@test.example')).toBeDefined();
+  });
+
+  test('checkSubscriptionLimits: limits instance-wide and per-address subscriptions', () => {
+    expect(checkSubscriptionLimits('alice@test.example', 16, 4).allowed).toBe(true);
+
+    for (let i = 0; i < 4; i++) {
+      saveWebhook({
+        id: `whk_cap_${i}`,
+        url: `https://example.com/${i}`,
+        address: 'alice@test.example',
+        events: ['mail.received'],
+        contentScope: 'metadata',
+        description: '',
+        state: 'enabled',
+        disabledReason: null,
+        secretPrefix: 'whs_…',
+        epoch: 0,
+        overlapUntil: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        rotatedAt: null,
+        consecutiveFailures: 0,
+        privateTargetGranted: false,
+        createdBy: 'alice@test.example',
+      });
+    }
+
+    // Per-address limit reached
+    const checkAddress = checkSubscriptionLimits('alice@test.example', 16, 4);
+    expect(checkAddress.allowed).toBe(false);
+    expect(checkAddress.reason).toBe('address_limit');
+
+    // Bob is still allowed under per-address
+    expect(checkSubscriptionLimits('bob@test.example', 16, 4).allowed).toBe(true);
+
+    // Global limit
+    expect(checkSubscriptionLimits('bob@test.example', 4, 4).allowed).toBe(false);
+    expect(checkSubscriptionLimits('bob@test.example', 4, 4).reason).toBe('instance_limit');
+  });
+});

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -580,6 +580,133 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(redeliverBody.eventId).toBe('evt_orig_1');
   });
 
+  test('R2 Item 1 & Item 2: OAuth tokens cannot DELETE or reveal secret', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-oauth-check',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+
+    // Item 2: GET /:id/secret rejects OAuth
+    const secretRes = await app.request(`/v1/webhooks/${sub.id}/secret`, {
+      headers: { Authorization: `Bearer ${oauthToken}` },
+    });
+    expect(secretRes.status).toBe(403);
+    const secretBody: any = await secretRes.json();
+    expect(secretBody.error).toBe('forbidden: oauth tokens may not reveal webhook secrets');
+
+    // Item 1: DELETE /:id rejects OAuth
+    const deleteRes = await app.request(`/v1/webhooks/${sub.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${oauthToken}` },
+    });
+    expect(deleteRes.status).toBe(403);
+    const deleteBody: any = await deleteRes.json();
+    expect(deleteBody.error).toBe('forbidden: oauth tokens may not mutate webhook subscriptions');
+  });
+
+  test('R2 Item 3: Identity caller cannot disable subscription created by admin', async () => {
+    const adminSub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-admin-created',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'admin',
+    });
+
+    const disableRes = await app.request(`/v1/webhooks/${adminSub.id}/disable`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(disableRes.status).toBe(403);
+    const body: any = await disableRes.json();
+    expect(body.error).toBe('forbidden: admin key required');
+
+    // Admin CAN disable
+    const adminDisableRes = await app.request(`/v1/webhooks/${adminSub.id}/disable`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(adminDisableRes.status).toBe(200);
+  });
+
+  test('R2 Item 10: Concurrent duplicate create requests with Idempotency-Key are race-safe', async () => {
+    const key = `idemp_concurrent_${Date.now()}`;
+    const req = () =>
+      app.request('/v1/webhooks', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${adminKey}`,
+          'Content-Type': 'application/json',
+          'Idempotency-Key': key,
+        },
+        body: JSON.stringify({
+          url: 'https://consumer.example/hook-concurrent',
+          address: 'bob@test.example',
+          events: ['mail.received'],
+        }),
+      });
+
+    const [res1, res2] = await Promise.all([req(), req()]);
+    expect(res1.status).toBe(201);
+    expect(res2.status).toBe(201);
+    const body1: any = await res1.json();
+    const body2: any = await res2.json();
+    expect(body1.id).toBe(body2.id);
+  });
+
+  test('R2 Item 11: POST /v1/webhooks/:id/rotate idempotency returns cached response', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-rot-idemp',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+
+    const rotKey = `rot_key_${Date.now()}`;
+    const res1 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Idempotency-Key': rotKey,
+      },
+    });
+    expect(res1.status).toBe(200);
+    const body1: any = await res1.json();
+    expect(body1.epoch).toBe(1);
+
+    // Replay same rotation key
+    const res2 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Idempotency-Key': rotKey,
+      },
+    });
+    expect(res2.status).toBe(200);
+    const body2: any = await res2.json();
+    expect(body2.epoch).toBe(1);
+    expect(body2.id).toBe(sub.id);
+  });
+
+  test('R2 Item 23: GET /v1/webhooks respects ?address= filter for admin and forbids identity', async () => {
+    const adminFilterRes = await app.request('/v1/webhooks?address=alice@test.example', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(adminFilterRes.status).toBe(200);
+    const adminBody: any = await adminFilterRes.json();
+    for (const w of adminBody.webhooks) {
+      expect(w.address).toBe('alice@test.example');
+    }
+
+    const userFilterRes = await app.request('/v1/webhooks?address=bob@test.example', {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(userFilterRes.status).toBe(403);
+    const userBody: any = await userFilterRes.json();
+    expect(userBody.error).toBe('forbidden: admin key required');
+  });
+
   afterAll(async () => {
     (config as any).dataDir = originalDataDir;
     (config.webhooks as any).enabled = false;

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -8,7 +8,7 @@ process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, rmSync } from 'node:fs';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const { createApp } = await import('../src/app.ts');
@@ -654,6 +654,11 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     const body1: any = await res1.json();
     const body2: any = await res2.json();
     expect(body1.id).toBe(body2.id);
+    const secrets = [body1.secret, body2.secret];
+    const revealed = secrets.filter((s) => typeof s === 'string' && /^whs_[a-f0-9]{64}$/.test(s));
+    const redacted = secrets.filter((s) => s === null);
+    expect(revealed).toHaveLength(1);
+    expect(redacted).toHaveLength(1);
   });
 
   test('R2 Item 11: POST /v1/webhooks/:id/rotate idempotency returns cached response', async () => {
@@ -688,6 +693,49 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     const body2: any = await res2.json();
     expect(body2.epoch).toBe(1);
     expect(body2.id).toBe(sub.id);
+    expect(body2.secret).toBeNull();
+  });
+
+  test('R4: POST /v1/webhooks/:id/rotate is rate-limited independently of cached idempotent hits', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-rot-limit',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    const oldRate = config.webhooks.rateTestPerMin;
+    (config.webhooks as any).rateTestPerMin = 1;
+    deliveryLimiter.reset();
+    try {
+      const key = `rot_limit_${Date.now()}`;
+      const res1 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Idempotency-Key': key,
+        },
+      });
+      expect(res1.status).toBe(200);
+      const replay = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Idempotency-Key': key,
+        },
+      });
+      expect(replay.status).toBe(200);
+
+      const res2 = await app.request(`/v1/webhooks/${sub.id}/rotate?force=true`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(res2.status).toBe(429);
+      expect(((await res2.json()) as any).error).toBe('rate_limited');
+      expect(res2.headers.get('Retry-After')).toBeTruthy();
+    } finally {
+      (config.webhooks as any).rateTestPerMin = oldRate;
+      deliveryLimiter.reset();
+    }
   });
 
   test('R2 Item 23: GET /v1/webhooks respects ?address= filter for admin and forbids identity', async () => {
@@ -828,6 +876,61 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
 
     // Reset DNS lookup for next tests
     setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+  });
+
+  test('R4: POST /v1/webhooks/:id/test ssrf_refused audit includes clientIp', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://ssrf-test.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'admin',
+    });
+    setWebhookDnsLookupForTests(async () => [{ address: '169.254.169.254', family: 4 }]);
+    try {
+      const probeRes = await app.request(`/v1/webhooks/${sub.id}/test`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${adminKey}` },
+      });
+      expect(probeRes.status).toBe(200);
+      const body: any = await probeRes.json();
+      expect(body.outcome).toBe('refused');
+      expect(body.reason).toBe('ssrf_refused');
+
+      const ssrf = readAuditEvents({ event: 'webhook.ssrf_refused' }).find(
+        (e) => e.webhookId === sub.id,
+      );
+      expect(ssrf).toBeDefined();
+      expect(ssrf?.ip).toEqual(expect.any(String));
+      expect(ssrf?.ip).toBeTruthy();
+    } finally {
+      setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+    }
+  });
+
+  test('R4: identity delete cascades webhooks before persisting identity removal', async () => {
+    const { createDelegation, invalidateDelegationStoreCache } = await import(
+      '../src/lib/delegations.ts'
+    );
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-cascade-order',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    createDelegation({
+      mailbox: 'alice@test.example',
+      grantee: 'bob@test.example',
+      createdBy: 'alice@test.example',
+    });
+    writeFileSync(join(TEST_DATA_DIR, 'delegations.json'), 'CORRUPTED_JSON{', { mode: 0o600 });
+    invalidateDelegationStoreCache();
+
+    expect(() => deleteIdentity('alice@test.example')).toThrow('delegation_store_corrupt');
+    expect(getWebhookSubscription(sub.id)).toBeUndefined();
+    const identitiesRaw = JSON.parse(
+      readFileSync(join(TEST_DATA_DIR, 'identities.json'), 'utf8'),
+    ) as Array<{ address: string }>;
+    expect(identitiesRaw.find((i) => i.address === 'alice@test.example')).toBeDefined();
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -487,6 +487,43 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(body.state).toBe('unverified');
   });
 
+  test('final: POST /v1/webhooks/:id is rate-limited on the create bucket', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/update-limit',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    const oldCreate = config.webhooks.rateCreatePerMin;
+    (config.webhooks as any).rateCreatePerMin = 1;
+    deliveryLimiter.reset();
+    try {
+      const first = await app.request(`/v1/webhooks/${sub.id}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ description: 'once' }),
+      });
+      expect(first.status).toBe(200);
+      const second = await app.request(`/v1/webhooks/${sub.id}`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ description: 'twice' }),
+      });
+      expect(second.status).toBe(429);
+      expect(((await second.json()) as any).error).toBe('rate_limited');
+      expect(second.headers.get('Retry-After')).toBeTruthy();
+    } finally {
+      (config.webhooks as any).rateCreatePerMin = oldCreate;
+      deliveryLimiter.reset();
+    }
+  });
+
   test('R9: url change resurrects threshold/refused disablement but keeps manual pause', async () => {
     const threshold = createWebhookSubscription({
       url: 'https://consumer.example/threshold-v1',

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -1,0 +1,592 @@
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'test-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'test-only';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'test-only';
+process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
+process.env.WEBHOOKS_ENABLED = 'true';
+process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
+
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const { createApp } = await import('../src/app.ts');
+const { config } = await import('../src/lib/config.ts');
+const {
+  deliveryLimiter,
+  deliveryQueue,
+  readAllDeliveryLogRows,
+  appendDeliveryLogRow,
+  setWebhookDnsLookupForTests,
+} = await import('../src/lib/webhook-delivery.ts');
+const {
+  createWebhookSubscription,
+  getWebhookSubscription,
+  listWebhookSubscriptions,
+  updateWebhookSubscription,
+} = await import('../src/lib/webhook-store.ts');
+const {
+  createIdentity,
+  deleteIdentity,
+} = await import('../src/lib/identities.ts');
+const {
+  putAccessTokenForTests,
+  resetOAuthStoreCacheForTests,
+} = await import('../src/lib/oauth-store.ts');
+
+const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhooks-route');
+const originalDataDir = config.dataDir;
+
+let app: ReturnType<typeof createApp>;
+let aliceToken: string;
+let bobToken: string;
+let oauthToken: string;
+const adminKey = [...config.apiKeys][0] || 'test-key';
+
+function setupTestDir(): void {
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DATA_DIR, { recursive: true, mode: 0o700 });
+  (config as any).dataDir = TEST_DATA_DIR;
+  (config.webhooks as any).enabled = true;
+  (config as any).taskSigningSecret = '01234567890123456789012345678901';
+  (config.webhooks as any).signingSecret = '01234567890123456789012345678901';
+  config.apiKeys.add('test-key');
+  (config.webhooks as any).allowPrivateTargets = false;
+  (config.webhooks as any).rateCreatePerMin = 10;
+  (config.webhooks as any).rateTestPerMin = 3;
+  (config.webhooks as any).maxSubscriptions = 16;
+  (config.webhooks as any).maxPerAddress = 4;
+  deliveryLimiter.reset();
+  deliveryQueue.cancelAll();
+  setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
+
+  // Create test identities
+  const alice = createIdentity({ localpart: 'alice', domain: 'test.example' });
+  aliceToken = alice?.token ?? '';
+  const bob = createIdentity({ localpart: 'bob', domain: 'test.example' });
+  bobToken = bob?.token ?? '';
+
+  resetOAuthStoreCacheForTests();
+  // Create test OAuth token
+  oauthToken = 'oa_access_test_oauth_32bytes_pad!';
+  putAccessTokenForTests({
+    token: oauthToken,
+    grantId: 'g-test-oauth',
+    address: 'alice@test.example',
+    aud: 'http://localhost/mcp',
+    expiresAt: Date.now() + 3600_000,
+    ensureGrant: { clientId: 'https://client.example/cb', clientName: 'Test Client' },
+  });
+
+  app = createApp();
+}
+
+describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
+  beforeEach(setupTestDir);
+  afterEach(() => {
+    setWebhookDnsLookupForTests(undefined);
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  test('dark landing: when WEBHOOKS_ENABLED is false, all routes return 404 webhooks_disabled', async () => {
+    (config.webhooks as any).enabled = false;
+
+    const res = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(res.status).toBe(404);
+    const body: any = await res.json();
+    expect(body.error).toBe('webhooks_disabled');
+  });
+
+  test('POST /v1/webhooks: Rule A: OAuth tokens are rejected on mutation', async () => {
+    const res = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${oauthToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body: any = await res.json();
+    expect(body.error).toBe('forbidden: oauth tokens may not mutate webhook subscriptions');
+  });
+
+  test('POST /v1/webhooks: admin can create metadata and preview subscriptions', async () => {
+    const res = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received', 'approval.requested'],
+        contentScope: 'preview',
+        description: 'Paging webhook',
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body: any = await res.json();
+    expect(body.id).toMatch(/^whk_/);
+    expect(body.url).toBe('https://consumer.example/hook');
+    expect(body.address).toBe('alice@test.example');
+    expect(body.events).toEqual(['mail.received', 'approval.requested']);
+    expect(body.contentScope).toBe('preview');
+    expect(body.secret).toMatch(/^whs_[a-f0-9]{64}$/);
+    expect(body.secretPrefix).toMatch(/^whs_[a-f0-9]{4}…$/);
+    expect(body.state).toBe('unverified');
+  });
+
+  test('POST /v1/webhooks: identity token can create metadata for own address only', async () => {
+    // Cannot create for another address
+    const badRes = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'bob@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(badRes.status).toBe(403);
+    expect(((await badRes.json()) as any).error).toBe('forbidden: token is scoped to another address');
+
+    // Cannot request preview contentScope
+    const previewRes = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+        contentScope: 'preview',
+      }),
+    });
+    expect(previewRes.status).toBe(403);
+    expect(((await previewRes.json()) as any).error).toBe('content_scope_requires_admin');
+
+    // Can create metadata for own address
+    const okRes = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(okRes.status).toBe(201);
+  });
+
+  test('POST /v1/webhooks Item 4 & Item 8 validation rules', async () => {
+    // Item 4: description <= 1000 characters
+    const overlongDesc = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+        description: 'a'.repeat(1001),
+      }),
+    });
+    expect(overlongDesc.status).toBe(400);
+
+    // Item 8: events non-empty
+    const emptyEvents = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: [],
+      }),
+    });
+    expect(emptyEvents.status).toBe(400);
+
+    // Item 8: events unique (no duplicates)
+    const duplicateEvents = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received', 'mail.received'],
+      }),
+    });
+    expect(duplicateEvents.status).toBe(400);
+  });
+
+  test('POST /v1/webhooks: idempotency key returns stored 201 response with secret: null', async () => {
+    const res1 = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem-create-abc',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(res1.status).toBe(201);
+    const body1: any = await res1.json();
+    expect(body1.secret).toBeDefined();
+
+    // Replay with same idempotency key
+    const res2 = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem-create-abc',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(res2.status).toBe(201);
+    const body2: any = await res2.json();
+    expect(body2.id).toBe(body1.id);
+    expect(body2.secret).toBeNull(); // Secret redacted on idempotency replay!
+  });
+
+  test('GET /v1/webhooks: admin lists all; identity lists only own; never leaks secret', async () => {
+    createWebhookSubscription({
+      url: 'https://alice.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    createWebhookSubscription({
+      url: 'https://bob.example/hook',
+      address: 'bob@test.example',
+      events: ['mail.received'],
+      createdBy: 'bob@test.example',
+    });
+
+    // Alice sees only 1
+    const aliceRes = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    const aliceBody: any = await aliceRes.json();
+    expect(aliceBody.webhooks.length).toBe(1);
+    expect(aliceBody.webhooks[0].address).toBe('alice@test.example');
+    expect(aliceBody.webhooks[0].secret).toBeUndefined();
+
+    // Admin sees both
+    const adminRes = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    const adminBody: any = await adminRes.json();
+    expect(adminBody.webhooks.length).toBe(2);
+    expect(adminBody.webhooks[0].secret).toBeUndefined();
+    expect(adminBody.webhooks[1].secret).toBeUndefined();
+  });
+
+  test('POST /v1/webhooks/:id: Item 7: url change resets consecutiveFailures to 0 and state to unverified', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/v1',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+
+    updateWebhookSubscription(sub.id, (s) => {
+      s.consecutiveFailures = 5;
+      s.state = 'enabled';
+    });
+
+    const res = await app.request(`/v1/webhooks/${sub.id}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/v2',
+      }),
+    });
+    expect(res.status).toBe(200);
+    const body: any = await res.json();
+    expect(body.url).toBe('https://consumer.example/v2');
+    expect(body.consecutiveFailures).toBe(0);
+    expect(body.state).toBe('unverified');
+  });
+
+  test('POST /v1/webhooks/:id: Rule B: identity cannot change url if contentScope is preview', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'preview',
+      createdBy: 'admin',
+    });
+
+    const res = await app.request(`/v1/webhooks/${sub.id}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        url: 'https://attacker.example/hijack',
+      }),
+    });
+    expect(res.status).toBe(403);
+    const body: any = await res.json();
+    expect(body.error).toBe('content_scope_requires_admin');
+  });
+
+  test('GET /v1/webhooks/:id/secret: Rule D: only creator can reveal secret', async () => {
+    // Subscription created by admin for alice
+    const adminCreated = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'admin',
+    });
+
+    // Alice attempts to reveal secret -> forbidden (admin required)
+    const aliceRes = await app.request(`/v1/webhooks/${adminCreated.id}/secret`, {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(aliceRes.status).toBe(403);
+    expect(((await aliceRes.json()) as any).error).toBe('forbidden: admin key required');
+
+    // Admin can reveal
+    const adminRes = await app.request(`/v1/webhooks/${adminCreated.id}/secret`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(adminRes.status).toBe(200);
+    expect(adminRes.headers.get('Cache-Control')).toBe('no-store');
+    const adminBody: any = await adminRes.json();
+    expect(adminBody.secret).toMatch(/^whs_[a-f0-9]{64}$/);
+
+    // Subscription created by alice
+    const aliceCreated = createWebhookSubscription({
+      url: 'https://consumer.example/hook2',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'alice@test.example',
+    });
+
+    // Alice can reveal own created subscription
+    const aliceOwnRes = await app.request(`/v1/webhooks/${aliceCreated.id}/secret`, {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(aliceOwnRes.status).toBe(200);
+    expect(aliceOwnRes.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  test('DELETE /v1/webhooks/:id cancels pending retries with subscription_deleted and records audit event', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'alice@test.example',
+    });
+
+    const res = await app.request(`/v1/webhooks/${sub.id}`, {
+      method: 'DELETE',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(res.status).toBe(200);
+    expect(getWebhookSubscription(sub.id)).toBeUndefined();
+  });
+
+  test('POST /v1/webhooks/:id/rotate increments epoch and enforces overlap window', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'metadata',
+      createdBy: 'alice@test.example',
+    });
+
+    const res1 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(res1.status).toBe(200);
+    const body1: any = await res1.json();
+    expect(body1.epoch).toBe(1);
+    expect(body1.overlapUntil).toBeDefined();
+
+    // Second rotation without force fails with 409
+    const res2 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(res2.status).toBe(409);
+    expect(((await res2.json()) as any).error).toBe('rotation_window_open');
+
+    // Force rotation succeeds
+    const res3 = await app.request(`/v1/webhooks/${sub.id}/rotate?force=true`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(res3.status).toBe(200);
+    expect(((await res3.json()) as any).epoch).toBe(2);
+  });
+
+  test('POST /v1/webhooks/:id/test: 409 when disabled; executes probe when enabled', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+
+    // Disabled endpoint returns 409
+    updateWebhookSubscription(sub.id, (s) => {
+      s.state = 'disabled';
+      s.disabledReason = 'manual';
+    });
+
+    const disabledRes = await app.request(`/v1/webhooks/${sub.id}/test`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(disabledRes.status).toBe(409);
+    const disabledBody: any = await disabledRes.json();
+    expect(disabledBody.error).toBe('webhook_disabled');
+    expect(disabledBody.disabledReason).toBe('manual');
+  });
+
+  test('POST /v1/webhooks/:id/disable and /enable state transitions', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+
+    // Alice disables subscription
+    const disRes = await app.request(`/v1/webhooks/${sub.id}/disable`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(disRes.status).toBe(200);
+    expect(getWebhookSubscription(sub.id)?.state).toBe('disabled');
+    expect(getWebhookSubscription(sub.id)?.disabledReason).toBe('manual');
+
+    // Alice cannot enable (admin only)
+    const userEnableRes = await app.request(`/v1/webhooks/${sub.id}/enable`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(userEnableRes.status).toBe(403);
+
+    // Admin enables
+    const adminEnableRes = await app.request(`/v1/webhooks/${sub.id}/enable`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(adminEnableRes.status).toBe(200);
+    expect(getWebhookSubscription(sub.id)?.state).toBe('unverified');
+    expect(getWebhookSubscription(sub.id)?.disabledReason).toBeNull();
+  });
+
+  test('GET /v1/webhooks/:id/deliveries and POST /v1/webhooks/deliveries/:id/redeliver are admin-only', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+
+    // Alice cannot list deliveries
+    const userListRes = await app.request(`/v1/webhooks/${sub.id}/deliveries`, {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(userListRes.status).toBe(403);
+
+    // Admin can list deliveries
+    const adminListRes = await app.request(`/v1/webhooks/${sub.id}/deliveries`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(adminListRes.status).toBe(200);
+    const listBody: any = await adminListRes.json();
+    expect(Array.isArray(listBody.deliveries)).toBe(true);
+
+    // Seed a completed delivery row
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_orig_1',
+      runId: 'run_0',
+      deliveryId: 'dlv_target_1',
+      type: 'webhook.ping',
+      address: 'alice@test.example',
+      messageId: '101',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 1,
+      outcome: 'success',
+      status: 200,
+      durationMs: 50,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    });
+
+    // Alice cannot redeliver
+    const userRedeliver = await app.request('/v1/webhooks/deliveries/dlv_target_1/redeliver', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(userRedeliver.status).toBe(403);
+
+    // Admin can redeliver
+    const adminRedeliver = await app.request('/v1/webhooks/deliveries/dlv_target_1/redeliver', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(adminRedeliver.status).toBe(200);
+    const redeliverBody: any = await adminRedeliver.json();
+    expect(redeliverBody.ok).toBe(true);
+    expect(redeliverBody.deliveryId).toMatch(/^dlv_/);
+    expect(redeliverBody.eventId).toBe('evt_orig_1');
+  });
+
+  afterAll(async () => {
+    (config as any).dataDir = originalDataDir;
+    setWebhookDnsLookupForTests(undefined);
+    deliveryQueue.cancelAll();
+    await new Promise((r) => setTimeout(r, 50));
+    deliveryQueue.cancelAll();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+});

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -334,6 +334,83 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(adminBody.webhooks[1].secret).toBeUndefined();
   });
 
+  test('R7: GET /v1/webhooks is rate-limited and lastDelivery is filled from one log pass', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://alice.example/hook-last',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_last_1',
+      runId: 'run_0',
+      deliveryId: 'dlv_last_1',
+      type: 'mail.received',
+      address: 'alice@test.example',
+      messageId: '1',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 1,
+      outcome: 'success',
+      status: 200,
+      durationMs: 10,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    });
+
+    const listRes = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(listRes.status).toBe(200);
+    const listBody: any = await listRes.json();
+    expect(listBody.webhooks[0].lastDelivery.deliveryId).toBe('dlv_last_1');
+
+    const oldCreate = config.webhooks.rateCreatePerMin;
+    (config.webhooks as any).rateCreatePerMin = 1;
+    deliveryLimiter.reset();
+    try {
+      const first = await app.request('/v1/webhooks', {
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(first.status).toBe(200);
+      const second = await app.request('/v1/webhooks', {
+        headers: { Authorization: `Bearer ${aliceToken}` },
+      });
+      expect(second.status).toBe(429);
+      expect(((await second.json()) as any).error).toBe('rate_limited');
+      expect(second.headers.get('Retry-After')).toBeTruthy();
+    } finally {
+      (config.webhooks as any).rateCreatePerMin = oldCreate;
+      deliveryLimiter.reset();
+    }
+  });
+
+  test('R7: Idempotency-Key longer than 128 is rejected', async () => {
+    const res = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${adminKey}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'k'.repeat(129),
+      },
+      body: JSON.stringify({
+        url: 'https://consumer.example/hook-idemp-len',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(res.status).toBe(400);
+    expect(((await res.json()) as any).error).toBe('invalid_request');
+  });
+
   test('POST /v1/webhooks/:id: Item 7: url change resets consecutiveFailures to 0 and state to unverified', async () => {
     const sub = createWebhookSubscription({
       url: 'https://consumer.example/v1',

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -301,6 +301,52 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(body2.secret).toBeNull(); // Secret redacted on idempotency replay!
   });
 
+  test('R9: create idempotency replay is served before the create rate limiter', async () => {
+    const oldRate = config.webhooks.rateCreatePerMin;
+    (config.webhooks as any).rateCreatePerMin = 1;
+    deliveryLimiter.reset();
+    try {
+      const headers = {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+        'Idempotency-Key': 'idem-create-rate',
+      };
+      const body = JSON.stringify({
+        url: 'https://consumer.example/hook-idemp-rate',
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      });
+      const res1 = await app.request('/v1/webhooks', { method: 'POST', headers, body });
+      expect(res1.status).toBe(201);
+      const created: any = await res1.json();
+
+      const replay = await app.request('/v1/webhooks', { method: 'POST', headers, body });
+      expect(replay.status).toBe(201);
+      const replayed: any = await replay.json();
+      expect(replayed.id).toBe(created.id);
+      expect(replayed.secret).toBeNull();
+
+      const other = await app.request('/v1/webhooks', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Content-Type': 'application/json',
+          'Idempotency-Key': 'idem-create-rate-other',
+        },
+        body: JSON.stringify({
+          url: 'https://consumer.example/hook-idemp-rate-2',
+          address: 'alice@test.example',
+          events: ['mail.received'],
+        }),
+      });
+      expect(other.status).toBe(429);
+      expect(((await other.json()) as any).error).toBe('rate_limited');
+    } finally {
+      (config.webhooks as any).rateCreatePerMin = oldRate;
+      deliveryLimiter.reset();
+    }
+  });
+
   test('GET /v1/webhooks: admin lists all; identity lists only own; never leaks secret', async () => {
     createWebhookSubscription({
       url: 'https://alice.example/hook',
@@ -441,6 +487,78 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(body.state).toBe('unverified');
   });
 
+  test('R9: url change resurrects threshold/refused disablement but keeps manual pause', async () => {
+    const threshold = createWebhookSubscription({
+      url: 'https://consumer.example/threshold-v1',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    updateWebhookSubscription(threshold.id, (s) => {
+      s.state = 'disabled';
+      s.disabledReason = 'threshold';
+      s.consecutiveFailures = 10;
+    });
+    const thresholdRes = await app.request(`/v1/webhooks/${threshold.id}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url: 'https://consumer.example/threshold-v2' }),
+    });
+    expect(thresholdRes.status).toBe(200);
+    const thresholdBody: any = await thresholdRes.json();
+    expect(thresholdBody.state).toBe('unverified');
+    expect(thresholdBody.disabledReason).toBeNull();
+    expect(thresholdBody.consecutiveFailures).toBe(0);
+
+    const refused = createWebhookSubscription({
+      url: 'https://consumer.example/refused-v1',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    updateWebhookSubscription(refused.id, (s) => {
+      s.state = 'disabled';
+      s.disabledReason = 'refused';
+    });
+    const refusedRes = await app.request(`/v1/webhooks/${refused.id}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url: 'https://consumer.example/refused-v2' }),
+    });
+    expect(refusedRes.status).toBe(200);
+    expect(((await refusedRes.json()) as any).state).toBe('unverified');
+
+    const manual = createWebhookSubscription({
+      url: 'https://consumer.example/manual-v1',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    updateWebhookSubscription(manual.id, (s) => {
+      s.state = 'disabled';
+      s.disabledReason = 'manual';
+    });
+    const manualRes = await app.request(`/v1/webhooks/${manual.id}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ url: 'https://consumer.example/manual-v2' }),
+    });
+    expect(manualRes.status).toBe(200);
+    const manualBody: any = await manualRes.json();
+    expect(manualBody.state).toBe('disabled');
+    expect(manualBody.disabledReason).toBe('manual');
+    expect(getWebhookSubscription(manual.id)?.url).toBe('https://consumer.example/manual-v2');
+  });
+
   test('POST /v1/webhooks/:id: Rule B: identity cannot change url if contentScope is preview', async () => {
     const sub = createWebhookSubscription({
       url: 'https://consumer.example/hook',
@@ -551,10 +669,19 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(res2.status).toBe(409);
     expect(((await res2.json()) as any).error).toBe('rotation_window_open');
 
-    // Force rotation succeeds
-    const res3 = await app.request(`/v1/webhooks/${sub.id}/rotate?force=true`, {
+    const queryForce = await app.request(`/v1/webhooks/${sub.id}/rotate?force=true`, {
       method: 'POST',
       headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(queryForce.status).toBe(409);
+
+    const res3 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aliceToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ force: true }),
     });
     expect(res3.status).toBe(200);
     expect(((await res3.json()) as any).epoch).toBe(2);
@@ -683,6 +810,108 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(redeliverBody.ok).toBe(true);
     expect(redeliverBody.deliveryId).toMatch(/^dlv_/);
     expect(redeliverBody.eventId).toBe('evt_orig_1');
+  });
+
+  test('R9: redeliver rejects non-terminal rows with 409', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-redeliver',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'alice@test.example',
+    });
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_pending_replay',
+      runId: 'run_0',
+      deliveryId: 'dlv_pending_replay',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 1,
+      outcome: 'pending',
+      status: null,
+      durationMs: null,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(Date.now() + 5000).toISOString(),
+      reason: null,
+    });
+    const pendingRes = await app.request('/v1/webhooks/deliveries/dlv_pending_replay/redeliver', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(pendingRes.status).toBe(409);
+    expect(((await pendingRes.json()) as any).error).toBe('delivery_not_replayable');
+
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_retryable_replay',
+      runId: 'run_0',
+      deliveryId: 'dlv_retryable_replay',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 1,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 10,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: new Date(Date.now() + 5000).toISOString(),
+      reason: 'server_error',
+    });
+    const retryableRes = await app.request(
+      '/v1/webhooks/deliveries/dlv_retryable_replay/redeliver',
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${adminKey}` },
+      },
+    );
+    expect(retryableRes.status).toBe(409);
+
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_ping_cap_replay',
+      runId: 'run_0',
+      deliveryId: 'dlv_ping_cap_replay',
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 3,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 10,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: 'server_error',
+    });
+    const capRes = await app.request('/v1/webhooks/deliveries/dlv_ping_cap_replay/redeliver', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(capRes.status).toBe(200);
   });
 
   test('R2 Item 1 & Item 2: OAuth tokens cannot DELETE or reveal secret', async () => {
@@ -829,9 +1058,13 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
       });
       expect(replay.status).toBe(200);
 
-      const res2 = await app.request(`/v1/webhooks/${sub.id}/rotate?force=true`, {
+      const res2 = await app.request(`/v1/webhooks/${sub.id}/rotate`, {
         method: 'POST',
-        headers: { Authorization: `Bearer ${aliceToken}` },
+        headers: {
+          Authorization: `Bearer ${aliceToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ force: true }),
       });
       expect(res2.status).toBe(429);
       expect(((await res2.json()) as any).error).toBe('rate_limited');

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -234,6 +234,33 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
       }),
     });
     expect(duplicateEvents.status).toBe(400);
+
+    const overlongUrl = `https://consumer.example/${'a'.repeat(2048)}`;
+    const overlongCreate = await app.request('/v1/webhooks', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        url: overlongUrl,
+        address: 'alice@test.example',
+        events: ['mail.received'],
+      }),
+    });
+    expect(overlongCreate.status).toBe(400);
+    expect(((await overlongCreate.json()) as any).error).toBe('invalid_request');
+
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'admin',
+    });
+    const overlongUpdate = await app.request(`/v1/webhooks/${sub.id}`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url: overlongUrl }),
+    });
+    expect(overlongUpdate.status).toBe(400);
+    expect(((await overlongUpdate.json()) as any).error).toBe('invalid_request');
   });
 
   test('POST /v1/webhooks: idempotency key returns stored 201 response with secret: null', async () => {

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -5,7 +5,6 @@ process.env.IMAP_PASS = 'test-only';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'test-only';
 process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
-process.env.WEBHOOKS_ENABLED = 'true';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
@@ -583,6 +582,8 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
 
   afterAll(async () => {
     (config as any).dataDir = originalDataDir;
+    (config.webhooks as any).enabled = false;
+    delete process.env.WEBHOOKS_ENABLED;
     setWebhookDnsLookupForTests(undefined);
     deliveryQueue.cancelAll();
     await new Promise((r) => setTimeout(r, 50));

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -34,6 +34,7 @@ const {
   putAccessTokenForTests,
   resetOAuthStoreCacheForTests,
 } = await import('../src/lib/oauth-store.ts');
+const { readAuditEvents } = await import('../src/lib/audit.ts');
 
 const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhooks-route');
 const originalDataDir = config.dataDir;
@@ -705,6 +706,128 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(userFilterRes.status).toBe(403);
     const userBody: any = await userFilterRes.json();
     expect(userBody.error).toBe('forbidden: admin key required');
+  });
+
+  test('P2-7a: GET /v1/webhooks/:id/deliveries returns 400 on invalid ?limit query parameter', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-limit-test',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'admin',
+    });
+
+    // NaN limit
+    const resAbc = await app.request(`/v1/webhooks/${sub.id}/deliveries?limit=abc`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(resAbc.status).toBe(400);
+    const bodyAbc: any = await resAbc.json();
+    expect(bodyAbc.error).toBe('invalid_request');
+
+    // Negative limit
+    const resNeg = await app.request(`/v1/webhooks/${sub.id}/deliveries?limit=-5`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(resNeg.status).toBe(400);
+
+    // Zero limit
+    const resZero = await app.request(`/v1/webhooks/${sub.id}/deliveries?limit=0`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(resZero.status).toBe(400);
+
+    // Float limit
+    const resFloat = await app.request(`/v1/webhooks/${sub.id}/deliveries?limit=2.5`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(resFloat.status).toBe(400);
+
+    // Valid positive integer limit
+    const resValid = await app.request(`/v1/webhooks/${sub.id}/deliveries?limit=5`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(resValid.status).toBe(200);
+    const bodyValid: any = await resValid.json();
+    expect(Array.isArray(bodyValid.deliveries)).toBe(true);
+  });
+
+  test('P2-2: POST /v1/webhooks/deliveries/:id/redeliver refuses redelivery when uidValidity is null', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-drift-test',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      createdBy: 'admin',
+    });
+
+    // Seed a mail.received delivery with uidValidity === null
+    const deliveryId = `dlv_drift_${Date.now()}`;
+    appendDeliveryLogRow({
+      ts: new Date().toISOString(),
+      webhookId: sub.id,
+      eventId: 'evt_drift_1',
+      runId: 'run_0',
+      deliveryId,
+      type: 'mail.received',
+      address: 'alice@test.example',
+      messageId: '555',
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date().toISOString(),
+      attempt: 1,
+      outcome: 'permanent',
+      status: 500,
+      durationMs: 50,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: 'test_seed',
+    });
+
+    // Attempting redelivery must fail closed with 409 uidvalidity_required
+    const res = await app.request(`/v1/webhooks/deliveries/${deliveryId}/redeliver`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(res.status).toBe(409);
+    const body: any = await res.json();
+    expect(body.error).toBe('uidvalidity_required');
+  });
+
+  test('P2-7b: POST /v1/webhooks/:id/test records audit outcome error (not denied) on non-auth failure', async () => {
+    const sub = createWebhookSubscription({
+      url: 'https://consumer.example/hook-probe-fail',
+      address: 'alice@test.example',
+      events: ['webhook.ping'],
+      createdBy: 'admin',
+    });
+
+    // Simulate network/dns failure for probe
+    setWebhookDnsLookupForTests(async () => {
+      const err: any = new Error('getaddrinfo ENOTFOUND');
+      err.code = 'ENOTFOUND';
+      throw err;
+    });
+
+    const probeRes = await app.request(`/v1/webhooks/${sub.id}/test`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(probeRes.status).toBe(200);
+    const body: any = await probeRes.json();
+    expect(body.outcome).toBe('retryable');
+    expect(body.reason).toBe('dns_error');
+
+    // Audit event must record outcome: 'error', NOT 'denied'
+    const auditEvents = readAuditEvents({ event: 'webhook.test', limit: 5 });
+    const latestEvent = auditEvents.find((e) => e.webhookId === sub.id);
+    expect(latestEvent).toBeDefined();
+    expect(latestEvent?.outcome).toBe('error');
+
+    // Reset DNS lookup for next tests
+    setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -637,6 +637,34 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(aliceRes.status).toBe(403);
     expect(((await aliceRes.json()) as any).error).toBe('forbidden: admin key required');
 
+    // 验证 403 分支 1 记录 webhook.reveal outcome=denied 审计 (§10.6)
+    const audit1 = readAuditEvents({ event: 'webhook.reveal', limit: 10 }).find(
+      (e) => e.webhookId === adminCreated.id && e.outcome === 'denied',
+    );
+    expect(audit1).toBeDefined();
+    expect(audit1?.address).toBe('alice@test.example');
+
+    // Preview 订阅（contentScope: 'preview'），即使 createdBy 匹配，身份令牌重显也必须 403 并记审计
+    const previewSub = createWebhookSubscription({
+      url: 'https://consumer.example/preview-hook',
+      address: 'alice@test.example',
+      events: ['mail.received'],
+      contentScope: 'preview',
+      createdBy: 'alice@test.example',
+    });
+    const alicePreviewRes = await app.request(`/v1/webhooks/${previewSub.id}/secret`, {
+      headers: { Authorization: `Bearer ${aliceToken}` },
+    });
+    expect(alicePreviewRes.status).toBe(403);
+    expect(((await alicePreviewRes.json()) as any).error).toBe('content_scope_requires_admin');
+
+    // 验证 403 分支 2 记录 webhook.reveal outcome=denied 审计 (§10.6)
+    const audit2 = readAuditEvents({ event: 'webhook.reveal', limit: 10 }).find(
+      (e) => e.webhookId === previewSub.id && e.outcome === 'denied',
+    );
+    expect(audit2).toBeDefined();
+    expect(audit2?.address).toBe('alice@test.example');
+
     // Admin can reveal
     const adminRes = await app.request(`/v1/webhooks/${adminCreated.id}/secret`, {
       headers: { Authorization: `Bearer ${adminKey}` },

--- a/packages/mcp/test/tools.test.ts
+++ b/packages/mcp/test/tools.test.ts
@@ -64,6 +64,11 @@ test("#56/#58 tools registry/schema metadata", () => {
     "task_claim",
     "task_renew",
     "task_release",
+    "mail_webhook_list",
+    "mail_webhook_create",
+    "mail_webhook_delete",
+    "mail_webhook_test",
+    "mail_webhook_disable",
   ];
   const missingLeaseTools = ["task_claim", "task_renew", "task_release"].filter(
     (name) => !toolConfigs.has(name),


### PR DESCRIPTION
Part of #128

### Overview
Implements the Outbound Webhook Subsystem according to RFC-0001 and followup rulings 2-9.

### Follow-up Items (2–9)
- **Item 2** (§8.2): Deferred delivery hitting 72h horizon transitions to terminal outcome `permanent` and reason `retry_horizon_exceeded`.
- **Item 3** (§10.6): Background `webhook.ssrf_refused` audit row omits `ip`.
- **Item 4** (§10.3, §10.7): `description <= 1000` chars enforced in create and update schemas.
- **Item 5** (§8.6): `rfc822MessageId <= 512` bytes, overlong treated as null (dead-letter fallback).
- **Item 6** (§10.5): Identity cascade performs hard-delete on subscriptions, records `webhook.delete` audit events, and cancels in-flight retries with `subscription_deleted`.
- **Item 7** (§10.3): URL change resets `consecutiveFailures = 0`, sets `state = unverified`, and fires a creation ping; manual `disabled` state remains disabled.
- **Item 8** (§10.3): `events` must be non-empty and unique (zod validation rejects duplicates/empty).
- **Item 9** (§8.6): Approval delivery log row persists `taskCreatedAt` + `expiresInSec` (+ `taskId`), boot reconstruction reuses exact values without clock drift.

### Subsystem Components
1. **Config Layer** (`packages/api/src/lib/config.ts`): All `WEBHOOK_*` env vars and boot validations (R1 fail-closed guard, port CSV parsing, payload bounding, public edge coercion).
2. **Storage Layer** (`packages/api/src/lib/webhook-store.ts`): 0600 file mode, atomic tmp+rename, fail-closed latch, forbidden secret key guard, idempotency records, cascade delete.
3. **Signing Layer** (`packages/api/src/lib/webhook-signing.ts`): Deterministic HMAC-SHA256 derived keys (`whs_<hex>`), dual-signature overlap for epoch rotation and root rotation (`WEBHOOK_SIGNING_SECRET_PREVIOUS`).
4. **Delivery Engine** (`packages/api/src/lib/webhook-delivery.ts`): 11 attempts over 72h with jitter, circuit breaker (threshold 10), durable JSONL delivery log with compaction, and boot reconstruction.
5. **Dispatcher Sink** (`packages/api/src/lib/webhook-sink.ts`): Registered in `startNotificationWatcher` (`notification-watcher.ts`), approval payloads trimmed to §6.3 schema.
6. **Identity Cascade** (`packages/api/src/lib/identities.ts`): Wired into `deleteIdentity`.
7. **REST API** (`packages/api/src/routes/webhooks.ts`): Mounted at `/v1/webhooks` with OAuth mutation protection and rate limiting.
8. **MCP Tools** (`packages/api/src/mcp/tools.ts`): 5 tools (`mail_webhook_create` [critical], `mail_webhook_delete` [minimal], `mail_webhook_disable` [minimal], `mail_webhook_test` [contained], `mail_webhook_list` [read]).
9. **RFC Documentation** (`docs/rfcs/0001-outbound-webhooks.md`): Updated to match items 2–9.

### §14 Test Matrix Coverage
- **item 1**: Public test vectors (`test/fixtures/webhook-signature-vectors.v1.json`) verified by JS and independent Python verifier (`scripts/verify-webhook-signature-vectors.py`).
- **items 3, 5-16**: Delivery outcomes, storage 0600 and fail-closed, payload bounding, authorization matrix and OAuth rejection, idempotency, approval emission, non-blocking hand-off, circuit breaker state machine, boot rules, boot reconstruction, and secret rotation overlap.
- **Dark landing**: `WEBHOOKS_ENABLED` defaults to `false`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added outbound webhook subscriptions for mail and approval events.
  * Added API and tool operations to manage, test, enable, disable, rotate, and delete webhooks.
  * Added signed webhook requests with key-rotation support.
  * Added delivery history, manual redelivery, durable retries, and automatic dead-lettering after 72 hours.
* **Security**
  * Added URL validation, private-target protection, rate limits, payload limits, and access controls.
* **Reliability**
  * Webhook state and pending deliveries are restored safely after restarts.
  * Added circuit-breaker handling and safer recovery from delivery and storage failures.
  * Identity deletion now removes associated webhook subscriptions and cancels pending deliveries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->