### PR TITLE
fix(api): accept byte-identical lease events as transport duplicates (#85)

### DIFF
--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -600,6 +600,11 @@ function isSameLeaseExpiryIdentity(
   return genA !== undefined && genA === genB && a.claimedUntil === b.claimedUntil;
 }
 
+/** #85：claim/renew/release 已认证事件的逐字节身份（canonical payload）。 */
+function isSameAuthenticatedLeaseEvent(a: LeaseEvent, b: LeaseEvent): boolean {
+  return canonicalLeaseEvent(a) === canonicalLeaseEvent(b);
+}
+
 function leaseEventStamp(
   id: string,
   state: TaskState,
@@ -1178,7 +1183,11 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
   let expiredLease: ExpiredLeaseReceipt | undefined;
   let firstClaimedAt: string | undefined;
   const appliedExpiryReceipts = new Map<number, ExpiredLeaseReceipt>();
-  const duplicateExpiryMessages = new Set<RawTaskMessage>();
+  const appliedClaims = new Map<number, ClaimLeaseEvent>();
+  const appliedRenews = new Map<number, RenewLeaseEvent[]>();
+  const appliedReleases = new Map<number, ReleaseLeaseEvent>();
+  // 传输层精确重复（含 expiry）不进入公开消息序列，也不推进权威。
+  const duplicateLeaseMessages = new Set<RawTaskMessage>();
   for (const message of leaseEvents) {
     const lease = message.lease;
     if (lease.event === 'expired') {
@@ -1192,7 +1201,7 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
       const priorReceipt = appliedExpiryReceipts.get(lease.generation);
       if (priorReceipt) {
         if (isSameLeaseExpiryIdentity(priorReceipt, lease)) {
-          duplicateExpiryMessages.add(message);
+          duplicateLeaseMessages.add(message);
           continue;
         }
         return null;
@@ -1220,6 +1229,15 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
       || !/^[A-Za-z0-9_-]{32,}$/.test(lease.tokenVerifier)
     ) return null;
     if (lease.event === 'claim') {
+      const priorClaim = appliedClaims.get(lease.generation);
+      if (priorClaim) {
+        // 同 generation 逐字节相同 → 幂等 no-op；任何字段差异仍 fail-closed。
+        if (isSameAuthenticatedLeaseEvent(priorClaim, lease)) {
+          duplicateLeaseMessages.add(message);
+          continue;
+        }
+        return null;
+      }
       const claimedAt = Date.parse(lease.at);
       const claimedUntil = Date.parse(lease.claimedUntil);
       const taskClaimedAt = firstClaimedAt ?? lease.at;
@@ -1244,9 +1262,15 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
         generationClaimedAt: lease.at,
         firstClaimedAt,
       };
+      appliedClaims.set(lease.generation, lease);
       continue;
     }
     if (lease.event === 'renew') {
+      const priorRenews = appliedRenews.get(lease.generation) ?? [];
+      if (priorRenews.some((prior) => isSameAuthenticatedLeaseEvent(prior, lease))) {
+        duplicateLeaseMessages.add(message);
+        continue;
+      }
       const renewedAt = Date.parse(lease.at);
       const claimedUntil = Date.parse(lease.claimedUntil);
       const generationClaimedAt = Date.parse(leaseAuthority?.generationClaimedAt ?? '');
@@ -1263,7 +1287,16 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
         || claimedUntil <= Date.parse(leaseAuthority.claimedUntil)
       ) return null;
       leaseAuthority = { ...leaseAuthority, claimedUntil: lease.claimedUntil };
+      appliedRenews.set(lease.generation, [...priorRenews, lease]);
       continue;
+    }
+    const priorRelease = appliedReleases.get(lease.generation);
+    if (priorRelease) {
+      if (isSameAuthenticatedLeaseEvent(priorRelease, lease)) {
+        duplicateLeaseMessages.add(message);
+        continue;
+      }
+      return null;
     }
     if (
       !leaseAuthority?.claimedUntil || !leaseAuthority.tokenVerifier
@@ -1279,6 +1312,7 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
       reason: lease.reason,
       ...(firstClaimedAt ? { firstClaimedAt } : {}),
     };
+    appliedReleases.set(lease.generation, lease);
   }
   const request = first.approval;
   if (request?.type === 'request') {
@@ -1326,7 +1360,7 @@ export function taskFromMessages(id: string, raw: RawTaskMessage[]): Task | null
   // (but validly signed) submitted/working mail can appear again in IMAP, but
   // it cannot reopen the completed/failed task. Before that point normal
   // concurrent writes retain mailbox-order last-writer-wins semantics.
-  const durableOrdered = ordered.filter((message) => !duplicateExpiryMessages.has(message)).map((message) => message.lease
+  const durableOrdered = ordered.filter((message) => !duplicateLeaseMessages.has(message)).map((message) => message.lease
     ? { ...message, date: message.lease.at }
     : message);
   const current = currentTaskMessage(durableOrdered);

--- a/packages/api/test/p2-85-lease-dedup.test.ts
+++ b/packages/api/test/p2-85-lease-dedup.test.ts
@@ -1,0 +1,268 @@
+// #85：claim/renew/release 传输层精确去重（拆卡后不含 #80/#84）。
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { FetchMessageObject } from 'imapflow';
+import nodemailer from 'nodemailer';
+import type { SendInput } from '../src/lib/smtp.ts';
+import type { RawTaskMessage, Task } from '../src/lib/tasks.ts';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+process.env.DATA_DIR = mkdtempSync(join(tmpdir(), 'oae-p2-85-dedup-'));
+process.env.TASK_LEASES_ENABLED = 'true';
+process.env.NODE_ENV = 'test';
+
+const { afterEach, describe, expect, test: bunTest } = await import('bun:test');
+const {
+  claimTask,
+  isTaskLeaseTokenCurrent,
+  releaseTask,
+  renewTask,
+  taskFromMessages,
+  toTaskView,
+} = await import('../src/lib/tasks.ts');
+const {
+  clearQueuedEventsForTests,
+  setTaskGetForTests,
+  setTaskNowForTests,
+  setTaskSendMailForTests,
+} = await import('./support/task-test-seams.ts');
+const { parseTaskMessageForTests, withTaskLeasesEnabledForTests } = await import('./support/task-lease-seams.ts');
+const test = (name: string, work: () => void | Promise<void>) => bunTest(name, () => withTaskLeasesEnabledForTests(true, work));
+
+const ID = '0fdc3207-056e-47c1-a65c-b29d39f66b83';
+const A = 'alpha@test.example';
+const B = 'bravo@test.example';
+const START = Date.parse('2026-08-24T00:00:00.000Z');
+
+function submittedRaw(): RawTaskMessage {
+  return {
+    uid: 1, from: A, to: B, subject: 'Lease this task',
+    date: '2026-08-24T00:00:00.000Z', state: 'submitted', body: 'Please claim.',
+  };
+}
+
+function submittedTask(): Task {
+  return taskFromMessages(ID, [submittedRaw()])!;
+}
+
+function source(input: SendInput): Buffer {
+  return Buffer.from([
+    `From: ${input.from}`,
+    `To: ${input.to[0]}`,
+    `Subject: ${input.subject}`,
+    ...Object.entries(input.headers ?? {}).map(([name, value]) => `${name}: ${value}`),
+    '',
+    input.text,
+  ].join('\r\n'), 'utf8');
+}
+
+async function parseCaptured(input: SendInput, uid: number): Promise<RawTaskMessage | null> {
+  return parseTaskMessageForTests({
+    uid,
+    source: source(input),
+    envelope: {
+      from: [{ address: input.from }],
+      to: [{ address: input.to[0] }],
+      subject: input.subject,
+    },
+    internalDate: new Date(START),
+  } as unknown as FetchMessageObject, ID);
+}
+
+afterEach(() => {
+  setTaskNowForTests(null);
+  setTaskGetForTests(null);
+  setTaskSendMailForTests(null);
+  clearQueuedEventsForTests();
+});
+
+describe('PR-2 #85 传输层精确去重（claim/renew/release）', () => {
+  test('邻接重复：逐字节相同的 claim/renew/release 幂等重建，公开视图不变', async () => {
+    let now = START;
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => submittedTask());
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<p2-85-adj-${sent.length}>` };
+    });
+    const first = await claimTask({ id: ID, from: B, leaseSec: 300 });
+    now = START + 1_000;
+    await renewTask({ id: ID, from: B, leaseToken: first.leaseToken, leaseSec: 300 });
+    await releaseTask({ id: ID, from: B, leaseToken: first.leaseToken, reason: 'done' });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+    const renew1 = (await parseCaptured(sent[1]!, 3))!;
+    const release1 = (await parseCaptured(sent[2]!, 4))!;
+    const claimDup = { ...claim1, uid: 5 };
+    const renewDup = { ...renew1, uid: 6 };
+    const releaseDup = { ...release1, uid: 7 };
+    const baseline = taskFromMessages(ID, [submittedRaw(), claim1, renew1, release1]);
+    const duplicated = taskFromMessages(ID, [submittedRaw(), claim1, renew1, release1, claimDup, renewDup, releaseDup]);
+    const baselineView = baseline ? toTaskView(baseline) : null;
+    const duplicateView = duplicated ? toTaskView(duplicated) : null;
+    expect({
+      baseline: baseline !== null,
+      duplicated: duplicated !== null,
+      publicViewsIdentical: JSON.stringify(baselineView) === JSON.stringify(duplicateView),
+      messageCount: duplicateView?.messages.length,
+      released: duplicated?.releasedLease?.leaseGeneration,
+    }).toEqual({
+      baseline: true,
+      duplicated: true,
+      publicViewsIdentical: true,
+      messageCount: 4,
+      released: 1,
+    });
+  });
+
+  test('延迟重复：晚于新 generation 到达的旧 claim 不得超越新权威', async () => {
+    let now = START;
+    let durable = submittedTask();
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => durable);
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<p2-85-late-${sent.length}>` };
+    });
+    const first = await claimTask({ id: ID, from: B, leaseSec: 300 });
+    durable = taskFromMessages(ID, [submittedRaw(), (await parseCaptured(sent[0]!, 2))!])!;
+    clearQueuedEventsForTests();
+    setTaskGetForTests(async () => durable);
+    now = Date.parse(first.claimedUntil);
+    const second = await claimTask({ id: ID, from: B, leaseSec: 300 });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+    const expiry1 = (await parseCaptured(sent[1]!, 3))!;
+    const claim2 = (await parseCaptured(sent[2]!, 4))!;
+    const lateClaim1 = { ...claim1, uid: 6 };
+    const rebuilt = taskFromMessages(ID, [submittedRaw(), claim1, expiry1, claim2, lateClaim1]);
+    expect({
+      valid: rebuilt !== null,
+      generation: rebuilt?.lease?.leaseGeneration,
+      gen2Current: rebuilt ? isTaskLeaseTokenCurrent(rebuilt, second.leaseToken) : null,
+      gen1Fenced: rebuilt ? isTaskLeaseTokenCurrent(rebuilt, first.leaseToken) : null,
+      messages: rebuilt ? toTaskView(rebuilt).messages.length : 0,
+    }).toEqual({
+      valid: true,
+      generation: 2,
+      gen2Current: true,
+      gen1Fenced: false,
+      messages: 4,
+    });
+  });
+
+  test('重启后重建：durable 流含重复事件仍保持 generation 单调', async () => {
+    let now = START;
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => submittedTask());
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<p2-85-restart-${sent.length}>` };
+    });
+    const first = await claimTask({ id: ID, from: B, leaseSec: 300 });
+    now = START + 1_000;
+    await renewTask({ id: ID, from: B, leaseToken: first.leaseToken, leaseSec: 300 });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+    const renew1 = (await parseCaptured(sent[1]!, 3))!;
+    clearQueuedEventsForTests();
+    // 重启后 IMAP 以新 UID 重放同一已认证事件；必须是不同对象，避免 Set 把首次也滤掉。
+    const restarted = taskFromMessages(ID, [
+      submittedRaw(),
+      claim1,
+      { ...claim1, uid: 4 },
+      renew1,
+      { ...renew1, uid: 5 },
+    ]);
+    expect({
+      valid: restarted !== null,
+      generation: restarted?.lease?.leaseGeneration,
+      claimedUntil: restarted?.lease?.claimedUntil,
+      messages: restarted ? toTaskView(restarted).messages.length : 0,
+    }).toEqual({
+      valid: true,
+      generation: 1,
+      claimedUntil: renew1.lease && 'claimedUntil' in renew1.lease ? renew1.lease.claimedUntil : undefined,
+      messages: 3,
+    });
+  });
+
+  test('混合事件类型：claim 重复不得被当成 renew/release，字段差异 fail-closed', async () => {
+    let now = START;
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => now);
+    setTaskGetForTests(async () => submittedTask());
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<p2-85-mix-${sent.length}>` };
+    });
+    const first = await claimTask({ id: ID, from: B, leaseSec: 300 });
+    now = START + 1_000;
+    await renewTask({ id: ID, from: B, leaseToken: first.leaseToken, leaseSec: 300 });
+    const claim1 = (await parseCaptured(sent[0]!, 2))!;
+    const renew1 = (await parseCaptured(sent[1]!, 3))!;
+    const alteredAt = {
+      ...claim1,
+      uid: 4,
+      lease: claim1.lease ? { ...claim1.lease, at: '2026-08-24T00:00:01.000Z' } : undefined,
+    };
+    const claimVerifier = claim1.lease && 'tokenVerifier' in claim1.lease ? claim1.lease.tokenVerifier : '';
+    const alteredVerifier = {
+      ...claim1,
+      uid: 5,
+      lease: claim1.lease ? { ...claim1.lease, tokenVerifier: `${claimVerifier.slice(0, -1)}X` } : undefined,
+    };
+    const alteredGeneration = {
+      ...claim1,
+      uid: 6,
+      lease: claim1.lease ? { ...claim1.lease, generation: 9 } : undefined,
+    };
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, alteredAt])).toBeNull();
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, alteredVerifier])).toBeNull();
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, alteredGeneration])).toBeNull();
+    expect(taskFromMessages(ID, [submittedRaw(), claim1, renew1, { ...claim1, uid: 8 }])?.lease?.claimedUntil)
+      .toBe(renew1.lease && 'claimedUntil' in renew1.lease ? renew1.lease.claimedUntil : undefined);
+  });
+
+  test('真实下游：nodemailer 折行源经生产 parser 后，重复 claim 仍幂等', async () => {
+    const sent: SendInput[] = [];
+    setTaskNowForTests(() => START);
+    setTaskGetForTests(async () => submittedTask());
+    setTaskSendMailForTests(async (input) => {
+      sent.push(input);
+      return { messageId: `<p2-85-wire-${sent.length}>` };
+    });
+    await claimTask({ id: ID, from: B, leaseSec: 300 });
+    const transport = nodemailer.createTransport({ streamTransport: true, buffer: true, newline: 'unix' });
+    const result = await transport.sendMail({
+      from: sent[0]!.from,
+      to: sent[0]!.to,
+      subject: sent[0]!.subject,
+      text: sent[0]!.text,
+      headers: sent[0]!.headers,
+    });
+    if (!Buffer.isBuffer(result.message)) throw new Error('stream transport must return buffered RFC 5322 source');
+    const asFetch = (uid: number) => ({
+      uid,
+      source: result.message,
+      envelope: { from: [{ address: sent[0]!.from }], to: [{ address: sent[0]!.to[0] }], subject: sent[0]!.subject },
+      internalDate: new Date(START),
+    } as unknown as FetchMessageObject);
+    const first = await parseTaskMessageForTests(asFetch(2), ID);
+    const duplicate = await parseTaskMessageForTests(asFetch(3), ID);
+    const rebuilt = first && duplicate
+      ? taskFromMessages(ID, [submittedRaw(), first, duplicate])
+      : null;
+    expect({
+      parsed: first?.lease?.event,
+      generation: rebuilt?.lease?.leaseGeneration,
+      messages: rebuilt ? toTaskView(rebuilt).messages.length : 0,
+    }).toEqual({ parsed: 'claim', generation: 1, messages: 2 });
+  });
+});

