### PR TITLE
chore(api): delegation ACL hardening follow-ups (#136)

### DIFF
--- a/packages/api/src/lib/delegations.ts
+++ b/packages/api/src/lib/delegations.ts
@@ -76,18 +76,19 @@ function isGrantShape(value: unknown): value is Record<string, unknown> {
   );
 }
 
-function coerceGrant(raw: Record<string, unknown>): DelegationGrant | null {
-  const rawScopes = Array.isArray(raw.scopes) ? (raw.scopes as string[]) : [];
-  const scopes = rawScopes.filter((s) => typeof s === 'string' && isSupportedScope(s));
-  if (scopes.length === 0) {
-    return null;
-  }
+/**
+ * 原始视图：字段规范化（小写/去空白）但**不做 scope 白名单过滤**。
+ * 仅供 load() 对收窄/剔除项留痕，以及 revoke 路径对「被剔除」的 grant
+ * 幂等落墓碑使用（Issue #136 R2）。
+ */
+function rawGrantView(raw: Record<string, unknown>): DelegationGrant {
+  const rawScopes = Array.isArray(raw.scopes) ? (raw.scopes as unknown[]) : [];
   return {
     ...raw,
     id: raw.id as string,
     mailbox: (raw.mailbox as string).trim().toLowerCase(),
     grantee: (raw.grantee as string).trim().toLowerCase(),
-    scopes,
+    scopes: rawScopes.filter((s): s is string => typeof s === 'string'),
     createdAt: raw.createdAt as string,
     createdBy: raw.createdBy as string,
     revokedAt: (raw.revokedAt as string | null) ?? null,
@@ -126,6 +127,8 @@ const MISSING_STORE_VERSION: StoreFileVersion = {
 type StoreCache = {
   version: StoreFileVersion;
   store: DelegationStoreFile;
+  /** load 时被整条剔除（无任何支持 scope）的 grant 原始视图：留痕 + 幂等撤销用。 */
+  droppedGrants: DelegationGrant[];
 };
 
 let storeCache: StoreCache | undefined;
@@ -160,11 +163,11 @@ function storeVersionsEqual(a: StoreFileVersion, b: StoreFileVersion): boolean {
   );
 }
 
-function load(): DelegationStoreFile {
+function loadCache(): StoreCache {
   const path = storePath();
   if (!existsSync(path)) {
     if (storeCache && storeVersionsEqual(storeCache.version, MISSING_STORE_VERSION)) {
-      return storeCache.store;
+      return storeCache;
     }
     storeCache = {
       version: MISSING_STORE_VERSION,
@@ -172,40 +175,58 @@ function load(): DelegationStoreFile {
         schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
         grants: [],
       },
+      droppedGrants: [],
     };
-    return storeCache.store;
+    return storeCache;
   }
   try {
     const version = fileVersionFromStat(statSync(path));
     if (storeCache && storeVersionsEqual(storeCache.version, version)) {
-      return storeCache.store;
+      return storeCache;
     }
     const parsed = JSON.parse(readFileSync(path, 'utf8'));
     if (!isDelegationStoreShape(parsed)) {
       throw new Error('invalid delegation store shape');
     }
     const grants: DelegationGrant[] = [];
+    const droppedGrants: DelegationGrant[] = [];
     for (const entry of parsed.grants) {
-      const coerced = coerceGrant(entry as Record<string, unknown>);
-      if (coerced) {
-        grants.push(coerced);
+      const view = rawGrantView(entry as Record<string, unknown>);
+      const scopes = view.scopes.filter((s) => isSupportedScope(s));
+      if (scopes.length === 0) {
+        // Issue #136 R2：整条剔除必须留痕，不能静默吞掉磁盘上的残留。
+        console.warn(
+          `[delegations] grant ${view.id} (${view.mailbox} → ${view.grantee}) dropped at load: no supported scopes in ${JSON.stringify(view.scopes)}`,
+        );
+        droppedGrants.push(view);
+        continue;
       }
+      if (scopes.length < view.scopes.length) {
+        console.warn(
+          `[delegations] grant ${view.id} (${view.mailbox} → ${view.grantee}) scopes narrowed at load: kept ${JSON.stringify(scopes)}, dropped ${JSON.stringify(view.scopes.filter((s) => !isSupportedScope(s)))}`,
+        );
+      }
+      grants.push({ ...view, scopes });
     }
-    const store: DelegationStoreFile = {
-      ...parsed,
-      schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
-      grants,
-    };
     storeCache = {
       version,
-      store,
+      store: {
+        ...parsed,
+        schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
+        grants,
+      },
+      droppedGrants,
     };
-    return storeCache.store;
+    return storeCache;
   } catch (err) {
     invalidateDelegationStoreCache();
     if ((err as Error).message === 'delegation_store_corrupt') throw err;
     throw new Error('delegation_store_corrupt', { cause: err });
   }
+}
+
+function load(): DelegationStoreFile {
+  return loadCache().store;
 }
 
 function save(store: DelegationStoreFile): void {
@@ -265,6 +286,15 @@ export function getDelegation(id: string): DelegationGrant | undefined {
   return store.grants.find((g) => g.id === id);
 }
 
+/**
+ * load() 整条剔除的 grant（如手工植入全不支持 scope 的脏数据）：返回其原始视图。
+ * 供 DELETE /v1/delegations/:id 做授权与幂等撤销「磁盘残留」——这类 id 对
+ * getDelegation / listDelegations 不可见（Issue #136 R2 顺清 3）。
+ */
+export function getDroppedDelegation(id: string): DelegationGrant | undefined {
+  return loadCache().droppedGrants.find((g) => g.id === id);
+}
+
 export function listDelegations(filter?: {
   mailbox?: string;
   grantee?: string;
@@ -306,6 +336,7 @@ export function hasActiveDelegation(
 /**
  * 撤销委托：写入 revokedAt 墓碑。
  * 幂等：若已撤销，保留原 revokedAt / revokedBy 返回。
+ * 被 load() 整条剔除的 grant 同样可撤销（磁盘原始记录就地落墓碑）。
  */
 export function revokeDelegation(
   id: string,
@@ -314,7 +345,9 @@ export function revokeDelegation(
 ): DelegationGrant | null {
   const store = load();
   const grant = store.grants.find((g) => g.id === id);
-  if (!grant) return null;
+  if (!grant) {
+    return revokeDroppedGrant(id, revokedBy, revokedAt);
+  }
   if (grant.revokedAt !== null) {
     return grant;
   }
@@ -322,6 +355,49 @@ export function revokeDelegation(
   grant.revokedBy = revokedBy;
   save(store);
   return grant;
+}
+
+/**
+ * 撤销被 load() 剔除的 grant：coerced store 不含它（save() 不会带走），
+ * 故直接在磁盘原始记录上落墓碑，保持墓碑语义可审计。幂等：已撤销则原样返回。
+ */
+function revokeDroppedGrant(
+  id: string,
+  revokedBy: string,
+  revokedAt?: string,
+): DelegationGrant | null {
+  const dropped = getDroppedDelegation(id);
+  if (!dropped) return null;
+  if (dropped.revokedAt !== null) return dropped;
+
+  const path = storePath();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(path, 'utf8'));
+  } catch (err) {
+    throw new Error('delegation_store_corrupt', { cause: err });
+  }
+  if (!isDelegationStoreShape(parsed)) {
+    throw new Error('delegation_store_corrupt', {
+      cause: new Error('invalid delegation store shape'),
+    });
+  }
+  const entry = (parsed.grants as Record<string, unknown>[]).find((g) => g.id === id);
+  if (!entry) return null;
+  if (typeof entry.revokedAt === 'string' && entry.revokedAt) {
+    // 磁盘上已被撤销（剔除视图落后于文件）：刷新缓存后按幂等语义返回。
+    invalidateDelegationStoreCache();
+    return getDroppedDelegation(id) ?? null;
+  }
+  const ts = revokedAt ?? new Date().toISOString();
+  entry.revokedAt = ts;
+  entry.revokedBy = revokedBy;
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, JSON.stringify(parsed, null, 2), { mode: 0o600 });
+  chmodSync(tmp, 0o600);
+  renameSync(tmp, path);
+  invalidateDelegationStoreCache();
+  return { ...dropped, revokedAt: ts, revokedBy };
 }
 
 function cascadeRevokeGrants(

--- a/packages/api/src/lib/delegations.ts
+++ b/packages/api/src/lib/delegations.ts
@@ -127,7 +127,11 @@ const MISSING_STORE_VERSION: StoreFileVersion = {
 type StoreCache = {
   version: StoreFileVersion;
   store: DelegationStoreFile;
-  /** load 时被整条剔除（无任何支持 scope）的 grant 原始视图：留痕 + 幂等撤销用。 */
+  /**
+   * load 时被整条剔除（无任何支持 scope）的 grant 原始视图。
+   * 三处消费（Issue #136 R2/R4）：留痕告警、幂等撤销、随 save() 一并写回
+   * 磁盘——dropped 记录不随全量重写消失，级联吊销也扫得到它们。
+   */
   droppedGrants: DelegationGrant[];
 };
 
@@ -229,7 +233,15 @@ function load(): DelegationStoreFile {
   return loadCache().store;
 }
 
+/**
+ * 全量原子重写存储文件。R4 语义：coerced grants 与 load 剔除的
+ * droppedGrants（原始视图，含原始 scopes/墓碑）**一并写回**——save 是整
+ * 文件 tmp+rename 重写，若只序列化 store.grants，任何一次普通写入都会把
+ * 磁盘上的 dropped 记录静默抹掉（之后 DELETE 404、级联墓碑写不出）。
+ * dropped 条目排在 coerced 之后，顺序无语义。
+ */
 function save(store: DelegationStoreFile): void {
+  const dropped = storeCache?.droppedGrants ?? [];
   invalidateDelegationStoreCache();
   mkdirSync(config.dataDir, { recursive: true, mode: 0o700 });
   try {
@@ -239,7 +251,11 @@ function save(store: DelegationStoreFile): void {
   }
   const path = storePath();
   const tmp = `${path}.tmp`;
-  writeFileSync(tmp, JSON.stringify(store, null, 2), { mode: 0o600 });
+  writeFileSync(
+    tmp,
+    JSON.stringify({ ...store, grants: [...store.grants, ...dropped] }, null, 2),
+    { mode: 0o600 },
+  );
   chmodSync(tmp, 0o600);
   renameSync(tmp, path);
 }
@@ -358,55 +374,40 @@ export function revokeDelegation(
 }
 
 /**
- * 撤销被 load() 剔除的 grant：coerced store 不含它（save() 不会带走），
- * 故直接在磁盘原始记录上落墓碑，保持墓碑语义可审计。幂等：已撤销则原样返回。
+ * 撤销被 load() 剔除的 grant：coerced store 不含它，故在其 dropped 原始
+ * 视图上就地落墓碑，再经 save() 把 coerced+dropped 全量写回（dropped 记
+ * 录连同原始 scopes 与墓碑一起持久化）。幂等：已撤销则原样返回。
  */
 function revokeDroppedGrant(
   id: string,
   revokedBy: string,
   revokedAt?: string,
 ): DelegationGrant | null {
-  const dropped = getDroppedDelegation(id);
+  const cache = loadCache();
+  const dropped = cache.droppedGrants.find((g) => g.id === id);
   if (!dropped) return null;
   if (dropped.revokedAt !== null) return dropped;
 
-  const path = storePath();
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(readFileSync(path, 'utf8'));
-  } catch (err) {
-    throw new Error('delegation_store_corrupt', { cause: err });
-  }
-  if (!isDelegationStoreShape(parsed)) {
-    throw new Error('delegation_store_corrupt', {
-      cause: new Error('invalid delegation store shape'),
-    });
-  }
-  const entry = (parsed.grants as Record<string, unknown>[]).find((g) => g.id === id);
-  if (!entry) return null;
-  if (typeof entry.revokedAt === 'string' && entry.revokedAt) {
-    // 磁盘上已被撤销（剔除视图落后于文件）：刷新缓存后按幂等语义返回。
-    invalidateDelegationStoreCache();
-    return getDroppedDelegation(id) ?? null;
-  }
-  const ts = revokedAt ?? new Date().toISOString();
-  entry.revokedAt = ts;
-  entry.revokedBy = revokedBy;
-  const tmp = `${path}.tmp`;
-  writeFileSync(tmp, JSON.stringify(parsed, null, 2), { mode: 0o600 });
-  chmodSync(tmp, 0o600);
-  renameSync(tmp, path);
-  invalidateDelegationStoreCache();
-  return { ...dropped, revokedAt: ts, revokedBy };
+  dropped.revokedAt = revokedAt ?? new Date().toISOString();
+  dropped.revokedBy = revokedBy;
+  save(cache.store);
+  return dropped;
 }
 
 function cascadeRevokeGrants(
   predicate: (grant: DelegationGrant) => boolean,
   opts?: { actor?: string; ts?: string },
 ): number {
-  const store = load();
+  const cache = loadCache();
+  const store = cache.store;
   const toRevoke = store.grants.filter((g) => g.revokedAt === null && predicate(g));
-  if (toRevoke.length === 0) return 0;
+  // R4：级联必须覆盖 load 剔除的 dropped 记录——它们对 coerce 后的世界不
+  // 可见，但在磁盘上仍是活性原始数据；不落墓碑的话，未来 scope 白名单
+  // 放开时该记录会原样复活（安全面）。
+  const droppedToRevoke = cache.droppedGrants.filter(
+    (g) => g.revokedAt === null && predicate(g),
+  );
+  if (toRevoke.length === 0 && droppedToRevoke.length === 0) return 0;
 
   const now = opts?.ts ?? new Date().toISOString();
   const actor = opts?.actor ?? 'cascade';
@@ -415,10 +416,14 @@ function cascadeRevokeGrants(
     grant.revokedAt = now;
     grant.revokedBy = actor;
   }
+  for (const grant of droppedToRevoke) {
+    grant.revokedAt = now;
+    grant.revokedBy = actor;
+  }
 
   save(store);
 
-  for (const grant of toRevoke) {
+  for (const grant of [...toRevoke, ...droppedToRevoke]) {
     recordAuditEvent({
       event: 'delegation.revoke.cascade',
       outcome: 'ok',
@@ -431,7 +436,7 @@ function cascadeRevokeGrants(
     });
   }
 
-  return toRevoke.length;
+  return toRevoke.length + droppedToRevoke.length;
 }
 
 /**

--- a/packages/api/src/lib/delegations.ts
+++ b/packages/api/src/lib/delegations.ts
@@ -1,8 +1,23 @@
 // Single-writer process assumption: Like identities.json, delegations.json assumes a
 // single-writer process and does not support multi-process concurrent mutations on the same DATA_DIR.
-// Scope note: Currently delegations only support 'read:messages'. If additional scopes are
-// introduced in the future, all forbidUnlessMailboxAccess call sites must be audited to ensure
-// delegations do not unintentionally grant write or admin capabilities.
+// Scope note: Currently delegations only support 'read:messages' (see SUPPORTED_SCOPES).
+// If additional scopes are introduced in the future, all forbidUnlessMailboxAccess call sites must be
+// audited to ensure delegations do not unintentionally grant write or admin capabilities.
+//
+// OAuth cascade revocation architecture note (Issue #136 Item 8):
+// In the current architecture, OAuth credentials are strictly forbidden from creating or revoking
+// delegation grants (enforced in routes/delegations.ts via attribution.kind === 'oauth' returning 403).
+// Consequently, all active delegations are established exclusively via direct identity credentials
+// or admin authority, and no OAuth-originated delegations exist in delegations.json.
+// Token lifecycle & revocation semantics:
+// 1. Grantee token rotation: Automatically cascades revocation of all delegations received by that
+//    grantee (see revokeDelegationsOnGranteeTokenRotate in identities.ts).
+// 2. Owner token rotation: Intentionally preserves delegations granted by the owner to avoid breaking
+//    delegated agent access upon routine credential rotation.
+// 3. Identity deletion: Bidirectionally revokes all delegations (both as owner and grantee).
+// 4. Future OAuth delegation expansion: If delegations are ever allowed to be created via OAuth tokens,
+//    DelegationGrant should store an optional `oauthGrantId?: string` field, and OAuth token revocation
+//    or rotation must cascade-revoke any grants linked to that `oauthGrantId`.
 
 import {
   existsSync,
@@ -18,6 +33,7 @@ import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import { config } from './config.ts';
 import { recordAuditEvent } from './audit.ts';
+import { isSupportedScope } from './identities.ts';
 
 export const DELEGATION_STORE_SCHEMA_VERSION = 1;
 export const DELEGATION_STORE_FILE = 'delegations.json';
@@ -60,13 +76,18 @@ function isGrantShape(value: unknown): value is Record<string, unknown> {
   );
 }
 
-function coerceGrant(raw: Record<string, unknown>): DelegationGrant {
+function coerceGrant(raw: Record<string, unknown>): DelegationGrant | null {
+  const rawScopes = Array.isArray(raw.scopes) ? (raw.scopes as string[]) : [];
+  const scopes = rawScopes.filter((s) => typeof s === 'string' && isSupportedScope(s));
+  if (scopes.length === 0) {
+    return null;
+  }
   return {
     ...raw,
     id: raw.id as string,
     mailbox: (raw.mailbox as string).trim().toLowerCase(),
     grantee: (raw.grantee as string).trim().toLowerCase(),
-    scopes: Array.isArray(raw.scopes) ? (raw.scopes as string[]) : [],
+    scopes,
     createdAt: raw.createdAt as string,
     createdBy: raw.createdBy as string,
     revokedAt: (raw.revokedAt as string | null) ?? null,
@@ -163,7 +184,13 @@ function load(): DelegationStoreFile {
     if (!isDelegationStoreShape(parsed)) {
       throw new Error('invalid delegation store shape');
     }
-    const grants = parsed.grants.map((entry) => coerceGrant(entry as Record<string, unknown>));
+    const grants: DelegationGrant[] = [];
+    for (const entry of parsed.grants) {
+      const coerced = coerceGrant(entry as Record<string, unknown>);
+      if (coerced) {
+        grants.push(coerced);
+      }
+    }
     const store: DelegationStoreFile = {
       ...parsed,
       schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
@@ -177,7 +204,7 @@ function load(): DelegationStoreFile {
   } catch (err) {
     invalidateDelegationStoreCache();
     if ((err as Error).message === 'delegation_store_corrupt') throw err;
-    throw new Error('delegation_store_corrupt');
+    throw new Error('delegation_store_corrupt', { cause: err });
   }
 }
 
@@ -213,11 +240,16 @@ export function createDelegation(params: {
   if (existing) {
     return existing;
   }
+  const rawScopes = params.scopes && params.scopes.length > 0 ? [...params.scopes] : ['read:messages'];
+  const scopes = rawScopes.filter((s) => typeof s === 'string' && isSupportedScope(s));
+  if (scopes.length === 0) {
+    throw new Error('invalid_scopes: no supported scopes provided');
+  }
   const grant: DelegationGrant = {
     id: params.id ?? `delg_${randomBytes(12).toString('hex')}`,
     mailbox,
     grantee,
-    scopes: params.scopes && params.scopes.length > 0 ? [...params.scopes] : ['read:messages'],
+    scopes,
     createdAt: params.createdAt ?? new Date().toISOString(),
     createdBy: params.createdBy,
     revokedAt: null,

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -1322,6 +1322,9 @@ async function waitWithPolling(
         return found;
       }
     } catch (err) {
+      if (err instanceof DelegationRevokedError) {
+        throw err;
+      }
       console.warn('[imap] poll failed:', (err as Error).message);
     }
     const remaining = deadline - Date.now();

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -1222,8 +1222,10 @@ export class DelegationRevokedError extends Error {
  * itself fails, fall back to plain 3 s polling with one-shot connections.
  *
  * When shouldContinue is provided (e.g. for delegated callers), it is invoked
- * each iteration and prior to returning any found match to eliminate TOCTOU
- * revocation windows.
+ * each iteration, prior to returning any found match, and once more right
+ * before a timeout returns null — a revocation landing in the final sleep
+ * must surface as DelegationRevokedError, not be masked by "no new mail"
+ * (Issue #136 R3).
  *
  * Returns the message detail, or null on timeout (route maps to 408).
  */
@@ -1274,6 +1276,9 @@ async function waitWithIdle(
       } catch {
         await sleep(Math.min(3000, deadline - Date.now()));
       }
+    }
+    if (shouldContinue && !shouldContinue()) {
+      throw new DelegationRevokedError();
     }
     return null;
   } catch (err) {
@@ -1330,6 +1335,9 @@ async function waitWithPolling(
     const remaining = deadline - Date.now();
     if (remaining <= 0) break;
     await sleep(Math.min(3000, remaining));
+  }
+  if (shouldContinue && !shouldContinue()) {
+    throw new DelegationRevokedError();
   }
   return null;
 }

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -1203,14 +1203,27 @@ async function findMatchWith(
 
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
 
+export class DelegationRevokedError extends Error {
+  constructor(message = 'delegation_revoked') {
+    super(message);
+    this.name = 'DelegationRevokedError';
+  }
+}
+
 /**
- * Wait for a message matching `filters` to appear for `address`.
+ * Wait for a message matching `filters` to arrive in `address`'s mailbox,
+ * up to `timeoutSec`.
  *
- * Hybrid strategy on one long-lived connection: re-check the mailbox,
+ * Dovecot shares a single catch-all INBOX across every identity, so we hold
+ * ONE connection in IDLE mode per wait. We first scan for already-arrived mail,
  * then race IMAP IDLE against a 3 s heartbeat — IDLE gives instant wakeup
  * when Dovecot reports new mail, the heartbeat keeps us correct on
  * servers/connections where IDLE events get lost. If the IDLE connection
  * itself fails, fall back to plain 3 s polling with one-shot connections.
+ *
+ * When shouldContinue is provided (e.g. for delegated callers), it is invoked
+ * each iteration and prior to returning any found match to eliminate TOCTOU
+ * revocation windows.
  *
  * Returns the message detail, or null on timeout (route maps to 408).
  */
@@ -1218,13 +1231,17 @@ export async function waitForMessage(
   address: string,
   filters: WaitFilters,
   timeoutSec: number,
+  shouldContinue?: () => boolean,
 ): Promise<MessageDetail | null> {
   const deadline = Date.now() + timeoutSec * 1000;
   try {
-    return await waitWithIdle(address, filters, deadline);
+    return await waitWithIdle(address, filters, deadline, shouldContinue);
   } catch (err) {
+    if (err instanceof DelegationRevokedError) {
+      throw err;
+    }
     console.warn('[imap] IDLE wait failed, falling back to polling:', (err as Error).message);
-    return waitWithPolling(address, filters, deadline);
+    return waitWithPolling(address, filters, deadline, shouldContinue);
   }
 }
 
@@ -1232,6 +1249,7 @@ async function waitWithIdle(
   address: string,
   filters: WaitFilters,
   deadline: number,
+  shouldContinue?: () => boolean,
 ): Promise<MessageDetail | null> {
   const client = await connectImap();
   let failed = false;
@@ -1239,8 +1257,16 @@ async function waitWithIdle(
   try {
     lock = await client.getMailboxLock('INBOX');
     while (Date.now() < deadline) {
+      if (shouldContinue && !shouldContinue()) {
+        throw new DelegationRevokedError();
+      }
       const found = await findMatchWith(client, address, filters);
-      if (found) return found;
+      if (found) {
+        if (shouldContinue && !shouldContinue()) {
+          throw new DelegationRevokedError();
+        }
+        return found;
+      }
       const remaining = deadline - Date.now();
       if (remaining <= 0) break;
       try {
@@ -1281,11 +1307,20 @@ async function waitWithPolling(
   address: string,
   filters: WaitFilters,
   deadline: number,
+  shouldContinue?: () => boolean,
 ): Promise<MessageDetail | null> {
   while (Date.now() < deadline) {
+    if (shouldContinue && !shouldContinue()) {
+      throw new DelegationRevokedError();
+    }
     try {
       const found = await withInbox((client) => findMatchWith(client, address, filters));
-      if (found) return found;
+      if (found) {
+        if (shouldContinue && !shouldContinue()) {
+          throw new DelegationRevokedError();
+        }
+        return found;
+      }
     } catch (err) {
       console.warn('[imap] poll failed:', (err as Error).message);
     }

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -217,14 +217,16 @@ export function resetDelegationDeniedAuditLimits(): void {
  * A wait holds one IMAP connection open for up to 600 s, and every identity
  * shares the single catch-all Dovecot account — so unbounded waits let one
  * caller exhaust that account's connection allowance and lock every other
- * identity out of its mail. Three ceilings, checked together (Issue #136 R2
- * dual constraint):
+ * identity out of its mail. Ceilings, checked together (Issue #136 R2/R3):
  *
  * - per caller+address slot: one token can't monopolize a mailbox it reads.
  *   Delegates wait on the owner's address under their OWN key, so a delegate
  *   never spends the owner's slot budget;
  * - per address, summed across ALL callers: N distinct delegates can't pool
- *   their slot budgets to squeeze one mailbox either;
+ *   their slot budgets to squeeze one mailbox either. Delegates (caller ≠
+ *   mailbox) top out at MAX_WAITS_PER_ADDRESS - 1 combined — the last slot
+ *   on a mailbox is reserved for its owner (caller === address), so a full
+ *   delegation fan-in still leaves the owner a way in (R3, CR Major);
  * - instance-wide total: stays under Dovecot's default
  *   mail_max_userip_connections (10) with room to spare for the short-lived
  *   list/read connections.
@@ -258,7 +260,11 @@ export function acquireWaitSlot(caller: string, targetAddress?: string): boolean
   const key = waitSlotKey(caller, targetAddress);
   const addressKey = waitAddressKey(caller, targetAddress);
   if ((waits.get(key) ?? 0) >= MAX_WAITS_PER_SLOT) return false;
-  if ((waitsPerAddress.get(addressKey) ?? 0) >= MAX_WAITS_PER_ADDRESS) return false;
+  // R3 owner reserve: delegates share MAX_WAITS_PER_ADDRESS - 1 at most, so
+  // the mailbox's final slot is always left for the owner's own waits.
+  const isOwner = waitAddressKey(caller) === addressKey;
+  const addressCeiling = isOwner ? MAX_WAITS_PER_ADDRESS : MAX_WAITS_PER_ADDRESS - 1;
+  if ((waitsPerAddress.get(addressKey) ?? 0) >= addressCeiling) return false;
   if (waitsTotal >= MAX_WAITS_TOTAL) return false;
   waits.set(key, (waits.get(key) ?? 0) + 1);
   waitsPerAddress.set(addressKey, (waitsPerAddress.get(addressKey) ?? 0) + 1);

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -243,11 +243,19 @@ const waits = new Map<string, number>();
 const waitsPerAddress = new Map<string, number>();
 let waitsTotal = 0;
 
-/** Build slot key: targetAddress ? `${caller}:${targetAddress}` : caller */
+/**
+ * Build slot key: `${caller}:${targetAddress}` for a delegated wait, plain
+ * caller otherwise. Omitting the target and passing target === caller MUST
+ * produce the same key — the tasks route omits while a message wait on the
+ * caller's own mailbox passes it explicitly, and two buckets for one
+ * caller+mailbox pair would let a caller bypass the per-slot ceiling by
+ * mixing the two routes (Issue #136 R5).
+ */
 export function waitSlotKey(caller: string, targetAddress?: string): string {
   const c = caller.trim().toLowerCase();
-  if (!targetAddress) return c;
-  return `${c}:${targetAddress.trim().toLowerCase()}`;
+  const t = targetAddress?.trim().toLowerCase();
+  if (!t || t === c) return c;
+  return `${c}:${t}`;
 }
 
 /** 聚合键：被读信箱本身（无 target 时即 caller 自己的信箱）。 */

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -217,19 +217,28 @@ export function resetDelegationDeniedAuditLimits(): void {
  * A wait holds one IMAP connection open for up to 600 s, and every identity
  * shares the single catch-all Dovecot account — so unbounded waits let one
  * caller exhaust that account's connection allowance and lock every other
- * identity out of its mail. Two ceilings: per caller+address slot (stops one
- * token from doing it alone or starving the mailbox owner) and global (stops
- * several tokens from doing it together).
+ * identity out of its mail. Three ceilings, checked together (Issue #136 R2
+ * dual constraint):
  *
- * The global ceiling stays under Dovecot's default mail_max_userip_connections
- * (10) with room to spare for the short-lived list/read connections.
+ * - per caller+address slot: one token can't monopolize a mailbox it reads.
+ *   Delegates wait on the owner's address under their OWN key, so a delegate
+ *   never spends the owner's slot budget;
+ * - per address, summed across ALL callers: N distinct delegates can't pool
+ *   their slot budgets to squeeze one mailbox either;
+ * - instance-wide total: stays under Dovecot's default
+ *   mail_max_userip_connections (10) with room to spare for the short-lived
+ *   list/read connections.
+ *
  * A few concurrent waits per caller+address are legitimate (different filters),
- * so the per-slot ceiling is not 1.
+ * so the per-slot ceiling is not 1; the per-address ceiling is higher still so
+ * a delegate at its own ceiling leaves the owner room to wait.
  */
-export const MAX_WAITS_PER_ADDRESS = 3;
+export const MAX_WAITS_PER_SLOT = 3;
+export const MAX_WAITS_PER_ADDRESS = 5;
 export const MAX_WAITS_TOTAL = 8;
 
 const waits = new Map<string, number>();
+const waitsPerAddress = new Map<string, number>();
 let waitsTotal = 0;
 
 /** Build slot key: targetAddress ? `${caller}:${targetAddress}` : caller */
@@ -239,12 +248,20 @@ export function waitSlotKey(caller: string, targetAddress?: string): string {
   return `${c}:${targetAddress.trim().toLowerCase()}`;
 }
 
+/** 聚合键：被读信箱本身（无 target 时即 caller 自己的信箱）。 */
+function waitAddressKey(caller: string, targetAddress?: string): string {
+  return (targetAddress ?? caller).trim().toLowerCase();
+}
+
 /** Take a wait slot; false means the caller should be told 429. */
 export function acquireWaitSlot(caller: string, targetAddress?: string): boolean {
   const key = waitSlotKey(caller, targetAddress);
-  const current = waits.get(key) ?? 0;
-  if (current >= MAX_WAITS_PER_ADDRESS || waitsTotal >= MAX_WAITS_TOTAL) return false;
-  waits.set(key, current + 1);
+  const addressKey = waitAddressKey(caller, targetAddress);
+  if ((waits.get(key) ?? 0) >= MAX_WAITS_PER_SLOT) return false;
+  if ((waitsPerAddress.get(addressKey) ?? 0) >= MAX_WAITS_PER_ADDRESS) return false;
+  if (waitsTotal >= MAX_WAITS_TOTAL) return false;
+  waits.set(key, (waits.get(key) ?? 0) + 1);
+  waitsPerAddress.set(addressKey, (waitsPerAddress.get(addressKey) ?? 0) + 1);
   waitsTotal += 1;
   return true;
 }
@@ -256,11 +273,17 @@ export function releaseWaitSlot(caller: string, targetAddress?: string): void {
   if (current <= 0) return;
   if (current === 1) waits.delete(key);
   else waits.set(key, current - 1);
+
+  const addressKey = waitAddressKey(caller, targetAddress);
+  const addressCount = waitsPerAddress.get(addressKey) ?? 0;
+  if (addressCount <= 1) waitsPerAddress.delete(addressKey);
+  else waitsPerAddress.set(addressKey, addressCount - 1);
   waitsTotal -= 1;
 }
 
 /** Test helper: drop all wait slots. */
 export function resetWaitSlots(): void {
   waits.clear();
+  waitsPerAddress.clear();
   waitsTotal = 0;
 }

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -93,6 +93,7 @@ export function releaseSendLimit(address: string, reservation: number | undefine
 /** Test helper: wipe all windows. */
 export function resetRateLimits(): void {
   buckets.clear();
+  resetDelegationDeniedAuditLimits();
 }
 
 /**
@@ -188,19 +189,42 @@ export function resetMcpPreauthIpRateLimits(): void {
   mcpPreauthIpBuckets.clear();
 }
 
+/** Delegation denied audit IP 桶（防非授权 token / OAuth 凭证刷爆审计日志）。 */
+const delegationDeniedIpBuckets = new Map<string, number[]>();
+export const DEFAULT_DELEGATION_DENIED_AUDIT_LIMIT = 10;
+
+/**
+ * 校验 delegation.grant.denied 审计写入限速（复用 slidingWindowCheck）。
+ * 键为 clientIp。超限仅抑制 audit 落盘防刷盘，不改变 403 状态码。
+ */
+export function checkDelegationDeniedAuditLimit(
+  ip: string,
+  limit: number = DEFAULT_DELEGATION_DENIED_AUDIT_LIMIT,
+  windowMs = 60_000,
+  now = Date.now(),
+): RateLimitResult {
+  return slidingWindowCheck(delegationDeniedIpBuckets, ip, limit, windowMs, now);
+}
+
+/** 测试辅助：清空 delegation denied 审计 IP 桶。 */
+export function resetDelegationDeniedAuditLimits(): void {
+  delegationDeniedIpBuckets.clear();
+}
+
 /**
  * Concurrency slots for POST /v1/messages/wait.
  *
  * A wait holds one IMAP connection open for up to 600 s, and every identity
  * shares the single catch-all Dovecot account — so unbounded waits let one
  * caller exhaust that account's connection allowance and lock every other
- * identity out of its mail. Two ceilings: per address (stops one token from
- * doing it alone) and global (stops several tokens from doing it together).
+ * identity out of its mail. Two ceilings: per caller+address slot (stops one
+ * token from doing it alone or starving the mailbox owner) and global (stops
+ * several tokens from doing it together).
  *
  * The global ceiling stays under Dovecot's default mail_max_userip_connections
  * (10) with room to spare for the short-lived list/read connections.
- * A few concurrent waits per address are legitimate (different filters), so
- * the per-address ceiling is not 1.
+ * A few concurrent waits per caller+address are legitimate (different filters),
+ * so the per-slot ceiling is not 1.
  */
 export const MAX_WAITS_PER_ADDRESS = 3;
 export const MAX_WAITS_TOTAL = 8;
@@ -208,9 +232,16 @@ export const MAX_WAITS_TOTAL = 8;
 const waits = new Map<string, number>();
 let waitsTotal = 0;
 
+/** Build slot key: targetAddress ? `${caller}:${targetAddress}` : caller */
+export function waitSlotKey(caller: string, targetAddress?: string): string {
+  const c = caller.trim().toLowerCase();
+  if (!targetAddress) return c;
+  return `${c}:${targetAddress.trim().toLowerCase()}`;
+}
+
 /** Take a wait slot; false means the caller should be told 429. */
-export function acquireWaitSlot(address: string): boolean {
-  const key = address.toLowerCase();
+export function acquireWaitSlot(caller: string, targetAddress?: string): boolean {
+  const key = waitSlotKey(caller, targetAddress);
   const current = waits.get(key) ?? 0;
   if (current >= MAX_WAITS_PER_ADDRESS || waitsTotal >= MAX_WAITS_TOTAL) return false;
   waits.set(key, current + 1);
@@ -219,8 +250,8 @@ export function acquireWaitSlot(address: string): boolean {
 }
 
 /** Give the slot back. Safe to call for a slot that was never taken. */
-export function releaseWaitSlot(address: string): void {
-  const key = address.toLowerCase();
+export function releaseWaitSlot(caller: string, targetAddress?: string): void {
+  const key = waitSlotKey(caller, targetAddress);
   const current = waits.get(key) ?? 0;
   if (current <= 0) return;
   if (current === 1) waits.delete(key);

--- a/packages/api/src/routes/delegations.ts
+++ b/packages/api/src/routes/delegations.ts
@@ -6,6 +6,7 @@ import {
   createDelegation,
   findActiveDelegation,
   getDelegation,
+  getDroppedDelegation,
   listDelegations,
   revokeDelegation,
 } from '../lib/delegations.ts';
@@ -211,7 +212,8 @@ export const delegationsRoute = new Hono()
       return c.json({ error: 'invalid_request' }, 400);
     }
 
-    const grant = getDelegation(id);
+    // load() 剔除的 grant 也要能撤销（幂等墓碑磁盘残留），授权基于其原始视图。
+    const grant = getDelegation(id) ?? getDroppedDelegation(id);
     if (!grant) {
       return c.json({ error: 'not_found' }, 404);
     }
@@ -221,17 +223,26 @@ export const delegationsRoute = new Hono()
     const actor = auth.kind === 'admin' ? 'admin' : auth.address.toLowerCase();
     const isAdmin = auth.kind === 'admin';
     const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === grant.mailbox.toLowerCase();
+    // 与 POST 的 delegation.grant.denied 同款限速：超限只抑制 audit 落盘，不改变 403。
+    const ip = clientIp(c);
+    const recordDeniedAuditIfAllowed = () => {
+      const rl = checkDelegationDeniedAuditLimit(ip);
+      if (rl.allowed) {
+        recordAuditEvent({
+          event: 'delegation.revoke',
+          outcome: 'denied',
+          grantId: grant.id,
+          actor,
+          mailbox: grant.mailbox,
+          grantee: grant.grantee,
+          scopes: grant.scopes,
+          ip,
+        });
+      }
+    };
 
     if (attribution?.kind === 'oauth') {
-      recordAuditEvent({
-        event: 'delegation.revoke',
-        outcome: 'denied',
-        grantId: grant.id,
-        actor,
-        mailbox: grant.mailbox,
-        grantee: grant.grantee,
-        scopes: grant.scopes,
-      });
+      recordDeniedAuditIfAllowed();
       return c.json(
         { error: 'forbidden: delegation management requires direct identity credentials' },
         403,
@@ -239,15 +250,7 @@ export const delegationsRoute = new Hono()
     }
 
     if (!isAdmin && !isOwner) {
-      recordAuditEvent({
-        event: 'delegation.revoke',
-        outcome: 'denied',
-        grantId: grant.id,
-        actor,
-        mailbox: grant.mailbox,
-        grantee: grant.grantee,
-        scopes: grant.scopes,
-      });
+      recordDeniedAuditIfAllowed();
       return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
     }
 

--- a/packages/api/src/routes/delegations.ts
+++ b/packages/api/src/routes/delegations.ts
@@ -1,7 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import { getAuth, getAttribution } from '../lib/auth.ts';
-import { validateScopesInput } from '../lib/identities.ts';
+import { findIdentity, validateScopesInput } from '../lib/identities.ts';
 import {
   createDelegation,
   findActiveDelegation,
@@ -10,6 +10,15 @@ import {
   revokeDelegation,
 } from '../lib/delegations.ts';
 import { recordAuditEvent } from '../lib/audit.ts';
+import { config } from '../lib/config.ts';
+import { clientIp } from '../lib/net.ts';
+import { checkDelegationDeniedAuditLimit } from '../lib/ratelimit.ts';
+
+function scopesEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const setA = new Set(a);
+  return b.every((s) => setA.has(s));
+}
 
 const postDelegationSchema = z.object({
   mailbox: z.string().email().max(320),
@@ -57,15 +66,24 @@ export const delegationsRoute = new Hono()
     const isAdmin = auth.kind === 'admin';
     const isOwner = auth.kind === 'identity' && auth.address.toLowerCase() === mailbox;
 
+    function recordDeniedAuditIfAllowed() {
+      const ip = clientIp(c);
+      const rl = checkDelegationDeniedAuditLimit(ip);
+      if (rl.allowed) {
+        recordAuditEvent({
+          event: 'delegation.grant.denied',
+          outcome: 'denied',
+          actor,
+          mailbox,
+          grantee,
+          scopes: requestedScopes,
+          ip,
+        });
+      }
+    }
+
     if (attribution?.kind === 'oauth') {
-      recordAuditEvent({
-        event: 'delegation.grant.denied',
-        outcome: 'denied',
-        actor,
-        mailbox,
-        grantee,
-        scopes: requestedScopes,
-      });
+      recordDeniedAuditIfAllowed();
       return c.json(
         { error: 'forbidden: delegation management requires direct identity credentials' },
         403,
@@ -73,19 +91,46 @@ export const delegationsRoute = new Hono()
     }
 
     if (!isAdmin && !isOwner) {
-      recordAuditEvent({
-        event: 'delegation.grant.denied',
-        outcome: 'denied',
-        actor,
-        mailbox,
-        grantee,
-        scopes: requestedScopes,
-      });
+      recordDeniedAuditIfAllowed();
       return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+    }
+
+    // Item 3 (#1451: 两拒——外部域 400，未注册 localpart 404):
+    const mailboxDomain = mailbox.split('@')[1]?.toLowerCase() ?? '';
+    if (!config.allDomains.has(mailboxDomain)) {
+      return c.json(
+        { error: 'invalid_domain', details: 'mailbox domain is not hosted by this instance' },
+        400,
+      );
+    }
+    if (!findIdentity(mailbox)) {
+      return c.json({ error: 'not_found', details: 'mailbox identity not found' }, 404);
+    }
+
+    const granteeDomain = grantee.split('@')[1]?.toLowerCase() ?? '';
+    if (!config.allDomains.has(granteeDomain)) {
+      return c.json(
+        { error: 'invalid_domain', details: 'grantee domain is not hosted by this instance' },
+        400,
+      );
+    }
+    if (!findIdentity(grantee)) {
+      return c.json({ error: 'not_found', details: 'grantee identity not found' }, 404);
     }
 
     const existing = findActiveDelegation(mailbox, grantee);
     if (existing) {
+      if (!scopesEqual(existing.scopes, requestedScopes)) {
+        return c.json(
+          {
+            error: 'conflict',
+            details: 'active delegation grant exists with different scopes',
+            existingScopes: existing.scopes,
+            requestedScopes,
+          },
+          409,
+        );
+      }
       return c.json(existing, 200);
     }
 

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -143,8 +143,9 @@ export const messagesRoute = new Hono()
     // schema 仍允许 ≤600（历史客户端）；服务端静默钳到 MCP_MAX_WAIT_SECONDS
     const effectiveTimeout = clampWaitSeconds(timeoutSec);
     c.header('X-OAE-Wait-Timeout-Sec', String(effectiveTimeout));
-    // Each wait pins an IMAP connection for up to the configured ceiling; cap
-    // how many can be in flight so one caller can't starve the whole mailbox.
+    // Each wait pins an IMAP connection for up to the configured ceiling. The
+    // dual constraint (per caller+address slot, per address across all callers)
+    // keeps one caller — or a pile of delegates — from starving a mailbox.
     if (!acquireWaitSlot(caller, address)) {
       return c.json({ error: 'too_many_waits', retryAfterSec: 5 }, 429);
     }

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -1,6 +1,7 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
 import {
+  DelegationRevokedError,
   getMessage,
   InvalidMailCursorError,
   listMessages,
@@ -9,9 +10,10 @@ import {
   StaleMessageGenerationError,
   waitForMessage,
 } from '../lib/imap.ts';
-import { forbidUnlessAddress, forbidUnlessMailboxAccess } from '../lib/auth.ts';
+import { forbidUnlessAddress, forbidUnlessMailboxAccess, getAuth } from '../lib/auth.ts';
 import { clampWaitSeconds } from '../lib/config.ts';
 import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
+import { hasActiveDelegation } from '../lib/delegations.ts';
 
 const listQuerySchema = z.object({
   address: z.string().email(),
@@ -129,12 +131,21 @@ export const messagesRoute = new Hono()
     const { address, fromContains, subjectContains, timeoutSec } = parsed.data;
     const denied = forbidUnlessMailboxAccess(c, address);
     if (denied) return denied;
+
+    const auth = getAuth(c);
+    const caller = auth.kind === 'admin' ? 'admin' : auth.address.toLowerCase();
+    const isDelegate =
+      auth.kind === 'identity' && auth.address.toLowerCase() !== address.toLowerCase();
+    const shouldContinue = isDelegate
+      ? () => hasActiveDelegation(address, auth.address, 'read:messages')
+      : undefined;
+
     // schema 仍允许 ≤600（历史客户端）；服务端静默钳到 MCP_MAX_WAIT_SECONDS
     const effectiveTimeout = clampWaitSeconds(timeoutSec);
     c.header('X-OAE-Wait-Timeout-Sec', String(effectiveTimeout));
     // Each wait pins an IMAP connection for up to the configured ceiling; cap
     // how many can be in flight so one caller can't starve the whole mailbox.
-    if (!acquireWaitSlot(address)) {
+    if (!acquireWaitSlot(caller, address)) {
       return c.json({ error: 'too_many_waits', retryAfterSec: 5 }, 429);
     }
     try {
@@ -142,13 +153,19 @@ export const messagesRoute = new Hono()
         address,
         { fromContains, subjectContains },
         effectiveTimeout,
+        shouldContinue,
       );
       if (!message) {
         // 暴露有效钳制值，便于客户端对齐轮询节奏（不 400 超参）
         return c.json({ error: 'timeout', timeoutSec: effectiveTimeout }, 408);
       }
       return c.json(message);
+    } catch (err) {
+      if (err instanceof DelegationRevokedError) {
+        return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
+      }
+      throw err;
     } finally {
-      releaseWaitSlot(address);
+      releaseWaitSlot(caller, address);
     }
   });

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -78,6 +78,7 @@ const {
 const {
   createDelegation,
   getDelegation,
+  getDroppedDelegation,
   listDelegations,
   hasActiveDelegation,
   findActiveDelegation,
@@ -1156,11 +1157,79 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       writeFileSync(storeFile, JSON.stringify(mockStore, null, 2), { mode: 0o600 });
       invalidateDelegationStoreCache();
 
-      const loaded = listDelegations();
+      const warnings: string[] = [];
+      const originalWarn = console.warn;
+      console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+      let loaded: ReturnType<typeof listDelegations>;
+      try {
+        loaded = listDelegations();
+      } finally {
+        console.warn = originalWarn;
+      }
       // delg_dirty_only is refused/omitted because its filtered scopes is empty
       expect(loaded.length).toBe(1);
       expect(loaded[0]!.id).toBe('delg_supported_and_dirty');
       expect(loaded[0]!.scopes).toEqual(['read:messages']);
+
+      // #136 R2 顺清 2：收窄/剔除不能静默——必须各留一条可观测警告
+      expect(
+        warnings.some((w) => w.includes('delg_dirty_only') && w.includes('dropped at load')),
+      ).toBe(true);
+      expect(
+        warnings.some((w) => w.includes('delg_supported_and_dirty') && w.includes('scopes narrowed at load')),
+      ).toBe(true);
+    });
+
+    test('Item 4b (R2 顺清 3): load-dropped grant stays revocable via DELETE with idempotent disk tombstone', async () => {
+      const owner = createIdentity({ localpart: 'dropped-owner' })!;
+      const storeFile = join(config.dataDir, 'delegations.json');
+      writeFileSync(storeFile, JSON.stringify({
+        schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
+        grants: [
+          {
+            id: 'delg_dropped_revoke',
+            mailbox: owner.identity.address,
+            grantee: 'bob@test.example',
+            scopes: ['totally:unsupported'],
+            createdAt: '2026-09-06T00:00:00Z',
+            createdBy: 'admin',
+            revokedAt: null,
+            revokedBy: null,
+          },
+        ],
+      }, null, 2), { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      // coerce 后的世界看不到它，但原始视图可查——否则磁盘残留永远删不掉
+      expect(getDelegation('delg_dropped_revoke')).toBeUndefined();
+      expect(getDroppedDelegation('delg_dropped_revoke')?.mailbox).toBe(owner.identity.address);
+
+      // owner 撤销 → 200，就地落墓碑
+      const res = await app.request('/v1/delegations/delg_dropped_revoke', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${owner.token}` },
+      });
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as any;
+      expect(body.revoked).toBe(true);
+      expect(typeof body.revokedAt).toBe('string');
+      expect(Date.parse(body.revokedAt)).not.toBeNaN();
+
+      // 磁盘原始记录（含不合规 scopes）被保留并落了墓碑，而不是被改写
+      const onDisk = JSON.parse(readFileSync(storeFile, 'utf8')) as any;
+      const entry = onDisk.grants.find((g: any) => g.id === 'delg_dropped_revoke');
+      expect(entry).toBeDefined();
+      expect(entry.revokedAt).toBe(body.revokedAt);
+      expect(entry.revokedBy).toBe(owner.identity.address);
+      expect(entry.scopes).toEqual(['totally:unsupported']);
+
+      // 重复撤销幂等：200 + 原 revokedAt（墓碑语义）
+      const res2 = await app.request('/v1/delegations/delg_dropped_revoke', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${owner.token}` },
+      });
+      expect(res2.status).toBe(200);
+      expect(((await res2.json()) as any).revokedAt).toBe(body.revokedAt);
     });
 
     test('Item 5: load() re-wraps corruption errors preserving { cause: err } error chain', () => {
@@ -1240,6 +1309,35 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       // Exactly DEFAULT_DELEGATION_DENIED_AUDIT_LIMIT (10) audit entries recorded, 5 throttled
       const deniedAudits = readAuditEvents().filter((e) => e.event === 'delegation.grant.denied');
       expect(deniedAudits.length).toBe(10);
+    });
+
+    test('Item 7b (R2 顺清 1): delegation.revoke denied audit writes on DELETE are throttled to 10/min per IP (returning 403)', async () => {
+      resetDelegationDeniedAuditLimits();
+      resetAuditForTests();
+
+      const alice = createIdentity({ localpart: 'alice-del-throttle' })!;
+      const carol = createIdentity({ localpart: 'carol-del-throttle' })!;
+      const grant = createDelegation({
+        mailbox: alice.identity.address,
+        grantee: carol.identity.address,
+        createdBy: alice.identity.address,
+      });
+
+      // Grantee (nor anyone but owner/admin) may revoke: 15 denied DELETEs from the same IP
+      for (let i = 0; i < 15; i++) {
+        const res = await app.request(`/v1/delegations/${grant.id}`, {
+          method: 'DELETE',
+          headers: { Authorization: `Bearer ${carol.token}` },
+        });
+        expect(res.status).toBe(403);
+      }
+
+      // Audit flush is capped at 10; the 403 itself is unaffected by throttling
+      const deniedAudits = readAuditEvents().filter(
+        (e) => e.event === 'delegation.revoke' && e.outcome === 'denied',
+      );
+      expect(deniedAudits.length).toBe(10);
+      expect(getDelegation(grant.id)?.revokedAt).toBeNull();
     });
 
     test('Item 8: OAuth credentials remain forbidden from managing delegations (403)', async () => {

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -1056,6 +1056,36 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       }
     });
 
+    test('Item 1b (R3): revocation landing in the final sleep surfaces as DelegationRevokedError, not a masked timeout', async () => {
+      const alice = createIdentity({ localpart: 'alice-wait-tail' })!;
+      const bob = createIdentity({ localpart: 'bob-wait-tail', scopes: ['read:messages'] })!;
+      const aliceAddr = alice.identity.address;
+      const bobAddr = bob.identity.address;
+      createDelegation({ mailbox: aliceAddr, grantee: bobAddr, createdBy: aliceAddr });
+
+      // Force the polling fallback (IDLE wait dies on mailbox lock) and make
+      // every poll fail fast, so iteration 1 is the ONLY one before its
+      // sleep spans straight to the deadline. shouldContinue therefore sees
+      // exactly one top-of-loop check (call #1, delegation live) and then
+      // only the pre-timeout re-verify (call #2, delegation "revoked") —
+      // without the R3 tail re-check this wait would resolve null (408)
+      // and mask the revocation.
+      const origLock = FakeImapFlow.prototype.getMailboxLock;
+      FakeImapFlow.prototype.getMailboxLock = async () => {
+        throw new Error('lock boom');
+      };
+      let calls = 0;
+      const shouldContinue = () => ++calls < 2;
+      try {
+        await expect(
+          waitForMessage(aliceAddr, {}, 0.2, shouldContinue),
+        ).rejects.toThrow(DelegationRevokedError);
+        expect(calls).toBe(2);
+      } finally {
+        FakeImapFlow.prototype.getMailboxLock = origLock;
+      }
+    });
+
     test('Item 2: wait slot key caller+address prevents delegate from starving owner slots', async () => {
       const alice = createIdentity({ localpart: 'alice-wait-slot' })!;
       const bob = createIdentity({ localpart: 'bob-wait-slot', scopes: ['read:messages'] })!;

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -1262,6 +1262,93 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
       expect(((await res2.json()) as any).revokedAt).toBe(body.revokedAt);
     });
 
+    test('Item 4c (R4): save() writes droppedGrants back — ordinary mutations never wipe disk residue', async () => {
+      const storeFile = join(config.dataDir, 'delegations.json');
+      writeFileSync(storeFile, JSON.stringify({
+        schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
+        grants: [
+          {
+            id: 'delg_dropped_keep',
+            mailbox: 'alice@test.example',
+            grantee: 'bob@test.example',
+            scopes: ['nope:unsupported'],
+            createdAt: '2026-09-06T00:00:00Z',
+            createdBy: 'admin',
+            revokedAt: null,
+            revokedBy: null,
+          },
+        ],
+      }, null, 2), { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      // Any ordinary mutation rewrites the WHOLE file through save().
+      createDelegation({
+        mailbox: 'carol@test.example',
+        grantee: 'dave@test.example',
+        createdBy: 'admin',
+      });
+
+      const onDisk = JSON.parse(readFileSync(storeFile, 'utf8')) as any;
+      const droppedEntry = onDisk.grants.find((g: any) => g.id === 'delg_dropped_keep');
+      // P1①: the dropped record survived the full rewrite, raw scopes intact
+      expect(droppedEntry).toBeDefined();
+      expect(droppedEntry.scopes).toEqual(['nope:unsupported']);
+      expect(droppedEntry.revokedAt).toBeNull();
+      expect(onDisk.grants.some((g: any) => g.mailbox === 'carol@test.example')).toBe(true);
+
+      // ...and it is still revocable afterwards (DELETE must not 404)
+      const alice = createIdentity({ localpart: 'alice' })!;
+      const del = await app.request('/v1/delegations/delg_dropped_keep', {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${alice.token}` },
+      });
+      expect(del.status).toBe(200);
+      const tomb = (await del.json()) as any;
+      expect(tomb.revoked).toBe(true);
+      const afterDisk = JSON.parse(readFileSync(storeFile, 'utf8')) as any;
+      expect(afterDisk.grants.find((g: any) => g.id === 'delg_dropped_keep')?.revokedAt)
+        .toBe(tomb.revokedAt);
+    });
+
+    test('Item 4d (R4): cascade revocation covers load-dropped grants — no resurrection', () => {
+      const storeFile = join(config.dataDir, 'delegations.json');
+      writeFileSync(storeFile, JSON.stringify({
+        schemaVersion: DELEGATION_STORE_SCHEMA_VERSION,
+        grants: [
+          {
+            id: 'delg_dropped_cascade',
+            mailbox: 'alice@test.example',
+            grantee: 'bob@test.example',
+            scopes: ['future:unsupported'],
+            createdAt: '2026-09-06T00:00:00Z',
+            createdBy: 'admin',
+            revokedAt: null,
+            revokedBy: null,
+          },
+        ],
+      }, null, 2), { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      // Owner identity deletion cascades across BOTH coerced and dropped grants
+      const revoked = revokeDelegationsForAddress('alice@test.example');
+      expect(revoked).toBe(1);
+
+      // P1②: the dropped record carries a tombstone on disk (and in the raw view)
+      const onDisk = JSON.parse(readFileSync(storeFile, 'utf8')) as any;
+      const entry = onDisk.grants.find((g: any) => g.id === 'delg_dropped_cascade');
+      expect(entry.revokedAt).toBeTruthy();
+      expect(entry.revokedBy).toBe('cascade');
+      expect(entry.scopes).toEqual(['future:unsupported']);
+      expect(getDroppedDelegation('delg_dropped_cascade')?.revokedAt).toBeTruthy();
+
+      // ...and the cascade audit trail records it
+      const audit = readAuditEvents().find(
+        (e) => e.event === 'delegation.revoke.cascade' && e.grantId === 'delg_dropped_cascade',
+      );
+      expect(audit).toBeDefined();
+      expect(audit?.mailbox).toBe('alice@test.example');
+    });
+
     test('Item 5: load() re-wraps corruption errors preserving { cause: err } error chain', () => {
       const storeFile = join(config.dataDir, 'delegations.json');
       writeFileSync(storeFile, 'INVALID_CORRUPTED_JSON{{{', { mode: 0o600 });

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -36,6 +36,9 @@ class FakeImapFlow extends EventEmitter {
   async getMailboxLock() {
     return { release() {} };
   }
+  async idle() {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
   async search() {
     return fakeMessages.map((m) => m.uid);
   }
@@ -84,6 +87,12 @@ const {
 const { readAuditEvents, resetAuditForTests } = await import('../src/lib/audit.ts');
 const { putAccessTokenForTests } = await import('../src/lib/oauth-store.ts');
 const { resolveResourceUri } = await import('../src/lib/oauth-url.ts');
+const {
+  acquireWaitSlot,
+  releaseWaitSlot,
+  resetWaitSlots,
+  resetDelegationDeniedAuditLimits,
+} = await import('../src/lib/ratelimit.ts');
 
 const adminKey = [...config.apiKeys][0]!;
 let app = createApp({ uiEnabled: true });
@@ -97,6 +106,8 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
     resetIdentitiesStore();
     resetDelegationStoreForTests();
     resetAuditForTests();
+    resetWaitSlots();
+    resetDelegationDeniedAuditLimits();
   });
 
   describe('1. Store layer (delegations.json)', () => {
@@ -943,6 +954,259 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
         body: JSON.stringify({ token: bob.token }),
       });
       expect(sessionRes.status).toBe(401);
+    });
+  });
+
+  describe('6. Issue #136: Delegation ACL hardening follow-ups', () => {
+    test('Item 1: wait periodically re-verifies active delegation in loop and aborts with 403 on mid-wait revocation', async () => {
+      const origMessages = fakeMessages;
+      fakeMessages = []; // no immediate match so wait must loop
+      try {
+        const alice = createIdentity({ localpart: 'alice-wait-toctou' })!;
+        const bob = createIdentity({ localpart: 'bob-wait-toctou', scopes: ['read:messages'] })!;
+        const aliceAddr = alice.identity.address;
+        const bobAddr = bob.identity.address;
+
+        const grant = createDelegation({
+          mailbox: aliceAddr,
+          grantee: bobAddr,
+          createdBy: aliceAddr,
+        });
+
+        // Revoke the delegation 40ms into wait
+        setTimeout(() => {
+          revokeDelegation(grant.id, aliceAddr);
+        }, 40);
+
+        const waitRes = await app.request('/v1/messages/wait', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${bob.token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ address: aliceAddr, timeoutSec: 2 }),
+        });
+
+        expect(waitRes.status).toBe(403);
+        expect(await waitRes.json()).toEqual({
+          error: 'forbidden: token is scoped to another address',
+        });
+      } finally {
+        fakeMessages = origMessages;
+      }
+    });
+
+    test('Item 2: wait slot key caller+address prevents delegate from starving owner slots', async () => {
+      const alice = createIdentity({ localpart: 'alice-wait-slot' })!;
+      const bob = createIdentity({ localpart: 'bob-wait-slot', scopes: ['read:messages'] })!;
+      const aliceAddr = alice.identity.address;
+      const bobAddr = bob.identity.address;
+
+      createDelegation({
+        mailbox: aliceAddr,
+        grantee: bobAddr,
+        createdBy: aliceAddr,
+      });
+
+      // Bob occupies 3 slots for Alice's mailbox
+      expect(acquireWaitSlot(bobAddr, aliceAddr)).toBe(true);
+      expect(acquireWaitSlot(bobAddr, aliceAddr)).toBe(true);
+      expect(acquireWaitSlot(bobAddr, aliceAddr)).toBe(true);
+      expect(acquireWaitSlot(bobAddr, aliceAddr)).toBe(false);
+
+      // Alice (mailbox owner) can still acquire wait slots on her own mailbox
+      expect(acquireWaitSlot(aliceAddr, aliceAddr)).toBe(true);
+
+      // Clean up
+      releaseWaitSlot(aliceAddr, aliceAddr);
+      releaseWaitSlot(bobAddr, aliceAddr);
+      releaseWaitSlot(bobAddr, aliceAddr);
+      releaseWaitSlot(bobAddr, aliceAddr);
+    });
+
+    test('Item 3: POST /v1/delegations rejects external domains (400) and unregistered localparts (404)', async () => {
+      const alice = createIdentity({ localpart: 'alice-item3' })!;
+      const bob = createIdentity({ localpart: 'bob-item3' })!;
+      const aliceAddr = alice.identity.address;
+      const bobAddr = bob.identity.address;
+
+      // 1. External mailbox domain -> 400 invalid_domain
+      const extMailbox = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'alice@external.com', grantee: bobAddr }),
+      });
+      expect(extMailbox.status).toBe(400);
+      expect((await extMailbox.json() as any).error).toBe('invalid_domain');
+
+      // 2. Unregistered mailbox on hosted domain -> 404 not_found
+      const unregMailbox = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${adminKey}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: 'ghost-owner@test.example', grantee: bobAddr }),
+      });
+      expect(unregMailbox.status).toBe(404);
+      expect((await unregMailbox.json() as any).error).toBe('not_found');
+
+      // 3. External grantee domain -> 400 invalid_domain
+      const extGrantee = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${alice.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: aliceAddr, grantee: 'bob@external.com' }),
+      });
+      expect(extGrantee.status).toBe(400);
+      expect((await extGrantee.json() as any).error).toBe('invalid_domain');
+
+      // 4. Unregistered grantee on hosted domain (fail-fast, no sleeping grants) -> 404 not_found
+      const unregGrantee = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${alice.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: aliceAddr, grantee: 'ghost-grantee@test.example' }),
+      });
+      expect(unregGrantee.status).toBe(404);
+      expect((await unregGrantee.json() as any).error).toBe('not_found');
+    });
+
+    test('Item 4: load() narrows scopes to SUPPORTED_SCOPES and refuses to load grant if empty', () => {
+      const storeFile = join(config.dataDir, 'delegations.json');
+      const mockStore = {
+        schemaVersion: 1,
+        grants: [
+          {
+            id: 'delg_supported_and_dirty',
+            mailbox: 'alice@test.example',
+            grantee: 'bob@test.example',
+            scopes: ['read:messages', 'admin:dirty', 'bogus:action'],
+            createdAt: '2026-09-06T00:00:00Z',
+            createdBy: 'admin',
+            revokedAt: null,
+            revokedBy: null,
+          },
+          {
+            id: 'delg_dirty_only',
+            mailbox: 'alice@test.example',
+            grantee: 'carol@test.example',
+            scopes: ['dirty:only', 'unsupported:action'],
+            createdAt: '2026-09-06T00:00:00Z',
+            createdBy: 'admin',
+            revokedAt: null,
+            revokedBy: null,
+          },
+        ],
+      };
+      writeFileSync(storeFile, JSON.stringify(mockStore, null, 2), { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      const loaded = listDelegations();
+      // delg_dirty_only is refused/omitted because its filtered scopes is empty
+      expect(loaded.length).toBe(1);
+      expect(loaded[0]!.id).toBe('delg_supported_and_dirty');
+      expect(loaded[0]!.scopes).toEqual(['read:messages']);
+    });
+
+    test('Item 5: load() re-wraps corruption errors preserving { cause: err } error chain', () => {
+      const storeFile = join(config.dataDir, 'delegations.json');
+      writeFileSync(storeFile, 'INVALID_CORRUPTED_JSON{{{', { mode: 0o600 });
+      invalidateDelegationStoreCache();
+
+      try {
+        listDelegations();
+        expect.unreachable();
+      } catch (err: any) {
+        expect(err.message).toBe('delegation_store_corrupt');
+        expect(err.cause).toBeDefined();
+        expect(err.cause instanceof SyntaxError).toBe(true);
+      }
+    });
+
+    test('Item 6: POST /v1/delegations returns 409 when matching existing active grant with different scopes', async () => {
+      const alice = createIdentity({ localpart: 'alice-cfl' })!;
+      const bob = createIdentity({ localpart: 'bob-cfl' })!;
+      const aliceAddr = alice.identity.address;
+      const bobAddr = bob.identity.address;
+
+      // 1. Initial grant created -> 201
+      const res1 = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${alice.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: aliceAddr, grantee: bobAddr, scopes: ['read:messages'] }),
+      });
+      expect(res1.status).toBe(201);
+
+      // 2. Idempotent repeat with identical scopes -> 200
+      const res2 = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${alice.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: aliceAddr, grantee: bobAddr, scopes: ['read:messages'] }),
+      });
+      expect(res2.status).toBe(200);
+
+      // 3. Simulate existing active grant having different scopes in memory/store
+      const existing = findActiveDelegation(aliceAddr, bobAddr)!;
+      existing.scopes = ['different:scope'];
+
+      const resConflict = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${alice.token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ mailbox: aliceAddr, grantee: bobAddr, scopes: ['read:messages'] }),
+      });
+      expect(resConflict.status).toBe(409);
+      const conflictBody = (await resConflict.json()) as any;
+      expect(conflictBody.error).toBe('conflict');
+      expect(conflictBody.details).toBe('active delegation grant exists with different scopes');
+    });
+
+    test('Item 7: delegation.grant.denied audit writes are throttled to 10/min per IP (returning 403)', async () => {
+      resetDelegationDeniedAuditLimits();
+      resetAuditForTests();
+
+      const alice = createIdentity({ localpart: 'alice-denied-throttle' })!;
+      const carol = createIdentity({ localpart: 'carol-denied-throttle' })!;
+      const aliceAddr = alice.identity.address;
+      const carolAddr = carol.identity.address;
+
+      // Send 15 unauthorized requests from unprivileged Carol attempting to grant Alice's mailbox
+      for (let i = 0; i < 15; i++) {
+        const res = await app.request('/v1/delegations', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${carol.token}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ mailbox: aliceAddr, grantee: carolAddr }),
+        });
+        expect(res.status).toBe(403);
+      }
+
+      // Exactly DEFAULT_DELEGATION_DENIED_AUDIT_LIMIT (10) audit entries recorded, 5 throttled
+      const deniedAudits = readAuditEvents().filter((e) => e.event === 'delegation.grant.denied');
+      expect(deniedAudits.length).toBe(10);
+    });
+
+    test('Item 8: OAuth credentials remain forbidden from managing delegations (403)', async () => {
+      const alice = createIdentity({ localpart: 'alice-oauth-cascade' })!;
+      const bob = createIdentity({ localpart: 'bob-oauth-cascade' })!;
+      const aliceAddr = alice.identity.address;
+      const bobAddr = bob.identity.address;
+
+      const resource = resolveResourceUri('http://localhost');
+      const oauthToken = 'oa_oauth_token_delg_manage';
+      putAccessTokenForTests({
+        token: oauthToken,
+        grantId: 'grant_delg_manage',
+        address: aliceAddr,
+        aud: resource,
+        expiresAt: Date.now() + 3600_000,
+        ensureGrant: { clientId: 'client-delg-manage', clientName: 'Client Delg Manage' },
+      });
+
+      const res = await app.request('/v1/delegations', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${oauthToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ mailbox: aliceAddr, grantee: bobAddr }),
+      });
+      expect(res.status).toBe(403);
+      expect((await res.json() as any).error).toContain('delegation management requires direct identity credentials');
     });
   });
 });

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -72,6 +72,10 @@ const {
   rotateIdentityToken,
 } = await import('../src/lib/identities.ts');
 const {
+  DelegationRevokedError,
+  waitForMessage,
+} = await import('../src/lib/imap.ts');
+const {
   createDelegation,
   getDelegation,
   listDelegations,
@@ -984,6 +988,64 @@ describe('Issue #125: Revocable mailbox delegation ACLs', () => {
           body: JSON.stringify({ address: aliceAddr, timeoutSec: 2 }),
         });
 
+        expect(waitRes.status).toBe(403);
+        expect(await waitRes.json()).toEqual({
+          error: 'forbidden: token is scoped to another address',
+        });
+      } finally {
+        fakeMessages = origMessages;
+      }
+    });
+
+    test('Item 1: wait re-verifies revocation when message is found in idle and polling paths', async () => {
+      const alice = createIdentity({ localpart: 'alice-wait-found' })!;
+      const bob = createIdentity({ localpart: 'bob-wait-found', scopes: ['read:messages'] })!;
+      const aliceAddr = alice.identity.address;
+      const bobAddr = bob.identity.address;
+
+      const grant = createDelegation({
+        mailbox: aliceAddr,
+        grantee: bobAddr,
+        createdBy: aliceAddr,
+      });
+
+      const origMessages = fakeMessages;
+      fakeMessages = [
+        {
+          uid: 501,
+          flags: new Set(),
+          envelope: {
+            date: new Date(),
+            subject: 'Found message test',
+            from: [{ address: 'sender@example.net', name: 'Sender' }],
+            to: [{ address: aliceAddr, name: 'Alice' }],
+          },
+          internalDate: new Date(),
+          source: Buffer.from(`From: sender@example.net\r\nTo: ${aliceAddr}\r\nSubject: Found\r\n\r\nBody`),
+        },
+      ];
+
+      try {
+        // Revoke before waitForMessage executes
+        revokeDelegation(grant.id, aliceAddr);
+
+        let invoked = false;
+        const shouldContinue = () => {
+          invoked = true;
+          return hasActiveDelegation(aliceAddr, bobAddr, 'read:messages');
+        };
+
+        await expect(
+          waitForMessage(aliceAddr, {}, 2, shouldContinue),
+        ).rejects.toThrow(DelegationRevokedError);
+        expect(invoked).toBe(true);
+
+        // Also test via API endpoint: when revoked, endpoint returns 403 instead of 200 with message
+        const waitRes = await app.request('/v1/messages/wait', {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${bob.token}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ address: aliceAddr, timeoutSec: 1 }),
+        });
         expect(waitRes.status).toBe(403);
         expect(await waitRes.json()).toEqual({
           error: 'forbidden: token is scoped to another address',

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -384,10 +384,10 @@ describe('IMAP source 分类（mail stamp）', () => {
 // 路由层的并发闸门：wait 会占住 IMAP 长连接，超过上限必须直接 429，
 // 而不是再开一条连接。这里跑的是真的 waitForMessage（对着假 IMAP 服务器）。
 describe('POST /v1/messages/wait 并发上限（端到端）', () => {
-  test('同一地址第 4 个并发 wait 拿到 429，而不是第 4 条 IMAP 连接', async () => {
+  test('同一 caller 第 4 个并发 wait 拿到 429，而不是第 4 条 IMAP 连接', async () => {
     const { Hono } = await import('hono');
     const { messagesRoute } = await import('../src/routes/messages.ts');
-    const { resetWaitSlots, MAX_WAITS_PER_ADDRESS } = await import('../src/lib/ratelimit.ts');
+    const { resetWaitSlots, MAX_WAITS_PER_SLOT } = await import('../src/lib/ratelimit.ts');
     resetWaitSlots();
 
     const app = new Hono();
@@ -405,11 +405,11 @@ describe('POST /v1/messages/wait 并发上限（端到端）', () => {
       });
 
     const responses = await Promise.all(
-      Array.from({ length: MAX_WAITS_PER_ADDRESS + 1 }, () => wait()),
+      Array.from({ length: MAX_WAITS_PER_SLOT + 1 }, () => wait()),
     );
     const statuses = responses.map((r) => r.status).sort();
     expect(statuses.filter((s) => s === 429)).toHaveLength(1);
-    expect(statuses.filter((s) => s === 408)).toHaveLength(MAX_WAITS_PER_ADDRESS);
+    expect(statuses.filter((s) => s === 408)).toHaveLength(MAX_WAITS_PER_SLOT);
   });
 });
 

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -172,23 +172,34 @@ describe('wait 并发槽位（双约束：caller+address 槽 × 每 address 全�
     expect(acquireWaitSlot('b@x.com')).toBe(true);
   });
 
-  test('每 address 全局上限：多个不同 caller 合计也不得超过（Issue #136 R2 必修）', () => {
+  test('每 address 全局上限 + owner 保留槽：受托合计最多 MAX-1，最后一槽留给 owner（Issue #136 R2/R3）', () => {
     resetWaitSlots();
     // N 个不同受托方各开 1 个 wait——谁都没碰到自己 slot=3 的上限——
-    // 合计到 MAX_WAITS_PER_ADDRESS 后，这个信箱对所有人关门。
+    // 合计到 MAX_WAITS_PER_ADDRESS - 1 后，这个信箱对受托方关门。
     let granted = 0;
     for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) {
       if (acquireWaitSlot(`delegate-${i}@x.com`, 'alice@x.com')) granted++;
     }
-    expect(granted).toBe(MAX_WAITS_PER_ADDRESS);
+    expect(granted).toBe(MAX_WAITS_PER_ADDRESS - 1);
 
-    // 新 caller 和老 caller（各自 slot 仍有余量）都被每 address 全局上限挡住
+    // 新老受托方都被"受托合计上限"挡住（各自 slot 仍有余量）
     expect(acquireWaitSlot('yet-another@x.com', 'alice@x.com')).toBe(false);
     expect(acquireWaitSlot('delegate-0@x.com', 'alice@x.com')).toBe(false);
+
+    // R3 必修（CR Major）：受托占满后 owner 本人仍可进——保留槽生效
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
+    // owner 拿走最后一槽后（合计已到 MAX），所有人都进不来，包括 owner 自己
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(false);
+    expect(acquireWaitSlot('delegate-0@x.com', 'alice@x.com')).toBe(false);
+
     // 别的信箱不受影响
     expect(acquireWaitSlot('someone@x.com', 'bob@x.com')).toBe(true);
 
-    // 释放一个名额后，其他 caller 能补位
+    // 释放 owner 的槽（合计回到 MAX-1）后，受托方仍被挡——保留槽不因
+    // owner 不用而回收到受托方池子
+    releaseWaitSlot('alice@x.com', 'alice@x.com');
+    expect(acquireWaitSlot('yet-another@x.com', 'alice@x.com')).toBe(false);
+    // 再释放一个受托名额（合计 MAX-2）后，受托方能补位
     releaseWaitSlot('delegate-0@x.com', 'alice@x.com');
     expect(acquireWaitSlot('yet-another@x.com', 'alice@x.com')).toBe(true);
   });
@@ -236,8 +247,12 @@ describe('wait 并发槽位（双约束：caller+address 槽 × 每 address 全�
     expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
     expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(false);
 
-    // Releasing Bob's slot allows Bob to acquire again
+    // Releasing one of Bob's slots is NOT enough while Alice holds two:
+    // combined 4 ≥ MAX-1 keeps delegates out — the reserve is unconditional,
+    // owner-held slots don't fold back into the delegate budget (R3)
     releaseWaitSlot('bob@x.com', 'alice@x.com');
+    expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(false);
+    releaseWaitSlot('alice@x.com', 'alice@x.com');
     expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(true);
   });
 });

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import {
   MAX_WAITS_PER_ADDRESS,
+  MAX_WAITS_PER_SLOT,
   MAX_WAITS_TOTAL,
   acquireWaitSlot,
   checkMcpRateLimit,
@@ -132,17 +133,20 @@ describe('预鉴权 IP 限量（oauth / mcp-preauth，复用 slidingWindow）', 
 
 // 每个 POST /v1/messages/wait 都会占住一条 IMAP 长连接，最长 600 秒。
 // 没有上限的话，一个身份令牌就能把 catch-all 账号的 Dovecot 连接名额占满，
-// 让所有身份都读不了信。
-describe('wait 并发槽位', () => {
-  test('全局上限必须留在 Dovecot 默认每 IP 连接数（10）之下', () => {
+// 让所有身份都读不了信。#136 R2 起是双约束并存：槽键 = caller+address
+// （delegate 花自己的槽，不占 owner 的），同时每个 address 跨所有 caller
+// 有全局上限（N 个受托方合伙也压不死一个信箱），外加实例级总量兜底。
+describe('wait 并发槽位（双约束：caller+address 槽 × 每 address 全局）', () => {
+  test('三层天花板满足 slot ≤ address < total ≤ 8（Dovecot 默认每 IP 10 连接）', () => {
     // 还要给 list / read 这类一次性连接留余量。
     expect(MAX_WAITS_TOTAL).toBeLessThanOrEqual(8);
     expect(MAX_WAITS_PER_ADDRESS).toBeLessThan(MAX_WAITS_TOTAL);
+    expect(MAX_WAITS_PER_SLOT).toBeLessThanOrEqual(MAX_WAITS_PER_ADDRESS);
   });
 
-  test('单个地址的并发 wait 有上限', () => {
+  test('同一 caller 对同一地址的并发 wait 有槽位上限', () => {
     resetWaitSlots();
-    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) {
+    for (let i = 0; i < MAX_WAITS_PER_SLOT; i++) {
       expect(acquireWaitSlot('a@x.com')).toBe(true);
     }
     expect(acquireWaitSlot('a@x.com')).toBe(false);
@@ -150,7 +154,7 @@ describe('wait 并发槽位', () => {
 
   test('释放一个槽位后又能拿到', () => {
     resetWaitSlots();
-    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) acquireWaitSlot('a@x.com');
+    for (let i = 0; i < MAX_WAITS_PER_SLOT; i++) acquireWaitSlot('a@x.com');
     expect(acquireWaitSlot('a@x.com')).toBe(false);
     releaseWaitSlot('a@x.com');
     expect(acquireWaitSlot('a@x.com')).toBe(true);
@@ -158,14 +162,35 @@ describe('wait 并发槽位', () => {
 
   test('地址大小写不同也算同一个身份', () => {
     resetWaitSlots();
-    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) acquireWaitSlot('A@X.com');
+    for (let i = 0; i < MAX_WAITS_PER_SLOT; i++) acquireWaitSlot('A@X.com');
     expect(acquireWaitSlot('a@x.com')).toBe(false);
   });
 
   test('一个地址占满不影响别的地址', () => {
     resetWaitSlots();
-    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) acquireWaitSlot('a@x.com');
+    for (let i = 0; i < MAX_WAITS_PER_SLOT; i++) acquireWaitSlot('a@x.com');
     expect(acquireWaitSlot('b@x.com')).toBe(true);
+  });
+
+  test('每 address 全局上限：多个不同 caller 合计也不得超过（Issue #136 R2 必修）', () => {
+    resetWaitSlots();
+    // N 个不同受托方各开 1 个 wait——谁都没碰到自己 slot=3 的上限——
+    // 合计到 MAX_WAITS_PER_ADDRESS 后，这个信箱对所有人关门。
+    let granted = 0;
+    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) {
+      if (acquireWaitSlot(`delegate-${i}@x.com`, 'alice@x.com')) granted++;
+    }
+    expect(granted).toBe(MAX_WAITS_PER_ADDRESS);
+
+    // 新 caller 和老 caller（各自 slot 仍有余量）都被每 address 全局上限挡住
+    expect(acquireWaitSlot('yet-another@x.com', 'alice@x.com')).toBe(false);
+    expect(acquireWaitSlot('delegate-0@x.com', 'alice@x.com')).toBe(false);
+    // 别的信箱不受影响
+    expect(acquireWaitSlot('someone@x.com', 'bob@x.com')).toBe(true);
+
+    // 释放一个名额后，其他 caller 能补位
+    releaseWaitSlot('delegate-0@x.com', 'alice@x.com');
+    expect(acquireWaitSlot('yet-another@x.com', 'alice@x.com')).toBe(true);
   });
 
   test('全局上限挡住"多身份齐上"的连接耗尽', () => {
@@ -182,7 +207,7 @@ describe('wait 并发槽位', () => {
     resetWaitSlots();
     releaseWaitSlot('ghost@x.com');
     releaseWaitSlot('ghost@x.com');
-    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) {
+    for (let i = 0; i < MAX_WAITS_PER_SLOT; i++) {
       expect(acquireWaitSlot('ghost@x.com')).toBe(true);
     }
     expect(acquireWaitSlot('ghost@x.com')).toBe(false);
@@ -193,17 +218,23 @@ describe('wait 并发槽位', () => {
     expect(waitSlotKey('Bob@X.com', 'Alice@X.com')).toBe('bob@x.com:alice@x.com');
   });
 
-  test('delegate 占满被读地址的槽位不影响 owner 自己并发 wait（Issue #136 Item 2）', () => {
+  test('delegate 占满自己的槽不占 owner 的槽（Issue #136 Item 2 / R2）', () => {
     resetWaitSlots();
-    // Bob (delegate) fills all slots on Alice's mailbox
-    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) {
+    // Bob (delegate) fills his OWN slot budget on Alice's mailbox
+    for (let i = 0; i < MAX_WAITS_PER_SLOT; i++) {
       expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(true);
     }
-    // Bob cannot acquire another slot on Alice
+    // Bob's next wait is blocked by his own slot ceiling
     expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(false);
 
-    // Alice (owner) is NOT blocked and can acquire her own wait slot
+    // Alice (owner) waits under her own caller+address key — Bob's slots
+    // never spend HERS. Her ceiling here is the shared per-address budget
+    // Bob already ate into (MAX_WAITS_PER_ADDRESS - MAX_WAITS_PER_SLOT = 2),
+    // not her own slot budget (3): blocked by the global cap, not by Bob
+    // squatting her slot key.
     expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(false);
 
     // Releasing Bob's slot allows Bob to acquire again
     releaseWaitSlot('bob@x.com', 'alice@x.com');

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -227,6 +227,28 @@ describe('wait 并发槽位（双约束：caller+address 槽 × 每 address 全�
   test('waitSlotKey 构造 caller+target 键并小写规范化', () => {
     expect(waitSlotKey('Alice@X.com')).toBe('alice@x.com');
     expect(waitSlotKey('Bob@X.com', 'Alice@X.com')).toBe('bob@x.com:alice@x.com');
+    // 省略 target 与 target===caller 归一到同一个键（大小写/空白无关）
+    expect(waitSlotKey('Alice@X.com', 'alice@x.com')).toBe('alice@x.com');
+    expect(waitSlotKey(' Alice@X.com ', ' Alice@X.com ')).toBe('alice@x.com');
+  });
+
+  test('task wait 与 message wait 同 caller+mailbox 归一到同一槽桶，不拆桶绕上限（Issue #136 R5）', () => {
+    resetWaitSlots();
+    // tasks 路由形态（无 target）与 messages 路由 owner 形态（target=caller）
+    // 必须合计计入同一个 slot 桶
+    expect(acquireWaitSlot('alice@x.com')).toBe(true);
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
+    // 两形态混用也封在 MAX_WAITS_PER_SLOT，而不是各得 3 个
+    expect(acquireWaitSlot('alice@x.com')).toBe(false);
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(false);
+
+    // delegate 形态（caller≠target）仍是独立桶，不受 owner 桶影响
+    expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(true);
+
+    // 释放走任一形态都能还给同一个桶
+    releaseWaitSlot('alice@x.com', 'alice@x.com');
+    expect(acquireWaitSlot('alice@x.com')).toBe(true);
   });
 
   test('delegate 占满自己的槽不占 owner 的槽（Issue #136 Item 2 / R2）', () => {

--- a/packages/api/test/ratelimit.test.ts
+++ b/packages/api/test/ratelimit.test.ts
@@ -10,6 +10,10 @@ import {
   releaseWaitSlot,
   checkMcpPreauthIpRateLimit,
   checkOauthIpRateLimit,
+  checkDelegationDeniedAuditLimit,
+  resetDelegationDeniedAuditLimits,
+  DEFAULT_DELEGATION_DENIED_AUDIT_LIMIT,
+  waitSlotKey,
   resetMcpPreauthIpRateLimits,
   resetMcpRateLimits,
   resetNotifyUserLimits,
@@ -182,5 +186,53 @@ describe('wait 并发槽位', () => {
       expect(acquireWaitSlot('ghost@x.com')).toBe(true);
     }
     expect(acquireWaitSlot('ghost@x.com')).toBe(false);
+  });
+
+  test('waitSlotKey 构造 caller+target 键并小写规范化', () => {
+    expect(waitSlotKey('Alice@X.com')).toBe('alice@x.com');
+    expect(waitSlotKey('Bob@X.com', 'Alice@X.com')).toBe('bob@x.com:alice@x.com');
+  });
+
+  test('delegate 占满被读地址的槽位不影响 owner 自己并发 wait（Issue #136 Item 2）', () => {
+    resetWaitSlots();
+    // Bob (delegate) fills all slots on Alice's mailbox
+    for (let i = 0; i < MAX_WAITS_PER_ADDRESS; i++) {
+      expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(true);
+    }
+    // Bob cannot acquire another slot on Alice
+    expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(false);
+
+    // Alice (owner) is NOT blocked and can acquire her own wait slot
+    expect(acquireWaitSlot('alice@x.com', 'alice@x.com')).toBe(true);
+
+    // Releasing Bob's slot allows Bob to acquire again
+    releaseWaitSlot('bob@x.com', 'alice@x.com');
+    expect(acquireWaitSlot('bob@x.com', 'alice@x.com')).toBe(true);
+  });
+});
+
+describe('checkDelegationDeniedAuditLimit', () => {
+  test('同 IP 在 60s 窗口内最多允许 10 次审计写入，超限后拒绝（Issue #136 Item 7）', () => {
+    resetDelegationDeniedAuditLimits();
+    const ip = '198.51.100.1';
+
+    for (let i = 0; i < DEFAULT_DELEGATION_DENIED_AUDIT_LIMIT; i++) {
+      const res = checkDelegationDeniedAuditLimit(ip);
+      expect(res.allowed).toBe(true);
+      expect(res.count).toBe(i + 1);
+    }
+
+    // 11th check is denied
+    const blocked = checkDelegationDeniedAuditLimit(ip);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSec).toBeGreaterThan(0);
+
+    // Different IP has an independent window
+    const other = checkDelegationDeniedAuditLimit('198.51.100.2');
+    expect(other.allowed).toBe(true);
+
+    // reset clears the limits
+    resetDelegationDeniedAuditLimits();
+    expect(checkDelegationDeniedAuditLimit(ip).allowed).toBe(true);
   });
 });

--- a/packages/api/test/tasks.test.ts
+++ b/packages/api/test/tasks.test.ts
@@ -16,7 +16,7 @@ process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-tasks-'));
 
 const { beforeEach, describe, expect, test } = await import('bun:test');
 const { Hono } = await import('hono');
-const { checkSendLimit, resetRateLimits, resetWaitSlots, MAX_WAITS_PER_ADDRESS } = await import('../src/lib/ratelimit.ts');
+const { checkSendLimit, resetRateLimits, resetWaitSlots, MAX_WAITS_PER_SLOT } = await import('../src/lib/ratelimit.ts');
 const { canAdvanceTask, currentTaskMessage, taskFromMessages, waitForTaskTerminalWith } = await import('../src/lib/tasks.ts');
 const { knownManagedIdentity } = await import('../src/lib/tasks-internal.ts');
 const { config } = await import('../src/lib/config.ts');
@@ -202,7 +202,8 @@ describe('task route ACL and state machine', () => {
     const wait = () => appFor({ kind: 'identity', address: A }, slow)
       .request(`/v1/tasks/${ID}?wait=true`);
 
-    const pending = Array.from({ length: MAX_WAITS_PER_ADDRESS }, wait);
+    // 同一 caller 对同一信箱：被挡的是它自己的 caller+address 槽位上限
+    const pending = Array.from({ length: MAX_WAITS_PER_SLOT }, wait);
     await new Promise((resolve) => setTimeout(resolve, 0));
     const blocked = await wait();
     expect(blocked.status).toBe(429);


### PR DESCRIPTION
Closes #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegated users can wait for messages when authorized.
  * Delegation creation now validates hosted domains and registered identities.
  * Delegation revocations are enforced during active message waits.
  * Wait limits now balance caller-specific capacity with mailbox-owner access.

* **Bug Fixes**
  * Scope conflicts now return a conflict response.
  * Dropped delegations are preserved and can be revoked reliably.
  * Revocation counts and audit records now include dropped grants.
  * Denied delegation actions are rate-limited per client IP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->