### PR TITLE
fix(tasks): fail closed when a poisoned lowest-UID root leaves only a later replay (#161)

### DIFF
--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -245,10 +245,12 @@ export type RawTaskMessage = {
   parentTaskId?: string;
 };
 
-/** Private poison marker: never populated from relationship metadata itself. */
+/** 私有毒化标记：不得从关系元数据自身填充。uid 透传 IMAP UID，供抑制分支 min-vs-min 序比对。 */
 type TaskRelationshipIntegrityFailure = {
   kind: 'relationship-integrity-failure';
   taskId: string;
+  /** 与 FetchMessageObject.uid 同型（number），不得 optional——语义比较字段必须有真值。 */
+  uid: number;
 };
 type ParsedTaskMessage = RawTaskMessage | TaskRelationshipIntegrityFailure | null;
 
@@ -1135,7 +1137,8 @@ async function relationshipIntegrityFailureFor(
       parsed.headers.get('x-oa-task-stamp'),
     );
     if (!hasRootWitness) return null;
-    return { kind: 'relationship-integrity-failure', taskId: id };
+    // 透传 IMAP UID：抑制分支按 min(root.uid) vs min(marker.uid) 判定，缺 UID 会静默升格 replay。
+    return { kind: 'relationship-integrity-failure', taskId: id, uid: message.uid };
   } catch {
     return null;
   }
