### PR TITLE
fix(api): rate-limit GET /v1/messages per authenticated caller

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,3 +43,13 @@ Pending retries are rebuilt from the delivery log on restart; events emitted whi
 - **代际保护**：游标严格绑定 `uidValidity`；若信箱代际变更（UIDVALIDITY 不匹配），请求将 fail-closed 返回 `400 invalid_cursor`。`GET /v1/messages/:id` 支持可选的 `?uidValidity=` 参数，代际不匹配时返回 `404 stale_message_generation`。
 - **服务端 SINCE 与 receivedAtMs 口径差异说明**：服务端 IMAP SEARCH SINCE 依据 RFC 3501 `INTERNALDATE` 检索（向前预留 1 天缓冲）；应用层 `receivedAtMs` 优先采用 `INTERNALDATE` 并回落至 `ENVELOPE.date`。若个别邮件缺失 `INTERNALDATE` 且其 `ENVELOPE.date` 晚于实际收信时间，此口径差异为 fail-safe（只漏不越权，后续追扫覆盖）。
 
+### Caller 列表限速（#143，单实例前提）
+
+仅 `GET /v1/messages`（普通列表与 `since` 共用同一 caller 桶）。身份键是已鉴权地址的小写形式，不是原始 token、也不是 query `address`。同一地址的 identity token 与 OAuth 凭证聚合；委托方无论轮换目标信箱都消耗**自己的**身份预算。全部 admin 凭证共享一个 `list:admin` 命名空间桶，不是无限豁免。
+
+- **预算：** 每 caller 滚动 60 次录取 / 60 秒；进程内单调毫秒窗口，重启清零。允许一次性打满 60（突发），随后 `429` `{error:"rate_limited",retryAfterSec}` 且带整数 `Retry-After`。
+- **顺序：** query schema 与 ACL（401/400/403）不消耗预算；预算在首次 IMAP 之前同步录取；下游错误（含不透明 `since` 游标失败、IMAP 失败）已录取不退款。
+- **内存：** 最多 10000 个 caller 桶，每桶最多 60 个活戳。仅当**新 key** 将触顶时懒清理过期/空桶（一次检查最多扫 10000 个桶、每桶最多 60 个戳，不是“只做 10000 次常量操作”）；不驱逐仍有活戳的桶，不做后台 janitor。新 caller 在满图且无法回收时拒绝，`retryAfterSec=60` 为保守提示，不保证届时一定能入场。
+- **明确不是：** 全局 IMAP 并发/耗尽保护。多身份与未纳入的路由（detail / wait / UI / MCP-direct）仍可叠加负载。多实例不共享内存桶，部署合同按单实例前提；水平扩展不会自动协调这份预算。
+- **独立：** 不改 send / MCP / wait 槽位的既有桶。
+

--- a/docs/security.md
+++ b/docs/security.md
@@ -153,6 +153,7 @@ Catch-all 信箱里，身份之间的读边界是**精确整邮箱**匹配（禁
 - `MCP_MAX_WAIT_SECONDS`（默认 60，可配 1..600）：`mail_wait_for` / `POST /v1/messages/wait` 的 `timeoutSec` 与 `task_*` wait 服务端封顶**静默钳制**到该值（schema 仍广告 max 600，不 400）。有效值见响应头 `X-OAE-Wait-Timeout-Sec` 与 408 体 `timeoutSec`。
 - `OAUTH_RATE_PER_MIN`（默认 30）：`/authorize`、`/oauth/token`、`/oauth/revoke` 每 IP 每分钟。
 - `MCP_PREAUTH_RATE_PER_MIN`（默认 120）：`POST /mcp` 无/坏 token 的 401 挑战路径每 IP 每分钟。OAuth 引导握手故意无 token 探 401 拿挑战是规范动作；共享出口 IP 下默认须留余量。超限 `429` + `Retry-After`。
+- `GET /v1/messages` caller 列表限速（固定 60/60s，无独立 env）：按已鉴权地址（admin 共享命名空间桶）进程内单调流逝窗口。满图懒清理最多扫 10000 桶 × 每桶 60 戳。这是 per-caller 速率上界，**不是**全局 IMAP 并发保护；允许窗口内突发 60 次，多实例不共享。详见 docs/api.md。
 
 ### 推荐公网部署姿态
 

--- a/packages/api/src/lib/ratelimit.ts
+++ b/packages/api/src/lib/ratelimit.ts
@@ -90,10 +90,11 @@ export function releaseSendLimit(address: string, reservation: number | undefine
   slidingWindowRelease(buckets, address.toLowerCase(), reservation);
 }
 