--- a/packages/api/test/task-lease-core.test.ts
+++ b/packages/api/test/task-lease-core.test.ts
@@ -360,7 +360,10 @@ describe('#56 R2 lease authority', () => {
 
     const sameGeneration = await parsedClaim(original, 3);
     expect(sameGeneration).not.toBeNull();
-    expect(taskFromMessages(ID, [submittedRaw(), (await parsedClaim(original, 2))!, sameGeneration!])).toBeNull();
+    // #85：逐字节相同的已认证 claim 是传输重复，幂等接受而非 fail-closed。
+    const duplicatedClaim = taskFromMessages(ID, [submittedRaw(), (await parsedClaim(original, 2))!, sameGeneration!]);
+    expect(duplicatedClaim?.lease?.leaseGeneration).toBe(1);
+    expect(toTaskView(duplicatedClaim!).messages).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
Closes #85.

Split out of PR #154 (closed per same-family escalation ruling) — this is the stable, independent #85 slice: transport-level exact dedup for claim/renew/release.

## What
Mirror the expiry-receipt idempotency pattern for the other lease event types: a same-generation, canonical **byte-identical** authenticated claim/renew/release is accepted as a no-op (`duplicateLeaseMessages`: excluded from the public message sequence, no authority advance). Any divergence in timing/actor/verifier/generation/payload stays fail-closed. Stale duplicates cannot supersede newer authority (generation monotonicity preserved — applied-identity match runs before the generation check).

No overlay-lifetime (#80) or recovery-path (#84) changes ride in this PR — those return to redesign; see comments on #80/#84.

## Tests
- New `p2-85-lease-dedup.test.ts`: adjacent duplicates, delayed duplicates after later generations, restart, mixed event types, real downstream (nodemailer) path.
- `task-lease-core.test.ts`: same-byte duplicate claim now idempotent-accepted.
- Worker full run + FC independent rerun (frozen lockfile): **1456 pass / 1 skip / 0 fail** (87 files).