### PR TITLE
fix(api): bind backward mail cursors to mailbox generation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -43,6 +43,14 @@ Pending retries are rebuilt from the delivery log on restart; events emitted whi
 - **代际保护**：游标严格绑定 `uidValidity`；若信箱代际变更（UIDVALIDITY 不匹配），请求将 fail-closed 返回 `400 invalid_cursor`。`GET /v1/messages/:id` 支持可选的 `?uidValidity=` 参数，代际不匹配时返回 `404 stale_message_generation`。
 - **服务端 SINCE 与 receivedAtMs 口径差异说明**：服务端 IMAP SEARCH SINCE 依据 RFC 3501 `INTERNALDATE` 检索（向前预留 1 天缓冲）；应用层 `receivedAtMs` 优先采用 `INTERNALDATE` 并回落至 `ENVELOPE.date`。若个别邮件缺失 `INTERNALDATE` 且其 `ENVELOPE.date` 晚于实际收信时间，此口径差异为 fail-safe（只漏不越权，后续追扫覆盖）。
 
+## Dashboard 后向列表游标（mail-cursor-v2 / #144）
+
+- Dashboard `GET /ui/api/messages` 的分页游标现为 **`mail-cursor-v2`**：HMAC 绑定 `folder`、`address`、`(receivedAtMs, uid)` 与 **canonical 正整数 `uidValidity`**。`nextCursor` 只绑定本次已验证的选中信箱代际。
+- **旧 `mail-cursor-v1` 一律作废**：解码 fail-closed（`InvalidMailCursorError` / `invalid_cursor`），无 v1 fallback、不从载荷推断代际。客户端必须丢弃旧游标、**不带 cursor 从第一页重新开始**。
+- 同一已 SELECT 的 INBOX 会话里，**search/fetch 之前**必须读到当前合法代际；缺代际（含首页无 cursor）或与游标代际不符均失败。空信箱同样先校验代际，再决定是否 search。
+- 排序、folder 过滤、`SCAN_BACK`、ACL、限速与成功响应形状不变。前向 `since` / `mail-fcursor-v1` 协议不变。不扩展 MessageDetail。REST **不**增加后向 `cursor` 参数。
+- **HTTP 映射（Commander2262 / 2269）：** codec / `listMessagesPage` 抛 `InvalidMailCursorError`（`error.code === 'invalid_cursor'`）。Dashboard `GET /ui/api/messages` 仍折成 **HTTP 400 `{error:"invalid_request"}`**。REST **不加**后向 `cursor` 参数。普通 `GET /v1/messages`（无 `since`）与 `POST /v1/messages/wait` 在缺代际或当前会话代际不可用时返回 **400 `{error:"invalid_cursor"}`**；客户端应丢弃会话位置、从第一页/新 wait 会话重启。MCP `mail_list_messages` / `mail_wait_for` 走同一 REST，自然继承。前向 `since` 仍是 `400 invalid_cursor`。auth / 限速 / 委托撤销等其它分支不变。
+
 ### Caller 列表限速（#143，单实例前提）
 
 仅 `GET /v1/messages`（普通列表与 `since` 共用同一 caller 桶）。身份键是已鉴权地址的小写形式，不是原始 token、也不是 query `address`。同一地址的 identity token 与 OAuth 凭证聚合；委托方无论轮换目标信箱都消耗**自己的**身份预算。全部 admin 凭证共享一个 `list:admin` 命名空间桶，不是无限豁免。

--- a/docs/security.md
+++ b/docs/security.md
@@ -88,6 +88,7 @@ acceptance with original-recipient acceptance.
 Catch-all 信箱里，身份之间的读边界是**精确整邮箱**匹配（禁止子串）。
 
 - **列表：** Inbox = 收件人（TO/Cc/Bcc/Delivered-To）；Sent = 信封 From 匹配 **且** Message-ID 在服务端出站登记表（`/v1/send` / `sendMail` 成功写入 `DATA_DIR/sent-registry.json`）；All Mail = 二者并集。Bearer `GET /v1/messages` 仍只列出 Inbox（TO），以免改 agent 列表契约。
+- **后向列表游标（#144 / Commander2262 / 2269）：** Dashboard 分页使用 `mail-cursor-v2`，`uidValidity` 写入 HMAC（数字串经 BigInt 规范化）。信箱重建后旧游标不可跨代复用。每个 `mail-cursor-v1` 立即作废，客户端须从第一页重启（不带 cursor）。无 v1 fallback。前向 `mail-fcursor-v1` 不变。UI 路由把 codec `invalid_cursor` 映射为既有 **400 `invalid_request`**。REST 不加后向 `cursor` 参数；普通 `GET /v1/messages` 与 `POST /v1/messages/wait` 缺/错代际为 **400 `invalid_cursor`**，应重启第一页或新 wait 会话。
 - **详情 / 已读标记 / Source：** 与列表同一条可信规则（TO ∨ 可信 Sent），不是「任意 FROM」。伪造 From 的信对非收件人在列表/详情/Source/Seen 四个入口均不可见（404）；identity 读他人 address 仍 403。
 - **伪造信：** 照常落收件人 Inbox（它本质就是一封信），但绝不进任何人的 Sent。
 - **Sent 源码：** identity 可读自身**可信** Sent 邮件源码（含 Received 链），属 #26 PR 2 设计决策。隔离边界仍是「这封信是否属于该身份」，Source 视图不剥 Received。