-/** Test helper: wipe all windows. */
+/** 测试辅助：清空 send/审计 以及列表 caller 桶（不改生产配额）。 */
 export function resetRateLimits(): void {
   buckets.clear();
   resetDelegationDeniedAuditLimits();
+  resetListMessagesLimits();
 }
 
 /**
@@ -300,4 +301,101 @@ export function resetWaitSlots(): void {
   waits.clear();
   waitsPerAddress.clear();
   waitsTotal = 0;
+}
+
+/**
+ * GET /v1/messages 独立 caller 桶。
+ * 与 send/MCP/wait 分图；只复用 slidingWindowCheck，不改那些桶。
+ * 生产路径用进程单调流逝毫秒（performance.now），墙钟拨动不改窗口；重启清零。
+ * 这不是全局 IMAP 并发保护。
+ */
+export const LIST_MESSAGES_LIMIT = 60;
+export const LIST_MESSAGES_WINDOW_MS = 60_000;
+export const LIST_MESSAGES_MAX_BUCKETS = 10_000;
+/** 新 key 触顶且无法回收过期桶时的保守提示，不保证届时一定能入场。 */
+export const LIST_MESSAGES_CAPACITY_RETRY_SEC = 60;
+
+const listMessagesBuckets = new Map<string, number[]>();
+let listMessagesTestNow: (() => number) | null = null;
+
+/** 列表限速时钟：默认进程单调流逝毫秒；测试可整段替换。 */
+export function listMessagesMonotonicNow(): number {
+  if (listMessagesTestNow) return listMessagesTestNow();
+  return performance.now();
+}
+
+/** 测试注入/清除列表限速时钟。 */
+export function setListMessagesNowForTests(now: number | (() => number) | null): void {
+  if (now === null) {
+    listMessagesTestNow = null;
+    return;
+  }
+  listMessagesTestNow = typeof now === 'function' ? now : () => now;
+}
+
+/**
+ * 命名空间桶键：全部 admin 凭证共享 list:admin；
+ * 同一 identity 地址（OAuth / oa_ 轮换）共享 list:id:<lowercased>。
+ */
+export function listMessagesCallerKey(auth: { kind: 'admin' } | { kind: 'identity'; address: string }): string {
+  if (auth.kind === 'admin') return 'list:admin';
+  return `list:id:${auth.address.trim().toLowerCase()}`;
+}
+
+/** 仅新 key 触顶时调用：回收空/过期桶，不驱逐仍有活戳的桶。 */
+function reclaimExpiredListBuckets(now: number): void {
+  const cutoff = now - LIST_MESSAGES_WINDOW_MS;
+  for (const [key, stamps] of listMessagesBuckets) {
+    const live = stamps.filter((t) => t > cutoff);
+    if (live.length === 0) listMessagesBuckets.delete(key);
+    else if (live.length !== stamps.length) listMessagesBuckets.set(key, live);
+  }
+}
+
+/**
+ * 录取 GET /v1/messages。已有 key 只滤本桶最多 60 个戳；
+ * 新 key 遇满员才懒清理（最多扫 10000），仍满则 60s 保守提示。
+ */
+export function checkListMessagesLimit(
+  key: string,
+  now = listMessagesMonotonicNow(),
+): RateLimitResult {
+  if (!listMessagesBuckets.has(key) && listMessagesBuckets.size >= LIST_MESSAGES_MAX_BUCKETS) {
+    reclaimExpiredListBuckets(now);
+    if (listMessagesBuckets.size >= LIST_MESSAGES_MAX_BUCKETS) {
+      return {
+        allowed: false,
+        retryAfterSec: LIST_MESSAGES_CAPACITY_RETRY_SEC,
+        count: 0,
+      };
+    }
+  }
+  return slidingWindowCheck(
+    listMessagesBuckets,
+    key,
+    LIST_MESSAGES_LIMIT,
+    LIST_MESSAGES_WINDOW_MS,
+    now,
+  );
+}
+
+/** 测试辅助：清空列表桶与测试时钟注入。 */
+export function resetListMessagesLimits(): void {
+  listMessagesBuckets.clear();
+  listMessagesTestNow = null;
+}
+
+/** 测试辅助：预置某一 caller 的时间戳（容量/回收矩阵）。 */
+export function seedListMessagesBucketForTests(key: string, stamps: number[]): void {
+  listMessagesBuckets.set(key, [...stamps]);
+}
+
+/** 测试辅助：当前桶数。 */
+export function listMessagesBucketCountForTests(): number {
+  return listMessagesBuckets.size;
+}
+
+/** 测试辅助：某 key 是否仍在图中（活桶不得被驱逐）。 */
+export function listMessagesHasBucketForTests(key: string): boolean {
+  return listMessagesBuckets.has(key);
 }

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -12,7 +12,12 @@ import {
 } from '../lib/imap.ts';
 import { forbidUnlessAddress, forbidUnlessMailboxAccess, getAuth } from '../lib/auth.ts';
 import { clampWaitSeconds } from '../lib/config.ts';