@@ -1158,14 +1161,21 @@ async function parseTaskMessageWithIntegrity(
 
 function taskFromParsedMessages(id: string, messages: ParsedTaskMessage[]): Task | null {
   const authenticated = messages.filter((message): message is RawTaskMessage => !!message && !isRelationshipIntegrityFailure(message));
-  // An injected stripped/tampered replay cannot suppress an intact authenticated
-  // relationship root already present in the same durable history. The marker
-  // remains fail-closed only when no such root survives, preventing downgrade
-  // after the real creation root was removed or corrupted.
-  if (
-    messages.some(isRelationshipIntegrityFailure)
-    && !authenticated.some((message) => message.parentTaskId !== undefined)
-  ) return null;
+  // 抑制分支按 min-vs-min 序敏感（#161 / lowest-UID-root 不变量）：
+  // markers = 全部 integrity-failure；roots = authenticated 中带 parentTaskId 的项。
+  // - 无 roots：与现状一致，v2 无根不可重建，return null。
+  // - min(root.uid) > min(marker.uid)：真根区被毒，幸存认证 replay 不得升格 creation root → null。
+  // - min(root.uid) < min(marker.uid)：完好认证根在噪声之下，忽略 markers 照常重建。
+  // - 相等不可能（同一 UID 不会既是 marker 又是 authenticated）；若代码上可达则 fail-closed。
+  // taskFromMessages 的 roots 循环不动：认证字段一致性与 replay-noise 语义仍由那边钉死。
+  const markers = messages.filter(isRelationshipIntegrityFailure);
+  if (markers.length > 0) {
+    const roots = authenticated.filter((message) => message.parentTaskId !== undefined);
+    if (roots.length === 0) return null;
+    const minRootUid = Math.min(...roots.map((root) => root.uid));
+    const minMarkerUid = Math.min(...markers.map((marker) => marker.uid));
+    if (minRootUid >= minMarkerUid) return null;
+  }
   return taskFromMessages(id, authenticated);
 }
 
@@ -1471,6 +1481,7 @@ type TaskLookupResult = {
 };
 
 async function findTaskMessages(id: string): Promise<TaskLookupResult> {
+  if (findTaskMessagesForTests) return findTaskMessagesForTests(id);
   return withInbox(async (client) => {
     const uids = await client.search({ header: { 'x-oa-task': id } }, { uid: true });
     if (!uids || uids.length === 0) return { messages: [], hadMatchingRows: false };
@@ -1734,6 +1745,8 @@ let nowFn: () => number = () => Date.now();
 let listCache: { at: number; snapshot: TaskListSnapshot } | null = null;
 let listAllForTests: (() => Promise<Task[]>) | null = null;
 let getTaskForTests: ((id: string) => Promise<Task | null>) | null = null;
+/** 测试注入 findTaskMessages 结果，用于走 getTaskSnapshot 的 hadMatchingRows 抑制路径。 */
+let findTaskMessagesForTests: ((id: string) => Promise<TaskLookupResult>) | null = null;
 let sendMailForTests: ((input: SendInput) => Promise<{ messageId: string }>) | null = null;
 /** Test-only deterministic child id; production always uses crypto.randomUUID. */
 let taskIdForTests: (() => string) | null = null;
@@ -1839,6 +1852,13 @@ export function setTaskListAllForTests(fn: (() => Promise<Task[]>) | null): void
 
 export function setTaskGetForTests(fn: ((id: string) => Promise<Task | null>) | null): void {
   getTaskForTests = fn;
+}
+
+/** 测试专用：注入 IMAP 查找结果，使 getTaskSnapshot 走真实 hadMatchingRows 分支。 */
+export function setFindTaskMessagesForTests(
+  fn: ((id: string) => Promise<{ messages: ParsedTaskMessage[]; hadMatchingRows: boolean }>) | null,
+): void {
+  findTaskMessagesForTests = fn;
 }
 
 export function setTaskSendMailForTests(

--- a/packages/api/src/lib/tasks-internal.ts
+++ b/packages/api/src/lib/tasks-internal.ts
@@ -1172,6 +1172,12 @@ function taskFromParsedMessages(id: string, messages: ParsedTaskMessage[]): Task
   if (markers.length > 0) {
     const roots = authenticated.filter((message) => message.parentTaskId !== undefined);
     if (roots.length === 0) return null;
+    // 缺 UID / NaN / Infinity 不得进入 Math.min：否则比较全假，会静默升格 replay。
+    // 两侧任一 uid 非有限值 → fail-closed（把「缺 UID 静默升格 replay」注释不变量落成代码）。
+    if (
+      roots.some((root) => !Number.isFinite(root.uid))
+      || markers.some((marker) => !Number.isFinite(marker.uid))
+    ) return null;
     const minRootUid = Math.min(...roots.map((root) => root.uid));
     const minMarkerUid = Math.min(...markers.map((marker) => marker.uid));
     if (minRootUid >= minMarkerUid) return null;

--- a/packages/api/test/parent-child-root.test.ts
+++ b/packages/api/test/parent-child-root.test.ts
@@ -693,6 +693,17 @@ test('#161 T1 intact low-UID v2 root ignores a higher-UID stripped replay marker
   expect(rebuilt).toMatchObject({ parentTaskId: PARENT, subject: 'Signed root', state: 'submitted' });
 });
 
+// #161 P2-1：注入 uid=NaN 的 marker + 有限 roots → fail-closed，不得静默升格 replay。
+test('#161 P2-1 non-finite marker uid with finite roots fails closed', async () => {
+  const intact = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID, uid: 1, source: rootSource(ID, PARENT), internalDate: '2026-08-30T00:00:00.000Z',
+  });
+  expect(intact).toMatchObject({ parentTaskId: PARENT, uid: 1 });
+  const nanMarker = { kind: 'relationship-integrity-failure' as const, taskId: ID, uid: Number.NaN };
+  expect(Number.isFinite(nanMarker.uid)).toBe(false);
+  expect(integrity.taskFromParsedMessagesForTests!(ID, [intact, nanMarker])).toBeNull();
+});
+
 // #161 T2：低 UID 根被剥（marker）+ 高 UID 认证 replay 根（同认证转录、展示字段不同）→ null。
 test('#161 T2 stripped low-UID root plus authenticated high-UID replay fails closed', async () => {
   const marker = await integrity.parseTaskMessageWithIntegrityForTests!({

--- a/packages/api/test/parent-child-root.test.ts
+++ b/packages/api/test/parent-child-root.test.ts
@@ -27,6 +27,10 @@ type IntegritySeams = {
   }) => Promise<unknown>;
   taskFromParsedMessagesForTests?: (id: string, messages: unknown[]) => unknown;
   setTaskIdForTests?: (fn: (() => string) | null) => void;
+  setFindTaskMessagesForTests?: (
+    fn: ((id: string) => Promise<{ messages: unknown[]; hadMatchingRows: boolean }>) | null,
+  ) => void;
+  getTaskSnapshot?: (id: string) => Promise<Task | null>;
   observeTaskSideEffectsForTests?: () => {
     notifications: string[]; cacheInvalidations: number; queuedTaskIds: string[];
   };
@@ -59,6 +63,7 @@ afterEach(() => {
   taskSeams.clearQueuedEventsForTests();
   taskSeams.setTaskNowForTests(null);
   integrity.setTaskIdForTests?.(null);
+  integrity.setFindTaskMessagesForTests?.(null);
   integrity.clearTaskSideEffectObserverForTests?.();
 });
 
@@ -669,6 +674,185 @@ test('R5f wait helper immediately rejects without hanging when concurrent operat
   ).rejects.toThrow('simulated_delivery_failure');
 
   await expect(failingOp).rejects.toThrow('simulated_delivery_failure');
+});
+
+// #161 T1：完好低 UID v2 根 + 高 UID 被剥 replay（marker）→ 重建成功且忽略 marker。
+test('#161 T1 intact low-UID v2 root ignores a higher-UID stripped replay marker', async () => {
+  const intact = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID, uid: 1, source: rootSource(ID, PARENT), internalDate: '2026-08-30T00:00:00.000Z',
+  });
+  const marker = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 9,
+    source: removeHeader(rootSource(ID, PARENT), 'X-OA-Task-Root'),
+    internalDate: '2026-08-30T00:09:00.000Z',
+  });
+  expect(intact).toMatchObject({ parentTaskId: PARENT, uid: 1, subject: 'Signed root' });
+  expect(marker).toMatchObject({ kind: 'relationship-integrity-failure', taskId: ID, uid: 9 });
+  const rebuilt = integrity.taskFromParsedMessagesForTests!(ID, [intact, marker]) as Task;
+  expect(rebuilt).toMatchObject({ parentTaskId: PARENT, subject: 'Signed root', state: 'submitted' });
+});
+
+// #161 T2：低 UID 根被剥（marker）+ 高 UID 认证 replay 根（同认证转录、展示字段不同）→ null。
+test('#161 T2 stripped low-UID root plus authenticated high-UID replay fails closed', async () => {
+  const marker = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 1,
+    source: removeHeader(rootSource(ID, PARENT, 'Original signed root'), 'X-OA-Task-Root'),
+    internalDate: '2026-08-30T00:00:00.000Z',
+  });
+  // 同认证转录的 replay：subject/body 未签名，故意写成与被剥根不同，证明不得升格替换展示。
+  const replay = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 8,
+    source: changeHeader(rootSource(ID, PARENT, 'forged replay subject'), 'Subject', 'forged replay subject')
+      .replace(/\r\n\r\n[\s\S]*$/, '\r\n\r\nforged replay body'),
+    internalDate: '2026-08-30T00:08:00.000Z',
+  });
+  expect(marker).toMatchObject({ kind: 'relationship-integrity-failure', taskId: ID, uid: 1 });
+  expect(replay).toMatchObject({
+    parentTaskId: PARENT,
+    uid: 8,
+    subject: 'forged replay subject',
+    body: 'forged replay body',
+  });
+  expect(integrity.taskFromParsedMessagesForTests!(ID, [marker, replay])).toBeNull();
+});
+
+// #161 T3：T2 场景走 getTaskSnapshot——hadMatchingRows 路径抑制 synthetic base 并返回 null。
+test('#161 T3 getTaskSnapshot suppresses synthetic base when T2 reconstruction fails closed', async () => {
+  taskSeams.setTaskNowForTests(() => Date.parse('2026-08-30T00:00:00.000Z'));
+  const sent = capture();
+  const created = await tasks.createTask({
+    from: FROM, to: TO, subject: 'Synthetic then poisoned', body: 'body', parentTaskId: PARENT,
+  } as Parameters<typeof tasks.createTask>[0]);
+  // 关掉 getTask 替身，让 getTaskSnapshot 走 findTaskMessages / hadMatchingRows 真路径。
+  // 先注入空查找，避免测试环境打真实 IMAP，同时证明 synthetic base 仍可读。
+  taskSeams.setTaskGetForTests(null);
+  expect(integrity.getTaskSnapshot).toBeFunction();
+  integrity.setFindTaskMessagesForTests!(async () => ({ messages: [], hadMatchingRows: false }));
+  expect(await integrity.getTaskSnapshot!(created.id)).toMatchObject({
+    id: created.id, subject: 'Synthetic then poisoned',
+  });
+
+  const marker = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: created.id,
+    uid: 1,
+    source: removeHeader(rfc822(sent[0]!), 'X-OA-Task-Root'),
+    internalDate: '2026-08-30T00:00:00.000Z',
+  });
+  const replay = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: created.id,
+    uid: 8,
+    source: changeHeader(rfc822(sent[0]!), 'Subject', 'forged replay subject')
+      .replace(/\r\n\r\n[\s\S]*$/, '\r\n\r\nforged replay body'),
+    internalDate: '2026-08-30T00:08:00.000Z',
+  });
+  expect(marker).toMatchObject({ kind: 'relationship-integrity-failure', uid: 1 });
+  expect(replay).toMatchObject({ parentTaskId: PARENT, uid: 8, subject: 'forged replay subject' });
+
+  integrity.setFindTaskMessagesForTests!(async (id) => (
+    id === created.id
+      ? { messages: [marker, replay], hadMatchingRows: true }
+      : { messages: [], hadMatchingRows: false }
+  ));
+  expect(await integrity.getTaskSnapshot!(created.id)).toBeNull();
+
+  // synthetic base 已被 hadMatchingRows 路径删除：空查找不得再回落到 synthetic。
+  integrity.setFindTaskMessagesForTests!(async () => ({ messages: [], hadMatchingRows: false }));
+  expect(await integrity.getTaskSnapshot!(created.id)).toBeNull();
+});
+
+// #161 T4：多 marker 两侧混布，按 min-vs-min 判定。
+test('#161 T4 min-vs-min with markers on both sides of the surviving root', async () => {
+  const markerLow = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 2,
+    source: removeHeader(rootSource(ID, PARENT), 'X-OA-Task-Root'),
+    internalDate: '2026-08-30T00:02:00.000Z',
+  });
+  const rootMid = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID, uid: 5, source: rootSource(ID, PARENT), internalDate: '2026-08-30T00:05:00.000Z',
+  });
+  const markerHigh = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 9,
+    source: changeHeader(
+      rootSource(ID, PARENT),
+      'X-OA-Task-Root',
+      Buffer.from(`{"version":2,"parentTaskId":"${OTHER_PARENT}"}`, 'utf8').toString('base64url'),
+    ),
+    internalDate: '2026-08-30T00:09:00.000Z',
+  });
+  expect(markerLow).toMatchObject({ kind: 'relationship-integrity-failure', uid: 2 });
+  expect(rootMid).toMatchObject({ parentTaskId: PARENT, uid: 5 });
+  expect(markerHigh).toMatchObject({ kind: 'relationship-integrity-failure', uid: 9 });
+  // marker@2 + 根@5 + marker@9 → min(root)=5 > min(marker)=2 → 真根区被毒。
+  expect(integrity.taskFromParsedMessagesForTests!(ID, [markerLow, rootMid, markerHigh])).toBeNull();
+
+  const rootLow = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID, uid: 2, source: rootSource(ID, PARENT), internalDate: '2026-08-30T00:02:00.000Z',
+  });
+  const markerMid = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 5,
+    source: removeHeader(rootSource(ID, PARENT), 'X-OA-Task-Root'),
+    internalDate: '2026-08-30T00:05:00.000Z',
+  });
+  expect(rootLow).toMatchObject({ parentTaskId: PARENT, uid: 2 });
+  expect(markerMid).toMatchObject({ kind: 'relationship-integrity-failure', uid: 5 });
+  // 根@2 + marker@5 + marker@9 → min(root)=2 < min(marker)=5 → 忽略 marker 重建。
+  expect(integrity.taskFromParsedMessagesForTests!(ID, [rootLow, markerMid, markerHigh])).toMatchObject({
+    parentTaskId: PARENT, subject: 'Signed root', state: 'submitted',
+  });
+});
+
+// #161 T5：完好根@1 + 高 UID 认证 replay 篡改 subject/body → 展示仍取根@1。
+test('#161 T5 lowest-UID-root display wins over a later authenticated replay', async () => {
+  const intact = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID, uid: 1, source: rootSource(ID, PARENT, 'Signed root'), internalDate: '2026-08-30T00:00:00.000Z',
+  });
+  const replay = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 8,
+    source: changeHeader(rootSource(ID, PARENT, 'forged unsigned subject'), 'Subject', 'forged unsigned subject')
+      .replace(/\r\n\r\n[\s\S]*$/, '\r\n\r\nforged unsigned body'),
+    internalDate: '2026-08-30T00:08:00.000Z',
+  });
+  expect(replay).toMatchObject({
+    parentTaskId: PARENT, uid: 8, subject: 'forged unsigned subject', body: 'forged unsigned body',
+  });
+  const rebuilt = integrity.taskFromParsedMessagesForTests!(ID, [intact, replay]) as Task;
+  expect(rebuilt).toMatchObject({ parentTaskId: PARENT, subject: 'Signed root' });
+  expect(rebuilt.messages[0]).toMatchObject({ subject: 'Signed root', body: 'body' });
+  expect(JSON.stringify(rebuilt)).not.toContain('forged unsigned');
+});
+
+// #161 T6：legacy 流（无 parentTaskId、无 marker）行为零变化。
+test('#161 T6 legacy parentless history without markers still reconstructs', async () => {
+  const legacy = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 1,
+    source: rfc822({
+      from: FROM, to: [TO], subject: 'Legacy ordinary', text: 'legacy body',
+      headers: { 'X-OA-Task': ID, 'X-OA-Task-State': 'submitted', 'X-OA-Task-Stamp': v1Stamp(ID, 'submitted', FROM, TO) },
+    }),
+    internalDate: '2026-08-30T00:00:00.000Z',
+  });
+  const later = await integrity.parseTaskMessageWithIntegrityForTests!({
+    id: ID,
+    uid: 2,
+    source: rfc822({
+      from: TO, to: [FROM], subject: 'Legacy ordinary', text: 'working',
+      headers: { 'X-OA-Task': ID, 'X-OA-Task-State': 'working', 'X-OA-Task-Stamp': v1Stamp(ID, 'working', TO, FROM) },
+    }),
+    internalDate: '2026-08-30T00:01:00.000Z',
+  });
+  expect(legacy).toMatchObject({ uid: 1, subject: 'Legacy ordinary', state: 'submitted' });
+  expect(legacy).not.toHaveProperty('parentTaskId');
+  const rebuilt = integrity.taskFromParsedMessagesForTests!(ID, [legacy, later]) as Task;
+  expect(rebuilt).toMatchObject({ subject: 'Legacy ordinary', state: 'working' });
+  expect(rebuilt).not.toHaveProperty('parentTaskId');
 });
 
 test('R5f wait helper times out with descriptive error when condition is never met', async () => {


### PR DESCRIPTION
## What

Closes #161 (P1, pre-existing — surfaced by Codex Local review of #160, proven pre-existing via hunk-range analysis at filing time).

`taskFromParsedMessages` decided root-replay integrity failures only by **existence**: any surviving authenticated root suppressed the poison marker, regardless of ordering. When the lowest-UID v2 root is stripped/tampered (marker) but a **later** authenticated root replay survives, the replay was promoted to creation root — and since subject/body are unsigned, the replay's display content replaced the original's, contradicting the documented lowest-UID-root invariant.

## Fix (min-vs-min, order-aware)

- `TaskRelationshipIntegrityFailure` now carries `uid` (plumbed from `FetchMessageObject.uid`; non-optional — a semantic comparison field must have a real value).
- Suppression branch compares lowest authenticated-root UID vs lowest marker UID:
  - no surviving root → `null` (unchanged);
  - `min(root.uid) > min(marker.uid)` → `null` — the true root region is poisoned; surviving "roots" are replays and must not be promoted (**the #161 fix**; `>=` also covers the impossible-equal case fail-closed);
  - `min(root.uid) < min(marker.uid)` → ignore markers, reconstruct as before (injected/stripped noise above an intact root — unchanged behavior).
- `taskFromMessages` roots loop untouched (authenticated-field consistency + replay-noise semantics stay pinned there).
- New narrow test seam `setFindTaskMessagesForTests` follows the existing `*ForTests` conventions (production default `null`) to exercise the real `getTaskSnapshot` → `hadMatchingRows` suppression path (T3).

Healthy streams are unaffected: the rule only tightens when a marker and a root coexist in inverted order — an attacker/noise-only condition.

## Tests

- T1 intact low-UID root + higher-UID stripped replay marker → reconstructs, marker ignored (regression pin).
- T2 stripped low-UID root + authenticated high-UID replay (same authenticated transcript, different unsigned subject/body) → `null`.
- T3 T2 through `getTaskSnapshot`: synthetic base suppressed, returns `null`.
- T4 markers on both sides of the surviving root → min-vs-min decides.
- T5 later authenticated replay with tampered subject/body above an intact root → display still from the lowest root.
- T6 legacy parentless history without markers → unchanged.
- Focused: 25/0. Full suite: **1489 tests / 88 files / 0 fail / 1 skip** (worker self-report 1488 pass + 1 skip; FC independent rerun from `packages/api` matches).

## Out of scope (recorded)

- Lease overlay / #80-#84 domain untouched (purity grep on `mergeQueuedEvents|LEASE_OVERLAY|pendingExpiryAudits|leaseEventIsIndexed|materializeLeaseExpiry` → 0 hits; also checked independently by FC).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task reconstruction when relationship-integrity issues occur.
  - Prevented incomplete or inconsistent task data from being reconstructed when required relationship roots are missing or out of order.
  - Improved handling of replayed messages and later integrity noise.
  - Preserved correct display-field precedence and legacy parentless task behavior.

- **Tests**
  - Added regression coverage for relationship ordering, snapshots, replay handling, and task reconstruction edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## R2 (fd171ac) — ZCode advisory P2-1 hardening

- `Number.isFinite` guard on both sides before the min-vs-min comparison: any non-finite uid → `null` (turns the "missing uid must not silently promote a replay" comment invariant into enforced code). Focused test added.
- Delta from 46518aa: 17 lines (6 guard + 11 test), single fixup commit; full suite on fd171ac: **1490 tests / 0 fail / 1 skip** (FC independent rerun matches).
- Final gates on fd171ac: CI ✅ · ZCode ✅ (P2×2 advisory, see below) · Codex Local ✅ · CR check pass but rate-limited on the new head (formal review on 46518aa: Review completed, zero findings, zero threads).

## Advisory P2s on final head (recorded, non-blocking per ZCode verdict)

- **Injection-race suppression**: a participant holding a signed root mail who strips `X-OA-Task-Root` and wins a delivery race could permanently suppress a single task (marker lands before the true root). ZCode judges this the **intended #161 design trade-off** (integrity over availability — indistinguishable from real corruption); suggested follow-up: emit an audit/alert event when the suppression branch fires (currently a silent null).
- **Test seam pattern**: `findTaskMessagesForTests` follows the existing `*ForTests` conventions, no production reach (grep-verified); long-term seam consolidation noted, not this card.
