### PR TITLE
fix(mcp): keep stdio client from parsing server env at import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,9 +38,10 @@ jobs:
           bun test
           bun run lint:ui
 
-      - name: Typecheck + build packages/mcp
+      - name: Typecheck + build + test packages/mcp
         working-directory: packages/mcp
         run: |
           bun install
           bunx tsc --noEmit
           bun run build
+          bun test

--- a/README.md
+++ b/README.md
@@ -393,7 +393,9 @@ produce two copies with a case-folding provider, so use consistent spelling.
 ## Use it from your agent (MCP)
 
 Requires Node.js 18+ on the machine running the MCP client — no install step,
-`npx` downloads and runs the package on first use.
+`npx` downloads and runs the package on first use. The stdio client only needs
+`OPENAGENTEMAIL_API_URL` and `OPENAGENTEMAIL_API_KEY`; it does not read the
+mail server's `DOMAIN` / `API_KEYS` / IMAP / SMTP variables.
 
 ```bash
 claude mcp add openagentemail \

--- a/packages/api/src/lib/identities.ts
+++ b/packages/api/src/lib/identities.ts
@@ -24,6 +24,11 @@ import {
 import { join } from 'node:path';
 import { createHash, randomBytes, randomInt, timingSafeEqual } from 'node:crypto';
 import { config } from './config.ts';
+import {
+  MAX_SCOPE_LENGTH,
+  MAX_SCOPES_COUNT,
+  isSupportedScope,
+} from './identity-scopes.ts';
 import { revokeGrantsForAddress } from './oauth-store.ts';
 import {
   revokeDelegationsForAddress,
@@ -48,14 +53,15 @@ export const DEFAULT_PUSH_CONTENT_TIER: PushContentTier = 1;
 export const PUSH_TIER3_WARNING =
   'Tier 3 includes message body previews and OTP codes/links in push notifications. That content leaves this server for the ntfy channel.';
 
-/** First-class supported identity token scopes. */
-export const SUPPORTED_SCOPES = ['read:messages'] as const;
-export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
-export const SUPPORTED_SCOPES_SET = new Set<string>(SUPPORTED_SCOPES);
-
-export function isSupportedScope(scope: string): scope is SupportedScope {
-  return SUPPORTED_SCOPES_SET.has(scope);
-}
+// 叶子常量再导出，服务端既有 import 面保持不变。
+export {
+  MAX_SCOPE_LENGTH,
+  MAX_SCOPES_COUNT,
+  SUPPORTED_SCOPES,
+  SUPPORTED_SCOPES_SET,
+  isSupportedScope,
+} from './identity-scopes.ts';
+export type { SupportedScope } from './identity-scopes.ts';
 
 export class LocalpartConflictError extends Error {
   readonly code = 'localpart_conflict';
@@ -66,9 +72,6 @@ export class LocalpartConflictError extends Error {
     this.domains = domains;
   }
 }
-
-export const MAX_SCOPES_COUNT = 10;
-export const MAX_SCOPE_LENGTH = 64;
 
 export type ScopeValidationResult =
   | { ok: true; scopes: string[] }

--- a/packages/api/src/lib/identity-scopes.ts
+++ b/packages/api/src/lib/identity-scopes.ts
@@ -1,0 +1,16 @@
+/**
+ * 身份 scope 叶子常量：无服务端 env / config 依赖。
+ * MCP stdio 客户端只应拉这份，禁止经 identities.ts 把 parseConfig 打进 bundle。
+ */
+
+/** 身份 token 一等支持的 scope。 */
+export const SUPPORTED_SCOPES = ['read:messages'] as const;
+export type SupportedScope = (typeof SUPPORTED_SCOPES)[number];
+export const SUPPORTED_SCOPES_SET = new Set<string>(SUPPORTED_SCOPES);
+
+export function isSupportedScope(scope: string): scope is SupportedScope {
+  return SUPPORTED_SCOPES_SET.has(scope);
+}
+
+export const MAX_SCOPES_COUNT = 10;
+export const MAX_SCOPE_LENGTH = 64;

--- a/packages/api/src/mcp/tools.ts
+++ b/packages/api/src/mcp/tools.ts
@@ -14,7 +14,8 @@ import {
   TOOL_TIER_SPEC,
   type ToolTier,
 } from "../lib/tool-tiers.ts";
-import { MAX_SCOPES_COUNT, SUPPORTED_SCOPES } from "../lib/identities.ts";
+// 只拉无 config 依赖的叶子常量，避免 stdio bundle 加载期 parse 服务端 env。
+import { MAX_SCOPES_COUNT, SUPPORTED_SCOPES } from "../lib/identity-scopes.ts";
 import { isTaskId } from "../lib/task-id.ts";
 import { ApiError, OpenAgentEmailClient } from "./client.ts";
 import { prepareMailToolMessage } from "./fence.ts";

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -28,6 +28,8 @@ The server is configured entirely via environment variables:
 
 If `OPENAGENTEMAIL_API_KEY` is missing the server exits immediately with a clear error.
 
+This stdio client does **not** read the mail server's `DOMAIN`, `API_KEYS`, `IMAP_*`, or `SMTP_*` variables. Those belong on the separately hosted API. A placeholder token may fail later on an authenticated API call; it must not crash the process at import.
+
 ## Tools
 
 | Tool | Description |

--- a/packages/mcp/test/clean-boot.test.ts
+++ b/packages/mcp/test/clean-boot.test.ts
@@ -1,0 +1,153 @@
+/**
+ * #168 净环境启动回归：stdio bundle 不得在模块加载期 parse 服务端 env。
+ * 只给 OPENAGENTEMAIL_API_URL + OPENAGENTEMAIL_API_KEY，必须完成 initialize + tools/list。
+ */
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const mcpRoot = join(here, "..");
+const distMain = join(mcpRoot, "dist/main.js");
+const SERVER_ENV_KEYS = [
+  "DOMAIN",
+  "API_KEYS",
+  "IMAP_USER",
+  "IMAP_PASS",
+  "SMTP_USER",
+  "SMTP_PASS",
+] as const;
+
+/** MCP SDK v2 stdio 是换行 JSON，不是 Content-Length。 */
+function encodeMcpMessage(payload: unknown): string {
+  return `${JSON.stringify(payload)}\n`;
+}
+
+function decodeMcpMessages(buffer: string): { messages: Record<string, unknown>[]; rest: string } {
+  const messages: Record<string, unknown>[] = [];
+  const lines = buffer.split("\n");
+  const rest = lines.pop() ?? "";
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      messages.push(JSON.parse(trimmed) as Record<string, unknown>);
+    } catch {
+      continue;
+    }
+  }
+  return { messages, rest };
+}
+
+async function handshakeCleanBoot(command: string, args: string[]): Promise<{
+  initialize: Record<string, unknown>;
+  tools: string[];
+  stderr: string;
+}> {
+  const env = { ...process.env };
+  for (const key of SERVER_ENV_KEYS) delete env[key];
+  env.OPENAGENTEMAIL_API_URL = "http://127.0.0.1:3100";
+  env.OPENAGENTEMAIL_API_KEY = "repro-placeholder-not-a-secret";
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env, stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let initialize: Record<string, unknown> | undefined;
+    let tools: string[] | undefined;
+
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      child.kill();
+      if (error) reject(error);
+      else resolve({ initialize: initialize!, tools: tools!, stderr });
+    };
+
+    const timer = setTimeout(() => {
+      finish(new Error(`clean-boot handshake timed out: ${stderr || "(no stderr)"}`));
+    }, 20_000);
+
+    const consume = () => {
+      const decoded = decodeMcpMessages(stdout);
+      stdout = decoded.rest;
+      for (const message of decoded.messages) {
+        if (message.id === 1 && message.result && !initialize) {
+          initialize = message.result as Record<string, unknown>;
+          child.stdin.write(encodeMcpMessage({
+            jsonrpc: "2.0",
+            method: "notifications/initialized",
+          }));
+          child.stdin.write(encodeMcpMessage({
+            jsonrpc: "2.0",
+            id: 2,
+            method: "tools/list",
+            params: {},
+          }));
+        }
+        if (message.id === 2 && message.result) {
+          const list = message.result as { tools?: Array<{ name?: string }> };
+          tools = (list.tools ?? []).map((tool) => tool.name ?? "").filter(Boolean);
+          if (tools.length === 0) {
+            finish(new Error("tools/list returned no tools"));
+            return;
+          }
+          finish();
+        }
+        if (message.error) {
+          finish(new Error(`MCP error: ${JSON.stringify(message.error)}`));
+        }
+      }
+    };
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+      consume();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+    });
+    child.on("error", (error) => finish(error));
+    child.on("exit", (code) => {
+      if (!settled) {
+        finish(new Error(`stdio bundle exited ${code} before handshake: ${stderr}`));
+      }
+    });
+
+    child.stdin.write(encodeMcpMessage({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-06-18",
+        capabilities: {},
+        clientInfo: { name: "clean-boot-regression", version: "0.0.0" },
+      },
+    }));
+  });
+}
+
+test("#168 净环境 dist bundle 完成 initialize + tools/list，且不含服务端 parseConfig", async () => {
+  if (!existsSync(distMain)) {
+    const build = spawn("bun", ["run", "build"], { cwd: mcpRoot, stdio: "inherit" });
+    const status = await new Promise<number>((resolve, reject) => {
+      build.on("error", reject);
+      build.on("exit", (code) => resolve(code ?? 1));
+    });
+    expect(status).toBe(0);
+  }
+  const bundle = readFileSync(distMain, "utf8");
+  expect(bundle).not.toContain("parseConfig(process.env)");
+  expect(bundle).not.toMatch(/envSchema\.parse\(\s*env\s*\)/);
+
+  const result = await handshakeCleanBoot("node", [distMain]);
+  const serverInfo = result.initialize.serverInfo as { name?: string; version?: string } | undefined;
+  expect(serverInfo?.name).toBe("openagentemail");
+  expect(result.tools).toContain("mail_list_identities");
+  expect(result.tools).toContain("task_list");
+  expect(result.stderr).not.toMatch(/ZodError|DOMAIN|IMAP_USER|SMTP_USER/);
+}, 20_000);

--- a/packages/mcp/test/shared-module.test.ts
+++ b/packages/mcp/test/shared-module.test.ts
@@ -9,6 +9,7 @@ import { registerOpenAgentEmailTools } from "../../api/src/mcp/tools.ts";
 
 const here = dirname(fileURLToPath(import.meta.url));
 const mainSrc = readFileSync(join(here, "../src/main.ts"), "utf8");
+const toolsSrc = readFileSync(join(here, "../../api/src/mcp/tools.ts"), "utf8");
 
 test("registerOpenAgentEmailTools 从共享模块导出", () => {
   expect(typeof registerOpenAgentEmailTools).toBe("function");
@@ -21,4 +22,10 @@ test("stdio main 从 ../../api/src/mcp 导入注册函数且自身不再 registe
   // 实现文件不得再留在 mcp/src/lib（移动而非复制）
   expect(mainSrc).not.toContain("./lib/client");
   expect(mainSrc).not.toContain("./lib/fence");
+});
+
+test("stdio 工具注册不得经 identities.ts 把服务端 parseConfig 打进 bundle", () => {
+  expect(toolsSrc).toContain("../lib/identity-scopes.ts");
+  expect(toolsSrc).not.toContain("../lib/identities.ts");
+  expect(toolsSrc).not.toContain("../lib/config.ts");
 });


### PR DESCRIPTION
Closes #168

## Summary
- 0.7.0 `tools.ts` imported `identities.ts`, which eagerly `parseConfig(process.env)` and crashed the published stdio client in a clean environment (no `DOMAIN` / IMAP / SMTP).
- Scope constants now live in a leaf module with no server-env dependency; the MCP bundle no longer parses server config at import.
- CI runs `packages/mcp` tests after build, including a clean-env `initialize` + `tools/list` handshake against `dist/main.js`.

## Test plan
- [x] `env -u DOMAIN -u API_KEYS -u IMAP_USER -u IMAP_PASS -u SMTP_USER -u SMTP_PASS` + client env: `node dist/main.js` starts; handshake test PASS
- [x] `cd packages/mcp && bun test` → 29/0
- [x] `cd packages/api && bun test` → 1491/0 (1 skip)
- [ ] Do not publish 0.7.1 in this PR (release waits for owner approval)


Made with [Cursor](https://cursor.com)