### PR TITLE
test(webhooks): #146 quota and latest-delivery IO contract regressions

### DIFF
--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -352,6 +352,19 @@ function emptyDeliveryLogIndex(path = ''): DeliveryLogIndex {
 
 let deliveryLogIndex: DeliveryLogIndex = emptyDeliveryLogIndex();
 
+/** 测试用投递日志 IO 计数：全量读 vs 增量读，不含 stat。 */
+type DeliveryLogIoStats = {
+  fullReads: number;
+  incrementalReads: number;
+  bytesRead: number;
+};
+
+let deliveryLogIoForTests: DeliveryLogIoStats = {
+  fullReads: 0,
+  incrementalReads: 0,
+  bytesRead: 0,
+};
+
 function groupKeyForRow(row: WebhookDeliveryLogRow): string {
   return `${row.webhookId}:${row.eventId}:${row.runId}`;
 }
@@ -483,6 +496,9 @@ function refreshDeliveryLogIndex(): DeliveryLogIndex {
   try {
     const buf = Buffer.alloc(length);
     const n = readSync(fd, buf, 0, length, deliveryLogIndex.size);
+    // 增量读计入测试 IO，证明热路径不是按订阅数全量扫盘
+    deliveryLogIoForTests.incrementalReads += 1;
+    deliveryLogIoForTests.bytesRead += n;
     const consumed = ingestIncrementalBytes(deliveryLogIndex, buf.subarray(0, n));
     deliveryLogIndex.size += consumed;
     deliveryLogIndex.mtimeMs = st.mtimeMs;
@@ -514,11 +530,23 @@ export function resetDeliveryLogIndexForTests(): void {
   deliveryLogIndex = emptyDeliveryLogIndex();
 }
 
+export function getDeliveryLogIoForTests(): DeliveryLogIoStats {
+  return { ...deliveryLogIoForTests };
+}
+
+export function resetDeliveryLogIoForTests(): void {
+  deliveryLogIoForTests = { fullReads: 0, incrementalReads: 0, bytesRead: 0 };
+}
+
 /** Full-file parse used by boot reconstruction and compaction. */
 export function readAllDeliveryLogRowsFromDisk(): WebhookDeliveryLogRow[] {
   const path = deliveryLogPath();
   if (!existsSync(path)) return [];
-  return parseDeliveryLogText(readFileSync(path, 'utf8'));
+  const text = readFileSync(path, 'utf8');
+  // 全量读计入测试 IO，list/probe 热路径不得随订阅数线性放大
+  deliveryLogIoForTests.fullReads += 1;
+  deliveryLogIoForTests.bytesRead += Buffer.byteLength(text, 'utf8');
+  return parseDeliveryLogText(text);
 }
 
 function sanitizeDeliveryLogRow(row: WebhookDeliveryLogRow): WebhookDeliveryLogRow {

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -352,7 +352,7 @@ function emptyDeliveryLogIndex(path = ''): DeliveryLogIndex {
 
 let deliveryLogIndex: DeliveryLogIndex = emptyDeliveryLogIndex();
 
-/** 测试用投递日志 IO 计数：全量读 vs 增量读，不含 stat。 */
+/** 投递日志数据读计数（全量/增量，不含 stat）。生产读路径始终累计，供测试读取。 */
 type DeliveryLogIoStats = {
   fullReads: number;
   incrementalReads: number;
@@ -496,7 +496,7 @@ function refreshDeliveryLogIndex(): DeliveryLogIndex {
   try {
     const buf = Buffer.alloc(length);
     const n = readSync(fd, buf, 0, length, deliveryLogIndex.size);
-    // 增量读计入测试 IO，证明热路径不是按订阅数全量扫盘
+    // 增量读计入始终开启的 IO 计数，热路径不得整文件重读
     deliveryLogIoForTests.incrementalReads += 1;
     deliveryLogIoForTests.bytesRead += n;
     const consumed = ingestIncrementalBytes(deliveryLogIndex, buf.subarray(0, n));
@@ -543,7 +543,7 @@ export function readAllDeliveryLogRowsFromDisk(): WebhookDeliveryLogRow[] {
   const path = deliveryLogPath();
   if (!existsSync(path)) return [];
   const text = readFileSync(path, 'utf8');
-  // 全量读计入测试 IO，list/probe 热路径不得随订阅数线性放大
+  // 全量读计入始终开启的 IO 计数，list/probe 不得随订阅数线性放大
   deliveryLogIoForTests.fullReads += 1;
   deliveryLogIoForTests.bytesRead += Buffer.byteLength(text, 'utf8');
   return parseDeliveryLogText(text);

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -542,11 +542,11 @@ export function resetDeliveryLogIoForTests(): void {
 export function readAllDeliveryLogRowsFromDisk(): WebhookDeliveryLogRow[] {
   const path = deliveryLogPath();
   if (!existsSync(path)) return [];
-  const text = readFileSync(path, 'utf8');
-  // Count a full-file read; list/probe must not scale this with subscription count.
+  // Read bytes once; record disk length without a second UTF-8 walk.
+  const buf = readFileSync(path);
   deliveryLogIoForTests.fullReads += 1;
-  deliveryLogIoForTests.bytesRead += Buffer.byteLength(text, 'utf8');
-  return parseDeliveryLogText(text);
+  deliveryLogIoForTests.bytesRead += buf.byteLength;
+  return parseDeliveryLogText(buf.toString('utf8'));
 }
 
 function sanitizeDeliveryLogRow(row: WebhookDeliveryLogRow): WebhookDeliveryLogRow {

--- a/packages/api/src/lib/webhook-delivery.ts
+++ b/packages/api/src/lib/webhook-delivery.ts
@@ -352,7 +352,7 @@ function emptyDeliveryLogIndex(path = ''): DeliveryLogIndex {
 
 let deliveryLogIndex: DeliveryLogIndex = emptyDeliveryLogIndex();
 
-/** 投递日志数据读计数（全量/增量，不含 stat）。生产读路径始终累计，供测试读取。 */
+/** Delivery-log data-read counters (full vs incremental; stats excluded). Production read paths always increment these; tests observe them. */
 type DeliveryLogIoStats = {
   fullReads: number;
   incrementalReads: number;
@@ -496,7 +496,7 @@ function refreshDeliveryLogIndex(): DeliveryLogIndex {
   try {
     const buf = Buffer.alloc(length);
     const n = readSync(fd, buf, 0, length, deliveryLogIndex.size);
-    // 增量读计入始终开启的 IO 计数，热路径不得整文件重读
+    // Count incremental bytes; the hot path must not reread the whole file.
     deliveryLogIoForTests.incrementalReads += 1;
     deliveryLogIoForTests.bytesRead += n;
     const consumed = ingestIncrementalBytes(deliveryLogIndex, buf.subarray(0, n));
@@ -543,7 +543,7 @@ export function readAllDeliveryLogRowsFromDisk(): WebhookDeliveryLogRow[] {
   const path = deliveryLogPath();
   if (!existsSync(path)) return [];
   const text = readFileSync(path, 'utf8');
-  // 全量读计入始终开启的 IO 计数，list/probe 不得随订阅数线性放大
+  // Count a full-file read; list/probe must not scale this with subscription count.
   deliveryLogIoForTests.fullReads += 1;
   deliveryLogIoForTests.bytesRead += Buffer.byteLength(text, 'utf8');
   return parseDeliveryLogText(text);

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -8,7 +8,7 @@ process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const { config } = await import('../src/lib/config.ts');
@@ -33,6 +33,8 @@ const {
   readAllDeliveryLogRowsFromDisk,
   readDeliveryLogRows,
   resetDeliveryLogIndexForTests,
+  getDeliveryLogIoForTests,
+  resetDeliveryLogIoForTests,
   reconstructPendingDeliveriesAtBoot,
   redeliverWebhookDelivery,
   setReconstructRetryDelaysForTests,
@@ -77,6 +79,7 @@ function setupTestDir(): void {
   setWebhooksFailClosedForTests(false);
   setReconstructRetryDelaysForTests();
   resetDeliveryLogIndexForTests();
+  resetDeliveryLogIoForTests();
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
   stopWebhookMaintenance();
@@ -1825,6 +1828,98 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
       setWebhookDnsLookupForTests(undefined);
       deliveryQueue.cancelAll();
     }
+  });
+
+  test('#146: latest-delivery IO stays bounded across warm/append/compact/replace', () => {
+    const logPath = join(TEST_DATA_DIR, 'webhook-deliveries.jsonl');
+    const row = (
+      id: string,
+      webhookId: string,
+      ts: string,
+      attempt = 1,
+    ): WebhookDeliveryLogRow => ({
+      ts,
+      webhookId,
+      eventId: `evt_${id}`,
+      runId: 'run_0',
+      deliveryId: `dlv_${id}`,
+      type: 'webhook.ping',
+      address: null,
+      messageId: null,
+      uidValidity: null,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: ts,
+      attempt,
+      outcome: 'success',
+      status: 200,
+      durationMs: 10,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    });
+
+    const now = Date.now();
+    const t1 = new Date(now - 3000).toISOString();
+    const t2 = new Date(now - 1000).toISOString();
+    appendDeliveryLogRow(row('a1', 'whk_a', t1, 1));
+    appendDeliveryLogRow(row('a2', 'whk_a', t1, 2));
+    appendDeliveryLogRow(row('c1', 'whk_c', t1, 1));
+    appendDeliveryLogRow(row('c2', 'whk_c', t2, 1));
+
+    // 冷启动允许一次重建；热查询不得再全量读
+    expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
+    resetDeliveryLogIoForTests();
+    expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
+    expect(getLatestDeliveryForWebhook('whk_b')).toBeNull();
+    expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c2');
+    const afterFirst = getDeliveryLogIoForTests();
+    expect(afterFirst.fullReads).toBe(0);
+
+    getLatestDeliveryForWebhook('whk_a');
+    getLatestDeliveryForWebhook('whk_b');
+    getLatestDeliveryForWebhook('whk_c');
+    const afterWarm = getDeliveryLogIoForTests();
+    expect(afterWarm.fullReads).toBe(afterFirst.fullReads);
+    expect(afterWarm.incrementalReads).toBe(afterFirst.incrementalReads);
+
+    for (let i = 0; i < 8; i++) {
+      appendDeliveryLogRow(row(`x${i}`, `whk_x${i}`, t2, 1));
+    }
+    resetDeliveryLogIoForTests();
+    for (let i = 0; i < 8; i++) {
+      expect(getLatestDeliveryForWebhook(`whk_x${i}`)?.deliveryId).toBe(`dlv_x${i}`);
+    }
+    expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
+    expect(getDeliveryLogIoForTests().fullReads).toBe(0);
+
+    const extra = row('c3', 'whk_c', new Date(now).toISOString(), 1);
+    appendFileSync(logPath, `${JSON.stringify(extra)}\n`);
+    resetDeliveryLogIoForTests();
+    expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c3');
+    const afterAppend = getDeliveryLogIoForTests();
+    expect(afterAppend.fullReads).toBe(0);
+    expect(afterAppend.incrementalReads).toBeGreaterThanOrEqual(1);
+
+    const oldTs = new Date(now - 40 * 86400000).toISOString();
+    appendDeliveryLogRow(row('old', 'whk_old', oldTs, 1));
+    compactDeliveryLog(now, 30);
+    resetDeliveryLogIoForTests();
+    expect(getLatestDeliveryForWebhook('whk_old')).toBeNull();
+    expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c3');
+    expect(getDeliveryLogIoForTests().fullReads).toBe(0);
+
+    const replacement = row('rep', 'whk_a', new Date(now + 1000).toISOString(), 1);
+    const tmp = `${logPath}.replace`;
+    writeFileSync(tmp, `${JSON.stringify(replacement)}\n`);
+    renameSync(tmp, logPath);
+    resetDeliveryLogIoForTests();
+    expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_rep');
+    expect(getLatestDeliveryForWebhook('whk_c')).toBeNull();
+    expect(getDeliveryLogIoForTests().fullReads).toBe(1);
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -1870,21 +1870,27 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     appendDeliveryLogRow(row('c1', 'whk_c', t1, 1));
     appendDeliveryLogRow(row('c2', 'whk_c', t2, 1));
 
-    // 冷启动允许一次重建；热查询不得再全量读
+    // 无追加/替换时数据读必须为 0：次数与字节一并封顶
+    const expectNoDataReads = () => {
+      expect(getDeliveryLogIoForTests()).toEqual({
+        fullReads: 0,
+        incrementalReads: 0,
+        bytesRead: 0,
+      });
+    };
+
+    // 冷启动允许一次重建；热查询不得再读数据
     expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
     resetDeliveryLogIoForTests();
     expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
     expect(getLatestDeliveryForWebhook('whk_b')).toBeNull();
     expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c2');
-    const afterFirst = getDeliveryLogIoForTests();
-    expect(afterFirst.fullReads).toBe(0);
+    expectNoDataReads();
 
     getLatestDeliveryForWebhook('whk_a');
     getLatestDeliveryForWebhook('whk_b');
     getLatestDeliveryForWebhook('whk_c');
-    const afterWarm = getDeliveryLogIoForTests();
-    expect(afterWarm.fullReads).toBe(afterFirst.fullReads);
-    expect(afterWarm.incrementalReads).toBe(afterFirst.incrementalReads);
+    expectNoDataReads();
 
     for (let i = 0; i < 8; i++) {
       appendDeliveryLogRow(row(`x${i}`, `whk_x${i}`, t2, 1));
@@ -1894,15 +1900,18 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
       expect(getLatestDeliveryForWebhook(`whk_x${i}`)?.deliveryId).toBe(`dlv_x${i}`);
     }
     expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
-    expect(getDeliveryLogIoForTests().fullReads).toBe(0);
+    expectNoDataReads();
 
     const extra = row('c3', 'whk_c', new Date(now).toISOString(), 1);
-    appendFileSync(logPath, `${JSON.stringify(extra)}\n`);
+    const extraLine = `${JSON.stringify(extra)}\n`;
+    const extraBytes = Buffer.byteLength(extraLine, 'utf8');
+    appendFileSync(logPath, extraLine);
     resetDeliveryLogIoForTests();
     expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c3');
     const afterAppend = getDeliveryLogIoForTests();
     expect(afterAppend.fullReads).toBe(0);
-    expect(afterAppend.incrementalReads).toBeGreaterThanOrEqual(1);
+    expect(afterAppend.incrementalReads).toBe(1);
+    expect(afterAppend.bytesRead).toBe(extraBytes);
 
     const oldTs = new Date(now - 40 * 86400000).toISOString();
     appendDeliveryLogRow(row('old', 'whk_old', oldTs, 1));
@@ -1910,16 +1919,21 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     resetDeliveryLogIoForTests();
     expect(getLatestDeliveryForWebhook('whk_old')).toBeNull();
     expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c3');
-    expect(getDeliveryLogIoForTests().fullReads).toBe(0);
+    expectNoDataReads();
 
     const replacement = row('rep', 'whk_a', new Date(now + 1000).toISOString(), 1);
+    const replacementLine = `${JSON.stringify(replacement)}\n`;
+    const replacementBytes = Buffer.byteLength(replacementLine, 'utf8');
     const tmp = `${logPath}.replace`;
-    writeFileSync(tmp, `${JSON.stringify(replacement)}\n`);
+    writeFileSync(tmp, replacementLine);
     renameSync(tmp, logPath);
     resetDeliveryLogIoForTests();
     expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_rep');
     expect(getLatestDeliveryForWebhook('whk_c')).toBeNull();
-    expect(getDeliveryLogIoForTests().fullReads).toBe(1);
+    const afterReplace = getDeliveryLogIoForTests();
+    expect(afterReplace.fullReads).toBe(1);
+    expect(afterReplace.incrementalReads).toBe(0);
+    expect(afterReplace.bytesRead).toBe(replacementBytes);
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhook-delivery.test.ts
+++ b/packages/api/test/webhook-delivery.test.ts
@@ -1866,7 +1866,9 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
     const t1 = new Date(now - 3000).toISOString();
     const t2 = new Date(now - 1000).toISOString();
     appendDeliveryLogRow(row('a1', 'whk_a', t1, 1));
-    appendDeliveryLogRow(row('a2', 'whk_a', t1, 2));
+    const a2 = row('a2', 'whk_a', t1, 2);
+    a2.reason = 'café-测试';
+    appendDeliveryLogRow(a2);
     appendDeliveryLogRow(row('c1', 'whk_c', t1, 1));
     appendDeliveryLogRow(row('c2', 'whk_c', t2, 1));
 
@@ -1879,8 +1881,19 @@ describe('webhook-delivery: Boot Reconstruction (§8.6, Item 9, §14 item 15)', 
       });
     };
 
-    // 冷启动允许一次重建；热查询不得再读数据
+    // 显式冷索引：一次全量读，字节按磁盘长度而非字符数
+    resetDeliveryLogIndexForTests();
+    resetDeliveryLogIoForTests();
     expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
+    expect(getLatestDeliveryForWebhook('whk_b')).toBeNull();
+    expect(getLatestDeliveryForWebhook('whk_c')?.deliveryId).toBe('dlv_c2');
+    const seededBuf = readFileSync(logPath);
+    const seededText = seededBuf.toString('utf8');
+    const cold = getDeliveryLogIoForTests();
+    expect(cold.fullReads).toBe(1);
+    expect(cold.incrementalReads).toBe(0);
+    expect(cold.bytesRead).toBe(seededBuf.byteLength);
+    expect(seededBuf.byteLength).toBeGreaterThan(seededText.length);
     resetDeliveryLogIoForTests();
     expect(getLatestDeliveryForWebhook('whk_a')?.deliveryId).toBe('dlv_a2');
     expect(getLatestDeliveryForWebhook('whk_b')).toBeNull();

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -8,7 +8,7 @@ process.env.TASK_SIGNING_SECRET = '01234567890123456789012345678901';
 process.env.WEBHOOK_SIGNING_SECRET = '01234567890123456789012345678901';
 
 import { afterAll, afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { appendFileSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 const { createApp } = await import('../src/app.ts');
@@ -1627,7 +1627,15 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
       reason: 'upstream',
     });
 
-    // 冷启动可重建一次；之后 list/probe 不得按订阅数再次全量读
+    const expectNoDataReads = () => {
+      expect(getDeliveryLogIoForTests()).toEqual({
+        fullReads: 0,
+        incrementalReads: 0,
+        bytesRead: 0,
+      });
+    };
+
+    // 冷启动可重建一次；无追加时 list/GET 数据读必须为 0
     const prime = await app.request('/v1/webhooks', {
       headers: { Authorization: `Bearer ${adminKey}` },
     });
@@ -1642,8 +1650,7 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(byId.get(empty.id).lastDelivery).toBeNull();
     expect(byId.get(older.id).lastDelivery.deliveryId).toBe('dlv_old_attempt2');
     expect(byId.get(newer.id).lastDelivery.deliveryId).toBe('dlv_new');
-    const afterList = getDeliveryLogIoForTests();
-    expect(afterList.fullReads).toBe(0);
+    expectNoDataReads();
 
     for (const sub of subs) {
       const detail = await app.request(`/v1/webhooks/${sub.id}`, {
@@ -1651,15 +1658,13 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
       });
       expect(detail.status).toBe(200);
     }
-    const afterProbes = getDeliveryLogIoForTests();
-    expect(afterProbes.fullReads).toBe(afterList.fullReads);
-    expect(afterProbes.incrementalReads).toBe(afterList.incrementalReads);
+    expectNoDataReads();
 
     const warmList = await app.request('/v1/webhooks', {
       headers: { Authorization: `Bearer ${adminKey}` },
     });
     expect(warmList.status).toBe(200);
-    expect(getDeliveryLogIoForTests().fullReads).toBe(afterList.fullReads);
+    expectNoDataReads();
 
     const extraSubs = Array.from({ length: 6 }, (_, i) =>
       createWebhookSubscription({
@@ -1702,7 +1707,61 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(scaled.status).toBe(200);
     const scaledBody: any = await scaled.json();
     expect(scaledBody.webhooks.length).toBe(12);
-    expect(getDeliveryLogIoForTests().fullReads).toBe(0);
+    expectNoDataReads();
+
+    // 外部 append 必须只付追加字节，并由 list/GET 消费
+    const appended = {
+      ts: new Date(now + 1000).toISOString(),
+      webhookId: newer.id,
+      eventId: 'evt_ext_append',
+      runId: 'run_0',
+      deliveryId: 'dlv_ext_append',
+      type: 'mail.received',
+      address: newer.address,
+      messageId: '9',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: new Date(now + 1000).toISOString(),
+      attempt: 1,
+      outcome: 'success',
+      status: 200,
+      durationMs: 7,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    };
+    const appendedLine = `${JSON.stringify(appended)}\n`;
+    const appendedBytes = Buffer.byteLength(appendedLine, 'utf8');
+    appendFileSync(join(TEST_DATA_DIR, 'webhook-deliveries.jsonl'), appendedLine);
+    resetDeliveryLogIoForTests();
+    const appendList = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(appendList.status).toBe(200);
+    const appendListBody: any = await appendList.json();
+    const appendById = new Map<string, any>(
+      appendListBody.webhooks.map((w: any) => [w.id, w]),
+    );
+    expect(appendById.get(newer.id).lastDelivery.deliveryId).toBe('dlv_ext_append');
+    const afterAppendList = getDeliveryLogIoForTests();
+    expect(afterAppendList.fullReads).toBe(0);
+    expect(afterAppendList.incrementalReads).toBe(1);
+    expect(afterAppendList.bytesRead).toBe(appendedBytes);
+
+    const appendGet = await app.request(`/v1/webhooks/${newer.id}`, {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(appendGet.status).toBe(200);
+    const appendGetBody: any = await appendGet.json();
+    expect(appendGetBody.lastDelivery.deliveryId).toBe('dlv_ext_append');
+    const afterAppendGet = getDeliveryLogIoForTests();
+    expect(afterAppendGet.fullReads).toBe(0);
+    expect(afterAppendGet.incrementalReads).toBe(1);
+    expect(afterAppendGet.bytesRead).toBe(appendedBytes);
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -18,6 +18,9 @@ const {
   deliveryQueue,
   readAllDeliveryLogRows,
   appendDeliveryLogRow,
+  getDeliveryLogIoForTests,
+  resetDeliveryLogIoForTests,
+  resetDeliveryLogIndexForTests,
   setWebhookDnsLookupForTests,
 } = await import('../src/lib/webhook-delivery.ts');
 const {
@@ -62,6 +65,8 @@ function setupTestDir(): void {
   (config.webhooks as any).maxPerAddress = 4;
   deliveryLimiter.reset();
   deliveryQueue.cancelAll();
+  resetDeliveryLogIndexForTests();
+  resetDeliveryLogIoForTests();
   resetWebhooksStoreForTests();
   setWebhooksFailClosedForTests(false);
   setWebhookDnsLookupForTests(async () => [{ address: '93.184.216.34', family: 4 }]);
@@ -1338,6 +1343,366 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
       readFileSync(join(TEST_DATA_DIR, 'identities.json'), 'utf8'),
     ) as Array<{ address: string }>;
     expect(identitiesRaw.find((i) => i.address === 'alice@test.example')).toBeDefined();
+  });
+
+  // #146 契约 1：单写运行时并发创建不得越过配额
+  function seedSubscriptions(address: string, count: number): void {
+    for (let i = 0; i < count; i++) {
+      createWebhookSubscription({
+        url: `https://consumer.example/seed-${address.split('@')[0]}-${i}`,
+        address,
+        events: ['mail.received'],
+        createdBy: 'admin',
+      });
+    }
+  }
+
+  function postCreate(opts: { address: string; url: string; key?: string }) {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${adminKey}`,
+      'Content-Type': 'application/json',
+    };
+    if (opts.key) headers['Idempotency-Key'] = opts.key;
+    return app.request('/v1/webhooks', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        url: opts.url,
+        address: opts.address,
+        events: ['mail.received'],
+      }),
+    });
+  }
+
+  /** 重叠 URL/DNS 解析完成点，再一起进入配额检查。 */
+  function installOverlappingDns(waiters: number) {
+    let arrived = 0;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    setWebhookDnsLookupForTests(async () => {
+      arrived += 1;
+      if (arrived >= waiters) release();
+      await gate;
+      return [{ address: '93.184.216.34', family: 4 }];
+    });
+    return () => arrived;
+  }
+
+  async function statusesOf(responses: Response[]): Promise<number[]> {
+    return Promise.all(responses.map((r) => r.status));
+  }
+
+  async function jsonBodies(responses: Response[]): Promise<any[]> {
+    return Promise.all(responses.map((r) => r.json()));
+  }
+
+  test('#146: overlapping distinct-key creates consume the last per-address slot once', async () => {
+    (config.webhooks as any).maxPerAddress = 3;
+    (config.webhooks as any).maxSubscriptions = 16;
+    (config.webhooks as any).rateCreatePerMin = 100;
+    deliveryLimiter.reset();
+    seedSubscriptions('alice@test.example', 2);
+
+    const n = 4;
+    installOverlappingDns(n);
+    const responses = await Promise.all(
+      Array.from({ length: n }, (_, i) =>
+        postCreate({
+          address: 'alice@test.example',
+          key: `quota-addr-${Date.now()}-${i}`,
+          url: `https://consumer.example/overlap-addr-${i}`,
+        }),
+      ),
+    );
+    const statuses = await statusesOf(responses);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(0);
+    expect(statuses.filter((s) => s === 201)).toHaveLength(1);
+    expect(statuses.filter((s) => s === 409)).toHaveLength(n - 1);
+    const bodies = await jsonBodies(responses);
+    for (const body of bodies.filter((_, i) => statuses[i] === 409)) {
+      expect(body.error).toBe('webhook_limit_reached');
+    }
+    expect(
+      listWebhookSubscriptions('alice@test.example').length,
+    ).toBe(3);
+  });
+
+  test('#146: overlapping distinct-address creates consume the last instance slot once', async () => {
+    (config.webhooks as any).maxPerAddress = 8;
+    (config.webhooks as any).maxSubscriptions = 3;
+    (config.webhooks as any).rateCreatePerMin = 100;
+    deliveryLimiter.reset();
+    seedSubscriptions('alice@test.example', 1);
+    seedSubscriptions('bob@test.example', 1);
+
+    const addrs = ['carol@test.example', 'dave@test.example', 'erin@test.example'];
+    installOverlappingDns(addrs.length);
+    const responses = await Promise.all(
+      addrs.map((address, i) =>
+        postCreate({
+          address,
+          key: `quota-inst-${Date.now()}-${i}`,
+          url: `https://consumer.example/overlap-inst-${i}`,
+        }),
+      ),
+    );
+    const statuses = await statusesOf(responses);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(0);
+    expect(statuses.filter((s) => s === 201)).toHaveLength(1);
+    expect(statuses.filter((s) => s === 409)).toHaveLength(addrs.length - 1);
+    expect(listWebhookSubscriptions().length).toBe(3);
+  });
+
+  test('#146: overlapping creates against an already-full address quota all 409', async () => {
+    (config.webhooks as any).maxPerAddress = 2;
+    (config.webhooks as any).maxSubscriptions = 16;
+    (config.webhooks as any).rateCreatePerMin = 100;
+    deliveryLimiter.reset();
+    seedSubscriptions('alice@test.example', 2);
+
+    const n = 3;
+    installOverlappingDns(n);
+    const responses = await Promise.all(
+      Array.from({ length: n }, (_, i) =>
+        postCreate({
+          address: 'alice@test.example',
+          key: `quota-full-addr-${Date.now()}-${i}`,
+          url: `https://consumer.example/full-addr-${i}`,
+        }),
+      ),
+    );
+    const statuses = await statusesOf(responses);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(0);
+    expect(statuses.every((s) => s === 409)).toBe(true);
+    expect(listWebhookSubscriptions('alice@test.example').length).toBe(2);
+  });
+
+  test('#146: overlapping creates against an already-full instance quota all 409', async () => {
+    (config.webhooks as any).maxPerAddress = 8;
+    (config.webhooks as any).maxSubscriptions = 2;
+    (config.webhooks as any).rateCreatePerMin = 100;
+    deliveryLimiter.reset();
+    seedSubscriptions('alice@test.example', 1);
+    seedSubscriptions('bob@test.example', 1);
+
+    const addrs = ['carol@test.example', 'dave@test.example'];
+    installOverlappingDns(addrs.length);
+    const responses = await Promise.all(
+      addrs.map((address, i) =>
+        postCreate({
+          address,
+          key: `quota-full-inst-${Date.now()}-${i}`,
+          url: `https://consumer.example/full-inst-${i}`,
+        }),
+      ),
+    );
+    const statuses = await statusesOf(responses);
+    expect(statuses.filter((s) => s === 429)).toHaveLength(0);
+    expect(statuses.every((s) => s === 409)).toBe(true);
+    expect(listWebhookSubscriptions().length).toBe(2);
+  });
+
+  test('#146: same-key overlapping create still discloses one secret', async () => {
+    (config.webhooks as any).maxPerAddress = 2;
+    (config.webhooks as any).maxSubscriptions = 16;
+    (config.webhooks as any).rateCreatePerMin = 100;
+    deliveryLimiter.reset();
+    seedSubscriptions('alice@test.example', 1);
+
+    const key = `quota-same-${Date.now()}`;
+    // 同键只跑一次 URL 解析；重叠门闩按 1 个 waiter，避免误等第二次 DNS
+    installOverlappingDns(1);
+    const [res1, res2] = await Promise.all([
+      postCreate({
+        address: 'alice@test.example',
+        key,
+        url: 'https://consumer.example/same-key-near-quota',
+      }),
+      postCreate({
+        address: 'alice@test.example',
+        key,
+        url: 'https://consumer.example/same-key-near-quota',
+      }),
+    ]);
+    expect(res1.status).toBe(201);
+    expect(res2.status).toBe(201);
+    const body1: any = await res1.json();
+    const body2: any = await res2.json();
+    expect(body1.id).toBe(body2.id);
+    const secrets = [body1.secret, body2.secret];
+    expect(secrets.filter((s) => typeof s === 'string' && /^whs_[a-f0-9]{64}$/.test(s))).toHaveLength(1);
+    expect(secrets.filter((s) => s === null)).toHaveLength(1);
+    expect(listWebhookSubscriptions('alice@test.example').length).toBe(2);
+  });
+
+  test('#146: list and GET probe latest-delivery without per-subscription full-log IO', async () => {
+    (config.webhooks as any).rateCreatePerMin = 100;
+    deliveryLimiter.reset();
+    const now = Date.now();
+    const t1 = new Date(now - 2000).toISOString();
+    const t2 = new Date(now - 500).toISOString();
+    const subs = Array.from({ length: 6 }, (_, i) =>
+      createWebhookSubscription({
+        url: `https://consumer.example/io-${i}`,
+        address: i < 3 ? 'alice@test.example' : 'bob@test.example',
+        events: ['mail.received'],
+        createdBy: 'admin',
+      }),
+    );
+    const empty = subs[1]!;
+    const older = subs[0]!;
+    const newer = subs[2]!;
+    appendDeliveryLogRow({
+      ts: t1,
+      webhookId: older.id,
+      eventId: 'evt_old',
+      runId: 'run_0',
+      deliveryId: 'dlv_old',
+      type: 'mail.received',
+      address: older.address,
+      messageId: '1',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: t1,
+      attempt: 1,
+      outcome: 'success',
+      status: 200,
+      durationMs: 10,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    });
+    appendDeliveryLogRow({
+      ts: t1,
+      webhookId: older.id,
+      eventId: 'evt_old2',
+      runId: 'run_0',
+      deliveryId: 'dlv_old_attempt2',
+      type: 'mail.received',
+      address: older.address,
+      messageId: '1',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: t1,
+      attempt: 2,
+      outcome: 'success',
+      status: 200,
+      durationMs: 11,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: null,
+    });
+    appendDeliveryLogRow({
+      ts: t2,
+      webhookId: newer.id,
+      eventId: 'evt_new',
+      runId: 'run_0',
+      deliveryId: 'dlv_new',
+      type: 'mail.received',
+      address: newer.address,
+      messageId: '2',
+      uidValidity: 1,
+      rfc822MessageId: null,
+      taskId: null,
+      taskCreatedAt: null,
+      expiresInSec: null,
+      eventCreatedAt: t2,
+      attempt: 1,
+      outcome: 'retryable',
+      status: 500,
+      durationMs: 20,
+      sensitive: false,
+      replay: false,
+      nextAttemptAt: null,
+      reason: 'upstream',
+    });
+
+    // 冷启动可重建一次；之后 list/probe 不得按订阅数再次全量读
+    const prime = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(prime.status).toBe(200);
+    resetDeliveryLogIoForTests();
+    const listRes = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(listRes.status).toBe(200);
+    const listBody: any = await listRes.json();
+    const byId = new Map<string, any>(listBody.webhooks.map((w: any) => [w.id, w]));
+    expect(byId.get(empty.id).lastDelivery).toBeNull();
+    expect(byId.get(older.id).lastDelivery.deliveryId).toBe('dlv_old_attempt2');
+    expect(byId.get(newer.id).lastDelivery.deliveryId).toBe('dlv_new');
+    const afterList = getDeliveryLogIoForTests();
+    expect(afterList.fullReads).toBe(0);
+
+    for (const sub of subs) {
+      const detail = await app.request(`/v1/webhooks/${sub.id}`, {
+        headers: { Authorization: `Bearer ${adminKey}` },
+      });
+      expect(detail.status).toBe(200);
+    }
+    const afterProbes = getDeliveryLogIoForTests();
+    expect(afterProbes.fullReads).toBe(afterList.fullReads);
+    expect(afterProbes.incrementalReads).toBe(afterList.incrementalReads);
+
+    const warmList = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(warmList.status).toBe(200);
+    expect(getDeliveryLogIoForTests().fullReads).toBe(afterList.fullReads);
+
+    const extraSubs = Array.from({ length: 6 }, (_, i) =>
+      createWebhookSubscription({
+        url: `https://consumer.example/io-more-${i}`,
+        address: 'alice@test.example',
+        events: ['mail.received'],
+        createdBy: 'admin',
+      }),
+    );
+    for (const sub of extraSubs) {
+      appendDeliveryLogRow({
+        ts: new Date().toISOString(),
+        webhookId: sub.id,
+        eventId: `evt_${sub.id}`,
+        runId: 'run_0',
+        deliveryId: `dlv_${sub.id}`,
+        type: 'mail.received',
+        address: sub.address,
+        messageId: null,
+        uidValidity: null,
+        rfc822MessageId: null,
+        taskId: null,
+        taskCreatedAt: null,
+        expiresInSec: null,
+        eventCreatedAt: new Date().toISOString(),
+        attempt: 1,
+        outcome: 'success',
+        status: 200,
+        durationMs: 5,
+        sensitive: false,
+        replay: false,
+        nextAttemptAt: null,
+        reason: null,
+      });
+    }
+    resetDeliveryLogIoForTests();
+    const scaled = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(scaled.status).toBe(200);
+    const scaledBody: any = await scaled.json();
+    expect(scaledBody.webhooks.length).toBe(12);
+    expect(getDeliveryLogIoForTests().fullReads).toBe(0);
   });
 
   afterAll(async () => {

--- a/packages/api/test/webhooks-route.test.ts
+++ b/packages/api/test/webhooks-route.test.ts
@@ -1635,11 +1635,8 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
       });
     };
 
-    // 冷启动可重建一次；无追加时 list/GET 数据读必须为 0
-    const prime = await app.request('/v1/webhooks', {
-      headers: { Authorization: `Bearer ${adminKey}` },
-    });
-    expect(prime.status).toBe(200);
+    // 显式冷索引：list 一次全量读，字节等于已播种日志磁盘长度
+    resetDeliveryLogIndexForTests();
     resetDeliveryLogIoForTests();
     const listRes = await app.request('/v1/webhooks', {
       headers: { Authorization: `Bearer ${adminKey}` },
@@ -1650,6 +1647,16 @@ describe('webhooks REST API (§10.3, §10.4, §10.6, §12)', () => {
     expect(byId.get(empty.id).lastDelivery).toBeNull();
     expect(byId.get(older.id).lastDelivery.deliveryId).toBe('dlv_old_attempt2');
     expect(byId.get(newer.id).lastDelivery.deliveryId).toBe('dlv_new');
+    const seededBytes = readFileSync(join(TEST_DATA_DIR, 'webhook-deliveries.jsonl')).byteLength;
+    const cold = getDeliveryLogIoForTests();
+    expect(cold.fullReads).toBe(1);
+    expect(cold.incrementalReads).toBe(0);
+    expect(cold.bytesRead).toBe(seededBytes);
+    resetDeliveryLogIoForTests();
+    const warmAfterCold = await app.request('/v1/webhooks', {
+      headers: { Authorization: `Bearer ${adminKey}` },
+    });
+    expect(warmAfterCold.status).toBe(200);
     expectNoDataReads();
 
     for (const sub of subs) {


### PR DESCRIPTION
## Summary
- Add deterministic overlapping-create tests so the last per-address and instance webhook slots admit exactly one 201 and durable count stays at the limit; already-full limits stay 409; same-key create still discloses one secret.
- Add always-on delivery-log IO counters and list/GET probe regressions proving latest-delivery reads do not full-scan JSONL per subscription. Warm list/GET have zero data reads; an external append costs exactly the appended payload (one incremental read) via both list and GET; compact/replace refresh results.
- R1: explicit count + byte caps. Independent 20× incremental full-log negative control: 5 pass / 2 fail.
- R2: explicit cold index reset plus one full-read/disk-byte assertion; `readAllDeliveryLogRowsFromDisk` records Buffer `byteLength` then decodes once (no second UTF-8 walk; non-ASCII fixture). Cloud discussions r3963337447 / r3963337450 applied in this head. Worker does not resolve those threads.
- ZCode `5593620647` on prior head: P0=0 P1=0 P2=2 MERGE=yes. P2-1 always-on counters accepted as intentional. P2-2 DNS latch timeout rejected (`bun test` default 5000ms + card `timeout 180`).
- No rewrite of the working single-writer limit check or delivery-log index; seven #146 comment debts remain OPEN.

## Head
`a6595eb76f0368ec2352c8cb29bb762922ac7318`. Artifact: `/home/ops/materials/146/completion.md`.

CodeRabbit waiver #1749 applied only to `8ba3f4e` and is **not inherited** by this head.

## Test plan
- [x] focused `#146` — 7 pass / 0 fail / 88 asserts (FC-verified)
- [x] `bun test` in `packages/api` — 1528 pass / 1 skip / 0 fail
- [x] independent cold-path double-read negative control — 5 pass / 2 fail (FC)
- [ ] Four gates on this new head (CI / CodeRabbit / Codex Local / ZCode). Sentinel green is not acceptance.

Refs #146