### PR TITLE
fix(api): P2 follow-ups #76 + #83 + #101 (batch PR-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           node-version: "22"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12.3"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           bun-version: "1.2.21"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.12.3"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,12 @@ prerequisite: it runs the independent approval canonical-vector corpus check.
 CI installs Python 3.12.3 explicitly; local contributors must install it before
 running the API suite.
 
+Decision (#101): local API `bun test` stays **fail-closed** when `python3` is
+missing — the independent verifier is not skipped. A skip-with-reason path
+would let corpus drift pass on a Python-less laptop and only fail in CI. CI
+continues to install Python 3.12.3 and run both `check:approval-publication`
+and the same bun suite.
+
 ```bash
 cd packages/api   && npx -y bun test
 cd packages/mcp   && npx -y bun test && npx -y bun run build

--- a/docs/security.md
+++ b/docs/security.md
@@ -114,6 +114,7 @@ Catch-all 信箱里，身份之间的读边界是**精确整邮箱**匹配（禁
 - **催办：** admin-only。新 event kind `reminder`（头 `X-OA-Task-Event: reminder` + 独立 HMAC `reminder\\nid\\nstate\\nfrom\\nto`），**不得**伪装成 `working` 状态转移；不改变 `task.state`。幂等 key 命中已有 reminder 则原样返回；最短冷却防双击刷信。已 terminal → 409。
 - **关闭：** admin-only。写 terminal `failed` + `{closed_by_admin:true, reason}`；UI 显示 Closed。已 terminal → 409。
 - **回复：** 仅 `input-required` 可 POST `/ui/api/tasks/:id/reply` 写 `working`。identity 只能用自身地址；admin 必须显式选择任务中的本方 `from`。
+- **Lease 永久政策：** `claim` / `renew` / `release`（REST `POST /v1/tasks/:id/{claim,lease,release}` 与 MCP `task_claim` / `task_renew` / `task_release`）**只接受 managed recipient identity**。Admin 凭证不能直接 claim/renew/release——路由层不接收 admin `from` 冒充，core 仍要求 `actor === task.to`。要覆盖一条仍持有 lease 的工单，使用既有 **admin-close** 覆盖（terminal `failed` + `closed_by_admin`，并清除 lease 字段）。这不是过渡缺口，是永久授权边界。
 
 ## OAuth access tokens（P3 AS）
 

--- a/packages/api/scripts/verify-approval-canonical-vectors.py
+++ b/packages/api/scripts/verify-approval-canonical-vectors.py
@@ -128,17 +128,21 @@ def pointer_tokens(pointer: str) -> list[str]:
 
 
 def mutated(source: Any, pointer: str, replacement: Any) -> Any:
-    result = copy.deepcopy(source)
-    tokens = pointer_tokens(pointer)
-    target = result
-    for token in tokens[:-1]:
-        target = target[int(token)] if isinstance(target, list) else target[token]
-    final = tokens[-1]
-    if isinstance(target, list):
-        target[int(final)] = replacement
-    else:
-        target[final] = replacement
-    return result
+    # 越界 JSON Pointer 归一成结构化 ValueError，避免裸 IndexError traceback。
+    try:
+        result = copy.deepcopy(source)
+        tokens = pointer_tokens(pointer)
+        target = result
+        for token in tokens[:-1]:
+            target = target[int(token)] if isinstance(target, list) else target[token]
+        final = tokens[-1]
+        if isinstance(target, list):
+            target[int(final)] = replacement
+        else:
+            target[final] = replacement
+        return result
+    except (IndexError, KeyError, TypeError, ValueError) as error:
+        raise ValueError(f"JSON Pointer mutation failed ({pointer}): {error}") from error
 
 
 def digest(value: Any) -> str:
@@ -161,6 +165,12 @@ def check_pointer_regressions() -> None:
         pass
     else:
         raise AssertionError("root JSON Pointer must be rejected")
+    try:
+        mutated({"z": [1]}, "/z/99", False)
+    except ValueError as error:
+        require("JSON Pointer mutation failed" in str(error), "out-of-range pointer must be structured")
+    else:
+        raise AssertionError("out-of-range JSON Pointer must fail closed")
 
 
 def check_number_boundaries(vector: dict[str, Any]) -> None:
@@ -217,6 +227,6 @@ def main() -> None:
 if __name__ == "__main__":
     try:
         main()
-    except (AssertionError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
+    except (AssertionError, IndexError, KeyError, TypeError, ValueError, json.JSONDecodeError) as error:
         print(f"approval canonical vector verification failed: {error}", file=sys.stderr)
         sys.exit(1)

--- a/packages/api/scripts/verify-approval-canonical-vectors.py
+++ b/packages/api/scripts/verify-approval-canonical-vectors.py
@@ -128,7 +128,7 @@ def pointer_tokens(pointer: str) -> list[str]:
 
 
 def mutated(source: Any, pointer: str, replacement: Any) -> Any:
-    # 越界 JSON Pointer 归一成结构化 ValueError，避免裸 IndexError traceback。
+    # 越界 JSON Pointer 归一成结构化 ValueError, 避免裸 IndexError traceback。
     try:
         result = copy.deepcopy(source)
         tokens = pointer_tokens(pointer)

--- a/packages/api/src/lib/task-authorization-read.ts
+++ b/packages/api/src/lib/task-authorization-read.ts
@@ -1,0 +1,29 @@
+import { taskService, type Task, type TaskService } from './tasks.ts';
+
+/** REST 与 Dashboard 共用的授权读服务面；只依赖 get / getForAuthorization。 */
+export type AuthorizationReadService = Pick<TaskService, 'get' | 'getForAuthorization'>;
+
+/**
+ * 注入隔离：custom service 若未覆盖 getForAuthorization，不得回落到全局实现。
+ * 生产 taskService 使用自身 snapshot 读；覆盖了该方法的注入服务使用覆盖实现。
+ */
+export function hasIsolatedAuthorizationRead(service: AuthorizationReadService): boolean {
+  return service === taskService || service.getForAuthorization !== taskService.getForAuthorization;
+}
+
+/**
+ * 路由授权检查专用读：优先无副作用 snapshot，绝不在拒绝路径上物化 expiry。
+ * 未隔离的注入服务回落到它自己的 get，不碰全局 fallback。
+ */
+export function readTaskForAuthorization(service: AuthorizationReadService, id: string): Promise<Task | null> {
+  const read = hasIsolatedAuthorizationRead(service) ? service.getForAuthorization : undefined;
+  return (read ?? service.get)(id);
+}
+
+/**
+ * 授权通过后是否再做一次会物化 expiry 的 detail get。
+ * 与授权读共用同一隔离条件，避免 REST / Dashboard 各自漂移。
+ */
+export function shouldMaterializeAuthorizedTask(service: AuthorizationReadService): boolean {
+  return Boolean(service.getForAuthorization && hasIsolatedAuthorizationRead(service));
+}

--- a/packages/api/src/routes/tasks.ts
+++ b/packages/api/src/routes/tasks.ts
@@ -6,6 +6,7 @@ import { config } from '../lib/config.ts';
 import { findIdentity } from '../lib/identities.ts';
 import { taskLeasesEnabled } from '../lib/task-lease-gate.ts';
 import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
+import { readTaskForAuthorization, shouldMaterializeAuthorizedTask } from '../lib/task-authorization-read.ts';
 import {
   TASK_STATES,
   type Task,
@@ -104,17 +105,10 @@ function taskViewFor(c: Context, task: Task, parent: Task | null | undefined) {
     : view;
 }
 
-function authorizationTask(service: TaskService, id: string): Promise<Task | null> {
-  const read = service === taskService || service.getForAuthorization !== taskService.getForAuthorization
-    ? service.getForAuthorization
-    : undefined;
-  return (read ?? service.get)(id);
-}
-
 async function projectedParentTask(service: TaskService, parentTaskId: string | undefined): Promise<Task | null> {
   if (!parentTaskId) return null;
   try {
-    return await authorizationTask(service, parentTaskId);
+    return await readTaskForAuthorization(service, parentTaskId);
   } catch {
     // Parent edges are optional ACL projections. A transient read must not
     // fail an already-durable create or an otherwise-readable child GET.
@@ -245,7 +239,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       const id = taskIdSchema.safeParse(c.req.param('id'));
       const query = childrenSchema.safeParse(c.req.query());
       if (!id.success || !query.success) return c.json({ error: 'invalid_request' }, 400);
-      const parent = await authorizationTask(service, id.data);
+      const parent = await readTaskForAuthorization(service, id.data);
       if (!parent) return c.json({ error: 'not_found' }, 404);
       if (!canReadTask(c, parent)) return c.json({ error: 'forbidden: task participant required' }, 403);
       if (!service.listChildren) return c.json({ error: 'not_found' }, 404);
@@ -266,10 +260,10 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
       const query = getSchema.safeParse(c.req.query());
       if (!query.success) return c.json({ error: 'invalid_request', details: query.error.issues }, 400);
-      const authorization = await authorizationTask(service, parsed.data);
+      const authorization = await readTaskForAuthorization(service, parsed.data);
       if (!authorization) return c.json({ error: 'not_found' }, 404);
       if (!canReadTask(c, authorization)) return c.json({ error: 'forbidden: task participant required' }, 403);
-      const task = service.getForAuthorization && (service === taskService || service.getForAuthorization !== taskService.getForAuthorization)
+      const task = shouldMaterializeAuthorizedTask(service)
         ? await service.get(parsed.data)
         : authorization;
       if (!task) return c.json({ error: 'not_found' }, 404);
@@ -296,7 +290,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!leasesEnabled()) return c.json({ error: 'task_leases_disabled' }, 409);
       const from = actorAddress(c, undefined);
       if (from instanceof Response) return from;
-      const task = await authorizationTask(service, id.data);
+      const task = await readTaskForAuthorization(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       if (from !== task.to) return c.json({ error: 'forbidden: task recipient required' }, 403);
       try {
@@ -327,7 +321,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!leasesEnabled()) return c.json({ error: 'task_leases_disabled' }, 409);
       const from = actorAddress(c, undefined);
       if (from instanceof Response) return from;
-      const task = await authorizationTask(service, id.data);
+      const task = await readTaskForAuthorization(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       if (from !== task.to) return c.json({ error: 'forbidden: task recipient required' }, 403);
       try {
@@ -345,7 +339,8 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
         if (code === 'lease_recipient_required') return c.json({ error: 'forbidden: task recipient required' }, 403);
         if (code === 'lease_service_unavailable') return c.json({ error: 'lease_service_unavailable' }, 503);
         if (code === 'invalid_lease_seconds' || code === 'invalid_request') return c.json({ error: 'invalid_request' }, 400);
-        if (code === 'stale_lease' || code === 'lease_already_released' || code === 'task_not_claimable' || code === 'task_already_terminal' || code === 'lease_tenure_exhausted' || code === 'lease_task_cap_exhausted') {
+        // lease_already_released 为不可达死映射：core 对已释放 lease 发 stale_lease（错 token/reason）或 200 幂等成功。
+        if (code === 'stale_lease' || code === 'task_not_claimable' || code === 'task_already_terminal' || code === 'lease_tenure_exhausted' || code === 'lease_task_cap_exhausted') {
           return c.json({ error: code }, 409);
         }
         console.warn('[task] renew failed');
@@ -366,7 +361,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!leasesEnabled()) return c.json({ error: 'task_leases_disabled' }, 409);
       const from = actorAddress(c, undefined);
       if (from instanceof Response) return from;
-      const task = await authorizationTask(service, id.data);
+      const task = await readTaskForAuthorization(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       if (from !== task.to) return c.json({ error: 'forbidden: task recipient required' }, 403);
       try {
@@ -384,7 +379,8 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
         if (code === 'lease_recipient_required') return c.json({ error: 'forbidden: task recipient required' }, 403);
         if (code === 'lease_service_unavailable') return c.json({ error: 'lease_service_unavailable' }, 503);
         if (code === 'invalid_lease_seconds' || code === 'invalid_request') return c.json({ error: 'invalid_request' }, 400);
-        if (code === 'stale_lease' || code === 'lease_already_released' || code === 'task_not_claimable' || code === 'task_already_terminal') {
+        // 同上：不映射 core 不会发出的 lease_already_released。
+        if (code === 'stale_lease' || code === 'task_not_claimable' || code === 'task_already_terminal') {
           return c.json({ error: code }, 409);
         }
         console.warn('[task] release failed');
@@ -404,7 +400,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!parsed.success) return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
       const from = actorAddress(c, parsed.data.from);
       if (from instanceof Response) return from;
-      const task = await authorizationTask(service, id.data);
+      const task = await readTaskForAuthorization(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       if (!canReadTask(c, task)) return c.json({ error: 'not_found' }, 404);
       if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
@@ -446,7 +442,7 @@ export function createTaskRoutes(options: TaskRouteOptions = {}) {
       if (!parsed.success) return c.json({ error: 'invalid_request', details: parsed.error.issues }, 400);
       const from = actorAddress(c, parsed.data.from);
       if (from instanceof Response) return from;
-      const task = await authorizationTask(service, id.data);
+      const task = await readTaskForAuthorization(service, id.data);
       if (!task) return c.json({ error: 'not_found' }, 404);
       // This is a hard server-side ACL boundary. A guessed task UUID alone
       // never gives another identity authority to advance its state.

--- a/packages/api/src/routes/ui.ts
+++ b/packages/api/src/routes/ui.ts
@@ -65,6 +65,7 @@ import {
   toUiTaskView,
 } from '../lib/tasks.ts';
 import { InvalidTaskCursorError } from '../lib/task-cursor.ts';
+import { readTaskForAuthorization, shouldMaterializeAuthorizedTask } from '../lib/task-authorization-read.ts';
 import { consumeOAuthReturnCookie } from '../lib/oauth-return.ts';
 import {
   UiSessionStore,
@@ -226,13 +227,6 @@ function canReadUiTask(c: Context, task: Task): boolean {
   const auth = getAuth(c);
   // 参与者集合按小写存；identity 会话地址比较前归一化，避免大小写漂移。
   return auth.kind === 'admin' || taskParticipants(task).has(auth.address.toLowerCase());
-}
-
-function authorizationUiTask(service: Pick<TaskService, 'get' | 'getForAuthorization'>, id: string): Promise<Task | null> {
-  const read = service === taskService || service.getForAuthorization !== taskService.getForAuthorization
-    ? service.getForAuthorization
-    : undefined;
-  return (read ?? service.get)(id);
 }
 
 /** GET :id 与 reply/remind/close 成功体同一套 viewer 投影，不扩权限。 */
@@ -918,10 +912,10 @@ export function createUiApiRoutes(
     const parsed = taskIdParamSchema.safeParse(c.req.param('id'));
     if (!parsed.success) return c.json({ error: 'invalid_request' }, 400);
     const service = dependencies.taskService ?? taskService;
-    const authorization = await authorizationUiTask(service, parsed.data);
+    const authorization = await readTaskForAuthorization(service, parsed.data);
     if (!authorization) return c.json({ error: 'not_found' }, 404);
     if (!canReadUiTask(c, authorization)) return c.json({ error: 'forbidden: task participant required' }, 403);
-    const task = service.getForAuthorization && (service === taskService || service.getForAuthorization !== taskService.getForAuthorization)
+    const task = shouldMaterializeAuthorizedTask(service)
       ? await service.get(parsed.data)
       : authorization;
     if (!task) return c.json({ error: 'not_found' }, 404);
@@ -943,7 +937,7 @@ export function createUiApiRoutes(
     const body = taskDecisionSchema.safeParse(raw);
     if (!body.success) return c.json({ error: 'invalid_request', details: body.error.issues }, 400);
     const service = dependencies.taskService ?? taskService;
-    const task = await authorizationUiTask(service, parsed.data);
+    const task = await readTaskForAuthorization(service, parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
     if (!canReadUiTask(c, task)) return c.json({ error: 'not_found' }, 404);
     if (task.kind !== 'approval' || !task.approval) return c.json({ error: 'not_approval_task' }, 409);
@@ -980,7 +974,7 @@ export function createUiApiRoutes(
       return c.json({ error: 'invalid_request', details: body.error.issues }, 400);
     }
     const service = dependencies.taskService ?? taskService;
-    const task = await authorizationUiTask(service, parsed.data);
+    const task = await readTaskForAuthorization(service, parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
     if (!canReadUiTask(c, task)) {
       return c.json({ error: 'forbidden: task participant required' }, 403);
@@ -1011,7 +1005,8 @@ export function createUiApiRoutes(
       return c.json({ error: 'invalid_request', details: body.error.issues }, 400);
     }
     const service = dependencies.taskService ?? taskService;
-    const task = await service.get(parsed.data);
+    // 授权读不得物化 expiry：approval 拒绝必须发生在任何会发信的 get 之前。
+    const task = await readTaskForAuthorization(service, parsed.data);
     if (!task) return c.json({ error: 'not_found' }, 404);
     if (task.kind === 'approval') return c.json({ error: 'approval_decision_required' }, 409);
     const from = taskActionFrom(c, task, body.data.from);

--- a/packages/api/test/task-authorization-read.test.ts
+++ b/packages/api/test/task-authorization-read.test.ts
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, test } from 'bun:test';
+import {
+  hasIsolatedAuthorizationRead,
+  readTaskForAuthorization,
+  shouldMaterializeAuthorizedTask,
+} from '../src/lib/task-authorization-read.ts';
+import { taskService, type Task } from '../src/lib/tasks.ts';
+
+const TASK: Task = {
+  id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+  from: 'fox@test.example',
+  to: 'owl@test.example',
+  subject: 'authorization-read fixture',
+  state: 'working',
+  createdAt: '2026-08-12T10:00:00.000Z',
+  updatedAt: '2026-08-12T11:00:00.000Z',
+  messages: [],
+};
+
+describe('#76 authorization-read 选择去重', () => {
+  test('REST 与 Dashboard 共用同一被测实现，禁止各自再写一份选择逻辑', () => {
+    const root = fileURLToPath(new URL('../src/routes/', import.meta.url));
+    const rest = readFileSync(`${root}tasks.ts`, 'utf8');
+    const dashboard = readFileSync(`${root}ui.ts`, 'utf8');
+    expect(rest).toContain("from '../lib/task-authorization-read.ts'");
+    expect(dashboard).toContain("from '../lib/task-authorization-read.ts'");
+    expect(rest).not.toContain('function authorizationTask');
+    expect(dashboard).not.toContain('function authorizationUiTask');
+  });
+
+  test('生产 taskService 走隔离的 getForAuthorization，授权通过后才允许物化', () => {
+    expect(hasIsolatedAuthorizationRead(taskService)).toBe(true);
+    expect(shouldMaterializeAuthorizedTask(taskService)).toBe(true);
+  });
+
+  test('注入服务未覆盖 getForAuthorization 时用自己的 get，不回落全局 snapshot', async () => {
+    const injected = {
+      ...taskService,
+      get: async () => TASK,
+    };
+    expect(hasIsolatedAuthorizationRead(injected)).toBe(false);
+    expect(shouldMaterializeAuthorizedTask(injected)).toBe(false);
+    expect(await readTaskForAuthorization(injected, TASK.id)).toEqual(TASK);
+  });
+
+  test('注入服务覆盖 getForAuthorization 后使用覆盖实现，并与全局 fallback 隔离', async () => {
+    const snapshot = { ...TASK, subject: 'auth-only snapshot' };
+    const injected = {
+      ...taskService,
+      get: async () => TASK,
+      getForAuthorization: async () => snapshot,
+    };
+    expect(hasIsolatedAuthorizationRead(injected)).toBe(true);
+    expect(shouldMaterializeAuthorizedTask(injected)).toBe(true);
+    expect(await readTaskForAuthorization(injected, TASK.id)).toEqual(snapshot);
+  });
+
+  test('仅提供 get 的注入服务回落到自身 get', async () => {
+    const injected = { get: async () => TASK };
+    expect(hasIsolatedAuthorizationRead(injected)).toBe(true);
+    expect(shouldMaterializeAuthorizedTask(injected)).toBe(false);
+    expect(await readTaskForAuthorization(injected, TASK.id)).toEqual(TASK);
+  });
+});

--- a/packages/api/test/task-lease-route-contract.test.ts
+++ b/packages/api/test/task-lease-route-contract.test.ts
@@ -98,14 +98,15 @@ describe('#83 lease 路由/core 契约', () => {
 
   test('admin 凭证不能直接 claim/renew/release，须 managed recipient identity', async () => {
     await withTaskLeasesEnabledForTests(true, async () => {
+      // unused stub：strict schema 须在 dispatch 前拒掉客户端 from，否则 service 会被调用。
       const app = appFor({ kind: 'admin' }, unusedService());
-      const claim = await post(app, 'claim', { leaseSec: 300 });
-      const renew = await post(app, 'lease', { leaseToken: 'opaque' });
-      const release = await post(app, 'release', { leaseToken: 'opaque' });
-      expect([claim, renew, release]).toEqual([
-        { status: 400, body: { error: 'from is required for an admin key' } },
-        { status: 400, body: { error: 'from is required for an admin key' } },
-        { status: 400, body: { error: 'from is required for an admin key' } },
+      const claim = await post(app, 'claim', { leaseSec: 300, from: RECIPIENT });
+      const renew = await post(app, 'lease', { leaseToken: 'opaque', from: RECIPIENT });
+      const release = await post(app, 'release', { leaseToken: 'opaque', from: RECIPIENT });
+      expect([claim, renew, release].map(({ status, body }) => ({ status, error: body.error }))).toEqual([
+        { status: 400, error: 'invalid_request' },
+        { status: 400, error: 'invalid_request' },
+        { status: 400, error: 'invalid_request' },
       ]);
     });
   });

--- a/packages/api/test/task-lease-route-contract.test.ts
+++ b/packages/api/test/task-lease-route-contract.test.ts
@@ -1,0 +1,148 @@
+import { mkdtempSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Hono } from 'hono';
+import type { Task, TaskService } from '../src/lib/tasks.ts';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-lease-route-contract-'));
+process.env.TASK_LEASES_ENABLED = 'true';
+process.env.NODE_ENV = 'test';
+
+const { afterEach, describe, expect, test } = await import('bun:test');
+const {
+  claimTask,
+  releaseTask,
+  renewTask,
+  taskFromMessages,
+} = await import('../src/lib/tasks.ts');
+const {
+  clearQueuedEventsForTests,
+  setTaskGetForTests,
+  setTaskNowForTests,
+  setTaskSendMailForTests,
+} = await import('./support/task-test-seams.ts');
+const { withTaskLeasesEnabledForTests } = await import('./support/task-lease-seams.ts');
+const { createTaskRoutes } = await import('../src/routes/tasks.ts');
+
+const ID = '0fdc3207-056e-47c1-a65c-b29d39f66b83';
+const REQUESTER = 'alpha@test.example';
+const RECIPIENT = 'bravo@test.example';
+const START = Date.parse('2026-08-24T00:00:00.000Z');
+
+function submittedTask(): Task {
+  return taskFromMessages(ID, [{
+    uid: 1, from: REQUESTER, to: RECIPIENT, subject: 'Lease contract',
+    date: '2026-08-24T00:00:00.000Z', state: 'submitted', body: 'Please claim.',
+  }])!;
+}
+
+function unusedService(): TaskService {
+  return {
+    async create() { throw new Error('unused'); },
+    async list() { return []; },
+    async listBoard() { throw new Error('unused'); },
+    async get() { return submittedTask(); },
+    async update() { throw new Error('unused'); },
+    async reply() { throw new Error('unused'); },
+    async remind() { throw new Error('unused'); },
+    async close() { throw new Error('unused'); },
+    async waitForTerminal() { return null; },
+  };
+}
+
+function appFor(auth: { kind: 'admin' } | { kind: 'identity'; address: string }, service: TaskService) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    c.set('auth', auth);
+    await next();
+  });
+  app.route('/v1/tasks', createTaskRoutes({
+    service,
+    findIdentity: (address) => ({ address, createdAt: '2026-08-24T00:00:00.000Z' }),
+  }));
+  return app;
+}
+
+async function post(
+  app: Hono,
+  path: 'claim' | 'lease' | 'release',
+  body: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const response = await app.request(`/v1/tasks/${ID}/${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: response.status, body: await response.json() as Record<string, unknown> };
+}
+
+afterEach(() => {
+  setTaskNowForTests(null);
+  setTaskGetForTests(null);
+  setTaskSendMailForTests(null);
+  clearQueuedEventsForTests();
+});
+
+describe('#83 lease 路由/core 契约', () => {
+  test('路由源码不再映射 core 不会发出的 lease_already_released', () => {
+    const source = readFileSync(fileURLToPath(new URL('../src/routes/tasks.ts', import.meta.url)), 'utf8');
+    expect(source).not.toMatch(/code === 'lease_already_released'/);
+  });
+
+  test('admin 凭证不能直接 claim/renew/release，须 managed recipient identity', async () => {
+    await withTaskLeasesEnabledForTests(true, async () => {
+      const app = appFor({ kind: 'admin' }, unusedService());
+      const claim = await post(app, 'claim', { leaseSec: 300 });
+      const renew = await post(app, 'lease', { leaseToken: 'opaque' });
+      const release = await post(app, 'release', { leaseToken: 'opaque' });
+      expect([claim, renew, release]).toEqual([
+        { status: 400, body: { error: 'from is required for an admin key' } },
+        { status: 400, body: { error: 'from is required for an admin key' } },
+        { status: 400, body: { error: 'from is required for an admin key' } },
+      ]);
+    });
+  });
+
+  test('注入 lease_already_released 不再折成 409，证明已删除死映射', async () => {
+    await withTaskLeasesEnabledForTests(true, async () => {
+      const service: TaskService = {
+        ...unusedService(),
+        async renew() { throw new Error('lease_already_released'); },
+        async release() { throw new Error('lease_already_released'); },
+      };
+      const app = appFor({ kind: 'identity', address: RECIPIENT }, service);
+      const renew = await post(app, 'lease', { leaseToken: 'opaque' });
+      const release = await post(app, 'release', { leaseToken: 'opaque' });
+      expect(renew).toEqual({ status: 502, body: { error: 'smtp_error' } });
+      expect(release).toEqual({ status: 502, body: { error: 'smtp_error' } });
+    });
+  });
+
+  test('core 释放后重放/续约发 stale_lease 或幂等成功，从不发 lease_already_released', async () => {
+    await withTaskLeasesEnabledForTests(true, async () => {
+      let durable = submittedTask();
+      setTaskNowForTests(() => START);
+      setTaskGetForTests(async () => durable);
+      setTaskSendMailForTests(async () => ({ messageId: '<lease-contract>' }));
+      const grant = await claimTask({ id: ID, from: RECIPIENT, leaseSec: 300 });
+      durable = grant.task;
+      const released = await releaseTask({ id: ID, from: RECIPIENT, leaseToken: grant.leaseToken, reason: 'done' });
+      durable = released;
+      await expect(releaseTask({ id: ID, from: RECIPIENT, leaseToken: grant.leaseToken, reason: 'done' }))
+        .resolves.toEqual(released);
+      await expect(releaseTask({ id: ID, from: RECIPIENT, leaseToken: grant.leaseToken, reason: 'other' }))
+        .rejects.toThrow('stale_lease');
+      await expect(renewTask({ id: ID, from: RECIPIENT, leaseToken: grant.leaseToken }))
+        .rejects.toThrow('stale_lease');
+      await expect(releaseTask({ id: ID, from: RECIPIENT, leaseToken: 'wrong', reason: 'done' }))
+        .rejects.toThrow('stale_lease');
+    });
+  });
+});