--- a/packages/api/src/lib/imap.ts
+++ b/packages/api/src/lib/imap.ts
@@ -16,6 +16,7 @@ import { simpleParser } from 'mailparser';
 import type { AddressObject } from 'mailparser';
 import { config } from './config.ts';
 import {
+  canonicalizeMailUidValidity,
   decodeMailCursor,
   decodeMailForwardCursor,
   encodeMailCursor,
@@ -781,7 +782,8 @@ function toDetail(uid: number, parsed: Awaited<ReturnType<typeof parseSource>>):
  * List newest-first message summaries for `address` in `folder`, up to `limit`.
  * Two passes: envelopes+Delivered-To for the last SCAN_BACK messages to
  * find matches cheaply, then full source for the (≤ limit) matches to
- * build snippets. Cursor is HMAC-bound to folder+address+(t,uid).
+ * build snippets. Cursor is HMAC-bound to folder+address+(t,uid)+uidValidity。
+ * 同一已 SELECT 会话上，search/fetch 之前必须拿到合法当前代际（含空信箱与首页）。
  */
 async function listMessagesPageWith(
   client: ImapFlow,
@@ -791,11 +793,19 @@ async function listMessagesPageWith(
   const folder = opts.folder;
   const limit = opts.limit;
   const normalized = address.toLowerCase();
+  // 选中会话上的当前代际：缺失/非法 → 400 invalid_cursor（含首页无 cursor）。
+  const generation = canonicalizeMailUidValidity(
+    client.mailbox ? client.mailbox.uidValidity : undefined,
+  );
   let cursorT: number | undefined;
   let cursorUid: number | undefined;
   if (opts.cursor) {
     const cursor = decodeMailCursor(opts.cursor, config.taskSigningSecret);
     if (cursor.folder !== folder || cursor.address !== normalized) {
+      throw new InvalidMailCursorError();
+    }
+    // 游标代际必须等于本次已验证的选中代际；禁止推断或回退。
+    if (String(cursor.uidValidity) !== generation) {
       throw new InvalidMailCursorError();
     }
     cursorT = cursor.t;
@@ -834,6 +844,7 @@ async function listMessagesPageWith(
             address: normalized,
             t: receivedAtMs(last),
             uid: last.uid,
+            uidValidity: generation,
           },
           config.taskSigningSecret,
         )
@@ -1242,6 +1253,10 @@ export async function waitForMessage(
     if (err instanceof DelegationRevokedError) {
       throw err;
     }
+    // 代际失败不是断线，禁止吞成轮询/超时（2269 wait → 400 invalid_cursor）。
+    if (err instanceof InvalidMailCursorError) {
+      throw err;
+    }
     console.warn('[imap] IDLE wait failed, falling back to polling:', (err as Error).message);
     return waitWithPolling(address, filters, deadline, shouldContinue);
   }
@@ -1328,6 +1343,9 @@ async function waitWithPolling(
       }
     } catch (err) {
       if (err instanceof DelegationRevokedError) {
+        throw err;
+      }
+      if (err instanceof InvalidMailCursorError) {
         throw err;
       }
       console.warn('[imap] poll failed:', (err as Error).message);

--- a/packages/api/src/lib/mail-cursor.ts
+++ b/packages/api/src/lib/mail-cursor.ts
@@ -1,15 +1,20 @@
 /**
  * Inbox 列表游标（HMAC 不透明 token）。
  *
- * 绑定 folder + address + (receivedAtMs, uid)，防止跨 folder/身份复用，
- * 以及客户端伪造「下一页」跳过或重复条目。密钥复用 taskSigningSecret，
- * 前缀 `mail-cursor-v1` 与 mail-stamp 做域分离。
+ * 后向分页现为 mail-cursor-v2：绑定 folder + address + (receivedAtMs, uid)
+ * + canonical 正整数 uidValidity，防止跨 folder/身份/信箱代际复用，
+ * 以及客户端伪造「下一页」。密钥复用 taskSigningSecret。
+ * 旧 mail-cursor-v1 一律失效，客户端须从第一页重启；无 v1 fallback。
+ * 前向 mail-fcursor-v1 协议不变，与后向互不通用。
  */
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 
-/** 协议版本前缀；变更字段规约时递增。 */
-export const MAIL_CURSOR_PREFIX = 'mail-cursor-v1';
+/** 后向游标协议版本前缀；v1 已退役，解码见前缀即拒。 */
+export const MAIL_CURSOR_PREFIX = 'mail-cursor-v2';
+
+/** 已退役的后向 v1 前缀；仅供文档/测试对照，编码器不得再发出。 */
+export const MAIL_CURSOR_V1_PREFIX = 'mail-cursor-v1';
 
 /** 前向游标版本前缀；载荷含 uidValidity，与既有后向游标互不通用。 */
 export const MAIL_FORWARD_CURSOR_PREFIX = 'mail-fcursor-v1';
@@ -22,12 +27,32 @@ export function isMailFolder(value: string): value is MailFolder {
   return (MAIL_FOLDERS as readonly string[]).includes(value);
 }
 
-/** 游标载荷：排序键 newest-first 为 (t desc, uid desc)。 */
+/**
+ * 将 uidValidity 收成规范正整数字符串（十进制、无前导零、无符号、>0）。
+ * 数字串一律经 BigInt(...).toString()；number 只接受安全正整数。
+ * 非法 / 缺失一律 InvalidMailCursorError（含首页拿不到当前代际）。
+ * 前向 mail-fcursor-v1 不走此函数，协议不变。
+ */
+export function canonicalizeMailUidValidity(value: unknown): string {
+  if (typeof value === 'bigint' && value > 0n) return value.toString();
+  if (typeof value === 'string' && /^\d+$/.test(value)) {
+    const normalized = BigInt(value).toString();
+    if (normalized === '0') throw new InvalidMailCursorError();
+    return normalized;
+  }
+  if (typeof value === 'number' && Number.isSafeInteger(value) && value > 0) {
+    return String(value);
+  }
+  throw new InvalidMailCursorError();
+}
+
+/** 游标载荷：排序键 newest-first 为 (t desc, uid desc)；v 为已验证代际。 */
 export type MailCursorPayload = {
   folder: MailFolder;
   address: string;
   t: number;
   uid: number;
+  uidValidity: string | number | bigint;
 };
 
 /** 前向游标载荷：绑定 uidValidity 代际，语义为 (t asc, uid asc) 之后的条目；可选 scanUid 为扫描预算水印。 */
@@ -50,29 +75,33 @@ export class InvalidMailCursorError extends Error {
 }
 
 function cursorMac(payload: MailCursorPayload, key: string): string {
+  const vStr = canonicalizeMailUidValidity(payload.uidValidity);
   return createHmac('sha256', key)
     .update(
-      `${MAIL_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}`,
+      `${MAIL_CURSOR_PREFIX}\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}\n${vStr}`,
     )
     .digest('base64url');
 }
 
-/** 编码不透明游标。address 必须已小写。 */
+/** 编码不透明后向游标。address 必须已小写；uidValidity 写入载荷与 MAC。 */
 export function encodeMailCursor(payload: MailCursorPayload, key: string): string {
+  const vStr = canonicalizeMailUidValidity(payload.uidValidity);
   const body = Buffer.from(
     JSON.stringify({
       f: payload.folder,
       a: payload.address,
       t: payload.t,
       u: payload.uid,
+      v: vStr,
     }),
   ).toString('base64url');
-  return `${MAIL_CURSOR_PREFIX}.${body}.${cursorMac(payload, key)}`;
+  return `${MAIL_CURSOR_PREFIX}.${body}.${cursorMac({ ...payload, uidValidity: vStr }, key)}`;
 }
 
-/** 解码并校验 HMAC。失败一律 InvalidMailCursorError（fail-closed）。 */
+/** 解码并校验 HMAC。v1 / 缺代际 / 篡改一律 InvalidMailCursorError（fail-closed）。 */
 export function decodeMailCursor(token: string, key: string): MailCursorPayload {
   const parts = token.split('.');
+  // 任何非 v2 前缀（含 mail-cursor-v1）直接拒，不推断代际。
   if (parts.length !== 3 || parts[0] !== MAIL_CURSOR_PREFIX || !parts[1] || !parts[2]) {
     throw new InvalidMailCursorError();
   }
@@ -83,18 +112,20 @@ export function decodeMailCursor(token: string, key: string): MailCursorPayload 
     throw new InvalidMailCursorError();
   }
   if (!parsed || typeof parsed !== 'object') throw new InvalidMailCursorError();
-  const raw = parsed as { f?: unknown; a?: unknown; t?: unknown; u?: unknown };
+  const raw = parsed as { f?: unknown; a?: unknown; t?: unknown; u?: unknown; v?: unknown };
   if (typeof raw.f !== 'string' || !isMailFolder(raw.f)) throw new InvalidMailCursorError();
   if (typeof raw.a !== 'string' || !raw.a.includes('@')) throw new InvalidMailCursorError();
   if (typeof raw.t !== 'number' || !Number.isFinite(raw.t)) throw new InvalidMailCursorError();
   if (typeof raw.u !== 'number' || !Number.isInteger(raw.u) || raw.u <= 0) {
     throw new InvalidMailCursorError();
   }
+  const vStr = canonicalizeMailUidValidity(raw.v);
   const payload: MailCursorPayload = {
     folder: raw.f,
     address: raw.a.toLowerCase(),
     t: raw.t,
     uid: raw.u,
+    uidValidity: vStr,
   };
   const expected = cursorMac(payload, key);
   try {

--- a/packages/api/src/routes/messages.ts
+++ b/packages/api/src/routes/messages.ts
@@ -69,19 +69,21 @@ export const messagesRoute = new Hono()
       c.header('Retry-After', String(listLimit.retryAfterSec));
       return c.json({ error: 'rate_limited', retryAfterSec: listLimit.retryAfterSec }, 429);
     }
-    if (parsed.data.since !== undefined) {
-      try {
+    // 普通列表与 since 共用 InvalidMailCursorError → 400 invalid_cursor（2269）。
+    // 不加后向 cursor 参数；auth/限速分支保持在此 try 之外。
+    try {
+      if (parsed.data.since !== undefined) {
         const page = await listMessagesSince(parsed.data.address, parsed.data.since, parsed.data.limit);
         return c.json({ messages: page.messages, nextCursor: page.nextCursor });
-      } catch (err) {
-        if (err instanceof InvalidMailCursorError) {
-          return c.json({ error: 'invalid_cursor' }, 400);
-        }
-        throw err;
       }
+      const messages = await listMessages(parsed.data.address, parsed.data.limit);
+      return c.json({ messages });
+    } catch (err) {
+      if (err instanceof InvalidMailCursorError) {
+        return c.json({ error: 'invalid_cursor' }, 400);
+      }
+      throw err;
     }
-    const messages = await listMessages(parsed.data.address, parsed.data.limit);
-    return c.json({ messages });
   })
   .get('/:id', async (c) => {
     const parsed = getQuerySchema.safeParse(c.req.query());
@@ -173,6 +175,10 @@ export const messagesRoute = new Hono()
       }
       return c.json(message);
     } catch (err) {
+      // 缺/错代际：400 invalid_cursor（2269）。委托撤销仍 403；其余上抛。
+      if (err instanceof InvalidMailCursorError) {
+        return c.json({ error: 'invalid_cursor' }, 400);
+      }
       if (err instanceof DelegationRevokedError) {
         return c.json({ error: 'forbidden: token is scoped to another address' }, 403);
       }

--- a/packages/api/test/delegations.test.ts
+++ b/packages/api/test/delegations.test.ts
@@ -32,6 +32,10 @@ let fakeMessages: any[] = [
 ];
 
 class FakeImapFlow extends EventEmitter {
+  // 选中会话必须暴露当前代际，供后向列表在 search 前校验（#144 / REPAIR-FIXTURES-01）。
+  get mailbox() {
+    return { uidValidity: 17n };
+  }
   async connect() {}
   async getMailboxLock() {
     return { release() {} };

--- a/packages/api/test/identity-scopes.test.ts
+++ b/packages/api/test/identity-scopes.test.ts
@@ -32,6 +32,10 @@ let fakeMessages: any[] = [
 ];
 
 class FakeImapFlow extends EventEmitter {
+  // 选中会话必须暴露当前代际，供后向列表在 search 前校验（#144 / REPAIR-FIXTURES-01）。
+  get mailbox() {
+    return { uidValidity: 17n };
+  }
   async connect() {}
   async getMailboxLock() {
     return { release() {} };

--- a/packages/api/test/imap-match.test.ts
+++ b/packages/api/test/imap-match.test.ts
@@ -25,6 +25,10 @@ const { describe, expect, mock, test } = await import('bun:test');
 let fakeMessages: any[] = [];
 
 class FakeImapFlow extends EventEmitter {
+  // 选中会话必须暴露当前代际，供后向列表在 search 前校验（#144）。
+  get mailbox() {
+    return { uidValidity: 17n };
+  }
   async connect() {}
   async getMailboxLock() {
     return { release() {} };
@@ -596,7 +600,7 @@ describe('listMessagesPage cursor — 无重复无跳页', () => {
       listMessagesPage('fox@test.example', { folder: 'inbox', cursor: 'not-a-cursor' }),
     ).rejects.toBeInstanceOf(InvalidMailCursorError);
     const foreign = encodeMailCursor(
-      { folder: 'sent', address: 'fox@test.example', t: Date.now(), uid: 1 },
+      { folder: 'sent', address: 'fox@test.example', t: Date.now(), uid: 1, uidValidity: 17 },
       config.taskSigningSecret,
     );
     await expect(

--- a/packages/api/test/imap.test.ts
+++ b/packages/api/test/imap.test.ts
@@ -688,6 +688,7 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
         address: 'victim@test.example',
         t: 1000,
         uid: 10,
+        uidValidity: 17,
       },
       config.taskSigningSecret,
     );
@@ -1271,5 +1272,66 @@ describe('GET /v1/messages 前向 since 查询与无损翻页', () => {
     expect(res.nextCursor).not.toBeNull();
     const dec = decodeMailForwardCursor(res.nextCursor!, config.taskSigningSecret);
     expect(dec.scanUid).toBe(100);
+  });
+});
+
+/**
+ * Commander2269：普通 GET /v1/messages 与 wait 缺代际 → 400 invalid_cursor。
+ * 走默认 messagesRoute + 真 listMessages/waitForMessage，不注入 mock 服务。
+ * 不加后向 cursor 参数；timeoutSec=1 仅钳测试，不改生产超时。
+ */
+describe('2269 ordinary list/wait missing generation → 400 invalid_cursor', () => {
+  let app: any;
+
+  beforeEach(async () => {
+    fakeMessages = [inboxMessage(8, 'victim@test.example', 'victim@test.example')];
+    failMailboxLock = false;
+    fakeUidValidity = 17n;
+    createdClients.length = 0;
+    const { Hono } = await import('hono');
+    const { messagesRoute } = await import('../src/routes/messages.ts');
+    app = new Hono();
+    // 仅新用例显式标注参数，避免新增 TS7006，指纹回到 baseline133（原有两处中间件仍是历史债务）。
+    app.use('*', async (c: { set: (key: string, value: unknown) => void }, next: () => Promise<void>) => {
+      c.set('auth', { kind: 'admin' });
+      await next();
+    });
+    app.route('/v1/messages', messagesRoute);
+  });
+
+  test('缺代际：普通 GET /v1/messages（无 since/cursor）400 invalid_cursor', async () => {
+    fakeUidValidity = undefined as unknown as bigint;
+    const res = await app.request('/v1/messages?address=victim@test.example');
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+  });
+
+  test('缺代际：POST /v1/messages/wait 400 invalid_cursor（不靠超时）', async () => {
+    fakeUidValidity = undefined as unknown as bigint;
+    const started = Date.now();
+    const res = await app.request('/v1/messages/wait', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ address: 'victim@test.example', timeoutSec: 1 }),
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_cursor' });
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  test('有代际：普通列表仍 200，形状不变', async () => {
+    const res = await app.request('/v1/messages?address=victim@test.example');
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as { messages: { id: string }[] };
+    expect(json.messages.map((m) => m.id)).toEqual(['8']);
+    expect((json as { nextCursor?: unknown }).nextCursor).toBeUndefined();
+  });
+
+  test('坏 address 仍是 schema 400 invalid_request，不是 invalid_cursor', async () => {
+    fakeUidValidity = undefined as unknown as bigint;
+    const res = await app.request('/v1/messages?address=not-an-email');
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toBe('invalid_request');
   });
 });

--- a/packages/api/test/mail-cursor-v2-generation.test.ts
+++ b/packages/api/test/mail-cursor-v2-generation.test.ts
@@ -1,0 +1,48 @@
+/**
+ * #144 / 2262 代际矩阵父包装：不 import/mock imap，只复用 143 isolate 运输。
+ * 父预算保持 bun 默认 5s；子进程立即 drain，超时 SIGKILL+reap。
+ */
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, test } from 'bun:test';
+import {
+  MATRIX_TIMEOUT_MS,
+  runIsolatedChild,
+} from './support/messages-list-rate-isolate.ts';
+
+const MATRIX_FILE = join(import.meta.dir, 'support/mail-cursor-v2-generation-matrix.ts');
+const NEGATIVE_FILE = join(import.meta.dir, 'support/mail-cursor-v2-canon-negative.ts');
+
+describe('mail-cursor-v2 isolate parent', () => {
+  test('代际矩阵子进程 10/0 且临时目录已回收', async () => {
+    const result = await runIsolatedChild({
+      argv: [process.execPath, 'test', MATRIX_FILE],
+      timeoutMs: MATRIX_TIMEOUT_MS,
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(0);
+    const childOut = `${result.stdout}\n${result.stderr}`;
+    expect(childOut).toContain('10 pass');
+    expect(childOut).toContain('0 fail');
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+
+  test('真实一处改写负控：去掉 BigInt.toString 后前导零合同失败', async () => {
+    const result = await runIsolatedChild({
+      argv: [process.execPath, NEGATIVE_FILE],
+      timeoutMs: MATRIX_TIMEOUT_MS,
+    });
+    expect(result.timedOut).toBe(false);
+    expect(result.exitCode).toBe(2);
+    const childOut = `${result.stdout}\n${result.stderr}`;
+    expect(childOut).toContain('NEGATIVE_HIT');
+    const negMatch = childOut.match(/^NEG_TEMP=(\S+)/m);
+    expect(negMatch).toBeTruthy();
+    const negTemp = negMatch![1];
+    // 证明泄漏的是负控自己的 oae-canon-neg 目录，且已被 finally 删掉（不是只回收 parent dataDir）。
+    expect(negTemp.includes('oae-canon-neg-')).toBe(true);
+    expect(negTemp).not.toBe(result.dataDir);
+    expect(existsSync(negTemp)).toBe(false);
+    expect(existsSync(result.dataDir)).toBe(false);
+  });
+});

--- a/packages/api/test/mail-cursor.test.ts
+++ b/packages/api/test/mail-cursor.test.ts
@@ -1,8 +1,10 @@
+import { createHmac } from 'node:crypto';
 import { describe, expect, test } from 'bun:test';
 import {
   MAIL_CURSOR_PREFIX,
   MAIL_FORWARD_CURSOR_PREFIX,
   InvalidMailCursorError,
+  canonicalizeMailUidValidity,
   decodeMailCursor,
   decodeMailForwardCursor,
   encodeMailCursor,
@@ -19,15 +21,19 @@ describe('mail-cursor', () => {
       address: 'fox@test.example',
       t: 1_752_000_000_000,
       uid: 42,
+      uidValidity: 17,
     };
     const token = encodeMailCursor(payload, KEY);
     expect(token.startsWith(`${MAIL_CURSOR_PREFIX}.`)).toBe(true);
-    expect(decodeMailCursor(token, KEY)).toEqual(payload);
+    expect(decodeMailCursor(token, KEY)).toEqual({
+      ...payload,
+      uidValidity: '17',
+    });
   });
 
   test('篡改 HMAC 或载荷一律失败', () => {
     const token = encodeMailCursor(
-      { folder: 'sent', address: 'fox@test.example', t: 1, uid: 1 },
+      { folder: 'sent', address: 'fox@test.example', t: 1, uid: 1, uidValidity: 17 },
       KEY,
     );
     const parts = token.split('.');
@@ -36,6 +42,20 @@ describe('mail-cursor', () => {
     );
     expect(() => decodeMailCursor('not-a-token', KEY)).toThrow(InvalidMailCursorError);
     expect(() => decodeMailCursor(token, 'other-key')).toThrow(InvalidMailCursorError);
+  });
+
+  test('改代际字段 v 且保留原 MAC 一律失败', () => {
+    const token = encodeMailCursor(
+      { folder: 'inbox', address: 'fox@test.example', t: 100, uid: 1, uidValidity: 17 },
+      KEY,
+    );
+    const parts = token.split('.');
+    const tamperedBody = Buffer.from(
+      JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: 100, u: 1, v: '18' }),
+    ).toString('base64url');
+    expect(() => decodeMailCursor(`${parts[0]}.${tamperedBody}.${parts[2]}`, KEY)).toThrow(
+      InvalidMailCursorError,
+    );
   });
 
   test('isMailFolder 只承认三 folder', () => {
@@ -65,7 +85,7 @@ describe('mail-cursor', () => {
 
     test('后向与前向游标互不通用（域隔离）', () => {
       const backwardToken = encodeMailCursor(
-        { folder: 'inbox', address: 'fox@test.example', t: 1000, uid: 10 },
+        { folder: 'inbox', address: 'fox@test.example', t: 1000, uid: 10, uidValidity: 17 },
         KEY,
       );
       const forwardToken = encodeMailForwardCursor(
@@ -252,5 +272,87 @@ describe('mail-cursor', () => {
       const strBody = Buffer.from(JSON.stringify({ f: 'inbox', a: 'fox@test.example', t: '1752000000000', u: 42, v: '17' })).toString('base64url');
       expect(() => decodeMailForwardCursor(`${prefix}.${strBody}.${sig}`, KEY)).toThrow(InvalidMailCursorError);
     });
+  });
+});
+
+/**
+ * 用与生产相同的 HMAC 域、但不经 canonicalize 的原始 v 签名。
+ * 供「正确签名的畸形代际」用例：失败必须来自校验，不能只靠坏 MAC。
+ */
+function signBackwardV2Raw(
+  bodyObj: { f: string; a: string; t: number; u: number; v?: unknown },
+  key: string,
+): string {
+  const vPart = bodyObj.v === undefined ? '' : String(bodyObj.v);
+  const mac = createHmac('sha256', key)
+    .update(`mail-cursor-v2\n${bodyObj.f}\n${bodyObj.a}\n${bodyObj.t}\n${bodyObj.u}\n${vPart}`)
+    .digest('base64url');
+  const body = Buffer.from(JSON.stringify(bodyObj)).toString('base64url');
+  return `mail-cursor-v2.${body}.${mac}`;
+}
+
+describe('mail-cursor-v2 canonical 代际（2262）', () => {
+  test('canonicalize：前导零数字串收成无前导零；0/00 拒', () => {
+    expect(canonicalizeMailUidValidity('00017')).toBe('17');
+    expect(canonicalizeMailUidValidity('17')).toBe('17');
+    expect(canonicalizeMailUidValidity(17n)).toBe('17');
+    expect(canonicalizeMailUidValidity(17)).toBe('17');
+    expect(() => canonicalizeMailUidValidity('0')).toThrow(InvalidMailCursorError);
+    expect(() => canonicalizeMailUidValidity('00')).toThrow(InvalidMailCursorError);
+  });
+
+  test('canonicalize：非安全整数 number 拒（含 1e21）', () => {
+    expect(() => canonicalizeMailUidValidity(1e21)).toThrow(InvalidMailCursorError);
+    expect(() => canonicalizeMailUidValidity(Number.MAX_SAFE_INTEGER + 1)).toThrow(
+      InvalidMailCursorError,
+    );
+    expect(() => canonicalizeMailUidValidity(1.5)).toThrow(InvalidMailCursorError);
+    expect(() => canonicalizeMailUidValidity(0)).toThrow(InvalidMailCursorError);
+    expect(() => canonicalizeMailUidValidity(-1)).toThrow(InvalidMailCursorError);
+  });
+
+  test('encode/decode 往返：前导零输入规范化为 17', () => {
+    const token = encodeMailCursor(
+      { folder: 'inbox', address: 'fox@test.example', t: 100, uid: 1, uidValidity: '00017' },
+      KEY,
+    );
+    expect(decodeMailCursor(token, KEY)).toEqual({
+      folder: 'inbox',
+      address: 'fox@test.example',
+      t: 100,
+      uid: 1,
+      uidValidity: '17',
+    });
+  });
+
+  test('encode 拒不安全 number，不发出科学计数游标', () => {
+    expect(() =>
+      encodeMailCursor(
+        { folder: 'inbox', address: 'fox@test.example', t: 100, uid: 1, uidValidity: 1e21 },
+        KEY,
+      ),
+    ).toThrow(InvalidMailCursorError);
+  });
+
+  test('正确签名的畸形代际仍拒（行使校验，不是坏 MAC）', () => {
+    const base = { f: 'inbox', a: 'fox@test.example', t: 100, u: 1 };
+    expect(() => decodeMailCursor(signBackwardV2Raw({ ...base, v: 0 }, KEY), KEY)).toThrow(
+      InvalidMailCursorError,
+    );
+    expect(() => decodeMailCursor(signBackwardV2Raw({ ...base, v: '0' }, KEY), KEY)).toThrow(
+      InvalidMailCursorError,
+    );
+    expect(() => decodeMailCursor(signBackwardV2Raw({ ...base, v: -1 }, KEY), KEY)).toThrow(
+      InvalidMailCursorError,
+    );
+    expect(() => decodeMailCursor(signBackwardV2Raw({ ...base, v: 'abc' }, KEY), KEY)).toThrow(
+      InvalidMailCursorError,
+    );
+    expect(() => decodeMailCursor(signBackwardV2Raw({ ...base }, KEY), KEY)).toThrow(
+      InvalidMailCursorError,
+    );
+    expect(() => decodeMailCursor(signBackwardV2Raw({ ...base, v: 1e21 }, KEY), KEY)).toThrow(
+      InvalidMailCursorError,
+    );
   });
 });

--- a/packages/api/test/support/mail-cursor-v2-canon-negative.ts
+++ b/packages/api/test/support/mail-cursor-v2-canon-negative.ts
@@ -1,0 +1,51 @@
+/**
+ * 真实一处改写负控：复制现行 mail-cursor.ts，只把
+ * `const normalized = BigInt(value).toString();` 改成 `const normalized = value;`，
+ * 再对副本跑前导零必须收成 "17"。副本应变红（exitCode 2）。
+ * 禁止手写假 canonicalize 替代。
+ * 禁止在 try 内 process.exit：会跳过 finally、泄漏 oae-canon-neg 临时目录。
+ * 只设 exitCode，finally 删目录后再自然结束。
+ */
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const SRC = join(import.meta.dir, '../../src/lib/mail-cursor.ts');
+const NEEDLE = 'const normalized = BigInt(value).toString();';
+const REPLACEMENT = 'const normalized = value;';
+
+let exitCode = 3;
+let dir: string | undefined;
+try {
+  const source = readFileSync(SRC, 'utf8');
+  const hits = source.split(NEEDLE).length - 1;
+  if (hits !== 1) {
+    console.error(`NEEDLE_COUNT_${hits}`);
+    exitCode = 3;
+  } else {
+    const mutated = source.replace(NEEDLE, REPLACEMENT);
+    if (mutated === source) {
+      console.error('MUTATION_NOOP');
+      exitCode = 3;
+    } else {
+      dir = mkdtempSync(join(tmpdir(), 'oae-canon-neg-'));
+      // 先打印真实负控目录，供父断言「此路径已删」，不是只查 isolate dataDir。
+      console.error(`NEG_TEMP=${dir}`);
+      writeFileSync(join(dir, 'mail-cursor.ts'), mutated);
+      const { canonicalizeMailUidValidity } = await import(join(dir, 'mail-cursor.ts'));
+      const got = canonicalizeMailUidValidity('00017');
+      if (got === '17') {
+        console.error('NEGATIVE_MISS: still canonical after one-change');
+        exitCode = 4;
+      } else {
+        console.error(`NEGATIVE_HIT: leading-zero stayed ${JSON.stringify(got)}`);
+        exitCode = 2;
+      }
+    }
+  }
+} finally {
+  if (dir) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+process.exitCode = exitCode;

--- a/packages/api/test/support/mail-cursor-v2-generation-matrix.ts
+++ b/packages/api/test/support/mail-cursor-v2-generation-matrix.ts
@@ -1,0 +1,325 @@
+/**
+ * #144 后向游标代际矩阵（子进程专用，勿被父进程与 imap-match 共载）。
+ * 不带 .test.ts，避免 bun test 自动发现重复跑。
+ */
+import { createHmac } from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import { Hono } from 'hono';
+
+process.env.DOMAIN = 'test.example';
+process.env.API_KEYS = 'admin-key';
+process.env.IMAP_USER = 'agent@test.example';
+process.env.IMAP_PASS = 'imap-secret';
+process.env.SMTP_USER = 'agent@test.example';
+process.env.SMTP_PASS = 'smtp-secret';
+
+type FakeMessage = {
+  uid: number;
+  envelope: {
+    from: { address: string }[];
+    to: { address: string }[];
+    subject: string;
+    date: Date;
+    messageId?: string;
+  };
+  internalDate: Date;
+  flags: Set<string>;
+  headers: Buffer;
+  source?: Buffer;
+};
+
+let fakeMessages: FakeMessage[] = [];
+/** null = 选中会话拿不到当前代际（勿传 undefined，会被默认参数吃掉） */
+let fakeUidValidity: bigint | number | string | null = 17n;
+let searchCalls = 0;
+let fetchCalls = 0;
+let fetchOneCalls = 0;
+
+class FakeImapFlow extends EventEmitter {
+  get mailbox() {
+    if (fakeUidValidity === null) return undefined;
+    return { uidValidity: fakeUidValidity };
+  }
+  async connect() {}
+  async getMailboxLock() {
+    return { release() {} };
+  }
+  async search() {
+    searchCalls += 1;
+    return fakeMessages.map((message) => message.uid);
+  }
+  async *fetch() {
+    fetchCalls += 1;
+    yield* fakeMessages;
+  }
+  async fetchOne(uid: number) {
+    fetchOneCalls += 1;
+    const message = fakeMessages.find((candidate) => candidate.uid === uid);
+    if (!message) return false;
+    return {
+      ...message,
+      source:
+        message.source ??
+        Buffer.from(
+          `From: sender@example.net\r\nTo: ${message.envelope.to[0]?.address}\r\n` +
+            `Subject: ${message.envelope.subject}\r\n\r\nbody`,
+        ),
+    };
+  }
+  async logout() {}
+  close() {}
+}
+
+const { mock, describe, expect, test, beforeEach } = await import('bun:test');
+mock.module('imapflow', () => ({ ImapFlow: FakeImapFlow }));
+
+const { listMessagesPage } = await import('../../src/lib/imap.ts');
+const { config } = await import('../../src/lib/config.ts');
+const {
+  InvalidMailCursorError,
+  decodeMailCursor,
+  encodeMailCursor,
+} = await import('../../src/lib/mail-cursor.ts');
+const { UiSessionStore } = await import('../../src/lib/ui-session.ts');
+const { createUiApiRoutes } = await import('../../src/routes/ui.ts');
+
+/** 手工复刻已退役的 v1 编码，供硬拒回归。 */
+function encodeLegacyV1(
+  payload: { folder: 'inbox' | 'sent' | 'all'; address: string; t: number; uid: number },
+  key: string,
+): string {
+  const body = Buffer.from(
+    JSON.stringify({
+      f: payload.folder,
+      a: payload.address,
+      t: payload.t,
+      u: payload.uid,
+    }),
+  ).toString('base64url');
+  const mac = createHmac('sha256', key)
+    .update(`mail-cursor-v1\n${payload.folder}\n${payload.address}\n${payload.t}\n${payload.uid}`)
+    .digest('base64url');
+  return `mail-cursor-v1.${body}.${mac}`;
+}
+
+function folderMessage(opts: { uid: number; from: string; to: string; at: string }): FakeMessage {
+  return {
+    uid: opts.uid,
+    envelope: {
+      from: [{ address: opts.from }],
+      to: [{ address: opts.to }],
+      subject: `m${opts.uid}`,
+      date: new Date(opts.at),
+      messageId: `<m${opts.uid}@test.example>`,
+    },
+    internalDate: new Date(opts.at),
+    flags: new Set<string>(),
+    headers: Buffer.from(`Delivered-To: ${opts.to}\r\n`, 'utf8'),
+  };
+}
+
+function resetImap(messages: FakeMessage[] = [], uidValidity: bigint | number | string | null = 17n) {
+  fakeMessages = messages;
+  fakeUidValidity = uidValidity;
+  searchCalls = 0;
+  fetchCalls = 0;
+  fetchOneCalls = 0;
+}
+
+function inboxFive(): FakeMessage[] {
+  const msgs: FakeMessage[] = [];
+  for (let i = 1; i <= 5; i += 1) {
+    msgs.push(
+      folderMessage({
+        uid: i,
+        from: 'ext@example.net',
+        to: 'fox@test.example',
+        at: `2026-08-01T10:0${i}:00Z`,
+      }),
+    );
+  }
+  return msgs;
+}
+
+describe('listMessagesPage 代际校验（search/fetch 之前）', () => {
+  beforeEach(() => {
+    resetImap(inboxFive(), 17n);
+  });
+
+  test('同代际成功：分页无重复，nextCursor 绑定已验证代际', async () => {
+    const page1 = await listMessagesPage('fox@test.example', { folder: 'inbox', limit: 2 });
+    expect(page1.messages.map((m) => m.id)).toEqual(['5', '4']);
+    expect(page1.nextCursor).toBeTruthy();
+    expect(page1.nextCursor!.startsWith('mail-cursor-v2.')).toBe(true);
+    const decoded = decodeMailCursor(page1.nextCursor!, config.taskSigningSecret);
+    expect(decoded.uidValidity).toBe('17');
+    expect(decoded.folder).toBe('inbox');
+    expect(decoded.address).toBe('fox@test.example');
+    expect(searchCalls).toBeGreaterThan(0);
+
+    const page2 = await listMessagesPage('fox@test.example', {
+      folder: 'inbox',
+      limit: 2,
+      cursor: page1.nextCursor!,
+    });
+    expect(page2.messages.map((m) => m.id)).toEqual(['3', '2']);
+    const overlap = page1.messages.filter((a) => page2.messages.some((b) => b.id === a.id));
+    expect(overlap).toEqual([]);
+  });
+
+  test('v1 游标在 search/fetch 之前抛 InvalidMailCursorError', async () => {
+    const v1 = encodeLegacyV1(
+      { folder: 'inbox', address: 'fox@test.example', t: Date.now(), uid: 5 },
+      config.taskSigningSecret,
+    );
+    searchCalls = 0;
+    fetchCalls = 0;
+    fetchOneCalls = 0;
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox', cursor: v1 }),
+    ).rejects.toMatchObject({ name: 'InvalidMailCursorError', code: 'invalid_cursor' });
+    expect(searchCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+    expect(fetchOneCalls).toBe(0);
+  });
+
+  test('信箱重建后代际不匹配：search/fetch 之前拒', async () => {
+    const stale = encodeMailCursor(
+      { folder: 'inbox', address: 'fox@test.example', t: Date.now(), uid: 5, uidValidity: 16 },
+      config.taskSigningSecret,
+    );
+    fakeUidValidity = 17n;
+    searchCalls = 0;
+    fetchCalls = 0;
+    fetchOneCalls = 0;
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox', cursor: stale }),
+    ).rejects.toBeInstanceOf(InvalidMailCursorError);
+    expect(searchCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+    expect(fetchOneCalls).toBe(0);
+  });
+
+  test('空信箱 + 代际不匹配：search/fetch 之前拒，不返回空页', async () => {
+    resetImap([], 18n);
+    const stale = encodeMailCursor(
+      { folder: 'inbox', address: 'fox@test.example', t: 1, uid: 1, uidValidity: 17 },
+      config.taskSigningSecret,
+    );
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox', cursor: stale }),
+    ).rejects.toBeInstanceOf(InvalidMailCursorError);
+    expect(searchCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+  });
+
+  test('空信箱 + 同代际：校验后代允许 search，返回空页', async () => {
+    resetImap([], 17n);
+    const page = await listMessagesPage('fox@test.example', { folder: 'inbox', limit: 2 });
+    expect(page).toEqual({ messages: [], nextCursor: null });
+    expect(searchCalls).toBe(1);
+  });
+
+  test('首页缺代际：无 cursor 也在 search/fetch 之前拒', async () => {
+    resetImap(inboxFive(), null);
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox', limit: 2 }),
+    ).rejects.toBeInstanceOf(InvalidMailCursorError);
+    expect(searchCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+    expect(fetchOneCalls).toBe(0);
+  });
+
+  test('空信箱首页缺代际同样 fail-closed', async () => {
+    resetImap([], null);
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox' }),
+    ).rejects.toBeInstanceOf(InvalidMailCursorError);
+    expect(searchCalls).toBe(0);
+  });
+
+  test('跨身份 / 跨 folder 的合法 v2 游标在 search 之前拒', async () => {
+    const otherAddr = encodeMailCursor(
+      { folder: 'inbox', address: 'owl@test.example', t: 1, uid: 1, uidValidity: 17 },
+      config.taskSigningSecret,
+    );
+    const otherFolder = encodeMailCursor(
+      { folder: 'sent', address: 'fox@test.example', t: 1, uid: 1, uidValidity: 17 },
+      config.taskSigningSecret,
+    );
+    searchCalls = 0;
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox', cursor: otherAddr }),
+    ).rejects.toBeInstanceOf(InvalidMailCursorError);
+    expect(searchCalls).toBe(0);
+    searchCalls = 0;
+    await expect(
+      listMessagesPage('fox@test.example', { folder: 'inbox', cursor: otherFolder }),
+    ).rejects.toBeInstanceOf(InvalidMailCursorError);
+    expect(searchCalls).toBe(0);
+  });
+});
+
+/**
+ * Commander2262：保留 UI HTTP 400 `{error:'invalid_request'}`；
+ * codec 仍是 invalid_cursor。注入 throw 只证明映射，默认路径才是端到端。
+ */
+function makeUiSessionApp(deps?: Parameters<typeof createUiApiRoutes>[1]) {
+  const store = new UiSessionStore({
+    resolveToken: (token) => (token === 'ok' ? { kind: 'admin' as const } : null),
+  });
+  const created = store.create('ok', '127.0.0.1');
+  if (!created.ok) throw new Error('test session was not created');
+  const app = new Hono();
+  app.route('/ui/api', deps ? createUiApiRoutes(store, deps) : createUiApiRoutes(store));
+  return { app, cookie: `oae_ui=${created.sid}` };
+}
+
+describe('UI 2262 映射（保留 invalid_request）', () => {
+  test('注入 throw：仅 mapper，UI 400 invalid_request（不是端到端）', async () => {
+    const { app, cookie } = makeUiSessionApp({
+      listIdentities: () => [],
+      listMessages: async () => {
+        throw new InvalidMailCursorError();
+      },
+      setMessageSeen: async () => true,
+      getMailboxScan: async () => ({
+        kind: 'ready' as const,
+        now: Date.now(),
+        snapshot: null,
+        cached: false,
+        revalidating: false,
+        refreshError: false,
+      }),
+      getMessage: async () => null,
+      setPushContentTier: () => null,
+    });
+    const res = await app.request(
+      '/ui/api/messages?address=fox%40test.example&cursor=mail-cursor-v1.dead.beef',
+      { headers: { cookie } },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+  });
+
+  test('默认服务路径 + v1：真 listMessagesPage，HTTP 400 invalid_request 且未 search', async () => {
+    resetImap(inboxFive(), 17n);
+    const v1 = encodeLegacyV1(
+      { folder: 'inbox', address: 'fox@test.example', t: Date.now(), uid: 5 },
+      config.taskSigningSecret,
+    );
+    const { app, cookie } = makeUiSessionApp();
+    searchCalls = 0;
+    fetchCalls = 0;
+    fetchOneCalls = 0;
+    const res = await app.request(
+      `/ui/api/messages?address=fox%40test.example&cursor=${encodeURIComponent(v1)}`,
+      { headers: { cookie } },
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'invalid_request' });
+    expect(searchCalls).toBe(0);
+    expect(fetchCalls).toBe(0);
+    expect(fetchOneCalls).toBe(0);
+  });
+});

--- a/packages/api/test/task-lease-journal-capacity.test.ts
+++ b/packages/api/test/task-lease-journal-capacity.test.ts
@@ -55,6 +55,14 @@ const FIRST_CLAIM = '2026-08-24T00:00:00.000Z';
 const FILL_TIMEOUT = 480_000;
 /** Cooperative check *between* admits only. Does not cancel in-flight persist IO. */
 const FILL_DEADLINE_MS = 460_000;
+/**
+ * Commander2362 isolated overrides for #4 and #8 only. Defaults above stay 460s/480s
+ * for every other caller. Empirical samples (not this edit): isolated ~251s / ~275s;
+ * historical suite fills ~390s / ~432s. Commander calibration rationale: reference-
+ * machine jitter ±60s on those samples — not a new measurement from this change.
+ */
+const CALIBRATED_FILL_DEADLINE_MS = 600_000;
+const CALIBRATED_FILL_TIMEOUT = 620_000;
 const POST_FILL_BUDGET_MS = 15_000;
 /** Optional durable path for local diagnosis. Unset → process temp file (CI must not need FC dirs). */
 const ADMIT_RATE_LOG = process.env.OAE_JOURNAL_ADMIT_RATE_LOG
@@ -156,7 +164,13 @@ function absentEvidence(): JournalExitEvidence {
   };
 }
 
-async function fillIndexedBody(count: number, start: number, epoch: number, signal: AbortSignal): Promise<void> {
+async function fillIndexedBody(
+  count: number,
+  start: number,
+  epoch: number,
+  signal: AbortSignal,
+  deadlineMs = FILL_DEADLINE_MS,
+): Promise<void> {
   const started = Date.now();
   const total = start + count - 1;
   const phase = `fillIndexed:${start}-${total}`;
@@ -166,9 +180,9 @@ async function fillIndexedBody(count: number, start: number, epoch: number, sign
       throw new Error(`${phase} aborted at n=${n}`);
     }
     const elapsed = Date.now() - started;
-    if (elapsed > FILL_DEADLINE_MS) {
+    if (elapsed > deadlineMs) {
       logAdmitEvent({ phase: `${phase}:deadline`, n: n - start, total: count, occupancy: journalOccupancyForTests(), elapsed_ms: elapsed });
-      throw new Error(`${phase} exceeded ${FILL_DEADLINE_MS}ms at n=${n}`);
+      throw new Error(`${phase} exceeded ${deadlineMs}ms at n=${n}`);
     }
     await upsertJournalRecord(indexedClaim(tid(n)));
     if (fillWasAborted(epoch, signal)) {
@@ -186,8 +200,8 @@ async function fillIndexedBody(count: number, start: number, epoch: number, sign
   });
 }
 
-function fillIndexed(count: number, start = 1): Promise<void> {
-  return trackFill(fillIndexedBody(count, start, fillEpoch, fillAbort.signal));
+function fillIndexed(count: number, start = 1, deadlineMs = FILL_DEADLINE_MS): Promise<void> {
+  return trackFill(fillIndexedBody(count, start, fillEpoch, fillAbort.signal, deadlineMs));
 }
 
 function freshDir(): void {
@@ -294,8 +308,9 @@ describe('M2 journal whole-task exit (v4 + addendum)', () => {
   }, FILL_TIMEOUT);
 
   test('permanently bad first candidate does not starve a later eligible task', async () => {
+    // 仅本用例覆盖 fill/test 墙钟；默认 460/480 不变。见 CALIBRATED_* 经验样本 vs 裁定抖动说明。
     freshDir();
-    await fillIndexed(TASK_LEASE_JOURNAL_MAX_RECORDS);
+    await fillIndexed(TASK_LEASE_JOURNAL_MAX_RECORDS, 1, CALIBRATED_FILL_DEADLINE_MS);
     const first = tid(1);
     const second = tid(2);
     setJournalExitEvidenceForTests(async (id) => {
@@ -310,7 +325,7 @@ describe('M2 journal whole-task exit (v4 + addendum)', () => {
     const file = await loadLeaseJournal();
     expect(file.records.some((row) => row.taskId === first)).toBe(true);
     expect(file.records.some((row) => row.taskId === second)).toBe(false);
-  }, FILL_TIMEOUT);
+  }, CALIBRATED_FILL_TIMEOUT);
 
   test('retry without new mark: second persist exits after first evidence failure', async () => {
     freshDir();
@@ -427,8 +442,9 @@ describe('M2 journal whole-task exit (v4 + addendum)', () => {
   });
 
   test('evidence lookup cannot reenter reconcile (nested mutation uses no extra query)', async () => {
+    // 仅本用例覆盖 fill/test 墙钟；默认 460/480 不变。见 CALIBRATED_* 经验样本 vs 裁定抖动说明。
     freshDir();
-    await fillIndexed(TASK_LEASE_JOURNAL_MAX_RECORDS - 1);
+    await fillIndexed(TASK_LEASE_JOURNAL_MAX_RECORDS - 1, 1, CALIBRATED_FILL_DEADLINE_MS);
     await upsertJournalRecord(intentClaim(tid(TASK_LEASE_JOURNAL_MAX_RECORDS)));
     let depthDuringLookup = -1;
     setJournalExitEvidenceForTests(async () => {
@@ -440,7 +456,7 @@ describe('M2 journal whole-task exit (v4 + addendum)', () => {
     await markJournalFate(intentClaim(tid(TASK_LEASE_JOURNAL_MAX_RECORDS)), 'indexed');
     expect(depthDuringLookup).toBeGreaterThan(0);
     expect(journalExitEvidenceQueryCountForTests() - before).toBe(1);
-  }, FILL_TIMEOUT);
+  }, CALIBRATED_FILL_TIMEOUT);
 
   test('production reconstruction: completed task still exits via historical claim receipts', async () => {
     freshDir();

--- a/packages/api/test/ui-overview.test.ts
+++ b/packages/api/test/ui-overview.test.ts
@@ -47,6 +47,10 @@ class FakeImapFlow extends EventEmitter {
     super();
     connections += 1;
   }
+  // 选中会话必须暴露当前代际，供后向列表在 search 前校验（#144 / REPAIR-FIXTURES-01）。
+  get mailbox() {
+    return { uidValidity: 17n };
+  }
   async connect() {}
   async getMailboxLock() {
     return { release() {} };


### PR DESCRIPTION
Backward mail cursors now authenticate the mailbox UIDVALIDITY with cursor v2, preventing a cursor from a previous mailbox generation from selecting messages after UID reuse. Invalid/legacy cursors and unavailable generation fail closed before search/fetch. UI retains `400 invalid_request`; ordinary REST list/wait map the codec error to `400 invalid_cursor`, including propagation through wait fallback. No new backward-cursor parameter is added to REST list/wait.

Refs #144. Documentation and regression controls cover generation binding, canonicalization, malformed/legacy cursors, and the UI/REST error mapping. Three existing IMAP fixtures now supply UIDVALIDITY while retaining their assertions.

Validation on the committed file contents:
- Complete full suite: 1704 pass / 1 skip / 0 fail, 11318 expects, 1705 tests across 99 files (2395.98s). All eight capacity controls passed. Commit content was checked against the tested 15-file manifest; working tree clean.
- Full log `full2362-01.log` SHA256 `3ffee0c624d1bc28e3cd6610d852c9c7dbc066cf7e72a2420c8f60bc3b91e890`; tested manifest SHA256 `cc42a28ea6f8ad41e73c723cbee4c229f11c0843637294a6bb611196ca29c935`.
- Earlier typecheck retained the historical 133 diagnostics; this is not a clean typecheck claim.

Explicit test-budget calibration: only “permanently bad first candidate does not starve a later eligible task” and “evidence lookup cannot reenter reconcile (nested mutation uses no extra query)” change fill deadline 460s→600s and enclosing test timeout 480s→620s. All other defaults, capacity 10000, fixtures and assertions remain unchanged. The DIAG→PROFILE→approved calibration followed full-suite deadline failures: isolated current-tree samples were 251s/275s, historical suite samples approximately 390s/432s. The approved reference-machine jitter allowance was ±60s, not a new measurement. Sequential A/B profiling did not show a slowdown in those samples and does not establish exclusive causality.

Earlier full-suite RED results remain recorded; four directed passes were not treated as full-suite acceptance. The complete full pass above is subsequent to the narrow calibration. Current-head CI and review gates remain pending; this PR is not merge approval.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Backward pagination cursors are now securely tied to the current mailbox generation.
  - Stale, malformed, legacy, or cross-mailbox cursors are rejected instead of being reused.
  - Invalid cursors consistently return a `400 invalid_cursor` response for message listing and waiting endpoints.
  - Invalid cursor errors no longer trigger unnecessary polling or timeout behavior.

- **Documentation**
  - Documented cursor versioning, validation, restart behavior, and HTTP error mappings across supported interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Final disposition 2405: deferred review items are tracked before merge:
- P2-1: https://github.com/openagentemail/openagentemail/issues/196
- P2-2-doc: https://github.com/openagentemail/openagentemail/issues/197
- P2-2-scope: https://github.com/openagentemail/openagentemail/issues/198
- P2-3: https://github.com/openagentemail/openagentemail/issues/199
- P2-5: https://github.com/openagentemail/openagentemail/issues/200
- P2-6: https://github.com/openagentemail/openagentemail/issues/201
- P2-7: https://github.com/openagentemail/openagentemail/issues/202

P2-4 is dispositioned by the explicit two-test budget calibration approval (2362). The exact matrix-count guard remains intact. For this PR only, the final reviewer accepts the current-head CodeRabbit status and structured comment in place of formal-review fields. Merge remains with the commander.
