### PR TITLE
fix(test): isolate DATA_DIR, reset fail-closed store, and clear maintenance timers across test files

### DIFF
--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -757,7 +757,10 @@ export function compactDeliveryLog(
   adoptDeliveryLogIndex(retainedRows);
 }
 
+let maintenanceTimer: ReturnType<typeof setTimeout> | undefined;
+
 export function startWebhookMaintenance(): void {
+  stopWebhookMaintenance();
   const tick = () => {
     try {
       compactDeliveryLog();
@@ -771,13 +774,20 @@ export function startWebhookMaintenance(): void {
     const d = new Date();
     const next = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1);
     const delay = Math.max(1_000, next - Date.now());
-    const timer = setTimeout(() => {
+    maintenanceTimer = setTimeout(() => {
       tick();
       schedule();
     }, delay);
-    timer.unref?.();
+    maintenanceTimer.unref?.();
   };
   schedule();
+}
+
+export function stopWebhookMaintenance(): void {
+  if (maintenanceTimer) {
+    clearTimeout(maintenanceTimer);
+    maintenanceTimer = undefined;
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1563,6 +1573,7 @@ class WebhookDeliveryQueue {
     this.activeTimers.clear();
     this.jobs.clear();
     cancelReconstructionRetries();
+    stopWebhookMaintenance();
   }
 
   isJobQueued(webhookId: string, eventId: string, runId: string): boolean {
@@ -2605,7 +2616,7 @@ export function pendingReconstructionRetryCount(): number {
   return reconstructRetryTimers.size;
 }
 
-function cancelReconstructionRetries(): void {
+export function cancelReconstructionRetries(): void {
   for (const timer of reconstructRetryTimers.values()) {
     clearTimeout(timer);
   }

--- a/packages/api/test/send-history.test.ts
+++ b/packages/api/test/send-history.test.ts
@@ -11,10 +11,9 @@ process.env.IMAP_USER = 'agent@test.example';
 process.env.IMAP_PASS = 'imap-secret';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
-const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-sendhist-'));
-process.env.DATA_DIR = TEST_DATA_DIR;
-process.env.TASK_SIGNING_SECRET = 'send-history-test-secret';
-process.env.UI_ENABLED = 'true';
+const originalEnvDataDir = process.env.DATA_DIR;
+const originalEnvTaskSecret = process.env.TASK_SIGNING_SECRET;
+const originalEnvUiEnabled = process.env.UI_ENABLED;
 
 const sendMail = mock(async () => ({ messageId: '<hist@test.example>' }));
 mock.module('../src/lib/smtp.ts', () => ({ sendMail }));
@@ -22,7 +21,16 @@ mock.module('../src/lib/smtp.ts', () => ({ sendMail }));
 const { afterAll, afterEach, beforeEach, describe, expect, test } = await import('bun:test');
 const { config } = await import('../src/lib/config.ts');
 const originalDataDir = config.dataDir;
+const originalTaskSigningSecret = config.taskSigningSecret;
+const originalUiEnabled = config.uiEnabled;
+
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-sendhist-'));
+process.env.DATA_DIR = TEST_DATA_DIR;
+process.env.TASK_SIGNING_SECRET = 'send-history-test-secret';
+process.env.UI_ENABLED = 'true';
 (config as any).dataDir = TEST_DATA_DIR;
+(config as any).taskSigningSecret = 'send-history-test-secret';
+(config as any).uiEnabled = true;
 
 const { createIdentity } = await import('../src/lib/identities.ts');
 const { sendRoute } = await import('../src/routes/send.ts');
@@ -77,7 +85,30 @@ afterEach(() => {
 });
 
 afterAll(() => {
-  (config as any).dataDir = originalDataDir;
+  if (originalDataDir && originalDataDir !== TEST_DATA_DIR) {
+    (config as any).dataDir = originalDataDir;
+  } else {
+    (config as any).dataDir = './data';
+  }
+  (config as any).taskSigningSecret = originalTaskSigningSecret;
+  (config as any).uiEnabled = originalUiEnabled;
+
+  if (originalEnvDataDir !== undefined) {
+    process.env.DATA_DIR = originalEnvDataDir;
+  } else {
+    delete process.env.DATA_DIR;
+  }
+  if (originalEnvTaskSecret !== undefined) {
+    process.env.TASK_SIGNING_SECRET = originalEnvTaskSecret;
+  } else {
+    delete process.env.TASK_SIGNING_SECRET;
+  }
+  if (originalEnvUiEnabled !== undefined) {
+    process.env.UI_ENABLED = originalEnvUiEnabled;
+  } else {
+    delete process.env.UI_ENABLED;
+  }
+
   try {
     rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   } catch {

--- a/packages/api/test/send-history.test.ts
+++ b/packages/api/test/send-history.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, rmSync, statSync } from 'node:fs';
 import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -11,14 +11,19 @@ process.env.IMAP_USER = 'agent@test.example';
 process.env.IMAP_PASS = 'imap-secret';
 process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'smtp-secret';
-process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-sendhist-'));
+const TEST_DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-sendhist-'));
+process.env.DATA_DIR = TEST_DATA_DIR;
 process.env.TASK_SIGNING_SECRET = 'send-history-test-secret';
 process.env.UI_ENABLED = 'true';
 
 const sendMail = mock(async () => ({ messageId: '<hist@test.example>' }));
 mock.module('../src/lib/smtp.ts', () => ({ sendMail }));
 
-const { afterEach, beforeEach, describe, expect, test } = await import('bun:test');
+const { afterAll, afterEach, beforeEach, describe, expect, test } = await import('bun:test');
+const { config } = await import('../src/lib/config.ts');
+const originalDataDir = config.dataDir;
+(config as any).dataDir = TEST_DATA_DIR;
+
 const { createIdentity } = await import('../src/lib/identities.ts');
 const { sendRoute } = await import('../src/routes/send.ts');
 const { createUiApiRoutes } = await import('../src/routes/ui.ts');
@@ -27,7 +32,6 @@ const { resetSendLogForTests, sendLogAlertsForTests, sendLogPathForTests } =
   await import('../src/lib/send-log.ts');
 const { macForMcpSendSource, SEND_SOURCE_MAC_HEADER } = await import('../src/lib/send-source.ts');
 const { OpenAgentEmailClient } = await import('../src/mcp/client.ts');
-const { config } = await import('../src/lib/config.ts');
 const { resetRateLimits } = await import('../src/lib/ratelimit.ts');
 const { readFileSync: readSrc } = await import('node:fs');
 
@@ -70,6 +74,15 @@ beforeEach(() => {
 
 afterEach(() => {
   resetSendLogForTests();
+});
+
+afterAll(() => {
+  (config as any).dataDir = originalDataDir;
+  try {
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
 });
 
 describe('send history ACL and audit', () => {
@@ -206,6 +219,9 @@ describe('send history ACL and audit', () => {
     expect(good.status).toBe(200);
     expect((await app.request(`/v1/send/history?address=${fox.identity.address}`).then((r) => r.json()))
       .items[0]?.source).toBe('mcp');
+
+    // Advance clock so the second send has a strictly newer sentAt timestamp
+    await new Promise((r) => setTimeout(r, 10));
 
     await app.request('/v1/send', {
       method: 'POST',

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -39,6 +39,7 @@ const {
   setWebhookDnsLookupForTests,
   pendingReconstructionRetryCount,
   countsTowardCircuitBreaker,
+  stopWebhookMaintenance,
   validateWebhookUrlResolution,
   validateWebhookUrlStatic,
 } = await import('../src/lib/webhook-delivery.ts');
@@ -48,6 +49,7 @@ const {
   createWebhookSubscription,
   deleteWebhookSubscription,
   getWebhookSubscription,
+  resetWebhooksStoreForTests,
   setWebhooksFailClosedForTests,
   updateWebhookSubscription,
 } = await import('../src/lib/webhook-store.ts');
@@ -71,11 +73,13 @@ function setupTestDir(): void {
   (config.webhooks as any).payloadMaxBytes = 16384;
   (config.webhooks as any).codeEntryChars = 200;
   (config as any).oaePublicEdge = false;
+  resetWebhooksStoreForTests();
   setWebhooksFailClosedForTests(false);
   setReconstructRetryDelaysForTests();
   resetDeliveryLogIndexForTests();
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
+  stopWebhookMaintenance();
 }
 
 async function waitUntil(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
@@ -1824,10 +1828,12 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
   });
 
   afterAll(async () => {
+    resetWebhooksStoreForTests();
     (config as any).dataDir = originalDataDir;
     (config.webhooks as any).enabled = false;
     delete process.env.WEBHOOKS_ENABLED;
     deliveryQueue.cancelAll();
+    stopWebhookMaintenance();
     await new Promise((r) => setTimeout(r, 50));
     deliveryQueue.cancelAll();
     rmSync(TEST_DATA_DIR, { recursive: true, force: true });

--- a/packages/api/test/webhook-mcp.test.ts
+++ b/packages/api/test/webhook-mcp.test.ts
@@ -24,6 +24,10 @@ const {
   deleteIdentity,
 } = await import('../src/lib/identities.ts');
 const {
+  resetWebhooksStoreForTests,
+  setWebhooksFailClosedForTests,
+} = await import('../src/lib/webhook-store.ts');
+const {
   putAccessTokenForTests,
   resetOAuthStoreCacheForTests,
 } = await import('../src/lib/oauth-store.ts');
@@ -56,6 +60,8 @@ function setupTestDir(): void {
   (config.webhooks as any).rateTestPerMin = 3;
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
+  resetWebhooksStoreForTests();
+  setWebhooksFailClosedForTests(false);
   setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
 
   const alice = createIdentity({ localpart: 'alice', domain: 'test.example' });
@@ -110,6 +116,7 @@ describe('Webhook MCP Tools & Tool Tiers (§10.7, D17)', () => {
   afterEach(() => {
     setWebhookDnsLookupForTests(undefined);
     deliveryQueue.cancelAll();
+    resetWebhooksStoreForTests();
     rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   });
 
@@ -230,6 +237,7 @@ describe('Webhook MCP Tools & Tool Tiers (§10.7, D17)', () => {
   });
 
   afterAll(async () => {
+    resetWebhooksStoreForTests();
     (config as any).dataDir = originalDataDir;
     (config.webhooks as any).enabled = false;
     delete process.env.WEBHOOKS_ENABLED;

--- a/packages/api/test/webhook-sink.test.ts
+++ b/packages/api/test/webhook-sink.test.ts
@@ -19,6 +19,7 @@ const {
 } = await import('../src/lib/webhook-delivery.ts');
 const {
   createWebhookSubscription,
+  resetWebhooksStoreForTests,
   setWebhooksFailClosedForTests,
 } = await import('../src/lib/webhook-store.ts');
 const { isSinkServiceFailure } = await import('../src/lib/event-dispatcher.ts');
@@ -35,6 +36,7 @@ function setupTestDir(): void {
   (config.webhooks as any).enabled = true;
   (config as any).taskSigningSecret = '01234567890123456789012345678901';
   (config.webhooks as any).signingSecret = '01234567890123456789012345678901';
+  resetWebhooksStoreForTests();
   setWebhooksFailClosedForTests(false);
   deliveryQueue.cancelAll();
 }
@@ -43,6 +45,7 @@ describe('webhook-sink: Dispatcher Sink Wiring (§11.4, §6.2, §6.3, Item 9)', 
   beforeEach(setupTestDir);
   afterEach(() => {
     deliveryQueue.cancelAll();
+    resetWebhooksStoreForTests();
     rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   });
 
@@ -211,6 +214,7 @@ describe('webhook-sink: Dispatcher Sink Wiring (§11.4, §6.2, §6.3, Item 9)', 
   });
 
   afterAll(async () => {
+    resetWebhooksStoreForTests();
     (config as any).dataDir = originalDataDir;
     (config.webhooks as any).enabled = false;
     delete process.env.WEBHOOKS_ENABLED;

--- a/packages/api/test/webhook-store.test.ts
+++ b/packages/api/test/webhook-store.test.ts
@@ -7,8 +7,8 @@ process.env.SMTP_PASS = 'test-only';
 process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { existsSync, mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const { config } = await import('../src/lib/config.ts');
@@ -34,13 +34,28 @@ const {
   WEBHOOK_IDEMPOTENCY_MAX_RECORDS,
 } = await import('../src/lib/webhook-store.ts');
 
+const TEST_DATA_DIR = join(import.meta.dir, 'tmp-webhook-store');
+const originalDataDir = config.dataDir;
+
+function setupTestDir(): void {
+  rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  mkdirSync(TEST_DATA_DIR, { recursive: true, mode: 0o700 });
+  (config as any).dataDir = TEST_DATA_DIR;
+  resetWebhooksStoreForTests();
+}
+
 describe('webhook-store storage conventions (§10.5, §14 item 5)', () => {
-  beforeEach(() => {
-    resetWebhooksStoreForTests();
-  });
+  beforeEach(setupTestDir);
 
   afterEach(() => {
     resetWebhooksStoreForTests();
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
+  });
+
+  afterAll(() => {
+    resetWebhooksStoreForTests();
+    (config as any).dataDir = originalDataDir;
+    rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   });
 
   test('creates 0600 file in 0700 dir, stores and retrieves subscriptions', () => {

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -24,6 +24,8 @@ const {
   createWebhookSubscription,
   getWebhookSubscription,
   listWebhookSubscriptions,
+  resetWebhooksStoreForTests,
+  setWebhooksFailClosedForTests,
   updateWebhookSubscription,
 } = await import('../src/lib/webhook-store.ts');
 const {
@@ -60,6 +62,8 @@ function setupTestDir(): void {
   (config.webhooks as any).maxPerAddress = 4;
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
+  resetWebhooksStoreForTests();
+  setWebhooksFailClosedForTests(false);
   setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
 
   // Create test identities
@@ -88,6 +92,7 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
   afterEach(() => {
     setWebhookDnsLookupForTests(undefined);
     deliveryQueue.cancelAll();
+    resetWebhooksStoreForTests();
     rmSync(TEST_DATA_DIR, { recursive: true, force: true });
   });
 
@@ -1336,6 +1341,7 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
   });
 
   afterAll(async () => {
+    resetWebhooksStoreForTests();
     (config as any).dataDir = originalDataDir;
     (config.webhooks as any).enabled = false;
     delete process.env.WEBHOOKS_ENABLED;


### PR DESCRIPTION
### Summary
Fixes main CI flakiness / cross-test pollution that broke on commit fc07337 after PR #145 merge:
1. **Isolated `DATA_DIR` across tests**:
   - `webhook-store.test.ts` now uses an isolated `tmp-webhook-store` directory and properly sets/restores `config.dataDir` to prevent leaving corrupt `webhooks.json` or `.failclosed` markers in repo `./data`.
   - `send-history.test.ts` binds `(config as any).dataDir = TEST_DATA_DIR` at import time and restores in `afterAll`, preventing writes to repo `./data/identities.json`.
2. **Fail-Closed Store & Latch Reset**:
   - Webhook test suites (`webhook-store`, `webhook-delivery`, `webhook-mcp`, `webhook-sink`, `webhooks-route`) explicitly invoke `resetWebhooksStoreForTests()` and `setWebhooksFailClosedForTests(false)` in `beforeEach`, `afterEach`, and `afterAll` to ensure fail-closed memory latches never bleed across test boundaries.
3. **Timer & Maintenance Lifecycle Cleanup**:
   - `startWebhookMaintenance()` unref'd timer is tracked via `maintenanceTimer` and cancellable via exported `stopWebhookMaintenance()`.
   - Wired `stopWebhookMaintenance()` into `deliveryQueue.cancelAll()`.
   - Exported `cancelReconstructionRetries()` and ensured timers are cleared between tests.
4. **Deterministic Send-Log Ordering**:
   - In `send-history.test.ts`, added a 10ms clock advancement between successive sends in the MAC audit test to prevent same-millisecond tuple tie-breakers from flipping the expected audit record source order.

### Verification
- Full test suite ran 3 consecutive times locally with 1404 pass, 0 fail.
- All linter and publication checks passed (`check:approval-publication`, `lint:ui`, `build`).
- Mail security shell suite 54/54 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Webhook maintenance can now be stopped cleanly, preventing scheduled work from continuing after webhook delivery is cancelled.
  - Starting webhook maintenance now replaces any existing maintenance schedule instead of creating overlapping schedules.

- **Tests**
  - Improved test isolation by resetting webhook state and using temporary data directories.
  - Added cleanup for maintenance timers and temporary test data.
  - Improved send-history test reliability by ensuring distinct send timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->