### PR TITLE
feat(ui): one-time exchange code flow for ?token= login hardening (#132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,9 +186,12 @@ rotate tokens, and delete identities directly from the overview table.
 
 The browser exchanges the token once for an `HttpOnly` session cookie; manually
 pasted tokens never enter the URL or browser storage. You can also bookmark
-`https://myinstance:3100/ui?token=<admin-token>` for direct login; the token is
-immediately stripped from the address bar via `history.replaceState` on load,
-though tokens passed in URLs can linger in browser history and server access logs.
+`https://myinstance:3100/ui?token=<admin-token>` for direct login. The server
+automatically issues a single-use exchange code (TTL ≤ 10 min) via a 302 redirect
+and sanitizes the URL with `Cache-Control: no-store` and `Referrer-Policy: no-referrer`,
+followed by client `history.replaceState` cleanup. Tokens passed in URLs can still linger
+in upstream reverse proxy access logs before redirection — see `docs/security.md` for
+reverse-proxy scrubbing guidance.
 Percent-encode the token if it contains URL-reserved characters like `+`, `&`, or `#`
 (e.g. `a+b` → `a%2Bb`), as `+` decodes to a space and `&` truncates the value.
 Only open `?token=` links you generated yourself; if you suspect a link has leaked,

--- a/docs/security.md
+++ b/docs/security.md
@@ -367,7 +367,7 @@ mail.example.com {
 
 #### 4. Traefik
 
-在 Traefik 中配置访问日志红线屏蔽：
+在 Traefik 中配置访问日志红线屏蔽。**注意**：Traefik 访问日志原生暂不支持针对特定 query 参数（如 `token`、`code`）进行细粒度正则脱敏。在 `fields.defaultMode: keep` 下，`RequestPath` 与 `RequestLine` 会完整记录包含 query 的原始 URL。因此反代配置必须显式将包含 query 的字段设为 `drop` 或 `redact`（若需审计访问路径，建议借助 Vector/Fluentd 等日志收集端对 JSON accessLog 进行正则脱敏）：
 
 ```yaml
 accessLog:
@@ -378,6 +378,11 @@ accessLog:
       - "200-599"
   fields:
     defaultMode: keep
+    names:
+      # RequestPath 与 RequestLine 包含原始 query 字符串（含 token/code），必须丢弃或脱敏
+      RequestPath: drop
+      RequestLine: drop
+      ClientUsername: drop
     headers:
       defaultMode: keep
       names:

--- a/docs/security.md
+++ b/docs/security.md
@@ -339,7 +339,7 @@ server {
 
 #### 2. Caddy
 
-在 Caddyfile 中使用 `format filter` 屏蔽 `token` 与 `code`：
+在 Caddyfile 中使用 `format filter` 与 `request>uri query` 屏蔽 `token` 与 `code` 查询参数：
 
 ```caddy
 mail.example.com {
@@ -348,16 +348,29 @@ mail.example.com {
         format filter {
             wrap json
             fields {
-                uri replace \?token=[^&]+ ?token=[REDACTED]
-                uri replace &token=[^&]+ &token=[REDACTED]
-                uri replace \?code=[^&]+ ?code=[REDACTED]
-                uri replace &code=[^&]+ &code=[REDACTED]
+                request>uri query {
+                    replace token REDACTED
+                    replace code REDACTED
+                }
             }
         }
     }
 
     reverse_proxy 127.0.0.1:3100
 }
+```
+
+> **可选（完全删除参数）**：如果希望在日志中完全移除这两个参数而不是替换为 `REDACTED`，可将 `replace` 替换为 `delete token` 与 `delete code`。
+
+**验证方法**：
+启动 Caddy 并发送带有敏感参数的测试请求：
+```bash
+curl -ik "https://mail.example.com/ui?token=test_token_secret&code=test_code_123"
+```
+检查 `/var/log/caddy/access.log` 中的 JSON 日志行，验证 `request.uri` 中的敏感参数已被脱敏：
+```bash
+tail -n 1 /var/log/caddy/access.log | jq .request.uri
+# 输出预期类似："/ui?code=REDACTED&token=REDACTED"
 ```
 
 #### 3. Cloudflare (Rules / Logpush)
@@ -367,7 +380,34 @@ mail.example.com {
 
 #### 4. Traefik
 
-在 Traefik 中配置访问日志红线屏蔽。**注意**：Traefik 访问日志原生暂不支持针对特定 query 参数（如 `token`、`code`）进行细粒度正则脱敏。在 `fields.defaultMode: keep` 下，`RequestPath` 与 `RequestLine` 会完整记录包含 query 的原始 URL。因此反代配置必须显式将包含 query 的字段设为 `drop` 或 `redact`（若需审计访问路径，建议借助 Vector/Fluentd 等日志收集端对 JSON accessLog 进行正则脱敏）：
+Traefik 访问日志原生不支持针对特定 query 参数（如 `token`、`code`）进行字段内正则细粒度替换。在默认模式下，`RequestLine`（记录形式为 `METHOD /path?query HTTP/version`）会记录完整包含 query 的原始 URL。为确保 query 参数绝对不落盘，提供了以下两种配置方式：
+
+##### 配置方式 A：白名单模式（推荐，`defaultMode: drop`）
+默认丢弃所有访问日志字段，仅显式 `keep` 明确安全的元数据字段。在此模式下，绝不放行 `RequestLine`，从根源上杜绝 query 泄漏：
+
+```yaml
+accessLog:
+  filePath: "/var/log/traefik/access.log"
+  format: json
+  filters:
+    statusCodes:
+      - "200-599"
+  fields:
+    defaultMode: drop
+    names:
+      RequestMethod: keep
+      DownstreamStatus: keep
+      Duration: keep
+      ClientAddr: keep
+      DownstreamContentSize: keep
+      # RequestPath 在 Traefik 中仅包含请求路径（如 /ui），不含 query 参数
+      RequestPath: keep
+    headers:
+      defaultMode: drop
+```
+
+##### 配置方式 B：黑名单模式（`defaultMode: keep`）
+若需要保留默认全量访问字段，必须显式将包含 query 的字段设为 `drop`（完全不落盘）或 `redact`（替换为 `"REDACTED"`）：
 
 ```yaml
 accessLog:
@@ -379,12 +419,24 @@ accessLog:
   fields:
     defaultMode: keep
     names:
-      # RequestPath 与 RequestLine 包含原始 query 字符串（含 token/code），必须丢弃或脱敏
-      RequestPath: drop
+      # RequestLine 包含原始 query 字符串（含 token/code），必须 drop 或 redact
       RequestLine: drop
+      # RequestPath 亦可设为 drop 或 redact 消除任何潜在差异风险
+      RequestPath: drop
       ClientUsername: drop
     headers:
       defaultMode: keep
       names:
         Authorization: redact
+```
+
+**验证方法**：
+发送测试请求：
+```bash
+curl -ik "https://mail.example.com/ui?token=test_token_secret&code=test_code_123"
+```
+检查 `/var/log/traefik/access.log`，确认无论是配置方式 A 还是配置方式 B，日志中均不包含 `token=` 或 `code=`：
+```bash
+grep -E "token=|code=" /var/log/traefik/access.log
+# 退出码为 1（无任何匹配结果），确认敏感 query 均未落盘
 ```

--- a/docs/security.md
+++ b/docs/security.md
@@ -274,3 +274,112 @@ confirm with the user when the trigger was not from a verified internal message.
 
 建议将 **发信、建任务、对外通知** 等有副作用的工具置于人工确认之后；
 仅依赖围栏文案不足以阻断被注入后的工具调用链。
+
+## UI Query-Token 登录与反向代理净化 (Issue #132)
+
+OpenAgentEmail 支持通过 `GET /ui?token=<admin-token>` 或深链 `GET /ui/tasks/123?token=...` 实现免密书签直达。为了防止长期有效的主凭据滞留在浏览器历史、Referer 头或反向代理日志中，系统采用了**服务端 302 净化 + 一次性交换码 + Provenance 审计**的三层纵深防御架构（Decision C）。
+
+### 架构与核心硬约束
+
+1. **服务端 302 净化与一次性交换码（Exchange Code）：**
+   - 当收到带有 `?token=` 的 UI 页面请求时，服务端立即在进入 UI Shell 路由时拦截并校验令牌有效性。
+   - 验证通过后，在服务端签发一个高熵随机的 32-byte base64url 一次性交换码，并返回 `302 Found` 重定向至 `${pathname}?code=${exchangeCode}`（保留其他 query 参数与 deep-link path）。
+   - 重定向响应中强制注入 `Cache-Control: no-store` 与 `Referrer-Policy: no-referrer`，防止下游反向代理/CDN 缓存重定向页面以及跨站 Referer 泄露。
+   - 令牌无效时，同样返回 302 重定向至无参干净路径（如 `/ui`），并记录审计拒绝日志，绝不把无效令牌回显或滞留在客户端。
+2. **硬约束 1：换过即焚（One-Time Use & Replay Prevention）：**
+   - 交换码在客户端通过 `POST /ui/api/session` 兑换成功后立即销毁并记录至已消费墓碑表。
+   - 任何对已消费交换码的重放请求立即拒绝（401 Unauthorized），并在审计日志记录 `event: "ui.session.login"`, `outcome: "denied"`。
+3. **硬约束 2：TTL ≤ 10 分钟（Strict Expiration）：**
+   - 交换码的有效期限严格限制在 10 分钟以内（服务端内部默认 10 分钟，且通过配置参数初始化时硬性 clamp 至最大 10 分钟）。
+   - 超时未消费的交换码立即失效作废，兑换时返回 401 Unauthorized。
+4. **硬约束 3：绑定签发对象（Recipient Binding）：**
+   - 交换码在签发时严格绑定原始令牌解析到的身份对象（Admin 或特定 Identity 地址），不可跨身份冒领或降权/越权换取他人会话。
+5. **客户端纵深防御：**
+   - 前端脚本消费 `?code=` 后立即调用 `history.replaceState` 从浏览器地址栏清除参数。
+   - 若客户端直接遇到 `?token=`，前端亦直接剥离参数并返回 null，绝不直接消费令牌本体，而是引导用户通过正常流程登录。
+6. **Provenance 来源审计：**
+   - 兑换请求显式携带 `provenance: "link-exchange"`，在审计事件 `ui.session.login` 中与普通表单粘贴登录严格区分。
+   - 链接登录建立的会话会标记 `oae-link-login` 状态，并在 UI 顶部和 OAuth 同意页醒目展示「Signed in via link as Admin session」警示横幅。
+
+### 反向代理日志净化建议 (Reverse-Proxy Query-String Scrubbing)
+
+虽然服务端的 302 重定向在首个网络往返中即可将长效 `?token=` 替换为短效一次性码，但在最外层反向代理或 CDN 的访问日志中，首个请求的 URL 查询参数仍可能被默认记录。
+
+强烈建议生产环境运维人员在接入层反向代理中配置查询参数过滤或日志屏蔽：
+
+#### 1. Nginx
+
+使用 `map` 指令在日志中过滤敏感 query 参数：
+
+```nginx
+# 过滤日志中的 URI 查询参数
+map $request_uri $scrubbed_request_uri {
+    ~^(?P<path>[^?]*)\?.*$  $path;
+    default                 $request_uri;
+}
+
+log_format scrubbed '$remote_addr - $remote_user [$time_local] '
+                    '"$request_method $scrubbed_request_uri $server_protocol" '
+                    '$status $body_bytes_sent "$http_referer" "$http_user_agent"';
+
+server {
+    listen 443 ssl http2;
+    server_name mail.example.com;
+
+    access_log /var/log/nginx/access.log scrubbed;
+
+    location / {
+        proxy_pass http://127.0.0.1:3100;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
+#### 2. Caddy
+
+在 Caddyfile 中使用 `format filter` 屏蔽 `token` 与 `code`：
+
+```caddy
+mail.example.com {
+    log {
+        output file /var/log/caddy/access.log
+        format filter {
+            wrap json
+            fields {
+                uri replace \?token=[^&]+ ?token=[REDACTED]
+                uri replace &token=[^&]+ &token=[REDACTED]
+                uri replace \?code=[^&]+ ?code=[REDACTED]
+                uri replace &code=[^&]+ &code=[REDACTED]
+            }
+        }
+    }
+
+    reverse_proxy 127.0.0.1:3100
+}
+```
+
+#### 3. Cloudflare (Rules / Logpush)
+
+- 在 **Logpush** 中开启敏感参数屏蔽：针对 `ClientRequestURI` 配置 Log Redaction 规则，过滤 `token` 与 `code` 查询参数。
+- 注意：请勿在 Cloudflare Transform Rules 中剥离向源站转发的 `token` 参数，否则服务端无法完成初次 302 交换码签发。
+
+#### 4. Traefik
+
+在 Traefik 中配置访问日志红线屏蔽：
+
+```yaml
+accessLog:
+  filePath: "/var/log/traefik/access.log"
+  format: json
+  filters:
+    statusCodes:
+      - "200-599"
+  fields:
+    defaultMode: keep
+    headers:
+      defaultMode: keep
+      names:
+        Authorization: redact
+```

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -143,7 +143,7 @@ export function createApp(options: AppOptions = {}): Hono {
     app.route('/ui/oauth', createUiOAuthPageRoutes(uiSessions, options.oauth ?? {}));
     app.route('/ui/frame', createUiFrameRoutes(uiSessions));
     // ADR #26：shell 深链必须在 API / OAuth / frame 之后，防止吞专用路由。
-    registerUiShell(app);
+    registerUiShell(app, uiSessions);
   }
 
   app.onError((err, c) => {

--- a/packages/api/src/lib/audit.ts
+++ b/packages/api/src/lib/audit.ts
@@ -56,6 +56,8 @@ export type AuditEvent = {
   prevScopes?: string[];
   /** 关联的 Webhook 订阅 ID（RFC-0001 §10.6）。 */
   webhookId?: string;
+  /** 登录/操作来源渠道（如 link-exchange）。 */
+  provenance?: string;
 };
 
 function auditPath(): string {
@@ -150,6 +152,9 @@ export function recordAuditEvent(
       : {}),
     ...(partial.webhookId !== undefined
       ? { webhookId: scrubAuditField(partial.webhookId, 64) }
+      : {}),
+    ...(partial.provenance !== undefined
+      ? { provenance: scrubAuditField(partial.provenance, 64) }
       : {}),
   };
 

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -29,10 +29,16 @@ const IP_FAILURE_WINDOW_MS = 5 * 60 * 1000;
 const GLOBAL_FAILURE_WINDOW_MS = 60 * 1000;
 const MAX_IP_FAILURES = 10;
 const MAX_GLOBAL_FAILURES = 60;
+const MAX_TRACKED_IPS = 1000;
+const MINT_DENIED_AUDIT_THROTTLE_MS = 60 * 1000;
 /** authenticate 更新 lastSeenAt 的落盘节流：默认 5 分钟内不重复写盘。 */
 export const LAST_SEEN_PERSIST_INTERVAL_MS = 5 * 60 * 1000;
 /** ?token= 换取的一次性交换码默认 TTL：硬约束 ≤10 分钟。 */
 export const EXCHANGE_CODE_TTL_MS = 10 * 60 * 1000;
+/** 全局活动一次性交换码上限。 */
+export const MAX_GLOBAL_EXCHANGE_CODES = 1000;
+/** 单个令牌同时持有的活动一次性交换码上限。 */
+export const MAX_EXCHANGE_CODES_PER_TOKEN = 5;
 
 type Session = {
   /** 仅进程内持有；落盘绝不写明文 token。重启后靠 tokenHash 反解。 */
@@ -97,6 +103,10 @@ type SessionStoreOptions = {
    * 一次性交换码 TTL（毫秒）。硬约束 ≤ 10 分钟；测试可注入更短值加速验证。
    */
   exchangeCodeTtlMs?: number;
+  /** 全局活动一次性交换码上限（默认 MAX_GLOBAL_EXCHANGE_CODES = 1000）。 */
+  maxExchangeCodes?: number;
+  /** 单个令牌同时持有的活动一次性交换码上限（默认 MAX_EXCHANGE_CODES_PER_TOKEN = 5）。 */
+  maxExchangeCodesPerToken?: number;
 };
 
 function sha256(value: string): string {
@@ -138,10 +148,13 @@ export class UiSessionStore {
   private globalFailures: number[] = [];
   private readonly exchangeCodes = new Map<string, ExchangeCodeRecord>();
   private readonly consumedCodes = new Map<string, ConsumedCodeRecord>();
+  private readonly lastMintDeniedAuditAt = new Map<string, number>();
   private readonly resolve: (token: string) => Auth | null;
   private readonly resolveHash: ((tokenHash: string) => Auth | null) | null;
   private readonly maxSessions: number;
   private readonly maxSessionsPerToken: number;
+  private readonly maxExchangeCodes: number;
+  private readonly maxExchangeCodesPerToken: number;
   private readonly persistPath: string | null;
   private readonly lastSeenPersistIntervalMs: number;
   private readonly exchangeCodeTtlMs: number;
@@ -153,6 +166,9 @@ export class UiSessionStore {
     this.resolveHash = options.resolveTokenHash ?? null;
     this.maxSessions = options.maxSessions ?? 200;
     this.maxSessionsPerToken = options.maxSessionsPerToken ?? 5;
+    this.maxExchangeCodes = options.maxExchangeCodes ?? MAX_GLOBAL_EXCHANGE_CODES;
+    this.maxExchangeCodesPerToken =
+      options.maxExchangeCodesPerToken ?? MAX_EXCHANGE_CODES_PER_TOKEN;
     this.persistPath = options.persistPath ?? null;
     this.lastSeenPersistIntervalMs =
       options.lastSeenPersistIntervalMs ?? LAST_SEEN_PERSIST_INTERVAL_MS;
@@ -260,7 +276,12 @@ export class UiSessionStore {
     token: string,
     ip: string,
     now = Date.now(),
-  ): { ok: true; code: string; auth: Auth } | { ok: false; reason: 'invalid_token' | 'rate_limited' } {
+  ):
+    | { ok: true; code: string; auth: Auth }
+    | { ok: false; reason: 'invalid_token' | 'rate_limited' | 'capacity' } {
+    // 必修 1: mint 入口先清理会话与限流窗，防止垃圾 GET 堆积 globalFailures 永久锁死
+    const removed = this.cleanup(now);
+    if (removed) this.persist();
     this.cleanupExchangeCodes(now);
     token = token.trim();
 
@@ -269,12 +290,13 @@ export class UiSessionStore {
       ipFailures.length >= MAX_IP_FAILURES ||
       this.globalFailures.length >= MAX_GLOBAL_FAILURES
     ) {
-      recordAuditEvent({
-        event: 'ui.token.exchange_mint',
-        outcome: 'rate_limited',
-        ip,
-      });
+      // 必修 2: 公开未认证端点防写放大——rate_limited 分支不落审计
       return { ok: false, reason: 'rate_limited' };
+    }
+
+    // 顺清 3: 全局交换码总量上界检查
+    if (this.exchangeCodes.size >= this.maxExchangeCodes) {
+      return { ok: false, reason: 'capacity' };
     }
 
     const auth = this.resolve(token);
@@ -282,17 +304,34 @@ export class UiSessionStore {
       ipFailures.push(now);
       this.ipFailures.set(ip, ipFailures);
       this.globalFailures.push(now);
-      recordAuditEvent({
-        event: 'ui.token.exchange_mint',
-        outcome: 'denied',
-        ip,
-      });
+
+      // 必修 2: 公开端点防写放大与冲刷取证——denied 分支按 IP 低频落盘（每 IP 每分钟至多 1 条）
+      const lastDeniedAudit = this.lastMintDeniedAuditAt.get(ip) ?? 0;
+      if (now - lastDeniedAudit >= MINT_DENIED_AUDIT_THROTTLE_MS) {
+        this.lastMintDeniedAuditAt.set(ip, now);
+        recordAuditEvent({
+          event: 'ui.token.exchange_mint',
+          outcome: 'denied',
+          ip,
+        });
+      }
       return { ok: false, reason: 'invalid_token' };
+    }
+
+    // 顺清 3: 单令牌活动交换码上界检查（≤ maxExchangeCodesPerToken）
+    const tokenHash = sha256(token);
+    let tokenCodes = 0;
+    for (const record of this.exchangeCodes.values()) {
+      if (record.tokenHash === tokenHash) {
+        tokenCodes++;
+      }
+    }
+    if (tokenCodes >= this.maxExchangeCodesPerToken) {
+      return { ok: false, reason: 'capacity' };
     }
 
     const code = randomBytes(32).toString('base64url');
     const codeHash = sha256(code);
-    const tokenHash = sha256(token);
     const expiresAt = now + this.exchangeCodeTtlMs;
 
     this.exchangeCodes.set(codeHash, {
@@ -318,6 +357,7 @@ export class UiSessionStore {
    * 硬约束 1: 换过即焚，重放 → 401 + 审计 denied。
    * 硬约束 2: TTL ≤ 10 分钟，过期即废。
    * 硬约束 3: 严格绑定签发对象（身份地址+签发上下文），不可换他人会话。
+   * 顺清 6: 先全部校验通过再焚毁 code（容量超限不焚码，允许后续重试）。
    */
   exchangeCode(
     code: string,
@@ -367,15 +407,7 @@ export class UiSessionStore {
       return { ok: false, reason: 'invalid_token' };
     }
 
-    // 硬约束 1: 换过即焚，进入已消费墓碑表
-    this.exchangeCodes.delete(codeHash);
-    this.consumedCodes.set(codeHash, {
-      auth: record.auth,
-      consumedAt: now,
-      expiresAt: record.expiresAt,
-    });
-
-    // 硬约束 3: 会话严格绑定签发对象身份（record.auth + record.tokenHash）
+    // 顺清 6: 校验容量与清理，先全部校验通过再焚毁 code
     const removed = this.cleanup(now);
 
     let principalSessions = 0;
@@ -389,17 +421,26 @@ export class UiSessionStore {
         oldestPrincipalHash = sidHash;
       }
     }
-    let evicted = false;
-    if (principalSessions >= this.maxSessionsPerToken) {
-      if (oldestPrincipalHash) {
-        this.sessions.delete(oldestPrincipalHash);
-        evicted = true;
-      }
-    }
-    if (this.sessions.size >= this.maxSessions) {
-      if (removed || evicted) this.persist();
+
+    const willEvict = principalSessions >= this.maxSessionsPerToken && oldestPrincipalHash !== null;
+    const projectedSessionsSize = this.sessions.size - (willEvict ? 1 : 0);
+    if (projectedSessionsSize >= this.maxSessions) {
+      if (removed) this.persist();
       return { ok: false, reason: 'capacity' };
     }
+
+    // 容量与校验已全部通过：执行驱逐、原子焚码并建会话
+    if (willEvict && oldestPrincipalHash) {
+      this.sessions.delete(oldestPrincipalHash);
+    }
+
+    // 硬约束 1: 换过即焚，进入已消费墓碑表
+    this.exchangeCodes.delete(codeHash);
+    this.consumedCodes.set(codeHash, {
+      auth: record.auth,
+      consumedAt: now,
+      expiresAt: record.expiresAt,
+    });
 
     const sid = randomBytes(32).toString('base64url');
     this.sessions.set(sha256(sid), {
@@ -514,6 +555,29 @@ export class UiSessionStore {
       );
       if (recent.length === 0) this.ipFailures.delete(ip);
       else this.ipFailures.set(ip, recent);
+    }
+    if (this.ipFailures.size > MAX_TRACKED_IPS) {
+      const excess = this.ipFailures.size - MAX_TRACKED_IPS;
+      let count = 0;
+      for (const key of this.ipFailures.keys()) {
+        this.ipFailures.delete(key);
+        count++;
+        if (count >= excess) break;
+      }
+    }
+    for (const [ip, lastAt] of this.lastMintDeniedAuditAt) {
+      if (now - lastAt > MINT_DENIED_AUDIT_THROTTLE_MS) {
+        this.lastMintDeniedAuditAt.delete(ip);
+      }
+    }
+    if (this.lastMintDeniedAuditAt.size > MAX_TRACKED_IPS) {
+      const excess = this.lastMintDeniedAuditAt.size - MAX_TRACKED_IPS;
+      let count = 0;
+      for (const key of this.lastMintDeniedAuditAt.keys()) {
+        this.lastMintDeniedAuditAt.delete(key);
+        count++;
+        if (count >= excess) break;
+      }
     }
     return removed;
   }
@@ -746,10 +810,14 @@ export function createUiSessionRoutes(store: UiSessionStore): Hono {
       const parsed = loginSchema.safeParse(parsedBody);
       if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
 
-      const remember = parsed.data.remember === true;
-      const provenance = parsed.data.provenance;
-      const result = parsed.data.code !== undefined
-        ? store.exchangeCode(parsed.data.code, connectionIp(c), undefined, remember, provenance)
+      const isCode = parsed.data.code !== undefined;
+      // 顺清 4: provenance 由服务端推导（code 兑换=link-exchange，令牌直换=undefined），客户端自报不予采信
+      // 顺清 5: 交换码换会话强制 remember: false，不信客户端自报的 remember
+      const remember = isCode ? false : parsed.data.remember === true;
+      const provenance = isCode ? 'link-exchange' : undefined;
+
+      const result = isCode
+        ? store.exchangeCode(parsed.data.code!, connectionIp(c), undefined, false, provenance)
         : store.create(parsed.data.token!, connectionIp(c), undefined, remember, provenance);
       if (!result.ok) {
         if (result.reason === 'invalid_token') {

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -18,6 +18,7 @@ import { z } from 'zod';
 import type { Auth } from './auth.ts';
 import { clientIp } from './net.ts';
 import { consumeOAuthReturnCookie } from './oauth-return.ts';
+import { recordAuditEvent } from './audit.ts';
 
 const COOKIE_NAME = 'oae_ui';
 const IDLE_TIMEOUT_MS = 12 * 60 * 60 * 1000;
@@ -30,6 +31,8 @@ const MAX_IP_FAILURES = 10;
 const MAX_GLOBAL_FAILURES = 60;
 /** authenticate 更新 lastSeenAt 的落盘节流：默认 5 分钟内不重复写盘。 */
 export const LAST_SEEN_PERSIST_INTERVAL_MS = 5 * 60 * 1000;
+/** ?token= 换取的一次性交换码默认 TTL：硬约束 ≤10 分钟。 */
+export const EXCHANGE_CODE_TTL_MS = 10 * 60 * 1000;
 
 type Session = {
   /** 仅进程内持有；落盘绝不写明文 token。重启后靠 tokenHash 反解。 */
@@ -38,6 +41,20 @@ type Session = {
   createdAt: number;
   lastSeenAt: number;
   remembered: boolean;
+};
+
+type ExchangeCodeRecord = {
+  auth: Auth;
+  tokenHash: string;
+  createdAt: number;
+  expiresAt: number;
+  ip: string;
+};
+
+type ConsumedCodeRecord = {
+  auth: Auth;
+  consumedAt: number;
+  expiresAt: number;
 };
 
 /** 落盘条目：仅 sidHash → 哈希与时间戳，无 sid/token 原文。 */
@@ -76,6 +93,10 @@ type SessionStoreOptions = {
   persistPath?: string;
   /** lastSeenAt 落盘节流间隔；默认 LAST_SEEN_PERSIST_INTERVAL_MS。 */
   lastSeenPersistIntervalMs?: number;
+  /**
+   * 一次性交换码 TTL（毫秒）。硬约束 ≤ 10 分钟；测试可注入更短值加速验证。
+   */
+  exchangeCodeTtlMs?: number;
 };
 
 function sha256(value: string): string {
@@ -115,12 +136,15 @@ export class UiSessionStore {
   private readonly sessions = new Map<string, Session>();
   private readonly ipFailures = new Map<string, number[]>();
   private globalFailures: number[] = [];
+  private readonly exchangeCodes = new Map<string, ExchangeCodeRecord>();
+  private readonly consumedCodes = new Map<string, ConsumedCodeRecord>();
   private readonly resolve: (token: string) => Auth | null;
   private readonly resolveHash: ((tokenHash: string) => Auth | null) | null;
   private readonly maxSessions: number;
   private readonly maxSessionsPerToken: number;
   private readonly persistPath: string | null;
   private readonly lastSeenPersistIntervalMs: number;
+  private readonly exchangeCodeTtlMs: number;
   /** 上次因 lastSeenAt 滑动而落盘的时间（按墙钟；节流用）。 */
   private lastSeenPersistedAt = 0;
 
@@ -132,10 +156,20 @@ export class UiSessionStore {
     this.persistPath = options.persistPath ?? null;
     this.lastSeenPersistIntervalMs =
       options.lastSeenPersistIntervalMs ?? LAST_SEEN_PERSIST_INTERVAL_MS;
+    this.exchangeCodeTtlMs = Math.min(
+      options.exchangeCodeTtlMs ?? EXCHANGE_CODE_TTL_MS,
+      EXCHANGE_CODE_TTL_MS,
+    );
     if (this.persistPath) this.loadFromDisk(Date.now());
   }
 
-  create(token: string, ip: string, now = Date.now(), remember = false): CreateResult {
+  create(
+    token: string,
+    ip: string,
+    now = Date.now(),
+    remember = false,
+    provenance?: string,
+  ): CreateResult {
     const removed = this.cleanup(now);
     token = token.trim();
 
@@ -145,6 +179,12 @@ export class UiSessionStore {
       this.globalFailures.length >= MAX_GLOBAL_FAILURES
     ) {
       if (removed) this.persist();
+      recordAuditEvent({
+        event: 'ui.session.login',
+        outcome: 'rate_limited',
+        ...(provenance !== undefined ? { provenance } : {}),
+        ip,
+      });
       return { ok: false, reason: 'rate_limited' };
     }
 
@@ -154,6 +194,12 @@ export class UiSessionStore {
       this.ipFailures.set(ip, ipFailures);
       this.globalFailures.push(now);
       if (removed) this.persist();
+      recordAuditEvent({
+        event: 'ui.session.login',
+        outcome: 'denied',
+        ...(provenance !== undefined ? { provenance } : {}),
+        ip,
+      });
       return { ok: false, reason: 'invalid_token' };
     }
 
@@ -194,7 +240,199 @@ export class UiSessionStore {
     // create / 驱逐 / 过期清理 → 必落盘；同时重置节流时钟避免紧随的 authenticate 再写一次
     this.persist();
     this.lastSeenPersistedAt = now;
+
+    recordAuditEvent({
+      event: 'ui.session.login',
+      outcome: 'ok',
+      ...(provenance !== undefined ? { provenance } : {}),
+      address: auth.kind === 'identity' ? auth.address : 'admin',
+      ip,
+    });
+
     return { ok: true, sid, auth };
+  }
+
+  /**
+   * 服务端验令牌并签发一次性交换码（GET /ui?token= 净化流核心）。
+   * 签发时刻落审计；硬约束 TTL ≤ 10 分钟。
+   */
+  mintExchangeCode(
+    token: string,
+    ip: string,
+    now = Date.now(),
+  ): { ok: true; code: string; auth: Auth } | { ok: false; reason: 'invalid_token' | 'rate_limited' } {
+    this.cleanupExchangeCodes(now);
+    token = token.trim();
+
+    const ipFailures = this.recentIpFailures(ip, now);
+    if (
+      ipFailures.length >= MAX_IP_FAILURES ||
+      this.globalFailures.length >= MAX_GLOBAL_FAILURES
+    ) {
+      recordAuditEvent({
+        event: 'ui.token.exchange_mint',
+        outcome: 'rate_limited',
+        ip,
+      });
+      return { ok: false, reason: 'rate_limited' };
+    }
+
+    const auth = this.resolve(token);
+    if (!auth) {
+      ipFailures.push(now);
+      this.ipFailures.set(ip, ipFailures);
+      this.globalFailures.push(now);
+      recordAuditEvent({
+        event: 'ui.token.exchange_mint',
+        outcome: 'denied',
+        ip,
+      });
+      return { ok: false, reason: 'invalid_token' };
+    }
+
+    const code = randomBytes(32).toString('base64url');
+    const codeHash = sha256(code);
+    const tokenHash = sha256(token);
+    const expiresAt = now + this.exchangeCodeTtlMs;
+
+    this.exchangeCodes.set(codeHash, {
+      auth,
+      tokenHash,
+      createdAt: now,
+      expiresAt,
+      ip,
+    });
+
+    recordAuditEvent({
+      event: 'ui.token.exchange_mint',
+      outcome: 'ok',
+      address: auth.kind === 'identity' ? auth.address : 'admin',
+      ip,
+    });
+
+    return { ok: true, code, auth };
+  }
+
+  /**
+   * 客户端消费一次性交换码换取会话（POST /ui/api/session { code, provenance: 'link-exchange' }）。
+   * 硬约束 1: 换过即焚，重放 → 401 + 审计 denied。
+   * 硬约束 2: TTL ≤ 10 分钟，过期即废。
+   * 硬约束 3: 严格绑定签发对象（身份地址+签发上下文），不可换他人会话。
+   */
+  exchangeCode(
+    code: string,
+    ip: string,
+    now = Date.now(),
+    remember = false,
+    provenance?: string,
+  ): CreateResult {
+    this.cleanupExchangeCodes(now);
+    code = code.trim();
+    const codeHash = sha256(code);
+
+    // 硬约束 1: 重放检测
+    if (this.consumedCodes.has(codeHash)) {
+      const consumed = this.consumedCodes.get(codeHash)!;
+      recordAuditEvent({
+        event: 'ui.session.login',
+        outcome: 'denied',
+        provenance: provenance ?? 'link-exchange',
+        address: consumed.auth.kind === 'identity' ? consumed.auth.address : 'admin',
+        ip,
+      });
+      return { ok: false, reason: 'invalid_token' };
+    }
+
+    const record = this.exchangeCodes.get(codeHash);
+    if (!record) {
+      recordAuditEvent({
+        event: 'ui.session.login',
+        outcome: 'denied',
+        provenance: provenance ?? 'link-exchange',
+        ip,
+      });
+      return { ok: false, reason: 'invalid_token' };
+    }
+
+    // 硬约束 2: TTL 检测
+    if (now >= record.expiresAt) {
+      this.exchangeCodes.delete(codeHash);
+      recordAuditEvent({
+        event: 'ui.session.login',
+        outcome: 'denied',
+        provenance: provenance ?? 'link-exchange',
+        address: record.auth.kind === 'identity' ? record.auth.address : 'admin',
+        ip,
+      });
+      return { ok: false, reason: 'invalid_token' };
+    }
+
+    // 硬约束 1: 换过即焚，进入已消费墓碑表
+    this.exchangeCodes.delete(codeHash);
+    this.consumedCodes.set(codeHash, {
+      auth: record.auth,
+      consumedAt: now,
+      expiresAt: record.expiresAt,
+    });
+
+    // 硬约束 3: 会话严格绑定签发对象身份（record.auth + record.tokenHash）
+    const removed = this.cleanup(now);
+
+    let principalSessions = 0;
+    let oldestPrincipalHash: string | null = null;
+    let oldestPrincipalSeen = Infinity;
+    for (const [sidHash, session] of this.sessions) {
+      if (session.tokenHash !== record.tokenHash) continue;
+      principalSessions += 1;
+      if (session.lastSeenAt < oldestPrincipalSeen) {
+        oldestPrincipalSeen = session.lastSeenAt;
+        oldestPrincipalHash = sidHash;
+      }
+    }
+    let evicted = false;
+    if (principalSessions >= this.maxSessionsPerToken) {
+      if (oldestPrincipalHash) {
+        this.sessions.delete(oldestPrincipalHash);
+        evicted = true;
+      }
+    }
+    if (this.sessions.size >= this.maxSessions) {
+      if (removed || evicted) this.persist();
+      return { ok: false, reason: 'capacity' };
+    }
+
+    const sid = randomBytes(32).toString('base64url');
+    this.sessions.set(sha256(sid), {
+      tokenHash: record.tokenHash,
+      createdAt: now,
+      lastSeenAt: now,
+      remembered: remember,
+    });
+    this.persist();
+    this.lastSeenPersistedAt = now;
+
+    recordAuditEvent({
+      event: 'ui.session.login',
+      outcome: 'ok',
+      provenance: provenance ?? 'link-exchange',
+      address: record.auth.kind === 'identity' ? record.auth.address : 'admin',
+      ip,
+    });
+
+    return { ok: true, sid, auth: record.auth };
+  }
+
+  private cleanupExchangeCodes(now: number): void {
+    for (const [hash, record] of this.exchangeCodes) {
+      if (now >= record.expiresAt) {
+        this.exchangeCodes.delete(hash);
+      }
+    }
+    for (const [hash, record] of this.consumedCodes) {
+      if (now >= record.expiresAt) {
+        this.consumedCodes.delete(hash);
+      }
+    }
   }
 
   authenticate(sid: string, now = Date.now()): { auth: Auth } | null {
@@ -234,6 +472,16 @@ export class UiSessionStore {
   /** 测试辅助：当前内存会话数。 */
   sizeForTests(): number {
     return this.sessions.size;
+  }
+
+  /** 测试辅助：当前活动一次性交换码数。 */
+  activeCodesCountForTests(): number {
+    return this.exchangeCodes.size;
+  }
+
+  /** 测试辅助：当前已消费交换码墓碑数。 */
+  consumedCodesCountForTests(): number {
+    return this.consumedCodes.size;
   }
 
   /** 测试辅助：lastSeen 落盘节流时钟（墙钟 ms）。 */
@@ -371,8 +619,17 @@ declare module 'hono' {
 }
 
 const loginSchema = z
-  .object({ token: z.string().min(1).max(512), remember: z.boolean().optional() })
-  .strict();
+  .object({
+    token: z.string().min(1).max(512).optional(),
+    code: z.string().min(1).max(512).optional(),
+    remember: z.boolean().optional(),
+    provenance: z.string().min(1).max(64).optional(),
+  })
+  .strict()
+  .refine(
+    (data) => (data.token !== undefined) !== (data.code !== undefined),
+    { message: 'Either token or code must be provided, but not both' },
+  );
 
 function cookieSecure(url: string): boolean {
   const parsed = new URL(url);
@@ -490,7 +747,10 @@ export function createUiSessionRoutes(store: UiSessionStore): Hono {
       if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
 
       const remember = parsed.data.remember === true;
-      const result = store.create(parsed.data.token, connectionIp(c), undefined, remember);
+      const provenance = parsed.data.provenance;
+      const result = parsed.data.code !== undefined
+        ? store.exchangeCode(parsed.data.code, connectionIp(c), undefined, remember, provenance)
+        : store.create(parsed.data.token!, connectionIp(c), undefined, remember, provenance);
       if (!result.ok) {
         if (result.reason === 'invalid_token') {
           return c.json({ error: 'invalid_token' }, 401);

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -20,7 +20,7 @@ import { clientIp } from './net.ts';
 import { consumeOAuthReturnCookie } from './oauth-return.ts';
 import { recordAuditEvent } from './audit.ts';
 
-const COOKIE_NAME = 'oae_ui';
+export const COOKIE_NAME = 'oae_ui';
 const IDLE_TIMEOUT_MS = 12 * 60 * 60 * 1000;
 const ABSOLUTE_TIMEOUT_MS = 24 * 60 * 60 * 1000;
 const REMEMBER_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000;
@@ -30,7 +30,8 @@ const GLOBAL_FAILURE_WINDOW_MS = 60 * 1000;
 const MAX_IP_FAILURES = 10;
 const MAX_GLOBAL_FAILURES = 60;
 const MAX_TRACKED_IPS = 1000;
-const MINT_DENIED_AUDIT_THROTTLE_MS = 60 * 1000;
+export const DENIED_AUDIT_THROTTLE_MS = 60 * 1000;
+const MINT_DENIED_AUDIT_THROTTLE_MS = DENIED_AUDIT_THROTTLE_MS;
 /** authenticate 更新 lastSeenAt 的落盘节流：默认 5 分钟内不重复写盘。 */
 export const LAST_SEEN_PERSIST_INTERVAL_MS = 5 * 60 * 1000;
 /** ?token= 换取的一次性交换码默认 TTL：硬约束 ≤10 分钟。 */
@@ -149,6 +150,7 @@ export class UiSessionStore {
   private readonly exchangeCodes = new Map<string, ExchangeCodeRecord>();
   private readonly consumedCodes = new Map<string, ConsumedCodeRecord>();
   private readonly lastMintDeniedAuditAt = new Map<string, number>();
+  private readonly lastSessionDeniedAuditAt = new Map<string, number>();
   private readonly resolve: (token: string) => Auth | null;
   private readonly resolveHash: ((tokenHash: string) => Auth | null) | null;
   private readonly maxSessions: number;
@@ -195,12 +197,7 @@ export class UiSessionStore {
       this.globalFailures.length >= MAX_GLOBAL_FAILURES
     ) {
       if (removed) this.persist();
-      recordAuditEvent({
-        event: 'ui.session.login',
-        outcome: 'rate_limited',
-        ...(provenance !== undefined ? { provenance } : {}),
-        ip,
-      });
+      // 必修 1: create() rate_limited 分支不落审计（防写放大）
       return { ok: false, reason: 'rate_limited' };
     }
 
@@ -210,12 +207,18 @@ export class UiSessionStore {
       this.ipFailures.set(ip, ipFailures);
       this.globalFailures.push(now);
       if (removed) this.persist();
-      recordAuditEvent({
-        event: 'ui.session.login',
-        outcome: 'denied',
-        ...(provenance !== undefined ? { provenance } : {}),
-        ip,
-      });
+
+      // 必修 1: create() denied 分支按 IP 节流（每 IP 每分钟至多 1 条）
+      const lastDenied = this.lastSessionDeniedAuditAt.get(ip) ?? 0;
+      if (now - lastDenied >= DENIED_AUDIT_THROTTLE_MS) {
+        this.lastSessionDeniedAuditAt.set(ip, now);
+        recordAuditEvent({
+          event: 'ui.session.login',
+          outcome: 'denied',
+          ...(provenance !== undefined ? { provenance } : {}),
+          ip,
+        });
+      }
       return { ok: false, reason: 'invalid_token' };
     }
 
@@ -370,40 +373,54 @@ export class UiSessionStore {
     code = code.trim();
     const codeHash = sha256(code);
 
+    // 必修 2: exchangeCode 失败计入限流，入口先检查限流桶；超限不落审计（防放大）
+    const ipFailures = this.recentIpFailures(ip, now);
+    if (
+      ipFailures.length >= MAX_IP_FAILURES ||
+      this.globalFailures.length >= MAX_GLOBAL_FAILURES
+    ) {
+      return { ok: false, reason: 'rate_limited' };
+    }
+
+    const recordFailureAndDeniedAudit = (address?: string) => {
+      // 必修 2: 重放/未知码/过期码计入限流桶
+      ipFailures.push(now);
+      this.ipFailures.set(ip, ipFailures);
+      this.globalFailures.push(now);
+
+      // 必修 1: 失败审计写盘节流（每 IP 每分钟至多 1 条）
+      const lastDenied = this.lastSessionDeniedAuditAt.get(ip) ?? 0;
+      if (now - lastDenied >= DENIED_AUDIT_THROTTLE_MS) {
+        this.lastSessionDeniedAuditAt.set(ip, now);
+        recordAuditEvent({
+          event: 'ui.session.login',
+          outcome: 'denied',
+          provenance: provenance ?? 'link-exchange',
+          ...(address ? { address } : {}),
+          ip,
+        });
+      }
+    };
+
     // 硬约束 1: 重放检测
     if (this.consumedCodes.has(codeHash)) {
       const consumed = this.consumedCodes.get(codeHash)!;
-      recordAuditEvent({
-        event: 'ui.session.login',
-        outcome: 'denied',
-        provenance: provenance ?? 'link-exchange',
-        address: consumed.auth.kind === 'identity' ? consumed.auth.address : 'admin',
-        ip,
-      });
+      const address = consumed.auth.kind === 'identity' ? consumed.auth.address : 'admin';
+      recordFailureAndDeniedAudit(address);
       return { ok: false, reason: 'invalid_token' };
     }
 
     const record = this.exchangeCodes.get(codeHash);
     if (!record) {
-      recordAuditEvent({
-        event: 'ui.session.login',
-        outcome: 'denied',
-        provenance: provenance ?? 'link-exchange',
-        ip,
-      });
+      recordFailureAndDeniedAudit();
       return { ok: false, reason: 'invalid_token' };
     }
 
     // 硬约束 2: TTL 检测
     if (now >= record.expiresAt) {
       this.exchangeCodes.delete(codeHash);
-      recordAuditEvent({
-        event: 'ui.session.login',
-        outcome: 'denied',
-        provenance: provenance ?? 'link-exchange',
-        address: record.auth.kind === 'identity' ? record.auth.address : 'admin',
-        ip,
-      });
+      const address = record.auth.kind === 'identity' ? record.auth.address : 'admin';
+      recordFailureAndDeniedAudit(address);
       return { ok: false, reason: 'invalid_token' };
     }
 
@@ -579,6 +596,20 @@ export class UiSessionStore {
         if (count >= excess) break;
       }
     }
+    for (const [ip, lastAt] of this.lastSessionDeniedAuditAt) {
+      if (now - lastAt > DENIED_AUDIT_THROTTLE_MS) {
+        this.lastSessionDeniedAuditAt.delete(ip);
+      }
+    }
+    if (this.lastSessionDeniedAuditAt.size > MAX_TRACKED_IPS) {
+      const excess = this.lastSessionDeniedAuditAt.size - MAX_TRACKED_IPS;
+      let count = 0;
+      for (const key of this.lastSessionDeniedAuditAt.keys()) {
+        this.lastSessionDeniedAuditAt.delete(key);
+        count++;
+        if (count >= excess) break;
+      }
+    }
     return removed;
   }
 
@@ -687,7 +718,8 @@ const loginSchema = z
     token: z.string().min(1).max(512).optional(),
     code: z.string().min(1).max(512).optional(),
     remember: z.boolean().optional(),
-    provenance: z.string().min(1).max(64).optional(),
+    /** 顺清 3: 客户端自报 provenance 标记忽略（死输入面），服务端凭证分支单向推导。 */
+    provenance: z.unknown().optional(),
   })
   .strict()
   .refine(

--- a/packages/api/src/lib/ui-session.ts
+++ b/packages/api/src/lib/ui-session.ts
@@ -369,6 +369,9 @@ export class UiSessionStore {
     remember = false,
     provenance?: string,
   ): CreateResult {
+    // 边角 R4: exchangeCode 入口先清理会话与限流窗，防止过期 globalFailures 导致 exchange 路径被误锁
+    let removed = this.cleanup(now);
+    if (removed) this.persist();
     this.cleanupExchangeCodes(now);
     code = code.trim();
     const codeHash = sha256(code);
@@ -425,7 +428,7 @@ export class UiSessionStore {
     }
 
     // 顺清 6: 校验容量与清理，先全部校验通过再焚毁 code
-    const removed = this.cleanup(now);
+    if (this.cleanup(now)) removed = true;
 
     let principalSessions = 0;
     let oldestPrincipalHash: string | null = null;

--- a/packages/api/src/routes/ui-assets.ts
+++ b/packages/api/src/routes/ui-assets.ts
@@ -4,6 +4,8 @@ import type { Hono } from 'hono';
 import { OUTER_CSP, UI_CSS, UI_HTML, UI_JS, UI_LOGO_SVG } from '../ui/assets.ts';
 import { resolveUiAssetUrl } from '../ui/load-ui-asset.ts';
 import { uiShellRegisterPaths } from '../ui/shell-routes.ts';
+import type { UiSessionStore } from '../lib/ui-session.ts';
+import { clientIp } from '../lib/net.ts';
 
 // Satoshi 字体与官网（website/public/fonts/）同源同文件；缺失时启动即报错，不半死不活。
 // 双布局与 JS/CSS loader 共用 resolveUiAssetUrl：源码树相邻（../ui/fonts/）；
@@ -87,12 +89,30 @@ export function registerUiAssets(app: Hono): void {
 /**
  * Dashboard shell 深链：必须在 /ui/api、/ui/frame、/ui/oauth 之后注册（ADR #26）。
  * 路径与 API 前缀无交集，但后挂才能保证后续加宽匹配时不吞专用路由。
+ * #132 加固：GET /ui?token= 经服务端验令牌后 302 净化到 /ui?code=（长期令牌不进客户端 JS）。
  */
-export function registerUiShell(app: Hono): void {
+export function registerUiShell(app: Hono, store?: UiSessionStore): void {
   // B6 0 期：旧 Overview 书签只做永久兼容跳转，不再返回旧 shell。
   app.get('/ui/overview', legacyOverviewRedirect);
   app.get('/ui/overview/', legacyOverviewRedirect);
   for (const path of UI_SHELL_PATHS) {
-    app.get(path, shell);
+    app.get(path, (c) => {
+      const rawToken = c.req.query('token');
+      if (rawToken !== undefined && store) {
+        const ip = clientIp(c);
+        const result = store.mintExchangeCode(rawToken, ip);
+        const url = new URL(c.req.url);
+        url.searchParams.delete('token');
+        if (result.ok) {
+          url.searchParams.set('code', result.code);
+        }
+        const cleanSearch = url.searchParams.toString();
+        const location = `${url.pathname}${cleanSearch ? `?${cleanSearch}` : ''}`;
+        c.header('Cache-Control', 'no-store');
+        c.header('Referrer-Policy', 'no-referrer');
+        return c.redirect(location, 302);
+      }
+      return shell(c);
+    });
   }
 }

--- a/packages/api/src/routes/ui-assets.ts
+++ b/packages/api/src/routes/ui-assets.ts
@@ -1,10 +1,11 @@
 import { readFileSync } from 'node:fs';
 import type { Context } from 'hono';
 import type { Hono } from 'hono';
+import { getCookie } from 'hono/cookie';
 import { OUTER_CSP, UI_CSS, UI_HTML, UI_JS, UI_LOGO_SVG } from '../ui/assets.ts';
 import { resolveUiAssetUrl } from '../ui/load-ui-asset.ts';
 import { uiShellRegisterPaths } from '../ui/shell-routes.ts';
-import type { UiSessionStore } from '../lib/ui-session.ts';
+import { COOKIE_NAME, type UiSessionStore } from '../lib/ui-session.ts';
 import { clientIp } from '../lib/net.ts';
 
 // Satoshi 字体与官网（website/public/fonts/）同源同文件；缺失时启动即报错，不半死不活。
@@ -99,12 +100,18 @@ export function registerUiShell(app: Hono, store?: UiSessionStore): void {
     app.get(path, (c) => {
       const rawToken = c.req.query('token');
       if (rawToken !== undefined && store) {
-        const ip = clientIp(c);
-        const result = store.mintExchangeCode(rawToken, ip);
         const url = new URL(c.req.url);
         url.searchParams.delete('token');
-        if (result.ok) {
-          url.searchParams.set('code', result.code);
+        url.searchParams.delete('code');
+
+        const sid = getCookie(c, COOKIE_NAME);
+        const existingSession = sid ? store.authenticate(sid) : null;
+        if (!existingSession) {
+          const ip = clientIp(c);
+          const result = store.mintExchangeCode(rawToken, ip);
+          if (result.ok) {
+            url.searchParams.set('code', result.code);
+          }
         }
         const cleanSearch = url.searchParams.toString();
         const location = `${url.pathname}${cleanSearch ? `?${cleanSearch}` : ''}`;

--- a/packages/api/src/routes/ui-oauth.ts
+++ b/packages/api/src/routes/ui-oauth.ts
@@ -175,6 +175,7 @@ function consentFormHtml(input: {
   loopbackWarning: boolean;
   identities: { address: string }[];
   error?: string;
+  hasLinkLoginMarker?: boolean;
 }): string {
   const host = clientHostname(input.clientId);
   const redirectHost = redirectHostname(input.redirectUri);
@@ -189,11 +190,16 @@ function consentFormHtml(input: {
     ? `<p class="warn">This client redirects to a loopback address (<strong>${escapeHtml(redirectHost)}</strong>). Only continue if you started this authorization yourself.</p>`
     : '';
 
+  const linkLoginNotice = input.hasLinkLoginMarker
+    ? `<p class="warn" id="link-login-notice" role="status" aria-live="polite">Signed in via link as Admin session</p>`
+    : '';
+
   return shell(
     'Authorize',
     `<section class="card">
       <h1>Authorize application</h1>
       <p class="muted"><strong>${escapeHtml(input.clientName)}</strong> wants access to an OpenAgent identity via MCP.</p>
+      ${linkLoginNotice}
       <dl class="meta">
         <dt>Client</dt><dd>${escapeHtml(input.clientName)}</dd>
         <dt>Client ID host</dt><dd>${escapeHtml(host)}</dd>
@@ -266,6 +272,8 @@ export function createUiOAuthPageRoutes(
       );
     }
 
+    const hasLinkLoginMarker = getCookie(c, 'oae-link-login') === '1';
+
     return htmlResponse(
       c,
       consentFormHtml({
@@ -277,6 +285,7 @@ export function createUiOAuthPageRoutes(
         resource: pre.resource,
         loopbackWarning: pre.loopbackWarning,
         identities: listIdentities(),
+        hasLinkLoginMarker,
       }),
     );
   });

--- a/packages/api/src/ui/client/app.js
+++ b/packages/api/src/ui/client/app.js
@@ -810,29 +810,33 @@
   configureClientsRefresh.addEventListener('click', function () { loadConfigureClients(); });
 
   /**
-   * Consumes and strips the ?token= query parameter from window.location via history.replaceState.
-   * Returns the token if present and successfully stripped, or null if absent or if stripping is unavailable.
+   * Consumes and strips the one-time exchange ?code= query parameter from window.location via history.replaceState.
+   * Under #132 hardening, the server redirects ?token= to ?code=<one-time-code>.
+   * Returns the code if present and successfully stripped, or null if absent or if stripping is unavailable.
    */
   function consumeQueryToken() {
     try {
       var url = new URL(window.location.href);
-      if (!url.searchParams.has('token')) return null;
+      if (!url.searchParams.has('code') && !url.searchParams.has('token')) return null;
       if (!window.history || typeof window.history.replaceState !== 'function') {
         return null;
       }
-      var token = url.searchParams.get('token');
+      var code = url.searchParams.get('code');
       url.searchParams.delete('token');
+      url.searchParams.delete('code');
       var cleanSearch = url.searchParams.toString();
       var cleanUrl = url.pathname + (cleanSearch ? '?' + cleanSearch : '') + url.hash;
       window.history.replaceState(window.history.state, '', cleanUrl);
-      return token;
+      return code;
     } catch (_err) {
       return null;
     }
   }
 
+  var consumeQueryCode = consumeQueryToken;
+
   /**
-   * Performs automated session login using a credential from a query parameter,
+   * Performs automated session login using an exchange code from a query parameter,
    * matching standard form submission semantics without echoing the credential on failure.
    */
   async function loginWithToken(credential) {
@@ -849,7 +853,7 @@
         method: 'POST',
         credentials: 'same-origin',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ token: credential, remember: false })
+        body: JSON.stringify({ code: credential, provenance: 'link-exchange', remember: false })
       });
       if (gen !== loginGeneration) return;
       if (!response.ok) {
@@ -882,6 +886,8 @@
       loginSubmit.disabled = !isLoginContextSafe();
     }
   }
+
+  var loginWithCode = loginWithToken;
 
   function setLinkLoginMarker() {
     try {

--- a/packages/api/src/ui/client/app.js
+++ b/packages/api/src/ui/client/app.js
@@ -889,10 +889,23 @@
 
   var loginWithCode = loginWithToken;
 
+  function isCookieSecure() {
+    try {
+      var loc = typeof window !== 'undefined' && window.location ? window.location : null;
+      if (loc && loc.protocol) {
+        var host = loc.hostname || '';
+        var local = host === 'localhost' || host === '127.0.0.1' || host === '[::1]' || host === '::1';
+        return !(loc.protocol === 'http:' && local);
+      }
+    } catch (_e) {}
+    return typeof window !== 'undefined' && Boolean(window.isSecureContext);
+  }
+
   function setLinkLoginMarker() {
     try {
       if (typeof document !== 'undefined') {
-        document.cookie = 'oae-link-login=1; path=/; SameSite=Strict';
+        var secure = isCookieSecure() ? '; Secure' : '';
+        document.cookie = 'oae-link-login=1; path=/; SameSite=Strict' + secure;
       }
     } catch (_err) {
       /* cookie unavailable or restricted */
@@ -902,7 +915,8 @@
   function clearLinkLoginMarker() {
     try {
       if (typeof document !== 'undefined') {
-        document.cookie = 'oae-link-login=; path=/; SameSite=Strict; Max-Age=0';
+        var secure = isCookieSecure() ? '; Secure' : '';
+        document.cookie = 'oae-link-login=; path=/; SameSite=Strict; Max-Age=0' + secure;
       }
     } catch (_err) {
       /* cookie unavailable or restricted */

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('2f2a23c585e44d62d379f89a68d7b5791c29f5304405943642d67ad311c40559');
+    expect(sha256(UI_JS)).toBe('5e9b6817b378b2139bdb4ad68f4f1f1e973e7e9359a3724b27b805ff1fb278e1');
     expect(sha256(UI_CSS)).toBe('8bd737bef63e5c751c23d80b57ece4ae1ee32c04e4acfb1cc05b3e1e076f7680');
   });
 });

--- a/packages/api/test/ui-real-files.test.ts
+++ b/packages/api/test/ui-real-files.test.ts
@@ -99,7 +99,7 @@ describe('UI real-file manifest (#520-A)', () => {
   test('served bundle bytes are pinned to the B6 real-file baseline', () => {
     const sha256 = (s: string) =>
       new Bun.CryptoHasher('sha256').update(Buffer.from(s, 'utf8')).digest('hex');
-    expect(sha256(UI_JS)).toBe('5e9b6817b378b2139bdb4ad68f4f1f1e973e7e9359a3724b27b805ff1fb278e1');
+    expect(sha256(UI_JS)).toBe('a04c16bbf18a83214450e67ab7aff4b48aeda7bff8dfe83e32dff58f86818aac');
     expect(sha256(UI_CSS)).toBe('8bd737bef63e5c751c23d80b57ece4ae1ee32c04e4acfb1cc05b3e1e076f7680');
   });
 });

--- a/packages/api/test/ui-token-query.test.ts
+++ b/packages/api/test/ui-token-query.test.ts
@@ -187,6 +187,12 @@ function createClientHarness(options: HarnessOptions) {
       set href(val: string) {
         currentUrl = val;
       },
+      get protocol() {
+        return new URL(currentUrl).protocol;
+      },
+      get hostname() {
+        return new URL(currentUrl).hostname;
+      },
       get pathname() {
         return new URL(currentUrl).pathname;
       },
@@ -1112,9 +1118,9 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(tab1.linkLoginNotice.hidden).toBe(false);
     expect(tab1.mockDocument.body.classList.contains('link-login-active')).toBe(true);
 
-    // 断言 2: 写入的 cookie 为 session cookie：无 Max-Age，无 Expires
+    // 断言 2: 写入的 cookie 为 session cookie：无 Max-Age，无 Expires，带 Secure
     const lastWrite = sharedCookieJar.writes[sharedCookieJar.writes.length - 1];
-    expect(lastWrite).toBe('oae-link-login=1; path=/; SameSite=Strict');
+    expect(lastWrite).toBe('oae-link-login=1; path=/; SameSite=Strict; Secure');
     expect(lastWrite).not.toContain('Max-Age');
     expect(lastWrite).not.toContain('Expires');
     expect(sharedCookieJar.get('oae-link-login')).toBe('1');
@@ -1138,7 +1144,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(tab2.linkLoginNotice.hidden).toBe(true);
     expect(sharedCookieJar.get('oae-link-login')).toBeUndefined();
     const clearWrite = sharedCookieJar.writes[sharedCookieJar.writes.length - 1];
-    expect(clearWrite).toBe('oae-link-login=; path=/; SameSite=Strict; Max-Age=0');
+    expect(clearWrite).toBe('oae-link-login=; path=/; SameSite=Strict; Max-Age=0; Secure');
 
     // Tab 3: 新开或刷新标签页，此时 cookie 已被全局清理，不展示横幅
     const tab3 = createClientHarness({
@@ -1151,7 +1157,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(tab3.mockDocument.body.classList.contains('link-login-active')).toBe(false);
 
     // Tab 4 (表单登录测试): 手动表单登录也清除 origin-wide cookie
-    sharedCookieJar.cookie = 'oae-link-login=1; path=/; SameSite=Strict';
+    sharedCookieJar.cookie = 'oae-link-login=1; path=/; SameSite=Strict; Secure';
     expect(sharedCookieJar.get('oae-link-login')).toBe('1');
     const tab4 = createClientHarness({
       initialUrl: 'https://admin.example/ui',
@@ -1743,5 +1749,213 @@ describe('Issue #132: one-time exchange code hardening (Decision C)', () => {
     const replay = store.exchangeCode(codeB, '127.0.0.1');
     expect(replay.ok).toBe(false);
     if (!replay.ok) expect(replay.reason).toBe('invalid_token');
+  });
+
+  // Rework R3 - Mandatory 1: Failure audit throttling on create() and exchangeCode() denied branches, zero audit on rate_limited
+  test('Rework R3 (Mandatory 1): failure audit throttling on create() and exchangeCode() denied branches, zero audit on rate_limited', () => {
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === 'valid-admin' ? { kind: 'admin' } : null),
+    });
+
+    resetAuditForTests();
+    const testIp1 = '198.51.100.1';
+
+    // 1. create() failure audit throttling:
+    // First failed login creates an audit event
+    const res1 = store.create('invalid-tok-1', testIp1);
+    expect(res1.ok).toBe(false);
+    let auditEvents = readAuditEvents({ event: 'ui.session.login' });
+    expect(auditEvents.length).toBe(1);
+    expect(auditEvents[0].outcome).toBe('denied');
+    expect((auditEvents[0] as any).ip).toBe(testIp1);
+
+    // Subsequent 4 failed logins from same IP within 60s throttle audit writes (still 1 event)
+    for (let i = 2; i <= 5; i++) {
+      const res = store.create(`invalid-tok-${i}`, testIp1);
+      expect(res.ok).toBe(false);
+    }
+    auditEvents = readAuditEvents({ event: 'ui.session.login' });
+    expect(auditEvents.length).toBe(1);
+
+    // Fail up to MAX_IP_FAILURES (10)
+    for (let i = 6; i <= 10; i++) {
+      store.create(`invalid-tok-${i}`, testIp1);
+    }
+
+    // 11th attempt hits rate limit -> returns rate_limited and writes ZERO audit events
+    const rateLimitedRes = store.create('invalid-tok-11', testIp1);
+    expect(rateLimitedRes.ok).toBe(false);
+    if (!rateLimitedRes.ok) expect(rateLimitedRes.reason).toBe('rate_limited');
+    auditEvents = readAuditEvents({ event: 'ui.session.login' });
+    expect(auditEvents.length).toBe(1); // Zero audit written for rate_limited!
+
+    // 2. exchangeCode() failure audit throttling & zero audit on rate_limited
+    resetAuditForTests();
+    const testIp2 = '198.51.100.2';
+
+    // First failed exchangeCode generates 1 denied audit event
+    const ex1 = store.exchangeCode('nonexistent-code-1', testIp2);
+    expect(ex1.ok).toBe(false);
+    auditEvents = readAuditEvents({ event: 'ui.session.login' });
+    expect(auditEvents.length).toBe(1);
+    expect(auditEvents[0].outcome).toBe('denied');
+    expect((auditEvents[0] as any).ip).toBe(testIp2);
+
+    // Subsequent failed attempts from same IP within 60s throttle audit writes
+    for (let i = 2; i <= 5; i++) {
+      const ex = store.exchangeCode(`nonexistent-code-${i}`, testIp2);
+      expect(ex.ok).toBe(false);
+    }
+    auditEvents = readAuditEvents({ event: 'ui.session.login' });
+    expect(auditEvents.length).toBe(1);
+  });
+
+  // Rework R3 - Mandatory 2: exchangeCode failures count towards rate limiting and entry checks rate limits
+  test('Rework R3 (Mandatory 2): exchangeCode failures increment rate limiting and entry checks rate limits with zero audit', async () => {
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === 'valid-admin' ? { kind: 'admin' } : null),
+    });
+
+    resetAuditForTests();
+    const testIp = '198.51.100.42';
+
+    // Mint a code and consume it to get a replayable code
+    const mint = store.mintExchangeCode('valid-admin', '198.51.100.99');
+    expect(mint.ok).toBe(true);
+    if (!mint.ok) return;
+    const consumedCode = mint.code;
+    const firstEx = store.exchangeCode(consumedCode, '198.51.100.99');
+    expect(firstEx.ok).toBe(true);
+
+    // 5 unknown code failures + 5 replay code failures = 10 failures for testIp
+    for (let i = 1; i <= 5; i++) {
+      const res = store.exchangeCode(`unknown-code-${i}`, testIp);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toBe('invalid_token');
+    }
+    for (let i = 1; i <= 5; i++) {
+      const res = store.exchangeCode(consumedCode, testIp);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toBe('invalid_token');
+    }
+
+    // 11th attempt hits rate limit
+    const rateLimitedEx = store.exchangeCode('any-code', testIp);
+    expect(rateLimitedEx.ok).toBe(false);
+    if (!rateLimitedEx.ok) expect(rateLimitedEx.reason).toBe('rate_limited');
+
+    // Verify rate_limited rejection produced zero rate_limited audit events
+    const rateLimitedAudits = readAuditEvents({ event: 'ui.session.login' }).filter(
+      (e) => e.outcome === 'rate_limited',
+    );
+    expect(rateLimitedAudits.length).toBe(0);
+
+    // Verify via HTTP route /ui/api/session that rate_limited returns 429
+    const app = new Hono();
+    app.route('/ui/api/session', createUiSessionRoutes(store));
+
+    // Exhaust 'unknown' (clientIp fallback in app.request)
+    for (let i = 1; i <= 10; i++) {
+      store.exchangeCode(`local-unknown-${i}`, 'unknown');
+    }
+    const httpRateLimited = await app.request('/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:3100',
+      },
+      body: JSON.stringify({ code: 'any-code' }),
+    });
+    expect(httpRateLimited.status).toBe(429);
+    const body = (await httpRateLimited.json()) as any;
+    expect(body.error).toBe('rate_limited');
+  });
+
+  // Rework R3 - Cleanup 3: 302 redirect strips incoming code parameter on invalid/valid tokens and loginSchema ignores dead provenance input
+  test('Rework R3 (Cleanup 3): 302 redirect strips incoming code parameter and loginSchema ignores dead provenance input', async () => {
+    const validToken = 'valid-token-r3';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const app = new Hono();
+    registerUiShell(app, store);
+    app.route('/ui/api/session', createUiSessionRoutes(store));
+
+    // 1. Invalid token with pre-existing code parameter: code MUST be stripped!
+    const resInvalid = await app.request('/ui?token=bad-token&code=attacker-pre-set-code');
+    expect(resInvalid.status).toBe(302);
+    expect(resInvalid.headers.get('location')).toBe('/ui');
+    expect(resInvalid.headers.get('cache-control')).toBe('no-store');
+    expect(resInvalid.headers.get('referrer-policy')).toBe('no-referrer');
+
+    // 2. Valid token with pre-existing code parameter: old code stripped, replaced by fresh code
+    const resValid = await app.request(`/ui?token=${validToken}&code=stale-code&extra=keep`);
+    expect(resValid.status).toBe(302);
+    const validLocation = resValid.headers.get('location')!;
+    expect(validLocation).not.toContain('stale-code');
+    expect(validLocation).toContain('extra=keep');
+    expect(validLocation).toMatch(/\/ui\?extra=keep&code=[A-Za-z0-9_-]+/);
+
+    // 3. loginSchema ignores dead provenance input
+    resetAuditForTests();
+    const sessionRes = await app.request('/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost:3100',
+      },
+      body: JSON.stringify({
+        token: validToken,
+        provenance: 'attacker-client-provenance', // dead input surface
+      }),
+    });
+    expect(sessionRes.status).toBe(200);
+    const auditLogs = readAuditEvents({ event: 'ui.session.login' });
+    const successAudit = auditLogs.find((e) => e.outcome === 'ok');
+    expect(successAudit).toBeDefined();
+    // Server derives provenance as undefined for token logins, ignoring client value
+    expect((successAudit as any).provenance).toBeUndefined();
+  });
+
+  // Rework R3 - Cleanup 5: Authenticated session accessing GET /ui?token= does NOT mint a new code
+  test('Rework R3 (Cleanup 5): authenticated session GET /ui?token= redirects to sanitized URL without minting code', async () => {
+    const validToken = 'valid-token-r3-clean5';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const app = new Hono();
+    registerUiShell(app, store);
+
+    // Create an authenticated session
+    const session = store.create(validToken, '127.0.0.1');
+    expect(session.ok).toBe(true);
+    if (!session.ok) return;
+
+    expect(store.activeCodesCountForTests()).toBe(0);
+
+    // Request GET /ui?token=validToken while authenticated
+    const resAuth = await app.request(`/ui?token=${validToken}`, {
+      headers: {
+        cookie: `oae_ui=${session.sid}`,
+      },
+    });
+
+    expect(resAuth.status).toBe(302);
+    expect(resAuth.headers.get('location')).toBe('/ui');
+    // Crucial: No exchange code was minted!
+    expect(store.activeCodesCountForTests()).toBe(0);
+
+    // Request with sub-path and extra params while authenticated
+    const resAuthSub = await app.request(`/ui/inbox?token=${validToken}&folder=sent&code=stale`, {
+      headers: {
+        cookie: `oae_ui=${session.sid}`,
+      },
+    });
+
+    expect(resAuthSub.status).toBe(302);
+    expect(resAuthSub.headers.get('location')).toBe('/ui/inbox?folder=sent');
+    expect(store.activeCodesCountForTests()).toBe(0);
   });
 });

--- a/packages/api/test/ui-token-query.test.ts
+++ b/packages/api/test/ui-token-query.test.ts
@@ -1241,7 +1241,7 @@ describe('Issue #132: one-time exchange code hardening (Decision C)', () => {
       body: JSON.stringify({ code: mint2.code, provenance: 'link-exchange' }),
     });
     expect(res2.status).toBe(401);
-    const body2 = await res2.json();
+    const body2 = (await res2.json()) as any;
     expect(body2.error).toBe('invalid_token');
   });
 
@@ -1312,7 +1312,7 @@ describe('Issue #132: one-time exchange code hardening (Decision C)', () => {
       body: JSON.stringify({ code: mintShort.code, provenance: 'link-exchange' }),
     });
     expect(resExpired.status).toBe(401);
-    const bodyExpired = await resExpired.json();
+    const bodyExpired = (await resExpired.json()) as any;
     expect(bodyExpired.error).toBe('invalid_token');
   });
 
@@ -1497,5 +1497,251 @@ describe('Issue #132: one-time exchange code hardening (Decision C)', () => {
     const htmlWithout = await resWithout.text();
     expect(htmlWithout).not.toContain('Signed in via link as Admin session');
     expect(htmlWithout).not.toContain('id="link-login-notice"');
+  });
+
+  // Rework R2 - Mandatory Item 1: mint rate-limit window pruning
+  test('Rework R2 (Mandatory 1): mintExchangeCode prunes globalFailures window and does not permanently lock out link logins', () => {
+    const validToken = 'admin-secret';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const t0 = 1000000;
+    // 60 failures across different IPs within 60s
+    for (let i = 0; i < 60; i++) {
+      const res = store.mintExchangeCode(`bad-token-${i}`, `10.0.0.${i + 1}`, t0 + i * 100);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toBe('invalid_token');
+    }
+
+    // 61st attempt within window hits global rate limit
+    const limitedRes = store.mintExchangeCode(validToken, '10.1.1.1', t0 + 6000);
+    expect(limitedRes.ok).toBe(false);
+    if (!limitedRes.ok) expect(limitedRes.reason).toBe('rate_limited');
+
+    // After GLOBAL_FAILURE_WINDOW_MS (60s) has elapsed (e.g. t0 + 61_000):
+    // mintExchangeCode entry cleanup(now) prunes expired failures and minting succeeds
+    const recoveredRes = store.mintExchangeCode(validToken, '10.1.1.1', t0 + 61000);
+    expect(recoveredRes.ok).toBe(true);
+    if (recoveredRes.ok) {
+      expect(recoveredRes.auth).toEqual({ kind: 'admin' });
+      expect(recoveredRes.code).toBeDefined();
+    }
+  });
+
+  // Rework R2 - Mandatory Item 2: unauthenticated GET audit write amplification prevention
+  test('Rework R2 (Mandatory 2): unauthenticated GET mint does not write audit on rate_limited and throttles denied events to 1/min per IP', () => {
+    const validToken = 'admin-secret';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const t0 = 2000000;
+    const attackerIp = '198.51.100.42';
+
+    // 1. Send 5 invalid requests within 10s (under MAX_IP_FAILURES = 10)
+    for (let i = 0; i < 5; i++) {
+      const res = store.mintExchangeCode(`invalid-${i}`, attackerIp, t0 + i * 1000);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toBe('invalid_token');
+    }
+
+    // Check denied audit throttle: exactly 1 event recorded within the 60s window
+    const auditsT0 = readAuditEvents({ event: 'ui.token.exchange_mint' }).filter(
+      (e) => e.outcome === 'denied' && (e as any).ip === attackerIp,
+    );
+    expect(auditsT0).toHaveLength(1);
+
+    // 2. After 60s cooldown from t0 (t0 + 60_001), send 6th invalid request (still under 10 failures)
+    const resAfterCooldown = store.mintExchangeCode('invalid-after-cooldown', attackerIp, t0 + 60001);
+    expect(resAfterCooldown.ok).toBe(false);
+    if (!resAfterCooldown.ok) expect(resAfterCooldown.reason).toBe('invalid_token');
+
+    // Denied audit count increases to 2
+    const auditsT60 = readAuditEvents({ event: 'ui.token.exchange_mint' }).filter(
+      (e) => e.outcome === 'denied' && (e as any).ip === attackerIp,
+    );
+    expect(auditsT60).toHaveLength(2);
+
+    // 3. Now send 5 more invalid requests to push over MAX_IP_FAILURES (10)
+    for (let i = 0; i < 4; i++) {
+      store.mintExchangeCode(`invalid-fill-${i}`, attackerIp, t0 + 60002 + i);
+    }
+    // 11th total failure triggers rate_limited
+    const rlRes = store.mintExchangeCode(`invalid-over-limit`, attackerIp, t0 + 60010);
+    expect(rlRes.ok).toBe(false);
+    if (!rlRes.ok) expect(rlRes.reason).toBe('rate_limited');
+
+    // Verify rate_limited NEVER writes an audit event (zero write amplification on flood)
+    const allMintAudits = readAuditEvents({ event: 'ui.token.exchange_mint' });
+    const rateLimitedAudits = allMintAudits.filter((e) => e.outcome === 'rate_limited');
+    expect(rateLimitedAudits).toHaveLength(0);
+  });
+
+  // Rework R2 - Cleanup Item 3: exchange code upper bounds (global and per-token)
+  test('Rework R2 (Cleanup 3): exchange code upper bounds (per-token <= 5, global <= 1000)', () => {
+    const adminToken = 'admin-secret';
+    const otherToken = 'other-secret';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => {
+        if (tok === adminToken) return { kind: 'admin' };
+        if (tok === otherToken) return { kind: 'identity', address: 'bob@example.com' };
+        return null;
+      },
+      maxExchangeCodes: 4,
+      maxExchangeCodesPerToken: 2,
+    });
+
+    // Per-token limit: mint 2 codes for adminToken
+    const mint1 = store.mintExchangeCode(adminToken, '127.0.0.1');
+    const mint2 = store.mintExchangeCode(adminToken, '127.0.0.1');
+    expect(mint1.ok).toBe(true);
+    expect(mint2.ok).toBe(true);
+    expect(store.activeCodesCountForTests()).toBe(2);
+
+    // 3rd code for adminToken exceeds maxExchangeCodesPerToken (2)
+    const mint3 = store.mintExchangeCode(adminToken, '127.0.0.1');
+    expect(mint3.ok).toBe(false);
+    if (!mint3.ok) expect(mint3.reason).toBe('capacity');
+
+    // otherToken can still mint up to 2
+    const mintBob1 = store.mintExchangeCode(otherToken, '127.0.0.1');
+    const mintBob2 = store.mintExchangeCode(otherToken, '127.0.0.1');
+    expect(mintBob1.ok).toBe(true);
+    expect(mintBob2.ok).toBe(true);
+    expect(store.activeCodesCountForTests()).toBe(4); // Global capacity reached (4)
+
+    // Exchanging one code frees up token capacity
+    if (mint1.ok) {
+      const ex1 = store.exchangeCode(mint1.code, '127.0.0.1');
+      expect(ex1.ok).toBe(true);
+    }
+    expect(store.activeCodesCountForTests()).toBe(3);
+
+    // Now adminToken has only 1 active code and global is 3 < 4, so adminToken can mint again
+    const mintAdminRecovered = store.mintExchangeCode(adminToken, '127.0.0.1');
+    expect(mintAdminRecovered.ok).toBe(true);
+    expect(store.activeCodesCountForTests()).toBe(4);
+
+    // Now global is 4 >= 4, any mint is rejected on capacity
+    const mintGlobalExceeded = store.mintExchangeCode(otherToken, '127.0.0.1');
+    expect(mintGlobalExceeded.ok).toBe(false);
+    if (!mintGlobalExceeded.ok) expect(mintGlobalExceeded.reason).toBe('capacity');
+  });
+
+  // Rework R2 - Cleanup Items 4 & 5: Server-derived provenance and enforced remember: false
+  test('Rework R2 (Cleanup 4 & 5): provenance strictly server-derived and code exchange forces remember: false', async () => {
+    const validToken = 'test-audit-token-r2';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const app = new Hono();
+    app.use('/ui/api/session', uiSessionBodyLimit);
+    app.use('/ui/api/session', requireUiOrigin);
+    app.route('/ui/api/session', createUiSessionRoutes(store));
+
+    // 1. Client tries to forge provenance on token paste login
+    const resPaste = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ token: validToken, provenance: 'link-exchange', remember: true }),
+    });
+    expect(resPaste.status).toBe(200);
+    // Token paste with remember: true gets persistent cookie (max-age set)
+    const pasteSetCookie = resPaste.headers.get('set-cookie');
+    expect(pasteSetCookie).toContain('Max-Age=');
+
+    // 2. Client tries to send remember: true and malicious provenance on code exchange
+    const mint = store.mintExchangeCode(validToken, '127.0.0.1');
+    expect(mint.ok).toBe(true);
+    if (!mint.ok) return;
+
+    const resCode = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ code: mint.code, remember: true, provenance: 'attacker-injected' }),
+    });
+    expect(resCode.status).toBe(200);
+    // Code exchange forces remember: false -> cookie does NOT have Max-Age
+    const codeSetCookie = resCode.headers.get('set-cookie');
+    expect(codeSetCookie).not.toContain('Max-Age=');
+
+    // Check audit logs
+    const logins = readAuditEvents({ event: 'ui.session.login' });
+    // Paste audit must have provenance === undefined (client-supplied 'link-exchange' was ignored)
+    const pasteAudit = logins.find(
+      (e) => e.outcome === 'ok' && (e as any).address === 'admin' && (e as any).provenance === undefined,
+    );
+    expect(pasteAudit).toBeDefined();
+
+    // Code exchange audit must have provenance === 'link-exchange' (client-supplied 'attacker-injected' was ignored)
+    const codeAudit = logins.find((e) => e.outcome === 'ok' && (e as any).provenance === 'link-exchange');
+    expect(codeAudit).toBeDefined();
+  });
+
+  // Rework R2 - Cleanup Item 6: exchangeCode checks capacity before burning code
+  test('Rework R2 (Cleanup 6): exchangeCode checks capacity before burning code (unburnt code can retry)', () => {
+    const tokenA = 'token-a';
+    const tokenB = 'token-b';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => {
+        if (tok === tokenA) return { kind: 'admin' };
+        if (tok === tokenB) return { kind: 'identity', address: 'b@example.com' };
+        return null;
+      },
+      maxSessions: 1,
+    });
+
+    // Fill capacity with session for tokenA
+    const sessionA = store.create(tokenA, '127.0.0.1');
+    expect(sessionA.ok).toBe(true);
+    expect(store.sizeForTests()).toBe(1);
+
+    // Mint exchange code for tokenB
+    const mintB = store.mintExchangeCode(tokenB, '127.0.0.1');
+    expect(mintB.ok).toBe(true);
+    if (!mintB.ok) return;
+    const codeB = mintB.code;
+    expect(store.activeCodesCountForTests()).toBe(1);
+
+    // Attempt exchange when store is at capacity
+    const exResult = store.exchangeCode(codeB, '127.0.0.1');
+    expect(exResult.ok).toBe(false);
+    if (!exResult.ok) expect(exResult.reason).toBe('capacity');
+
+    // Verify code is NOT burned (still active, not consumed)
+    expect(store.activeCodesCountForTests()).toBe(1);
+    expect(store.consumedCodesCountForTests()).toBe(0);
+
+    // Free up session capacity by destroying sessionA
+    if (sessionA.ok) {
+      store.destroy(sessionA.sid);
+    }
+    expect(store.sizeForTests()).toBe(0);
+
+    // Retry exchange with the exact same codeB -> succeeds!
+    const retryResult = store.exchangeCode(codeB, '127.0.0.1');
+    expect(retryResult.ok).toBe(true);
+    if (retryResult.ok) {
+      expect(retryResult.auth).toEqual({ kind: 'identity', address: 'b@example.com' });
+    }
+
+    // Now codeB is burned
+    expect(store.activeCodesCountForTests()).toBe(0);
+    expect(store.consumedCodesCountForTests()).toBe(1);
+
+    // Replay is rejected as invalid_token
+    const replay = store.exchangeCode(codeB, '127.0.0.1');
+    expect(replay.ok).toBe(false);
+    if (!replay.ok) expect(replay.reason).toBe('invalid_token');
   });
 });

--- a/packages/api/test/ui-token-query.test.ts
+++ b/packages/api/test/ui-token-query.test.ts
@@ -1958,4 +1958,39 @@ describe('Issue #132: one-time exchange code hardening (Decision C)', () => {
     expect(resAuthSub.headers.get('location')).toBe('/ui/inbox?folder=sent');
     expect(store.activeCodesCountForTests()).toBe(0);
   });
+
+  // Rework R4 - Item 1: exchangeCode prunes globalFailures window at entry and does not lock out exchanges
+  test('Rework R4 (Item 1): exchangeCode prunes globalFailures window at entry and does not lock out exchanges', () => {
+    const validToken = 'admin-secret-r4';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const t0 = 1000000;
+    // Mint a valid exchange code
+    const mint = store.mintExchangeCode(validToken, '10.99.99.99', t0);
+    expect(mint.ok).toBe(true);
+    if (!mint.ok) return;
+    const validCode = mint.code;
+
+    // 60 failed exchange attempts across different IPs within 60s
+    for (let i = 0; i < 60; i++) {
+      const res = store.exchangeCode(`bad-code-${i}`, `10.0.0.${i + 1}`, t0 + i * 100);
+      expect(res.ok).toBe(false);
+      if (!res.ok) expect(res.reason).toBe('invalid_token');
+    }
+
+    // 61st exchange attempt within window hits global rate limit
+    const limitedRes = store.exchangeCode(validCode, '10.1.1.1', t0 + 6000);
+    expect(limitedRes.ok).toBe(false);
+    if (!limitedRes.ok) expect(limitedRes.reason).toBe('rate_limited');
+
+    // After GLOBAL_FAILURE_WINDOW_MS (60s) has elapsed (t0 + 61_000):
+    // exchangeCode entry cleanup(now) prunes expired failures and code exchange succeeds!
+    const recoveredRes = store.exchangeCode(validCode, '10.1.1.1', t0 + 61000);
+    expect(recoveredRes.ok).toBe(true);
+    if (recoveredRes.ok) {
+      expect(recoveredRes.auth).toEqual({ kind: 'admin' });
+    }
+  });
 });

--- a/packages/api/test/ui-token-query.test.ts
+++ b/packages/api/test/ui-token-query.test.ts
@@ -12,7 +12,7 @@ process.env.SMTP_USER = 'agent@test.example';
 process.env.SMTP_PASS = 'x';
 process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-ui-token-query-'));
 
-const { describe, expect, test } = await import('bun:test');
+const { describe, expect, test, beforeEach } = await import('bun:test');
 const { Hono } = await import('hono');
 const {
   UiSessionStore,
@@ -21,6 +21,9 @@ const {
   uiSessionBodyLimit,
   requireUiOrigin,
 } = await import('../src/lib/ui-session.ts');
+const { registerUiShell } = await import('../src/routes/ui-assets.ts');
+const { readAuditEvents, resetAuditForTests } = await import('../src/lib/audit.ts');
+const { createUiOAuthPageRoutes } = await import('../src/routes/ui-oauth.ts');
 
 const APP_JS = readFileSync(
   resolve(import.meta.dir, '../src/ui/client/app.js'),
@@ -456,10 +459,10 @@ function createClientHarness(options: HarnessOptions) {
 }
 
 describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
-  // 1. 无会话 + ?token=<valid> → 自动登录成功，进入应用，URL 中 token 已剥离（断言 replaceState 后的 location）。
-  test('1. Unauthenticated + ?token=<valid> auto-logins successfully and strips token from URL', async () => {
+  // 1. 无会话 + ?code=<valid> → 自动登录成功，进入应用，URL 中 code 已剥离（断言 replaceState 后的 location）。
+  test('1. Unauthenticated + ?code=<valid> auto-logins successfully and strips code from URL', async () => {
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=secret-token-123',
+      initialUrl: 'https://admin.example/ui?code=secret-code-123',
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
     });
@@ -468,17 +471,17 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
 
     await harness.instance.runStart();
 
-    // 断言 1: URL 中 token 已被 replaceState 剥离
+    // 断言 1: URL 中 code 已被 replaceState 剥离
     expect(harness.getCurrentUrl()).toBe('https://admin.example/ui');
     expect(harness.calls.replacedUrls).toEqual(['/ui']);
 
-    // 断言 2: 请求了 /ui/api/me 后再请求 /ui/api/session，且 remember 始终为 false（复选框自身不被重置）
+    // 断言 2: 请求了 /ui/api/me 后再请求 /ui/api/session，且 remember 始终为 false（复选框自身不被重置），带 provenance
     expect(harness.calls.fetches.length).toBe(2);
     expect(harness.calls.fetches[0].url).toBe('/ui/api/me');
     expect(harness.calls.fetches[1].url).toBe('/ui/api/session');
     expect(harness.calls.fetches[1].init?.method).toBe('POST');
     const sentBody = JSON.parse(harness.calls.fetches[1].init?.body as string);
-    expect(sentBody).toEqual({ token: 'secret-token-123', remember: false });
+    expect(sentBody).toEqual({ code: 'secret-code-123', provenance: 'link-exchange', remember: false });
     expect(harness.loginRemember.checked).toBe(true);
 
     // 断言 3: 进入应用
@@ -488,7 +491,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.loginView.hidden).toBe(true);
     expect(harness.state.me).toEqual({ kind: 'admin' });
 
-    // 断言 4: 登录输入框被清空，不留 token
+    // 断言 4: 登录输入框被清空，不留 token / code
     expect(harness.loginToken.value).toBe('');
 
     // 断言 5: 链接登录成功展示 visible notice banner 且激活 body class
@@ -497,12 +500,12 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.mockDocument.body.classList.contains('link-login-active')).toBe(true);
   });
 
-  // 2. 无会话 + ?token=<invalid> → 登录表单显示、错误文案正确、token 不回显、参数已剥离。
-  test('2. Unauthenticated + ?token=<invalid> shows login error, strips token from URL, and never echoes token', async () => {
+  // 2. 无会话 + ?code=<invalid> → 登录表单显示、错误文案正确、credential 不回显、参数已剥离。
+  test('2. Unauthenticated + ?code=<invalid> shows login error, strips code from URL, and never echoes credential', async () => {
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=bad-token-xyz',
+      initialUrl: 'https://admin.example/ui?code=bad-code-xyz',
       meResponse: { status: 401 },
-      sessionResponse: { status: 401, body: { error: 'invalid_token' } },
+      sessionResponse: { status: 401, body: { error: 'invalid_exchange_code' } },
     });
 
     await harness.instance.runStart();
@@ -520,16 +523,16 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.loginError.textContent).toBe('That token is not valid.');
     expect(harness.calls.showLogin).toContain('That token is not valid.');
 
-    // 断言 4: token 不得回显到输入框或错误文案中
+    // 断言 4: credential 不得回显到输入框或错误文案中
     expect(harness.loginToken.value).toBe('');
-    expect(harness.loginError.textContent).not.toContain('bad-token-xyz');
+    expect(harness.loginError.textContent).not.toContain('bad-code-xyz');
   });
 
-  // 3. 有会话 + ?token=<anything> → 直接进应用、不发起第二个 session POST、参数剥离、原会话保持。
-  test('3. Authenticated (200 on /ui/api/me) + ?token=<anything> enters app directly, strips parameter, and skips session POST', async () => {
+  // 3. 有会话 + ?code=<anything> → 直接进应用、不发起第二个 session POST、参数剥离、原会话保持。
+  test('3. Authenticated (200 on /ui/api/me) + ?code=<anything> enters app directly, strips parameter, and skips session POST', async () => {
     const existingSession = { kind: 'admin', email: 'existing@test.example' };
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=ignored-token-override',
+      initialUrl: 'https://admin.example/ui?code=ignored-code-override',
       meResponse: { status: 200, body: existingSession },
     });
 
@@ -551,11 +554,11 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.loginView.hidden).toBe(true);
   });
 
-  // 4. 剥离后刷新/重进不再用旧 token 重放（参数不在 location）。
-  test('4. Reload after parameter stripping has clean location and does not replay old token', async () => {
-    // 第一次访问：带 token
+  // 4. 剥离后刷新/重进不再用旧 code 重放（参数不在 location）。
+  test('4. Reload after parameter stripping has clean location and does not replay old code', async () => {
+    // 第一次访问：带 code
     const firstHarness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=one-time-token',
+      initialUrl: 'https://admin.example/ui?code=one-time-code',
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
     });
@@ -567,7 +570,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
 
     // 用户刷新页面（模拟浏览器用当前的 cleanUrl 重新初始化加载）
     const reloadHarness = createClientHarness({
-      initialUrl: cleanUrl, // 刷新时已无 token query 参数
+      initialUrl: cleanUrl, // 刷新时已无 code query 参数
       meResponse: { status: 401 }, // 假定 session 此时已失效
     });
 
@@ -585,7 +588,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
   // 5. 参数剥离应保留其余 query 参数和 URL hash
   test('5. Parameter stripping preserves other query parameters and URL hash', () => {
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?foo=bar&token=secret123&page=2#tab-settings',
+      initialUrl: 'https://admin.example/ui?foo=bar&code=secret123&page=2#tab-settings',
     });
 
     const consumed = harness.instance.consumeQueryToken();
@@ -594,17 +597,17 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.calls.replacedUrls).toEqual(['/ui?foo=bar&page=2#tab-settings']);
   });
 
-  // 6. 不安全 HTTP 环境（非 loopback）剥离 token，且拒绝发送 session POST
-  test('6. Insecure HTTP context strips token parameter but refuses to submit token over network', async () => {
+  // 6. 不安全 HTTP 环境（非 loopback）剥离 code，且拒绝发送 session POST
+  test('6. Insecure HTTP context strips code parameter but refuses to submit code over network', async () => {
     const harness = createClientHarness({
-      initialUrl: 'http://remote.example.com/ui?token=secret123',
+      initialUrl: 'http://remote.example.com/ui?code=secret123',
       isSecure: false,
       meResponse: { status: 401 },
     });
 
     await harness.instance.runStart();
 
-    // URL token 仍被剥离以防残留
+    // URL code 仍被剥离以防残留
     expect(harness.getCurrentUrl()).toBe('http://remote.example.com/ui');
 
     // 绝对不向服务端 POST session 凭据
@@ -618,10 +621,10 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.loginToken.value).toBe('');
   });
 
-  // 7. 深链深层路径（如 /ui/tasks/task-42?token=...）剥离参数时保持路由路径
-  test('7. Deep link path is preserved during token consumption', () => {
+  // 7. 深链深层路径（如 /ui/tasks/task-42?code=...）剥离参数时保持路由路径
+  test('7. Deep link path is preserved during code consumption', () => {
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui/tasks/task-42?token=secret123',
+      initialUrl: 'https://admin.example/ui/tasks/task-42?code=secret123',
     });
 
     const consumed = harness.instance.consumeQueryToken();
@@ -630,8 +633,20 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.calls.replacedUrls).toEqual(['/ui/tasks/task-42']);
   });
 
-  // 8. 与真实服务端 UiSessionStore 端到端集成测试
-  test('8. End-to-end integration with real UiSessionStore', async () => {
+  // 7b. 纵深防御：客户端遇到直接传递的 ?token=，剥离 URL 参数并返回 null，绝不直接消费令牌本体
+  test('7b. Defense-in-depth: client encountering direct ?token= strips it via replaceState and returns null', () => {
+    const harness = createClientHarness({
+      initialUrl: 'https://admin.example/ui?token=secret123',
+    });
+
+    const consumed = harness.instance.consumeQueryToken();
+    expect(consumed).toBeNull();
+    expect(harness.getCurrentUrl()).toBe('https://admin.example/ui');
+    expect(harness.calls.replacedUrls).toEqual(['/ui']);
+  });
+
+  // 8. 与真实服务端 UiSessionStore 及 registerUiShell 302 交换码重定向端到端集成测试
+  test('8. End-to-end integration with real UiSessionStore and 302 exchange-code redirection', async () => {
     const validAdminToken = 'admin-secret-token';
     const validTokenHash = createHash('sha256').update(validAdminToken).digest('hex');
 
@@ -641,6 +656,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     });
 
     const app = new Hono();
+    registerUiShell(app, store);
     app.use('/ui/api/session', uiSessionBodyLimit);
     app.use('/ui/api/session', requireUiOrigin);
     app.route('/ui/api/session', createUiSessionRoutes(store));
@@ -674,8 +690,17 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     };
 
     // 场景 A: 无会话访问 http://localhost:3100/ui?token=admin-secret-token
+    // 服务端拦截返回 302 重定向至 /ui?code=...
+    const initialGet = await app.request('http://localhost:3100/ui?token=admin-secret-token');
+    expect(initialGet.status).toBe(302);
+    const redirectLocation = initialGet.headers.get('location')!;
+    expect(redirectLocation).toMatch(/^\/ui\?code=[A-Za-z0-9_-]+/);
+    expect(initialGet.headers.get('cache-control')).toBe('no-store');
+    expect(initialGet.headers.get('referrer-policy')).toBe('no-referrer');
+
+    // 客户端随后在重定向后的 URL 加载并启动
     const clientA = createClientHarness({
-      initialUrl: 'http://localhost:3100/ui?token=admin-secret-token',
+      initialUrl: `http://localhost:3100${redirectLocation}`,
       customFetch: e2eFetch,
     });
 
@@ -708,9 +733,9 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
   });
 
   // 9. Fix 1 (ZCode P2-2): history.replaceState 不可用时 fail-closed：拒绝 query 自动登录，退回表单登录，token 不回显
-  test('9. Unavailable history.replaceState fails closed: refuses query auto-login, shows form, does not echo token', async () => {
+  test('9. Unavailable history.replaceState fails closed: refuses query auto-login, shows form, does not echo code', async () => {
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=super-secret-token',
+      initialUrl: 'https://admin.example/ui?code=super-secret-code',
       hasReplaceState: false,
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
@@ -718,7 +743,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
 
     await harness.instance.runStart();
 
-    // 断言 1: 没有发起 POST /ui/api/session 发送 token（硬性拒绝，避免凭据残留在地址栏）
+    // 断言 1: 没有发起 POST /ui/api/session 发送 code（硬性拒绝，避免凭据残留在地址栏）
     expect(harness.calls.fetches.length).toBe(1);
     expect(harness.calls.fetches[0].url).toBe('/ui/api/me');
 
@@ -728,7 +753,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(harness.calls.showInboxCount).toBe(0);
     expect(harness.calls.showLogin).toEqual(['']);
 
-    // 断言 3: token 永不回显进输入框，也不展示链接登录提示
+    // 断言 3: code 永不回显进输入框，也不展示链接登录提示
     expect(harness.loginToken.value).toBe('');
     expect(harness.loginError.textContent).toBe('');
     expect(harness.calls.announced).toHaveLength(0);
@@ -738,9 +763,9 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
 
   // 10. Fix 2 (ZCode P2-3) & R4 Fix 1 (ZCode P1-1) & R5 & R8: query 链接登录成功展示 visible banner 与 announcement 提示并设置 sessionStorage marker 与 body class，粘贴表单登录不展示且清除 marker 与 class
   test('10. Visible notice appears on query-login success and does NOT appear on paste-form login success', async () => {
-    // 场景 A: Admin 身份 query token 登录成功 → 提示 "Signed in via link as Admin session" 并写入 sessionStorage marker 与 body class
+    // 场景 A: Admin 身份 query code 登录成功 → 提示 "Signed in via link as Admin session" 并写入 sessionStorage marker 与 body class
     const adminLinkHarness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=admin-query-token',
+      initialUrl: 'https://admin.example/ui?code=admin-query-code',
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
     });
@@ -752,9 +777,9 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(adminLinkHarness.sessionStorage.getItem('oae-link-login')).toBe('1');
     expect(adminLinkHarness.mockDocument.body.classList.contains('link-login-active')).toBe(true);
 
-    // 场景 B: Identity 身份 query token 登录成功 → 提示 "Signed in via link as <address>" 并写入 marker 与 class
+    // 场景 B: Identity 身份 query code 登录成功 → 提示 "Signed in via link as <address>" 并写入 marker 与 class
     const identityLinkHarness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=identity-query-token',
+      initialUrl: 'https://admin.example/ui?code=identity-query-code',
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'identity', address: 'agent-bot@example.com' } },
     });
@@ -876,7 +901,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
   test('13. Storage-throws case: login succeeds even if sessionStorage throws (fail-open try/catch)', async () => {
     // 场景 A: query link 登录在 sessionStorage 抛出异常时仍顺利进入应用
     const queryHarness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=safe-query-token',
+      initialUrl: 'https://admin.example/ui?code=safe-query-code',
       storageThrows: true,
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
@@ -916,7 +941,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     });
 
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=query-link-token',
+      initialUrl: 'https://admin.example/ui?code=query-link-code',
       customFetch: async (url, init) => {
         if (url === '/ui/api/me') {
           return mePromise;
@@ -926,7 +951,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
           return {
             status: 200,
             ok: true,
-            json: async () => ({ kind: 'identity', address: `${body.token}@manual.example` }),
+            json: async () => ({ kind: 'identity', address: `${body.token || body.code}@manual.example` }),
           } as unknown as Response;
         }
         throw new Error(`Unexpected fetch ${url}`);
@@ -964,7 +989,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     const postCallsAfterMe = harness.calls.fetches.filter(
       (f) => f.url === '/ui/api/session' && f.init?.method === 'POST',
     );
-    expect(postCallsAfterMe).toHaveLength(1); // 仍然只有 1 次 POST，没有为 query token 发送 POST
+    expect(postCallsAfterMe).toHaveLength(1); // 仍然只有 1 次 POST，没有为 query code 发送 POST
     expect(harness.state.me).toEqual({ kind: 'identity', address: 'manual-user@manual.example' });
     expect(harness.linkLoginNotice.hidden).toBe(true);
     expect(harness.sessionStorage.getItem('oae-link-login')).toBeNull();
@@ -979,7 +1004,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     });
 
     const harness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=early-banner-token',
+      initialUrl: 'https://admin.example/ui?code=early-banner-code',
       hangStartSession: hangPromise,
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
@@ -1012,7 +1037,7 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
   test('16. document.body.classList manages link-login-active in sync with link-login notice', async () => {
     // 场景 A: query login 成功 → 添加 link-login-active
     const linkHarness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=link-token',
+      initialUrl: 'https://admin.example/ui?code=link-code',
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
     });
@@ -1032,9 +1057,9 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
   test('17. Query login with returnTo sets marker before redirect, and banner is restored on subsequent load', async () => {
     const sharedCookieJar = new CookieJar();
 
-    // 步骤 1: 首次访问带 ?token=query-token，POST /ui/api/session 返回带 returnTo 的响应
+    // 步骤 1: 首次访问带 ?code=query-oauth-code，POST /ui/api/session 返回带 returnTo 的响应
     const oauthLoginHarness = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=query-oauth-token',
+      initialUrl: 'https://admin.example/ui?code=query-oauth-code',
       sharedCookieJar,
       meResponse: { status: 401 },
       sessionResponse: {
@@ -1074,9 +1099,9 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
   test('18. Origin-wide JS session cookie shares provenance across tabs and clears on logout or form login', async () => {
     const sharedCookieJar = new CookieJar();
 
-    // Tab 1: 通过 ?token= 链接登录
+    // Tab 1: 通过 ?code= 链接登录
     const tab1 = createClientHarness({
-      initialUrl: 'https://admin.example/ui?token=tab1-link-token',
+      initialUrl: 'https://admin.example/ui?code=tab1-link-code',
       sharedCookieJar,
       meResponse: { status: 401 },
       sessionResponse: { status: 200, body: { kind: 'admin' } },
@@ -1139,5 +1164,338 @@ describe('Issue #60: bookmarkable ?token= query parameter direct login', () => {
     expect(sharedCookieJar.get('oae-link-login')).toBeUndefined();
     expect(tab4.linkLoginNotice.hidden).toBe(true);
     expect(tab4.mockDocument.body.classList.contains('link-login-active')).toBe(false);
+  });
+});
+
+describe('Issue #132: one-time exchange code hardening (Decision C)', () => {
+  beforeEach(() => {
+    resetAuditForTests();
+  });
+
+  // Hard Constraint 1: One-time exchange code burned immediately; replay returns 401 and logs outcome denied
+  test('Hard Constraint 1: Exchange code is one-time; replay is rejected with 401 and logged as denied', async () => {
+    const validToken = 'test-admin-token';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    // 1. Mint exchange code
+    const mintResult = store.mintExchangeCode(validToken, '192.168.1.100');
+    expect(mintResult.ok).toBe(true);
+    if (!mintResult.ok) return;
+    const code = mintResult.code;
+
+    // Verify mint audit event
+    const mintEvents = readAuditEvents({ event: 'ui.token.exchange_mint' });
+    expect(mintEvents.length).toBeGreaterThan(0);
+    expect(mintEvents[0].outcome).toBe('ok');
+
+    // 2. First exchange succeeds
+    const firstExchange = store.exchangeCode(code, '192.168.1.100', Date.now(), false, 'link-exchange');
+    expect(firstExchange.ok).toBe(true);
+    if (firstExchange.ok) {
+      expect(firstExchange.auth).toEqual({ kind: 'admin' });
+    }
+
+    // 3. Replay exchange fails immediately
+    const replayExchange = store.exchangeCode(code, '192.168.1.100', Date.now(), false, 'link-exchange');
+    expect(replayExchange.ok).toBe(false);
+
+    // Verify replay audit event has outcome: 'denied'
+    const loginEvents = readAuditEvents({ event: 'ui.session.login' });
+    const deniedEvent = loginEvents.find(
+      (e) => e.outcome === 'denied' && (e as any).provenance === 'link-exchange',
+    );
+    expect(deniedEvent).toBeDefined();
+
+    // 4. Also verify via HTTP API route
+    const app = new Hono();
+    app.use('/ui/api/session', uiSessionBodyLimit);
+    app.use('/ui/api/session', requireUiOrigin);
+    app.route('/ui/api/session', createUiSessionRoutes(store));
+
+    const mint2 = store.mintExchangeCode(validToken, '127.0.0.1');
+    expect(mint2.ok).toBe(true);
+    if (!mint2.ok) return;
+
+    // HTTP first exchange -> 200
+    const res1 = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ code: mint2.code, provenance: 'link-exchange' }),
+    });
+    expect(res1.status).toBe(200);
+
+    // HTTP replay -> 401
+    const res2 = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ code: mint2.code, provenance: 'link-exchange' }),
+    });
+    expect(res2.status).toBe(401);
+    const body2 = await res2.json();
+    expect(body2.error).toBe('invalid_token');
+  });
+
+  // Hard Constraint 2: Code TTL <= 10 min; expired exchange codes are rejected (401 + denied audit)
+  test('Hard Constraint 2: Exchange code TTL <= 10 min; expired codes return 401 and are logged as denied', async () => {
+    const validToken = 'test-admin-token';
+    // Test that store clamps exchangeCodeTtlMs to max 10 min (600,000 ms)
+    const storeOverClamped = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+      exchangeCodeTtlMs: 30 * 60 * 1000, // 30 min requested -> clamped to 10 min
+    });
+    const t0 = 1000000;
+    const mintClamped = storeOverClamped.mintExchangeCode(validToken, '127.0.0.1', t0);
+    expect(mintClamped.ok).toBe(true);
+    if (!mintClamped.ok) return;
+
+    // At t0 + 10 min - 1 ms -> still valid
+    const validJustBefore = storeOverClamped.exchangeCode(
+      mintClamped.code,
+      '127.0.0.1',
+      t0 + 10 * 60 * 1000 - 1,
+    );
+    expect(validJustBefore.ok).toBe(true);
+
+    // Test with another code that expires at t0 + 10 min + 1 ms
+    const mintExpired = storeOverClamped.mintExchangeCode(validToken, '127.0.0.1', t0);
+    expect(mintExpired.ok).toBe(true);
+    if (!mintExpired.ok) return;
+
+    const expiredRes = storeOverClamped.exchangeCode(
+      mintExpired.code,
+      '127.0.0.1',
+      t0 + 10 * 60 * 1000 + 1,
+    );
+    expect(expiredRes.ok).toBe(false);
+
+    // Verify expired audit event has outcome: 'denied'
+    const loginEvents = readAuditEvents({ event: 'ui.session.login' });
+    const expiredEvent = loginEvents.find(
+      (e) => e.outcome === 'denied' && (e as any).provenance === 'link-exchange',
+    );
+    expect(expiredEvent).toBeDefined();
+
+    // Also verify via HTTP route with short TTL
+    const storeShort = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+      exchangeCodeTtlMs: 50, // 50 ms
+    });
+    const app = new Hono();
+    app.use('/ui/api/session', uiSessionBodyLimit);
+    app.use('/ui/api/session', requireUiOrigin);
+    app.route('/ui/api/session', createUiSessionRoutes(storeShort));
+
+    const mintShort = storeShort.mintExchangeCode(validToken, '127.0.0.1');
+    expect(mintShort.ok).toBe(true);
+    if (!mintShort.ok) return;
+
+    // Wait 60 ms for expiry
+    await new Promise((r) => setTimeout(r, 60));
+
+    const resExpired = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ code: mintShort.code, provenance: 'link-exchange' }),
+    });
+    expect(resExpired.status).toBe(401);
+    const bodyExpired = await resExpired.json();
+    expect(bodyExpired.error).toBe('invalid_token');
+  });
+
+  // Hard Constraint 3: Exchange code is bound to recipient identity
+  test('Hard Constraint 3: Exchange code is strictly bound to original auth and cannot create session for another principal', async () => {
+    const adminToken = 'admin-secret';
+    const identityToken = 'identity-secret';
+
+    const store = new UiSessionStore({
+      resolveToken: (tok) => {
+        if (tok === adminToken) return { kind: 'admin' };
+        if (tok === identityToken) return { kind: 'identity', address: 'alice@test.example' };
+        return null;
+      },
+    });
+
+    // Mint code for admin
+    const mintAdmin = store.mintExchangeCode(adminToken, '127.0.0.1');
+    expect(mintAdmin.ok).toBe(true);
+    if (!mintAdmin.ok) return;
+
+    // Mint code for identity
+    const mintIdentity = store.mintExchangeCode(identityToken, '127.0.0.1');
+    expect(mintIdentity.ok).toBe(true);
+    if (!mintIdentity.ok) return;
+
+    // Exchanging admin code yields admin auth
+    const sessionAdmin = store.exchangeCode(mintAdmin.code, '127.0.0.1');
+    expect(sessionAdmin.ok).toBe(true);
+    if (sessionAdmin.ok) {
+      expect(sessionAdmin.auth).toEqual({ kind: 'admin' });
+    }
+
+    // Exchanging identity code yields identity auth
+    const sessionIdentity = store.exchangeCode(mintIdentity.code, '127.0.0.1');
+    expect(sessionIdentity.ok).toBe(true);
+    if (sessionIdentity.ok) {
+      expect(sessionIdentity.auth).toEqual({ kind: 'identity', address: 'alice@test.example' });
+    }
+  });
+
+  // Provenance audit logging: differentiates link-exchange from paste login
+  test('Provenance audit: differentiates link-exchange from direct paste login', async () => {
+    const validToken = 'test-audit-token';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const app = new Hono();
+    app.use('/ui/api/session', uiSessionBodyLimit);
+    app.use('/ui/api/session', requireUiOrigin);
+    app.route('/ui/api/session', createUiSessionRoutes(store));
+
+    // 1. Link exchange login
+    const mint = store.mintExchangeCode(validToken, '127.0.0.1');
+    expect(mint.ok).toBe(true);
+    if (!mint.ok) return;
+
+    const resExchange = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ code: mint.code, provenance: 'link-exchange' }),
+    });
+    expect(resExchange.status).toBe(200);
+
+    // 2. Direct form paste login (no code, no provenance)
+    const resPaste = await app.request('http://localhost/ui/api/session', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        origin: 'http://localhost',
+        'sec-fetch-site': 'same-origin',
+      },
+      body: JSON.stringify({ token: validToken }),
+    });
+    expect(resPaste.status).toBe(200);
+
+    // Check audit events
+    const loginAudits = readAuditEvents({ event: 'ui.session.login' });
+    const exchangeAudit = loginAudits.find((e) => (e as any).provenance === 'link-exchange');
+    expect(exchangeAudit).toBeDefined();
+    expect(exchangeAudit?.outcome).toBe('ok');
+
+    const pasteAudit = loginAudits.find(
+      (e) => (e as any).provenance === undefined && e.outcome === 'ok',
+    );
+    expect(pasteAudit).toBeDefined();
+  });
+
+  // Server 302 Redirection & URL Sanitization
+  test('Server 302: valid ?token= redirects to ?code=... with no-store and no-referrer', async () => {
+    const validToken = 'admin-pass';
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === validToken ? { kind: 'admin' } : null),
+    });
+
+    const app = new Hono();
+    registerUiShell(app, store);
+
+    // Valid token on /ui
+    const resValid = await app.request('http://localhost/ui?token=admin-pass');
+    expect(resValid.status).toBe(302);
+    const locValid = resValid.headers.get('location')!;
+    expect(locValid).toMatch(/^\/ui\?code=[A-Za-z0-9_-]+/);
+    expect(locValid).not.toContain('admin-pass');
+    expect(resValid.headers.get('cache-control')).toBe('no-store');
+    expect(resValid.headers.get('referrer-policy')).toBe('no-referrer');
+
+    // Valid token on deep path /ui/tasks/10 with extra params
+    const resDeep = await app.request('http://localhost/ui/tasks/10?token=admin-pass&filter=unread');
+    expect(resDeep.status).toBe(302);
+    const locDeep = resDeep.headers.get('location')!;
+    expect(locDeep).toContain('/ui/tasks/10');
+    expect(locDeep).toContain('filter=unread');
+    expect(locDeep).toMatch(/code=[A-Za-z0-9_-]+/);
+    expect(locDeep).not.toContain('admin-pass');
+
+    // Invalid token on /ui -> sanitized 302 to /ui without token
+    const resInvalid = await app.request('http://localhost/ui?token=bad-token-xyz');
+    expect(resInvalid.status).toBe(302);
+    expect(resInvalid.headers.get('location')).toBe('/ui');
+    expect(resInvalid.headers.get('cache-control')).toBe('no-store');
+    expect(resInvalid.headers.get('referrer-policy')).toBe('no-referrer');
+
+    // Verify invalid mint recorded denied audit event
+    const mintEvents = readAuditEvents({ event: 'ui.token.exchange_mint' });
+    const deniedMint = mintEvents.find((e) => e.outcome === 'denied');
+    expect(deniedMint).toBeDefined();
+  });
+
+  // OAuth Consent Page: link login notice banner rendered when oae-link-login cookie is present
+  test('OAuth Consent Page: renders link-login-notice banner when oae-link-login=1 cookie is present', async () => {
+    const store = new UiSessionStore({
+      resolveToken: (tok) => (tok === 'admin-token' ? { kind: 'admin' } : null),
+    });
+    const created = store.create('admin-token', '127.0.0.1', Date.now());
+    expect(created.ok).toBe(true);
+    if (!created.ok) return;
+
+    const options = {
+      cimdFetcher: async () =>
+        new Response(
+          JSON.stringify({
+            client_name: 'Test OAuth App',
+            client_id: 'https://client.example/metadata.json',
+            redirect_uris: ['https://client.example/cb'],
+          }),
+          { status: 200, headers: { 'content-type': 'application/json' } },
+        ),
+    };
+
+    const app = new Hono();
+    app.route('/ui/oauth', createUiOAuthPageRoutes(store, options as any));
+
+    const q = new URLSearchParams({
+      response_type: 'code',
+      client_id: 'https://client.example/metadata.json',
+      redirect_uri: 'https://client.example/cb',
+      code_challenge: 'E9Melhoa2OwvFrGMTJguCH5rtx64NetqiSTUUcfDcUI',
+      code_challenge_method: 'S256',
+      resource: 'http://localhost/mcp',
+    });
+
+    // 场景 A: 带 oae-link-login=1 cookie 访问同意页
+    const resWithLinkCookie = await app.request(`http://localhost/ui/oauth/authorize?${q}`, {
+      headers: { cookie: `oae_ui=${created.sid}; oae-link-login=1` },
+    });
+    expect(resWithLinkCookie.status).toBe(200);
+    const htmlWithLink = await resWithLinkCookie.text();
+    expect(htmlWithLink).toContain('Signed in via link as Admin session');
+    expect(htmlWithLink).toContain('id="link-login-notice"');
+
+    // 场景 B: 不带 oae-link-login cookie 访问同意页
+    const resWithout = await app.request(`http://localhost/ui/oauth/authorize?${q}`, {
+      headers: { cookie: `oae_ui=${created.sid}` },
+    });
+    expect(resWithout.status).toBe(200);
+    const htmlWithout = await resWithout.text();
+    expect(htmlWithout).not.toContain('Signed in via link as Admin session');
+    expect(htmlWithout).not.toContain('id="link-login-notice"');
   });
 });


### PR DESCRIPTION
Closes #132

### Design Decision & Hardening Architecture (Decision C)

Implements Option C hardening for `/ui?token=` bookmark direct logins:
302 sanitization + one-time exchange code + provenance audit logging.

1. **Legacy Entry Preservation & Server 302 Redirection**:
   The `?token=` query entry point is preserved without breaking bookmarks
   or external links. On incoming requests to UI shell paths with `?token=`,
   the server verifies the token and immediately responds with a 302 redirect
   to `${pathname}?code=${exchangeCode}` with `Cache-Control: no-store` and
   `Referrer-Policy: no-referrer`. If invalid, redirects to clean path. The
   long-lived token is never directly exposed to or consumed by client JS.

2. **Hard Constraint 1: One-time Code (Exchange & Burn)**:
   The exchange code is burned immediately upon exchange. Replay attempts
   are rejected with 401 Unauthorized and audited with outcome 'denied'.

3. **Hard Constraint 2: Code TTL <= 10 min**:
   Exchange code lifetime is strictly capped at <= 10 minutes (server clamped).
   Expired exchange codes are rejected with 401 and logged as denied.

4. **Hard Constraint 3: Bound to Recipient Identity**:
   Exchange codes are bound to the authenticated principal resolved at mint
   time (admin or identity), preventing cross-principal exchange.

5. **Provenance Audit & UI Notice**:
   `POST /ui/api/session` accepts an optional `provenance: 'link-exchange'`
   payload, differentiating link exchange logins from form paste logins in
   `ui.session.login` audit logs. Link sessions display the persistent
   "Signed in via link" banner across UI and OAuth consent pages.

6. **Documentation**:
   Documented reverse-proxy query scrubbing (Nginx, Caddy, Cloudflare, Traefik)
   in `docs/security.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Sign-in links now use short-lived, single-use exchange codes instead of exposing long-lived tokens after redirection.
  * Sensitive URL parameters are sanitized through secure redirects and browser cleanup, with guidance for reverse-proxy log scrubbing.
  * Replayed, expired, or improperly bound codes are rejected.
  * Link-based Admin sessions now display a warning on the OAuth consent page.
* **Documentation**
  * Updated the README and security guide with the new sign-in flow and deployment recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->