-import { acquireWaitSlot, releaseWaitSlot } from '../lib/ratelimit.ts';
+import {
+  acquireWaitSlot,
+  checkListMessagesLimit,
+  listMessagesCallerKey,
+  releaseWaitSlot,
+} from '../lib/ratelimit.ts';
 import { hasActiveDelegation } from '../lib/delegations.ts';
 
 const listQuerySchema = z.object({
@@ -58,6 +63,12 @@ export const messagesRoute = new Hono()
     }
     const denied = forbidUnlessMailboxAccess(c, parsed.data.address);
     if (denied) return denied;
+    // schema + ACL 之后、首个 IMAP await 之前同步录取；下游失败不退款。
+    const listLimit = checkListMessagesLimit(listMessagesCallerKey(getAuth(c)));
+    if (!listLimit.allowed) {
+      c.header('Retry-After', String(listLimit.retryAfterSec));
+      return c.json({ error: 'rate_limited', retryAfterSec: listLimit.retryAfterSec }, 429);
+    }
     if (parsed.data.since !== undefined) {
       try {
         const page = await listMessagesSince(parsed.data.address, parsed.data.since, parsed.data.limit);

--- a/packages/api/test/messages-list-rate.test.ts
+++ b/packages/api/test/messages-list-rate.test.ts
@@ -1,0 +1,94 @@
+/**
+ * 列表限速父包装：不导入 app/config/imap，只拉起 support 子进程并证明回收。
+ */
+import { existsSync } from 'node:fs';
+import { describe, expect, test } from 'bun:test';
+import {
+  MATRIX_FILE,
+  MATRIX_TIMEOUT_MS,
+  PROBE_FILE,
+  PROBE_TIMEOUT_MS,
+  STALL_FILE,
+  STALL_PARENT_BUDGET_MS,
+  VERBOSE_BYTES_PER_STREAM,
+  VERBOSE_FILE,
+  VERBOSE_TIMEOUT_MS,
+  runIsolatedChild,
+} from './support/messages-list-rate-isolate.ts';
+
+describe('list-rate isolate parent', () => {
+  test('list-rate isolate: 矩阵子进程 16/0 且临时目录已回收', async () => {
+    const result = await runIsolatedChild({
+      argv: [process.execPath, 'test', MATRIX_FILE],
+      timeoutMs: MATRIX_TIMEOUT_MS,
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    const childOut = `${result.stdout}\n${result.stderr}`;
+    expect(childOut).toContain('16 pass');
+    expect(childOut).toContain('0 fail');
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+
+  test('list-rate isolate: resetRateLimits 现会清列表桶', async () => {
+    const result = await runIsolatedChild({
+      argv: [process.execPath, PROBE_FILE],
+      timeoutMs: PROBE_TIMEOUT_MS,
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    const line = result.stdout.trim().split('\n').filter(Boolean).at(-1) ?? '';
+    const report = JSON.parse(line) as {
+      afterFillAllowed: boolean;
+      sizeAfterFill: number;
+      sizeAfterCommonReset: number;
+      afterCommonResetAllowed: boolean;
+      commonResetClearsList: boolean;
+    };
+    expect(report.afterFillAllowed).toBe(false);
+    expect(report.sizeAfterFill).toBe(1);
+    expect(report.sizeAfterCommonReset).toBe(0);
+    expect(report.afterCommonResetAllowed).toBe(true);
+    expect(report.commonResetClearsList).toBe(true);
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+
+  test('list-rate isolate: 超时 SIGKILL 并 reap，再进入下一用例', async () => {
+    const started = Date.now();
+    const result = await runIsolatedChild({
+      argv: [process.execPath, STALL_FILE],
+      timeoutMs: STALL_PARENT_BUDGET_MS,
+      env: { LIST_RATE_STALL_MS: '10000' },
+    });
+    const elapsed = Date.now() - started;
+    expect(result.timedOut).toBe(true);
+    expect(result.reaped).toBe(true);
+    expect(elapsed).toBeLessThan(5_000);
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+
+  test('list-rate isolate: 超管道容量立即 drain 且正常退出', async () => {
+    const result = await runIsolatedChild({
+      argv: [process.execPath, VERBOSE_FILE],
+      timeoutMs: VERBOSE_TIMEOUT_MS,
+      env: { LIST_RATE_VERBOSE_BYTES: String(VERBOSE_BYTES_PER_STREAM) },
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.includes('VERBOSE_OK')).toBe(true);
+    expect(result.stderr.includes('VERBOSE_ERR_OK')).toBe(true);
+    expect(result.stdout.length).toBeGreaterThan(65_536);
+    expect(result.stderr.length).toBeGreaterThan(65_536);
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+
+  test('list-rate isolate: 非零退出原样上浮', async () => {
+    const result = await runIsolatedChild({
+      argv: [process.execPath, '-e', 'process.exit(7)'],
+      timeoutMs: PROBE_TIMEOUT_MS,
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(7);
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+});

--- a/packages/api/test/support/messages-list-rate-isolate.ts
+++ b/packages/api/test/support/messages-list-rate-isolate.ts
@@ -1,0 +1,124 @@
+/**
+ * 列表限速矩阵的子进程运输：父测试只 spawn/回收，不加载 app/config/imap。
+ */
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+export const PKG_DIR = join(import.meta.dir, '..');
+/** 必须传绝对路径：`bun test support/foo.ts` 会被当成过滤器，不会跑文件。 */
+export const MATRIX_FILE = join(import.meta.dir, 'messages-list-rate-matrix.ts');
+export const PROBE_FILE = join(import.meta.dir, 'messages-list-rate-reset-probe.ts');
+export const STALL_FILE = join(import.meta.dir, 'messages-list-rate-stall-child.ts');
+export const VERBOSE_FILE = join(import.meta.dir, 'messages-list-rate-verbose-child.ts');
+
+/** 必须低于 bun:test 默认 5s 父预算，并留出 kill/reap/drain 余量。不扩大父超时。 */
+export const MATRIX_TIMEOUT_MS = 3_500;
+export const PROBE_TIMEOUT_MS = 3_500;
+export const STALL_PARENT_BUDGET_MS = 1_500;
+export const VERBOSE_TIMEOUT_MS = 3_500;
+/** 超过常见 64KiB 管道容量，用来证明立即 drain 而不是等 exited。 */
+export const VERBOSE_BYTES_PER_STREAM = 128 * 1024;
+
+export type IsolatedChildResult = {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  reaped: boolean;
+  dataDir: string;
+};
+
+function childEnv(dataDir: string, extra?: Record<string, string | undefined>): Record<string, string> {
+  const merged: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) merged[key] = value;
+  }
+  merged.NODE_ENV = 'test';
+  merged.DOMAIN = 'test.example';
+  merged.API_KEYS = 'admin-list-rate-a,admin-list-rate-b';
+  merged.IMAP_USER = 'agent@test.example';
+  merged.IMAP_PASS = 'imap-secret';
+  merged.SMTP_USER = 'agent@test.example';
+  merged.SMTP_PASS = 'smtp-secret';
+  merged.MCP_PUBLIC_URL = 'http://localhost';
+  merged.DATA_DIR = dataDir;
+  if (extra) {
+    for (const [key, value] of Object.entries(extra)) {
+      if (value !== undefined) merged[key] = value;
+    }
+  }
+  return merged;
+}
+
+function drainText(stream: ReadableStream<Uint8Array> | number | undefined): Promise<string> {
+  if (stream && typeof stream === 'object' && 'getReader' in stream) {
+    return new Response(stream).text();
+  }
+  return Promise.resolve('');
+}
+
+/** 有界 spawn：spawn 后立即并发 drain 双管道；超时 SIGKILL+reap 后先收齐流再返回。 */
+export async function runIsolatedChild(opts: {
+  argv: string[];
+  timeoutMs: number;
+  env?: Record<string, string | undefined>;
+}): Promise<IsolatedChildResult> {
+  const dataDir = mkdtempSync(join(tmpdir(), 'oae-list-rate-child-'));
+  mkdirSync(dataDir, { recursive: true, mode: 0o700 });
+  const child = Bun.spawn(opts.argv, {
+    cwd: PKG_DIR,
+    env: childEnv(dataDir, opts.env),
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  const stdoutP = drainText(child.stdout);
+  const stderrP = drainText(child.stderr);
+  const deadline = Date.now() + opts.timeoutMs;
+  let timedOut = false;
+  let reaped = false;
+  let exitCode = -1;
+  try {
+    for (;;) {
+      const outcome = await Promise.race([
+        child.exited.then((code) => ({ done: true as const, code })),
+        new Promise<{ done: false }>((resolve) => setTimeout(() => resolve({ done: false }), 50)),
+      ]);
+      if (outcome.done) {
+        exitCode = outcome.code;
+        break;
+      }
+      if (Date.now() > deadline) {
+        timedOut = true;
+        try {
+          child.kill('SIGKILL');
+        } catch {
+          /* 已退出 */
+        }
+        exitCode = await child.exited.catch(() => -1);
+        reaped = true;
+        break;
+      }
+    }
+    const [stdout, stderr] = await Promise.all([stdoutP, stderrP]);
+    return {
+      exitCode,
+      stdout,
+      stderr,
+      timedOut,
+      reaped,
+      dataDir,
+    };
+  } finally {
+    if (child.exitCode === null) {
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        /* 已退出 */
+      }
+      await child.exited.catch(() => undefined);
+      reaped = true;
+    }
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+}

--- a/packages/api/test/support/messages-list-rate-matrix.ts
+++ b/packages/api/test/support/messages-list-rate-matrix.ts
@@ -1,0 +1,504 @@
+/**
+ * 列表限速 16 项矩阵：只由父包装以精确文件路径拉起，避免 bun test 自动发现重复跑。
+ * 子进程内 mock imapflow；进程退出即丢弃，不把任何实现标成“原生”。
+ */
+import { EventEmitter } from 'node:events';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } = await import('bun:test');
+
+process.env.DOMAIN ??= 'test.example';
+process.env.API_KEYS ??= 'admin-list-rate-a,admin-list-rate-b';
+process.env.IMAP_USER ??= 'agent@test.example';
+process.env.IMAP_PASS ??= 'imap-secret';
+process.env.SMTP_USER ??= 'agent@test.example';
+process.env.SMTP_PASS ??= 'smtp-secret';
+process.env.MCP_PUBLIC_URL ??= 'http://localhost';
+
+let imapConnects = 0;
+let imapSearchCalls = 0;
+let failNextSearch = false;
+
+class FakeImapFlow extends EventEmitter {
+  constructor() {
+    super();
+    imapConnects += 1;
+  }
+  get mailbox() {
+    return { uidValidity: 17n };
+  }
+  async connect() {}
+  async getMailboxLock() {
+    return { release() {} };
+  }
+  async idle() {
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  async search() {
+    imapSearchCalls += 1;
+    if (failNextSearch) {
+      failNextSearch = false;
+      throw new Error('imap_search_boom');
+    }
+    return [];
+  }
+  async *fetch() {
+    yield* [];
+  }
+  async fetchOne() {
+    return false;
+  }
+  async logout() {}
+  close() {}
+}
+
+mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
+
+const { config } = await import('../../src/lib/config.ts');
+const { createApp } = await import('../../src/app.ts');
+const { createIdentity, rotateIdentityToken } = await import('../../src/lib/identities.ts');
+const { createDelegation, resetDelegationStoreForTests } = await import('../../src/lib/delegations.ts');
+const { putAccessTokenForTests, resetOAuthStoreCacheForTests } = await import('../../src/lib/oauth-store.ts');
+const { resolveResourceUri } = await import('../../src/lib/oauth-url.ts');
+const { encodeMailForwardCursor } = await import('../../src/lib/mail-cursor.ts');
+const {
+  LIST_MESSAGES_CAPACITY_RETRY_SEC,
+  LIST_MESSAGES_LIMIT,
+  LIST_MESSAGES_MAX_BUCKETS,
+  LIST_MESSAGES_WINDOW_MS,
+  checkListMessagesLimit,
+  checkMcpRateLimit,
+  checkSendLimit,
+  listMessagesBucketCountForTests,
+  listMessagesCallerKey,
+  listMessagesHasBucketForTests,
+  resetListMessagesLimits,
+  resetMcpRateLimits,
+  resetNotifyUserLimits,
+  resetRateLimits,
+  resetWaitSlots,
+  seedListMessagesBucketForTests,
+  setListMessagesNowForTests,
+} = await import('../../src/lib/ratelimit.ts');
+
+const ADMIN_A = 'admin-list-rate-a';
+const ADMIN_B = 'admin-list-rate-b';
+
+type HarnessSnap = { dataDir: string; apiKeys: Set<string> };
+
+function snapshotHarness(): HarnessSnap {
+  return { dataDir: config.dataDir, apiKeys: new Set(config.apiKeys) };
+}
+
+function restoreHarness(snap: HarnessSnap): void {
+  (config as { dataDir: string }).dataDir = snap.dataDir;
+  config.apiKeys.clear();
+  for (const key of snap.apiKeys) config.apiKeys.add(key);
+}
+
+const importSnap = snapshotHarness();
+const scopedDataDir = config.dataDir;
+
+function applyScopedHarness(): void {
+  mkdirSync(scopedDataDir, { recursive: true, mode: 0o700 });
+  (config as { dataDir: string }).dataDir = scopedDataDir;
+  config.apiKeys.add(ADMIN_A);
+  config.apiKeys.add(ADMIN_B);
+}
+
+function resetIdentitiesStore(): void {
+  writeFileSync(join(config.dataDir, 'identities.json'), '[]', { mode: 0o600 });
+}
+
+function resetTouchedStores(): void {
+  resetIdentitiesStore();
+  resetDelegationStoreForTests();
+  resetOAuthStoreCacheForTests();
+  resetRateLimits();
+  resetWaitSlots();
+  resetMcpRateLimits();
+  resetNotifyUserLimits();
+  setListMessagesNowForTests(null);
+  imapConnects = 0;
+  imapSearchCalls = 0;
+  failNextSearch = false;
+}
+
+const app = createApp();
+
+async function listAs(token: string, address: string, extra = ''): Promise<Response> {
+  return app.request(`http://localhost/v1/messages?address=${encodeURIComponent(address)}${extra}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+async function admitN(token: string, address: string, n: number, extra = ''): Promise<number[]> {
+  const statuses: number[] = [];
+  for (let i = 0; i < n; i++) {
+    statuses.push((await listAs(token, address, extra)).status);
+  }
+  return statuses;
+}
+
+function validSince(address: string): string {
+  return encodeMailForwardCursor(
+    {
+      folder: 'inbox',
+      address,
+      t: 1000,
+      uid: 1,
+      uidValidity: 17,
+    },
+    config.taskSigningSecret,
+  );
+}
+
+describe('GET /v1/messages caller list rate', () => {
+  beforeAll(() => {
+    applyScopedHarness();
+    resetTouchedStores();
+  });
+
+  beforeEach(() => {
+    applyScopedHarness();
+    resetTouchedStores();
+  });
+
+  afterEach(() => {
+    resetTouchedStores();
+    applyScopedHarness();
+  });
+
+  afterAll(() => {
+    resetTouchedStores();
+    restoreHarness(importSnap);
+  });
+
+  test('signed RED: 同一 caller 第 61 次普通列表必须 429 rate_limited', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-red' })!;
+    const address = minted.identity.address;
+    const token = minted.token;
+
+    expect(await admitN(token, address, 60)).toEqual(Array(60).fill(200));
+
+    const limited = await listAs(token, address);
+    expect(limited.status).toBe(429);
+    const body = (await limited.json()) as { error: string; retryAfterSec: number };
+    expect(body.error).toBe('rate_limited');
+    expect(Number.isInteger(body.retryAfterSec)).toBe(true);
+    expect(body.retryAfterSec).toBeGreaterThan(0);
+    expect(limited.headers.get('Retry-After')).toBe(String(body.retryAfterSec));
+  });
+
+  test('ordinary+since 与 query 别名共用 caller 桶', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-mixed' })!;
+    const address = minted.identity.address;
+    const since = `&since=${encodeURIComponent(validSince(address))}`;
+    expect(await admitN(minted.token, address, 30)).toEqual(Array(30).fill(200));
+    expect(await admitN(minted.token, address.toUpperCase(), 30, since)).toEqual(Array(30).fill(200));
+    const limited = await listAs(minted.token, address, since);
+    expect(limited.status).toBe(429);
+    expect((await limited.json() as { error: string }).error).toBe('rate_limited');
+  });
+
+  test('since 分支 429 对下游 IMAP 零增量', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-since-429' })!;
+    const since = `&since=${encodeURIComponent(validSince(minted.identity.address))}`;
+    expect(await admitN(minted.token, minted.identity.address, 60, since)).toEqual(Array(60).fill(200));
+    const connectsAfter = imapConnects;
+    const searchesAfter = imapSearchCalls;
+    const limited = await listAs(minted.token, minted.identity.address, since);
+    expect(limited.status).toBe(429);
+    expect(((await limited.json()) as { error: string }).error).toBe('rate_limited');
+    expect(imapConnects).toBe(connectsAfter);
+    expect(imapSearchCalls).toBe(searchesAfter);
+  });
+
+  test('凭证轮换与 OAuth 同一地址聚合', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-cred' })!;
+    const address = minted.identity.address;
+    expect(await admitN(minted.token, address, 20)).toEqual(Array(20).fill(200));
+
+    const rotated = rotateIdentityToken(address)!;
+    expect(await admitN(rotated, address, 20)).toEqual(Array(20).fill(200));
+
+    const oauthToken = 'oauth-list-rate-token-32bytes-pad!!';
+    putAccessTokenForTests({
+      token: oauthToken,
+      grantId: 'g-list-rate',
+      address,
+      aud: resolveResourceUri('http://localhost'),
+      expiresAt: Date.now() + 3600_000,
+      ensureGrant: { clientId: 'https://client.example/cb', clientName: 'ListRate' },
+    });
+    expect(await admitN(oauthToken, address, 20)).toEqual(Array(20).fill(200));
+
+    const limited = await listAs(oauthToken, address);
+    expect(limited.status).toBe(429);
+  });
+
+  test('scope 拒绝的 OAuth 不消耗列表预算', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-noscope', scopes: [] })!;
+    const address = minted.identity.address;
+    const oauthToken = 'oauth-list-rate-denied-scope-32b!!';
+    putAccessTokenForTests({
+      token: oauthToken,
+      grantId: 'g-list-rate-denied',
+      address,
+      aud: resolveResourceUri('http://localhost'),
+      expiresAt: Date.now() + 3600_000,
+      ensureGrant: { clientId: 'https://client.example/cb', clientName: 'ListRateDenied' },
+    });
+
+    const denied = await listAs(oauthToken, address);
+    expect(denied.status).toBe(403);
+    expect(await denied.json()).toEqual({ error: 'forbidden: insufficient_scope' });
+    expect(imapConnects).toBe(0);
+
+    const usable = rotateIdentityToken(address, ['read:messages'])!;
+    expect(await admitN(usable, address, 60)).toEqual(Array(60).fill(200));
+    expect((await listAs(usable, address)).status).toBe(429);
+  });
+
+  test('委托目标轮换不能重置 caller 预算；身份隔离', async () => {
+    const alice = createIdentity({ localpart: 'list-rate-alice' })!;
+    const bob = createIdentity({ localpart: 'list-rate-bob' })!;
+    const carol = createIdentity({ localpart: 'list-rate-carol' })!;
+    createDelegation({
+      mailbox: alice.identity.address,
+      grantee: bob.identity.address,
+      createdBy: alice.identity.address,
+    });
+    createDelegation({
+      mailbox: carol.identity.address,
+      grantee: bob.identity.address,
+      createdBy: carol.identity.address,
+    });
+
+    expect(await admitN(bob.token, alice.identity.address, 30)).toEqual(Array(30).fill(200));
+    expect(await admitN(bob.token, carol.identity.address, 30)).toEqual(Array(30).fill(200));
+    expect((await listAs(bob.token, alice.identity.address)).status).toBe(429);
+    expect((await listAs(alice.token, alice.identity.address)).status).toBe(200);
+  });
+
+  test('全部 admin 凭证共享一个命名空间桶', async () => {
+    expect(await admitN(ADMIN_A, 'anyone@test.example', 30)).toEqual(Array(30).fill(200));
+    expect(await admitN(ADMIN_B, 'other@test.example', 30)).toEqual(Array(30).fill(200));
+    expect((await listAs(ADMIN_A, 'third@test.example')).status).toBe(429);
+    const minted = createIdentity({ localpart: 'list-rate-notadmin' })!;
+    expect((await listAs(minted.token, minted.identity.address)).status).toBe(200);
+  });
+
+  test('invalid query / forbidden / unauthorized 保持原状态且不耗预算', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-acl' })!;
+    const other = createIdentity({ localpart: 'list-rate-other' })!;
+
+    const badQuery = await app.request('http://localhost/v1/messages?limit=1', {
+      headers: { Authorization: `Bearer ${minted.token}` },
+    });
+    expect(badQuery.status).toBe(400);
+    expect(((await badQuery.json()) as { error: string }).error).toBe('invalid_request');
+
+    const forbidden = await listAs(minted.token, other.identity.address);
+    expect(forbidden.status).toBe(403);
+    expect(await forbidden.json()).toEqual({
+      error: 'forbidden: token is scoped to another address',
+    });
+
+    const unauth = await app.request(`http://localhost/v1/messages?address=${minted.identity.address}`);
+    expect(unauth.status).toBe(401);
+
+    expect(imapConnects).toBe(0);
+    expect(await admitN(minted.token, minted.identity.address, 60)).toEqual(Array(60).fill(200));
+  });
+
+  test('429 零 IMAP；detail/wait 不受列表预算影响', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-zeroimap' })!;
+    expect(await admitN(minted.token, minted.identity.address, 60)).toEqual(Array(60).fill(200));
+    const connectsAfterAdmit = imapConnects;
+    const searchesAfterAdmit = imapSearchCalls;
+
+    const limited = await listAs(minted.token, minted.identity.address);
+    expect(limited.status).toBe(429);
+    expect(imapConnects).toBe(connectsAfterAdmit);
+    expect(imapSearchCalls).toBe(searchesAfterAdmit);
+
+    const detail = await app.request(
+      `http://localhost/v1/messages/101?address=${encodeURIComponent(minted.identity.address)}`,
+      { headers: { Authorization: `Bearer ${minted.token}` } },
+    );
+    expect(detail.status).not.toBe(429);
+    expect(detail.status).toBe(404);
+
+    const wait = await app.request('http://localhost/v1/messages/wait', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${minted.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ address: minted.identity.address, timeoutSec: 1 }),
+    });
+    expect(wait.status).not.toBe(429);
+    expect([200, 408]).toContain(wait.status);
+  });
+
+  test('下游 IMAP/游标失败已录取不退款', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-down' })!;
+    const address = minted.identity.address;
+    expect(await admitN(minted.token, address, 58)).toEqual(Array(58).fill(200));
+
+    const tampered = `${validSince(address).split('.').slice(0, 2).join('.')}.badhmac`;
+    const cursorRes = await listAs(minted.token, address, `&since=${encodeURIComponent(tampered)}`);
+    expect(cursorRes.status).toBe(400);
+    expect(await cursorRes.json()).toEqual({ error: 'invalid_cursor' });
+
+    failNextSearch = true;
+    const boom = await listAs(minted.token, address);
+    expect(boom.status).toBe(500);
+
+    const limited = await listAs(minted.token, address);
+    expect(limited.status).toBe(429);
+  });
+
+  test('注入时钟：窗口到期恢复且 Retry-After 跟随最老活戳', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-clock' })!;
+    const t0 = 4_000_000;
+    setListMessagesNowForTests(t0);
+    expect(await admitN(minted.token, minted.identity.address, 60)).toEqual(Array(60).fill(200));
+    const limited = await listAs(minted.token, minted.identity.address);
+    expect(limited.status).toBe(429);
+    const body = (await limited.json()) as { retryAfterSec: number };
+    expect(body.retryAfterSec).toBe(60);
+    expect(limited.headers.get('Retry-After')).toBe('60');
+
+    setListMessagesNowForTests(t0 + LIST_MESSAGES_WINDOW_MS);
+    expect((await listAs(minted.token, minted.identity.address)).status).toBe(200);
+  });
+
+  test('生产时钟走线：墙钟双向跳动不得提前释放或冻结配额，流逝钟控制恢复', async () => {
+    const minted = createIdentity({ localpart: 'list-rate-mono' })!;
+    const realDateNow = Date.now;
+    const realPerfNow = performance.now.bind(performance);
+    let elapsed = 12_000;
+    const wallBase = 1_700_000_000_000;
+    try {
+      Date.now = () => wallBase;
+      (performance as { now: () => number }).now = () => elapsed;
+
+      expect(await admitN(minted.token, minted.identity.address, 60)).toEqual(Array(60).fill(200));
+      expect((await listAs(minted.token, minted.identity.address)).status).toBe(429);
+
+      Date.now = () => wallBase + 3_600_000;
+      expect((await listAs(minted.token, minted.identity.address)).status).toBe(429);
+
+      Date.now = () => wallBase - 3_600_000;
+      elapsed = 12_000 + 30_000;
+      expect((await listAs(minted.token, minted.identity.address)).status).toBe(429);
+
+      elapsed = 12_000 + LIST_MESSAGES_WINDOW_MS;
+      expect((await listAs(minted.token, minted.identity.address)).status).toBe(200);
+    } finally {
+      Date.now = realDateNow;
+      (performance as { now: typeof realPerfNow }).now = realPerfNow;
+    }
+  });
+
+  test('restoreHarness 恢复其捕获的异种 admin/dataDir，不手写回滚', async () => {
+    const foreignDir = mkdtempSync(join(tmpdir(), 'oae-list-rate-foreign-'));
+    const foreignFixture = JSON.stringify([
+      { address: 'keep@test.example', createdAt: '2026-01-01T00:00:00.000Z' },
+    ]);
+    writeFileSync(join(foreignDir, 'identities.json'), foreignFixture, { mode: 0o600 });
+
+    config.apiKeys.clear();
+    config.apiKeys.add('foreign-earlier-admin-key');
+    (config as { dataDir: string }).dataDir = foreignDir;
+    resetOAuthStoreCacheForTests();
+    const foreignSnap = snapshotHarness();
+
+    applyScopedHarness();
+    resetIdentitiesStore();
+    expect(config.apiKeys.has(ADMIN_A)).toBe(true);
+    const res = await listAs(ADMIN_A, 'anyone@test.example');
+    expect(res.status).toBe(200);
+
+    restoreHarness(foreignSnap);
+    expect(config.dataDir).toBe(foreignDir);
+    expect(readFileSync(join(foreignDir, 'identities.json'), 'utf8')).toBe(foreignFixture);
+    expect([...config.apiKeys]).toEqual(['foreign-earlier-admin-key']);
+    expect(config.apiKeys.has(ADMIN_A)).toBe(false);
+
+    applyScopedHarness();
+    rmSync(foreignDir, { recursive: true, force: true });
+  });
+});
+
+describe('list limiter unit seams', () => {
+  beforeEach(() => {
+    resetRateLimits();
+    resetMcpRateLimits();
+    resetNotifyUserLimits();
+  });
+
+  afterEach(() => {
+    resetRateLimits();
+    resetMcpRateLimits();
+    resetNotifyUserLimits();
+    setListMessagesNowForTests(null);
+  });
+
+  test('N/N+1、精确窗口边界、命名空间键', () => {
+    const key = listMessagesCallerKey({ kind: 'identity', address: 'Mix@Test.EXAMPLE' });
+    expect(key).toBe('list:id:mix@test.example');
+    expect(listMessagesCallerKey({ kind: 'admin' })).toBe('list:admin');
+
+    const t0 = 8_000_000;
+    for (let i = 0; i < LIST_MESSAGES_LIMIT; i++) {
+      expect(checkListMessagesLimit(key, t0).allowed).toBe(true);
+    }
+    const blocked = checkListMessagesLimit(key, t0);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.retryAfterSec).toBe(60);
+
+    expect(checkListMessagesLimit(key, t0 + LIST_MESSAGES_WINDOW_MS).allowed).toBe(true);
+  });
+
+  test('新 key 满图保守 60s；不驱逐活桶；过期桶可回收', () => {
+    const now = 9_000_000;
+    for (let i = 0; i < LIST_MESSAGES_MAX_BUCKETS; i++) {
+      seedListMessagesBucketForTests(`list:id:cap-${i}@test.example`, [now]);
+    }
+    expect(listMessagesBucketCountForTests()).toBe(LIST_MESSAGES_MAX_BUCKETS);
+
+    const full = checkListMessagesLimit('list:id:newcomer@test.example', now);
+    expect(full.allowed).toBe(false);
+    expect(full.retryAfterSec).toBe(LIST_MESSAGES_CAPACITY_RETRY_SEC);
+    expect(listMessagesHasBucketForTests('list:id:cap-1@test.example')).toBe(true);
+    expect(listMessagesBucketCountForTests()).toBe(LIST_MESSAGES_MAX_BUCKETS);
+
+    const existing = checkListMessagesLimit('list:id:cap-0@test.example', now);
+    expect(existing.allowed).toBe(true);
+
+    resetListMessagesLimits();
+    const liveKey = 'list:id:live@test.example';
+    for (let i = 0; i < LIST_MESSAGES_MAX_BUCKETS - 1; i++) {
+      seedListMessagesBucketForTests(`list:id:expired-${i}@test.example`, [now - LIST_MESSAGES_WINDOW_MS]);
+    }
+    seedListMessagesBucketForTests(liveKey, [now]);
+    expect(listMessagesBucketCountForTests()).toBe(LIST_MESSAGES_MAX_BUCKETS);
+    const admitted = checkListMessagesLimit('list:id:after-reclaim@test.example', now);
+    expect(admitted.allowed).toBe(true);
+    expect(listMessagesHasBucketForTests(liveKey)).toBe(true);
+    expect(listMessagesHasBucketForTests('list:id:expired-0@test.example')).toBe(false);
+  });
+
+  test('send/MCP 桶互不占额', () => {
+    expect(checkSendLimit('a@test.example', 1, 60_000, 10_000).allowed).toBe(true);
+    expect(checkSendLimit('a@test.example', 1, 60_000, 10_000).allowed).toBe(false);
+    expect(checkMcpRateLimit('g-list', 'read', 1, 60_000, 10_000).allowed).toBe(true);
+    expect(checkListMessagesLimit('list:id:a@test.example', 10_000).allowed).toBe(true);
+    expect(checkListMessagesLimit('list:id:a@test.example', 10_000).allowed).toBe(true);
+  });
+});

--- a/packages/api/test/support/messages-list-rate-reset-probe.ts
+++ b/packages/api/test/support/messages-list-rate-reset-probe.ts
@@ -1,0 +1,31 @@
+/**
+ * 便宜、确定的 reset 约定探测：只导入限速模块，不打 HTTP/IMAP。
+ * 输出一行 JSON，不含凭证。
+ */
+const {
+  LIST_MESSAGES_LIMIT,
+  checkListMessagesLimit,
+  listMessagesBucketCountForTests,
+  resetRateLimits,
+} = await import('../../src/lib/ratelimit.ts');
+
+const key = 'list:id:reset-probe@test.example';
+const now = 2_000_000;
+for (let i = 0; i < LIST_MESSAGES_LIMIT; i++) {
+  checkListMessagesLimit(key, now);
+}
+const afterFill = checkListMessagesLimit(key, now);
+const sizeAfterFill = listMessagesBucketCountForTests();
+resetRateLimits();
+const sizeAfterCommon = listMessagesBucketCountForTests();
+const afterCommon = checkListMessagesLimit(key, now);
+
+const report = {
+  afterFillAllowed: afterFill.allowed,
+  sizeAfterFill,
+  sizeAfterCommonReset: sizeAfterCommon,
+  afterCommonResetAllowed: afterCommon.allowed,
+  commonResetClearsList: sizeAfterCommon === 0 && afterFill.allowed === false && afterCommon.allowed === true,
+};
+console.log(JSON.stringify(report));
+process.exit(0);

--- a/packages/api/test/support/messages-list-rate-stall-child.ts
+++ b/packages/api/test/support/messages-list-rate-stall-child.ts
@@ -1,0 +1,6 @@
+/** 仅用于父包装超时回收证明；不加载业务模块。 */
+const stallMs = Number(process.env.LIST_RATE_STALL_MS ?? 0);
+if (stallMs > 0) {
+  await new Promise((resolve) => setTimeout(resolve, stallMs));
+}
+process.exit(0);

--- a/packages/api/test/support/messages-list-rate-verbose-child.ts
+++ b/packages/api/test/support/messages-list-rate-verbose-child.ts
@@ -1,0 +1,29 @@
+/**
+ * 写出超过管道容量的填充字节；等双流写回调与 drain 都成功后再自然退出。
+ * 填充不含凭证。禁止未 flush 就 process.exit。
+ */
+const bytes = Number(process.env.LIST_RATE_VERBOSE_BYTES ?? String(128 * 1024));
+const chunk = 'v'.repeat(1024);
+const n = Math.max(1, Math.ceil(bytes / chunk.length));
+const payload = chunk.repeat(n);
+
+/** 等本次 write 回调成功；若仍需排空则再等 drain。 */
+async function writeFully(stream: NodeJS.WriteStream, data: string): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    stream.write(data, (err) => {
+      if (err) reject(err);
+      else resolve();
+    });
+  });
+  if (stream.writableNeedDrain) {
+    await new Promise<void>((resolve) => {
+      stream.once('drain', resolve);
+    });
+  }
+}
+
+await Promise.all([
+  writeFully(process.stdout, `${payload}\nVERBOSE_OK bytes=${payload.length}\n`),
+  writeFully(process.stderr, `${payload}\nVERBOSE_ERR_OK bytes=${payload.length}\n`),
+]);
+// 双流已确认写完，自然退出，不调用 process.exit。


### PR DESCRIPTION
## Summary

GET `/v1/messages` (ordinary list and `since`) had no per-caller admission
budget before IMAP. A single authenticated identity could therefore
repeat listing without a local cap.

This change adds a process-local sliding window of **60 admissions /
60 seconds** for that list route only:

- Caller key is the authenticated lowercased address (never the raw
  token or query `address`). OAuth and identity-token rotation for the
  same address share one bucket. Delegates spend the **caller** budget
  across targets. All admin credentials share `list:admin`.
- Schema and ACL run before the budget; the budget runs before IMAP.
  Downstream errors are charged (no refund).
- 429 body is `{error:'rate_limited', retryAfterSec}` plus `Retry-After`.
- At most 10000 buckets. Lazy expired-only cleanup runs only when a
  **new** key hits capacity. No live eviction and no janitor. Cleanup
  cost is up to 10000 buckets × 60 stamps. A full map denies with a
  conservative `retryAfterSec=60` hint.
- Clock is process elapsed monotonic milliseconds (`performance.now()`).
  Restart resets the map. Send / MCP / wait maps are unchanged.
- Not a global IMAP concurrency lock. A burst of 60 is allowed. The
  premise is a single instance; multiple instances are not coordinated.

Out of scope: detail GET, wait, UI, MCP-direct listing, M2 journal
semantics, dependency or deploy changes.

## Evidence

- Signed first RED on unfixed source: 61st list still 200 (expected 429).
  Original log preserved (`logs/red-signed-r1.log`).
- Focused isolate parent after transport repairs: 5 pass / 0 fail / 27
  expects (matrix 16/0 inside the child). FC reproduced the parent
  GREEN (5/0/27).
- Archived earlier full RED (FULL-2213-01, PID 1755111): 1691 pass /
  1 skip / 1 fail. The single fail was
  `exact-full already-retired: cleanup then new write without a new mark`
  at fillIndexed 460000ms / n=8828. That RED remains RED and is not
  rewritten.
- Same-source diagnosis (DIAG-2230-01): the exact-full control passed
  once at original cap 10000 / fill 460s / test 480s (1 pass / 0 fail /
  4 expects; 10000/10000 admitted in 358197ms). Diagnosis only.
- Full GREEN (FULL-2230-02, PID 2196938, original budgets): **1692 pass /
  1 skip / 0 fail**, 11275 expects, 98 files, 3416.22s, rc=0. All eight
  capacity fills passed, including exact-full at 366576.21ms. Bound
  source was the 10-file manifest
  `dc658e406c35b2ea872003f832aa952aa2314025d5d1cfcbf22ccc55407bca69`
  at parent 13856ead. Full log SHA-256
  016f55c87e6ae2a31affb75d90040d6375ad53bca33e7303deca2b7db6bd771b.
- Typecheck remains **133** historical `error TS` (fingerprint
  1880a0d76458b89b256dea91a6dceec31549412d1aeaf893b07bf332349d8602),
  identical to baseline133. This is existing debt, **not** a typecheck
  green. None of those errors are in the touched list-limiter sources.

## Limitations

- Process-local only; multi-instance listing is not coordinated.
- Not global IMAP concurrency protection.
- Existing list tests that never call `resetRateLimits` can still
  accumulate the same caller across files in one `bun test` process.
- Historical typecheck 133 is unchanged.

Closes #143


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-caller rate limiting to `GET /v1/messages`: up to 60 requests per 60 seconds.
  - Exceeding the limit returns `429` with retry guidance.
  - Listing and `since` queries share the same caller quota; administrative credentials share one quota.
  - Invalid or unauthorized requests do not consume quota, while downstream failures are not refunded.
  - Added capacity safeguards and documented single-instance behavior.

- **Documentation**
  - Updated API and security documentation with rate-limit behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->