--- a/packages/api/test/ui-tasks.test.ts
+++ b/packages/api/test/ui-tasks.test.ts
@@ -894,6 +894,35 @@ describe('UI approval decision endpoint', () => {
     });
   });
 
+  test('#76: admin remind rejects an expired approval without materializing expiry or sending mail', async () => {
+    const boundary = '2026-08-24T00:00:00.000Z';
+    const sent: unknown[] = [];
+    setTaskNowForTests(() => Date.parse('2026-08-23T23:59:59.999Z'));
+    setTaskSendMailForTests(async (input) => { sent.push(input); return { messageId: `<r76-remind-${sent.length}@test.example>` }; });
+    const task = await taskService.createApproval!({
+      from: 'fox@test.example', to: 'owl@test.example', subject: 'R76 remind must not expire', body: 'record only',
+      action: { type: 'deployment', name: 'preview', arguments: {} }, expiresAt: boundary,
+    });
+    setTaskGetForTests(async () => task);
+    const { app, cookie } = makeApp({ kind: 'admin' }, { taskService }, [task]);
+    setTaskNowForTests(() => Date.parse(boundary));
+    const response = await app.request(`/ui/api/tasks/${task.id}/remind`, {
+      method: 'POST', headers: { cookie, ...ORIGIN, 'content-type': 'application/json' },
+      body: JSON.stringify({ from: 'fox@test.example', body: 'must not deliver' }),
+    });
+    expect({
+      status: response.status,
+      body: await response.json(),
+      deliveries: sent.length,
+      durable: { state: task.state, messages: task.messages.length, result: task.result ?? null },
+    }).toEqual({
+      status: 409,
+      body: { error: 'approval_decision_required' },
+      deliveries: 1,
+      durable: { state: 'input-required', messages: 1, result: null },
+    });
+  });
+
   test('R8-E RED: an injected dashboard service never falls back to global approval decisions', async () => {
     const sent: unknown[] = [];
     setTaskGetForTests(async () => APPROVAL_TASK);

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -46,9 +46,9 @@ If `OPENAGENTEMAIL_API_KEY` is missing the server exits immediately with a clear
 | `task_create(to, subject, body, wait?, parentTaskId?)` or `task_create(to, subject, kind: "approval", approval: { action, expiresAt }, body?, wait?, parentTaskId?)` | Create an ordinary email-backed task (required `body`) or a typed approval (required `approval.action` and `approval.expiresAt`); `parentTaskId` must be a durable readable parent and never changes task state |
 | `task_list_children(parentTaskId, limit?, cursor?)` | List only direct readable children (20/50/100, default 20); cursor is scoped to parent and caller, with no totals or descendants |
 | `task_decide(id, decision)` | Stored reviewer approves or rejects a pending typed approval |
-| `task_claim(id, leaseSec?)` | Claim a recipient task for an optional lease duration |
-| `task_renew(id, leaseToken, leaseSec?)` | Renew a claimed task using its opaque bearer |
-| `task_release(id, leaseToken, reason?)` | Release a claimed task using its opaque bearer |
+| `task_claim(id, leaseSec?)` | Claim a recipient task for an optional lease duration. **Permanent policy:** admin credentials cannot claim/renew/release; the caller must be the managed recipient identity. Admin close remains the override for a live lease. |
+| `task_renew(id, leaseToken, leaseSec?)` | Renew a claimed task using its opaque bearer (managed recipient identity only; see `task_claim`) |
+| `task_release(id, leaseToken, reason?)` | Release a claimed task using its opaque bearer (managed recipient identity only; see `task_claim`) |
 | `task_list(state?)` | List this identity's task threads, optionally by current state |
 | `task_get(id, wait?)` | Read one task thread and its stamped state history; `wait:true` waits up to 10 minutes |
 | `task_update(id, state, body?, result?, leaseToken?)` | Advance a participating task; `result` is written as a JSON block in the reply body |
@@ -135,3 +135,12 @@ OPENAGENTEMAIL_API_KEY=dev-key bun run src/main.ts   # stdio; speaks JSON-RPC on
 ```
 
 The server connects to the API lazily — it starts fine even if the API isn't up yet, and reports a connection error on the first tool call if not.
+
+Publication scripts (`check:approval-publication`, `sync:approval-publication`,
+`prepack`, `prepublishOnly`) invoke
+`packages/api/scripts/sync-approval-publication.mjs` via the sibling path
+`../api/scripts/`. They must be run from this monorepo checkout; a standalone
+clone of `packages/mcp` (or the published npm tarball) cannot resolve that
+path. The published package already bundles `approval-digest.md` and
+`approval-canonical-vectors.v1.json`, so consumers of `@openagentemail/mcp`
+do not need the sibling `packages/api` directory.


### PR DESCRIPTION
## What
P2 follow-up batch first card: #76 + #83 + #101 — zero policy-decision implementation + tooling hygiene.

Closes #76
Closes #83
Closes #101

## #76 — side-effect-free approval reminder rejection + shared authorization read
- New `task-authorization-read.ts`: one authorization-read selection shared by REST (`routes/tasks.ts`) and dashboard (`routes/ui.ts`); injected services without `getForAuthorization` no longer fall back to the global snapshot.
- Dashboard `POST /ui/api/tasks/:id/remind` performs the authorization read (snapshot) before the `kind === 'approval'` check — the admin rejection path no longer calls the lazy-materializing `get()`, so it materializes no expiry and sends no mail.
- Ordinary remind behavior, close path, signed event formats unchanged; approval authority not expanded.

## #83 — drop unreachable mapping + document admin exclusion
- **Decision: remove `lease_already_released`** rather than add an emit path: core never emits it; released-lease semantics are already covered by `stale_lease` + idempotent 200 on same token+reason. A new error code would conflict with the existing contract.
- Documented as **permanent policy** (`docs/security.md`, `packages/mcp/README.md`): admin credentials cannot claim/renew/release directly — managed recipient identity required; admin-close remains the intentional override. Route/core contract tests added.

## #101 — publication tooling hardening
- Pin `actions/setup-python` to full SHA in `ci.yml`/`release.yml` (only the dependency newly added by #100; repo-wide pinning stays a separate policy).
- **Decision: verifier stays fail-closed without local Python** — no skip path, documented in `CONTRIBUTING.md`.
- Python verifier: out-of-range JSON Pointer mutations raise structured `ValueError` (no raw traceback); regression pinned in `check_pointer_regressions()`.
- `packages/mcp/README.md` documents the publication scripts' sibling `packages/api/scripts/` dependency (monorepo checkout required; published package self-contained).

## Tests
- Worker: api 1451 pass / 1 skip / 0 fail (86 files); mcp 26 pass + tsc + build; setup 35 pass.
- FC independent rerun (same tree, frozen lockfile): 1451 pass / 1 skip / 0 fail.

## Out of scope (recorded, not touched)
- `POST /tasks/:id/close` still uses `service.get()` (pre-existing pattern).
- renew/release `task_already_terminal` mapping possibly dead too — left for review.
- checkout/setup-bun/setup-node not yet SHA-pinned (repo-wide policy separate card).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task authorization consistency across REST, dashboard, and MCP workflows.
  * Prevented unauthorized administrators from directly claiming, renewing, or releasing managed task leases.
  * Improved handling of expired approvals and stale lease requests.
  * Invalid approval-vector pointers now fail with clear, consistent errors.

* **Documentation**
  * Documented task lease authorization rules and administrator override behavior.
  * Clarified approval publication development requirements and package contents.
  * Added testing guidance for fail-closed behavior when Python is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->