### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project are documented here, one section per release, newest first.
+
+## v0.7.0 — 2026-09-07
+
+### Added
+
+- **Multi-domain identities**: serve several domains from one instance via `DOMAIN` + `EXTRA_DOMAINS` (#133).
+- **Revocable mailbox delegation ACLs**: delegate scoped mailbox access to other identities, revocable at any time (#125, #135; hardening follow-ups #136, #151).
+- **Outbound webhook subsystem**: notify your own endpoints on mailbox events — shared pinned fetcher with SSRF hardening (incl. IPv6-embedded-IPv4), process-wide event dispatcher with per-sink watermark isolation, forward-`since` query with `uidValidity` generation precondition (#128 PR1–PR4: #140, #141, #142, #145).
+- **Approval expiry projection**: list/board views now project unmaterialized approval expiry with signed display metadata, so "waiting on you" never lies about the deadline (#75, #160).
+- **Bookmarkable admin UI login** via `?token=` query, hardened with a one-time exchange-code flow (#131, #132/#150).
+- **Read-only identity token scopes** enforced across the API (#124); OAuth access-token resolution now inherits identity scopes (#129).
+
+### Fixed
+
+- **Transport-level exact dedup** for lease claim/renew/release events: byte-identical authenticated duplicates are accepted as no-ops, any divergence fails closed (#85, #158).
+- **Authorization-read isolation**: REST and dashboard share one authorization-read surface that never materializes expiry on a reject path (#76, #83, #101; #153).
+- Task API hardening: children cursor length cap, case-insensitive participant matching, mutation responses share the parent ACL projection, MCP task output schema aligned with the durable-id predicate (#103, #107; #159).
+- Review follow-ups batch (#130, #148) and test isolation hardening (#147).
+
+### Notes
+
+- All changes dogfooded on our own instance before release; full test suite green (1459 tests).
+- Follow-ups already tracked: #155–#157, #161–#163. #80/#84 (lease overlay bounds / audit retry queue) were sent back for redesign after review surfaced a design-level conflict — they will return in a future release.

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagentemail/mcp",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "mcpName": "io.github.openagentemail/mcp",
   "description": "MCP server for openagent.email \u2014 unlimited agent mailboxes via REST + MCP",
   "license": "Apache-2.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/openagentemail/openagentemail",
     "source": "github"
   },
-  "version": "0.6.0",
+  "version": "0.7.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@openagentemail/mcp",
-      "version": "0.5.2",
+      "version": "0.7.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version bump for v0.7.0 release: packages/mcp 0.6.0→0.7.0, server.json 对齐（含存量 packages[].version 0.5.2→0.7.0 修正），并新建 CHANGELOG.md（首条即 v0.7.0，发版说明制度化起步）。

业主已授权本次发版由总指挥择机执行。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for multi-domain identities and read-only identity token scopes.
  - Added revocable mailbox delegation controls and outbound webhooks with SSRF protection.
  - Added approval expiry tracking and bookmarkable admin UI login.
- **Bug Fixes**
  - Improved message deduplication, authorization-read isolation, Task API security, and review/test isolation.
- **Documentation**
  - Added release documentation covering version 0.7.0 features, fixes, and follow-up items.
- **Chores**
  - Updated server and package versions to 0.7.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->