### PR TITLE
chore(release): v0.7.2 — webhook compose wiring + tasks lease hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,8 @@ All notable changes to this project are documented here, one section per release
 
 ### Fixed
 
-- **Tasks: bound public-read lease overlay replay**: public read projections cap lease overlay replay at 15 minutes, preventing unbounded replay on read paths (#80, #84; #171).
-- **Tasks: decouple reclaim from expiry-audit SMTP**: lease reclaim no longer depends on the expiry-audit mail path, with late-receipt tolerance (#80, #84; #167).
+- **Tasks: bound public-read lease overlay replay** (opt-in): public read projections cap lease overlay replay at 15 minutes, preventing unbounded replay on read paths. Disabled by default — enable with `TASK_LEASES_OVERLAY_BOUND=true` (#80, #84; #171).
+- **Tasks: decouple reclaim from expiry-audit SMTP** (opt-in): lease reclaim no longer depends on the expiry-audit mail path, with late-receipt tolerance. Disabled by default — enable with `TASK_LEASES_EXPIRY_AUDIT_M3=true` (#80, #84; #167).
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project are documented here, one section per release, newest first.
 
+## v0.7.2 — 2026-09-09
+
+### Added
+
+- **Webhook env wiring for compose deployments**: all 22 webhook configuration keys are now wired through the API service in `compose.yaml` and `compose.api-only.yaml`, with `.env` examples — compose-based installs can enable and tune the outbound webhook subsystem without touching code. Safe defaults preserved: signing secrets stay `undefined` when unset, explicit empty/short values are rejected, and the public-edge guard keeps `private=false` (#149, #174).
+
+### Fixed
+
+- **Tasks: bound public-read lease overlay replay**: public read projections cap lease overlay replay at 15 minutes, preventing unbounded replay on read paths (#80, #84; #171).
+- **Tasks: decouple reclaim from expiry-audit SMTP**: lease reclaim no longer depends on the expiry-audit mail path, with late-receipt tolerance (#80, #84; #167).
+
+### Tests
+
+- Webhook quota and latest-delivery IO contract regression coverage: exact read/byte accounting under real compose rendering, including negative controls (#146, #173).
+
 ## v0.7.1 — 2026-09-08
 
 ### Fixed

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openagentemail/mcp",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "mcpName": "io.github.openagentemail/mcp",
   "description": "MCP server for openagent.email \u2014 unlimited agent mailboxes via REST + MCP",
   "license": "Apache-2.0",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/openagentemail/openagentemail",
     "source": "github"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "@openagentemail/mcp",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
Version alignment for v0.7.2 release: packages/mcp 0.7.1→0.7.2, server.json both version fields, CHANGELOG v0.7.2 section. Contents: #174 (compose webhook wiring), #171 (lease overlay replay bound), #167 (reclaim/SMTP decoupling), #173 (webhook IO contract tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook environment wiring for Compose deployments.
  * Limited public-read lease overlay replay to 15 minutes.
  * Improved lease reclamation by separating it from expiry-audit email delivery and tolerating late receipts.
* **Tests**
  * Added regression coverage for webhook quota and latest-delivery behavior.
* **Documentation**
  * Added changelog details for release 0.7.2.
* **Release**
  * Updated the MCP package and server version to 0.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->