### PR TITLE
chore(release): v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented here, one section per release, newest first.
 
+## v0.7.1 — 2026-09-08
+
+### Fixed
+
+- **MCP stdio clean boot**: v0.7.0 crashed on startup in a clean client environment — an import chain pulled the mail server's env schema (`DOMAIN`/`API_KEYS`/IMAP/SMTP) into the MCP bundle before the handshake. Scope constants moved to a config-free leaf module; the stdio client now boots with only `OPENAGENTEMAIL_API_URL` + `OPENAGENTEMAIL_API_KEY` (#168, #169).
+
+### Notes
+
+- Regression guard added: `packages/mcp/test/clean-boot.test.ts` runs an initialize + tools/list handshake against the built bundle with all server-side env removed, wired into CI.
+
 ## v0.7.0 — 2026-09-07
 
 ### Added

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagentemail/mcp",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "mcpName": "io.github.openagentemail/mcp",
   "description": "MCP server for openagent.email \u2014 unlimited agent mailboxes via REST + MCP",
   "license": "Apache-2.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/openagentemail/openagentemail",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@openagentemail/mcp",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version alignment for v0.7.1 hotfix release (#168 / PR #169). Bumps packages/mcp + server.json, adds CHANGELOG section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed a crash that could prevent the MCP stdio client from starting cleanly.
  - MCP startup now requires only the API URL and API key configuration.
  - Added regression coverage to help prevent the startup issue from returning.

- **Chores**
  - Updated the MCP package and server registry version to 0.7.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->